### PR TITLE
build(wheels): Build wheels on Travis and prepare for releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,3 @@
+targets:
+  - github
+  - pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,9 @@ matrix:
 
   include:
     - stage: deploy
-      before_script: pip install wheel
+      before_script:
+        - virtualenv -p python ~/virtualenv
+        - ~/virtualenv/bin/activate
       script: make wheel
       env: DEPLOY=1
       osx_image: xcode6.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,52 @@
 language: rust
 dist: trusty
+osx_version: xcode7.3
+
+os:
+  - linux
+  - osx
 
 rust:
   - stable
   - beta
   - nightly
 
+git:
+  depth: 1
+
+script: make
+
 matrix:
   allow_failures:
     - rust: nightly
 
-script: make
+  include:
+    - script: make wheel
+      env: DEPLOY=1
+      osx_image: xcode6.4
+      os: osx
+
+    - script: make wheel-manylinux IMAGE=quay.io/pypa/manylinux1_x86_64
+      env: DEPLOY=1
+      sudo: required
+      services:
+        - docker
+
+    - script: make wheel-manylinux IMAGE=quay.io/pypa/manylinux1_i686
+      env: DEPLOY=1
+      sudo: required
+      services:
+        - docker
+
+deploy:
+  provider: s3
+  access_key_id: AKIAJKYWAF3QS7SFL75Q
+  secret_access_key:
+    secure: QCXIoUbIJ53PHskm36Nm9exO44/4gHH1sGA6O3pLt36HLDU+Q02GQVnI4IvWkXeA8zzUVLqXUMpxvgnt2OsosaCufQ9x9xTSItqs+en4hmew1z3pnugq7S9Efsk6qcffN5VCGuKBGpQxS0XSlvB7I1o+ZfuoUsdjoD1w7WZ219H9tImqe1wzCsbqKnLwCLtuoeTJFHg5gcdMWIrSxP3Q959mdzzJr60HH8z2c9UIz/eKIlKPyh2LSqbkocg5XCpw23lg+Jw1spwshbRn2k4w0I4hnN/UWQ3pkW1gzAhPwG4G63u4u9r2eRQ8D3kfSwz/MOyQkTPIQlapAFZPzeBzW6anle0W/KMW/qZ4PDLc+CZ8+UwwL9MgWKP4H2aYpZlz40d7Nl4JrfIyOfP/2Yd3CcjYHrWWC3cTyeQeVwmTJn5Xy+EPu1AksENOj8WXjqWEfzwk/S2+QbBejx2korZZIIiBKCyOwmmJoDYiqnaN1lHtbyZ8GwkGrV0HabwuG7cmJaG3l2NGB5rhLwqyHDRxhqoSbCtgyiRRk/ZhW6tr5Aw89HcIrSQPMkROJNq+6zVQrbaqzFk9YFcS5maH6u8tyPoeqsa0NVLHjWdBMfkvqZ3ZyBKKIJeDHJR4pfVR/dnkHTCpmsSwlcEZ9ke69JcEgS8B00snVa5E59yKC155Isc=
+  bucket: getsentry-builds
+  skip_cleanup: true
+  local_dir: py/dist
+  upload-dir: $TRAVIS_REPO_SLUG/$TRAVIS_COMMIT
+  acl: public_read
+  on:
+    condition: $DEPLOY = 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ matrix:
   include:
     - stage: deploy
       before_script:
-        - virtualenv -p python ~/virtualenv
+        - sudo easy_install virtualenv
+        - virtualenv ~/virtualenv
         - ~/virtualenv/bin/activate
       script: make wheel
       env: DEPLOY=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
 
   include:
     - script: make wheel
+      before_script: pip install wheel
       env: DEPLOY=1
       osx_image: xcode6.4
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,5 @@ deploy:
   upload-dir: $TRAVIS_REPO_SLUG/$TRAVIS_COMMIT
   acl: public_read
   on:
+    all_branches: true
     condition: $DEPLOY = 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ rust:
 git:
   depth: 1
 
-script: make
-
 matrix:
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ matrix:
     - rust: nightly
 
   include:
-    - script: make wheel
+    - stage: deploy
       before_script: pip install wheel
+      script: make wheel
       env: DEPLOY=1
       osx_image: xcode6.4
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       before_script:
         - sudo easy_install virtualenv
         - virtualenv ~/virtualenv
-        - ~/virtualenv/bin/activate
+        - source ~/virtualenv/bin/activate
       script: make wheel
       env: DEPLOY=1
       osx_image: xcode6.4

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-all: test doc
+all: build test
 
-doc:
-	@cargo doc
+build:
+	@cargo build --all
 
-test:
+test: build
 	@cargo test --all
 
 wheel:

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,10 @@ doc:
 test:
 	@cargo test --all
 
-.PHONY: all doc test
+wheel:
+	cd py && python setup.py bdist_wheel
+
+wheel-manylinux:
+	docker run --rm -it -v $(CURDIR):/work -w /work/py $(IMAGE) sh manylinux.sh
+
+.PHONY: all doc test docker wheel wheel-manylinux

--- a/py/manylinux.sh
+++ b/py/manylinux.sh
@@ -11,3 +11,9 @@ export PATH=~/.cargo/bin:$PATH
 # Build wheels
 which linux32 && LINUX32=linux32
 $LINUX32 /opt/python/cp27-cp27mu/bin/python setup.py bdist_wheel
+
+# Audit wheels
+for wheel in dist/*-linux_*.whl; do
+  auditwheel repair $wheel -w dist/
+  rm $wheel
+done

--- a/py/manylinux.sh
+++ b/py/manylinux.sh
@@ -9,4 +9,5 @@ curl https://sh.rustup.rs -sSf | sh -s -- -y
 export PATH=~/.cargo/bin:$PATH
 
 # Build wheels
-/opt/python/cp27-cp27mu/bin/python setup.py bdist_wheel
+which linux32 && LINUX32=linux32
+$LINUX32 /opt/python/cp27-cp27mu/bin/python setup.py bdist_wheel

--- a/py/manylinux.sh
+++ b/py/manylinux.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Install dependencies needed by our wheel
+yum -y install gcc libffi-devel
+
+# Install Rust
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+export PATH=~/.cargo/bin:$PATH
+
+# Build wheels
+/opt/python/cp27-cp27mu/bin/python setup.py bdist_wheel


### PR DESCRIPTION
- [x] Add a Makefile target to build wheels locally
- [x] Add a Makefile target to build wheels inside Docker
- [x] Amend Travis config to also build wheels
- [x] Deploy wheels to S3 compatible to [probot-release](https://getsentry.com/getsentry/probot-release)
- [x] Run `auditwheel` to generate manylinux1 wheels
- [x] Activate probot-release and setup wheel deployment (not ready)