### PR TITLE
feat: Expose more minidump attributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,13 +6,9 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
 
-[*.{rs,json}]
+[*.{c,cc,cpp,h,rs,json}]
 indent_style = space
 indent_size = 4
-
-[*.{c,cc,cpp,h}]
-indent_style = space
-indent_size = 2
 
 [.travis.yml]
 indent_style = space

--- a/cabi/include/symbolic.h
+++ b/cabi/include/symbolic.h
@@ -167,6 +167,17 @@ typedef struct {
 } SymbolicLookupResult;
 
 /*
+ * OS and CPU information
+ */
+typedef struct {
+  SymbolicStr os_name;
+  SymbolicStr os_version;
+  SymbolicStr cpu_family;
+  SymbolicStr cpu_info;
+  uint32_t cpu_count;
+} SymbolicSystemInfo;
+
+/*
  * Contains the absolute instruction address and image information of a stack frame
  */
 typedef struct {
@@ -190,6 +201,12 @@ typedef struct {
  * State of a crashed process
  */
 typedef struct {
+  int32_t requesting_thread;
+  uint64_t timestamp;
+  uint64_t crash_address;
+  SymbolicStr crash_reason;
+  SymbolicStr assertion;
+  SymbolicSystemInfo system_info;
   SymbolicCallStack *threads;
   size_t thread_count;
 } SymbolicProcessState;
@@ -456,7 +473,8 @@ void symbolic_sourceview_free(SymbolicSourceView *ssv);
 /*
  * Creates a source view from a given path.
  *
- * This shares the underlying memory and does not copy it.
+ * This shares the underlying memory and does not copy it if that is
+ * possible.  Will ignore utf-8 decoding errors.
  */
 SymbolicSourceView *symbolic_sourceview_from_bytes(const char *bytes, size_t len);
 

--- a/minidump/cpp/data_definitions.h
+++ b/minidump/cpp/data_definitions.h
@@ -5,6 +5,7 @@
 #include "google_breakpad/processor/code_module.h"
 #include "google_breakpad/processor/process_state.h"
 #include "google_breakpad/processor/stack_frame.h"
+#include "google_breakpad/processor/system_info.h"
 
 #include "cpp/c_mapping.h"
 
@@ -12,5 +13,6 @@ typedef_extern_c(call_stack_t, google_breakpad::CallStack);
 typedef_extern_c(code_module_t, google_breakpad::CodeModule);
 typedef_extern_c(process_state_t, google_breakpad::ProcessState);
 typedef_extern_c(stack_frame_t, google_breakpad::StackFrame);
+typedef_extern_c(system_info_t, google_breakpad::SystemInfo);
 
 #endif

--- a/minidump/cpp/data_structures.cpp
+++ b/minidump/cpp/data_structures.cpp
@@ -26,6 +26,94 @@ call_stack_t *const *process_state_threads(process_state_t *state,
     return reinterpret_cast<call_stack_t *const *>(threads->data());
 }
 
+int32_t process_state_requesting_thread(const process_state_t *state) {
+    if (state == nullptr) {
+        return -1;
+    }
+
+    return process_state_t::cast(state)->requesting_thread();
+}
+
+uint64_t process_state_timestamp(const process_state_t *state) {
+    if (state == nullptr) {
+        return 0;
+    }
+
+    return process_state_t::cast(state)->time_date_stamp();
+}
+
+uint64_t process_state_crash_address(const process_state_t *state) {
+    if (state == nullptr) {
+        return 0;
+    }
+
+    return process_state_t::cast(state)->crash_address();
+}
+
+char *process_state_crash_reason(const process_state_t *state) {
+    if (state == nullptr) {
+        return nullptr;
+    }
+
+    return string_from(process_state_t::cast(state)->crash_reason());
+}
+
+char *process_state_assertion(const process_state_t *state) {
+    if (state == nullptr) {
+        return nullptr;
+    }
+
+    return string_from(process_state_t::cast(state)->assertion());
+}
+
+const system_info_t *process_state_system_info(const process_state_t *state) {
+    if (state == nullptr) {
+        return nullptr;
+    }
+
+    return system_info_t::cast(process_state_t::cast(state)->system_info());
+}
+
+char *system_info_os_name(const system_info_t *info) {
+    if (info == nullptr) {
+        return nullptr;
+    }
+
+    return string_from(system_info_t::cast(info)->os);
+}
+
+char *system_info_os_version(const system_info_t *info) {
+    if (info == nullptr) {
+        return nullptr;
+    }
+
+    return string_from(system_info_t::cast(info)->os_version);
+}
+
+char *system_info_cpu_family(const system_info_t *info) {
+    if (info == nullptr) {
+        return nullptr;
+    }
+
+    return string_from(system_info_t::cast(info)->cpu);
+}
+
+char *system_info_cpu_info(const system_info_t *info) {
+    if (info == nullptr) {
+        return nullptr;
+    }
+
+    return string_from(system_info_t::cast(info)->cpu_info);
+}
+
+uint32_t system_info_cpu_count(const system_info_t *info) {
+    if (info == nullptr) {
+        return 0;
+    }
+
+    return system_info_t::cast(info)->cpu_count;
+}
+
 uint32_t call_stack_thread_id(const call_stack_t *stack) {
     return (stack == nullptr) ? 0 : call_stack_t::cast(stack)->tid();
 }

--- a/minidump/cpp/data_structures.h
+++ b/minidump/cpp/data_structures.h
@@ -27,6 +27,9 @@ struct process_state_t;
 /// source code locations and code offsets.
 struct stack_frame_t;
 
+/// Information about the CPU and OS on which a minidump was generated.
+struct system_info_t;
+
 /// Releases memory of a process state struct. Assumes ownership of the pointer.
 void process_state_delete(process_state_t *state);
 
@@ -35,6 +38,79 @@ void process_state_delete(process_state_t *state);
 /// returned in the size_out parameter.
 call_stack_t *const *process_state_threads(process_state_t *state,
                                            size_t *size_out);
+
+/// The index of the thread that requested a dump be written in the
+/// threads vector.  If a dump was produced as a result of a crash, this
+/// will point to the thread that crashed.  If the dump was produced as
+/// by user code without crashing, and the dump contains extended Breakpad
+/// information, this will point to the thread that requested the dump.
+/// If the dump was not produced as a result of an exception and no
+/// extended Breakpad information is present, this field will be set to -1,
+/// indicating that the dump thread is not available.
+int32_t process_state_requesting_thread(const process_state_t *state);
+
+/// The time-date stamp of the minidump (time_t format)
+uint64_t process_state_timestamp(const process_state_t *state);
+
+/// If the process crashed, and if crash_reason implicates memory,
+/// the memory address that caused the crash.  For data access errors,
+/// this will be the data address that caused the fault.  For code errors,
+/// this will be the address of the instruction that caused the fault.
+uint64_t process_state_crash_address(const process_state_t *state);
+
+/// If the process crashed, the type of crash.  OS- and possibly CPU-
+/// specific.  For example, "EXCEPTION_ACCESS_VIOLATION" (Windows),
+/// "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS" (Mac OS X), "SIGSEGV"
+/// (other Unix).
+///
+/// The return value is an owning pointer. Release memory with string_delete.
+char *process_state_crash_reason(const process_state_t *state);
+
+/// If there was an assertion that was hit, a textual representation
+/// of that assertion, possibly including the file and line at which
+/// it occurred.
+///
+/// The return value is an owning pointer. Release memory with string_delete.
+char *process_state_assertion(const process_state_t *state);
+
+/// Returns a weak pointer to OS and CPU information.
+const system_info_t *process_state_system_info(const process_state_t *state);
+
+/// A string identifying the operating system, such as "Windows NT",
+/// "Mac OS X", or "Linux".  If the information is present in the dump but
+/// its value is unknown, this field will contain a numeric value.  If
+/// the information is not present in the dump, this field will be empty.
+///
+/// The return value is an owning pointer. Release memory with string_delete.
+char *system_info_os_name(const system_info_t *info);
+
+/// A string identifying the version of the operating system, such as
+/// "5.1.2600 Service Pack 2" or "10.4.8 8L2127".  If the dump does not
+/// contain this information, this field will be empty.
+///
+/// The return value is an owning pointer. Release memory with string_delete.
+char *system_info_os_version(const system_info_t *info);
+
+/// A string identifying the basic CPU family, such as "x86" or "ppc".
+/// If this information is present in the dump but its value is unknown,
+/// this field will contain a numeric value.  If the information is not
+/// present in the dump, this field will be empty.  The values stored in
+/// this field should match those used by MinidumpSystemInfo::GetCPU.
+///
+/// The return value is an owning pointer. Release memory with string_delete.
+char *system_info_cpu_family(const system_info_t *info);
+
+/// A string further identifying the specific CPU, such as
+/// "GenuineIntel level 6 model 13 stepping 8".  If the information is not
+/// present in the dump, or additional identifying information is not
+/// defined for the CPU family, this field will be empty.
+///
+/// The return value is an owning pointer. Release memory with string_delete.
+char *system_info_cpu_info(const system_info_t *info);
+
+/// The number of processors in the system.  Will be greater than one for
+/// multi-core systems.
+uint32_t system_info_cpu_count(const system_info_t *info);
 
 /// Returns the thread identifier of this callstack.
 uint32_t call_stack_thread_id(const call_stack_t *stack);

--- a/py/symbolic/minidump.py
+++ b/py/symbolic/minidump.py
@@ -164,10 +164,10 @@ class ProcessState(RustObject):
 
     @property
     def crash_time(self):
-        """The time at which the process crashed"""
+        """The UTC time at which the process crashed"""
         if self.timestamp == 0:
             return None
-        return datetime.fromtimestamp(float(self.timestamp))
+        return datetime.utcfromtimestamp(float(self.timestamp))
 
     @property
     def crash_address(self):

--- a/py/tests/test_minidump.py
+++ b/py/tests/test_minidump.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 
+from datetime import datetime
 from symbolic import FatObject, FrameInfoMap, ProcessState
 
 
@@ -8,6 +9,19 @@ def test_macos_without_cfi(res_path):
     path = os.path.join(res_path, 'minidump', 'crash_macos.dmp')
     state = ProcessState.from_minidump(path)
     assert state.thread_count == 1
+    assert state.requesting_thread == 0
+    assert state.timestamp == 1505305307L
+    assert state.crash_time == datetime(2017, 9, 13, 14, 21, 47)
+    assert state.crash_address == 69  # memory address: *(0x45) = 0;
+    assert state.crash_reason == 'EXC_BAD_ACCESS / KERN_INVALID_ADDRESS'
+    assert state.assertion == ''
+
+    info = state.system_info
+    assert info.os_name == 'Mac OS X'
+    assert info.os_version == '10.12.6 16G29'
+    assert info.cpu_family == 'amd64'
+    assert info.cpu_info == 'family 6 model 70 stepping 1'
+    assert info.cpu_count == 8
 
     thread = state.get_thread(0)
     assert thread.thread_id == 775
@@ -26,6 +40,19 @@ def test_linux_without_cfi(res_path):
     path = os.path.join(res_path, 'minidump', 'crash_linux.dmp')
     state = ProcessState.from_minidump(path)
     assert state.thread_count == 1
+    assert state.requesting_thread == 0
+    assert state.timestamp == 1505305040L
+    assert state.crash_time == datetime(2017, 9, 13, 14, 17, 20)
+    assert state.crash_address == 0  # memory address: *(0x0) = 0;
+    assert state.crash_reason == 'SIGSEGV'
+    assert state.assertion == ''
+
+    info = state.system_info
+    assert info.os_name == 'Linux'
+    assert info.os_version == '0.0.0 Linux 4.9.46-moby #1 SMP Thu Sep 7 02:53:42 UTC 2017 x86_64'
+    assert info.cpu_family == 'amd64'
+    assert info.cpu_info == 'family 6 model 70 stepping 1'
+    assert info.cpu_count == 4
 
     thread = state.get_thread(0)
     assert thread.thread_id == 133
@@ -48,6 +75,19 @@ def test_macos_with_cfi(res_path):
     minidump_path = os.path.join(res_path, "minidump", "crash_macos.dmp")
     state = ProcessState.from_minidump(minidump_path, cfi)
     assert state.thread_count == 1
+    assert state.requesting_thread == 0
+    assert state.timestamp == 1505305307L
+    assert state.crash_time == datetime(2017, 9, 13, 14, 21, 47)
+    assert state.crash_address == 69  # memory address: *(0x45) = 0;
+    assert state.crash_reason == 'EXC_BAD_ACCESS / KERN_INVALID_ADDRESS'
+    assert state.assertion == ''
+
+    info = state.system_info
+    assert info.os_name == 'Mac OS X'
+    assert info.os_version == '10.12.6 16G29'
+    assert info.cpu_family == 'amd64'
+    assert info.cpu_info == 'family 6 model 70 stepping 1'
+    assert info.cpu_count == 8
 
     thread = state.get_thread(0)
     assert thread.thread_id == 775
@@ -70,6 +110,19 @@ def test_linux_with_cfi(res_path):
     minidump_path = os.path.join(res_path, "minidump", "crash_linux.dmp")
     state = ProcessState.from_minidump(minidump_path, cfi)
     assert state.thread_count == 1
+    assert state.requesting_thread == 0
+    assert state.timestamp == 1505305040L
+    assert state.crash_time == datetime(2017, 9, 13, 14, 17, 20)
+    assert state.crash_address == 0  # memory address: *(0x0) = 0;
+    assert state.crash_reason == 'SIGSEGV'
+    assert state.assertion == ''
+
+    info = state.system_info
+    assert info.os_name == 'Linux'
+    assert info.os_version == '0.0.0 Linux 4.9.46-moby #1 SMP Thu Sep 7 02:53:42 UTC 2017 x86_64'
+    assert info.cpu_family == 'amd64'
+    assert info.cpu_info == 'family 6 model 70 stepping 1'
+    assert info.cpu_count == 4
 
     thread = state.get_thread(0)
     assert thread.thread_id == 133

--- a/py/tests/test_minidump.py
+++ b/py/tests/test_minidump.py
@@ -11,7 +11,7 @@ def test_macos_without_cfi(res_path):
     assert state.thread_count == 1
     assert state.requesting_thread == 0
     assert state.timestamp == 1505305307L
-    assert state.crash_time == datetime(2017, 9, 13, 14, 21, 47)
+    assert state.crash_time == datetime(2017, 9, 13, 12, 21, 47)
     assert state.crash_address == 69  # memory address: *(0x45) = 0;
     assert state.crash_reason == 'EXC_BAD_ACCESS / KERN_INVALID_ADDRESS'
     assert state.assertion == ''
@@ -42,7 +42,7 @@ def test_linux_without_cfi(res_path):
     assert state.thread_count == 1
     assert state.requesting_thread == 0
     assert state.timestamp == 1505305040L
-    assert state.crash_time == datetime(2017, 9, 13, 14, 17, 20)
+    assert state.crash_time == datetime(2017, 9, 13, 12, 17, 20)
     assert state.crash_address == 0  # memory address: *(0x0) = 0;
     assert state.crash_reason == 'SIGSEGV'
     assert state.assertion == ''
@@ -77,7 +77,7 @@ def test_macos_with_cfi(res_path):
     assert state.thread_count == 1
     assert state.requesting_thread == 0
     assert state.timestamp == 1505305307L
-    assert state.crash_time == datetime(2017, 9, 13, 14, 21, 47)
+    assert state.crash_time == datetime(2017, 9, 13, 12, 21, 47)
     assert state.crash_address == 69  # memory address: *(0x45) = 0;
     assert state.crash_reason == 'EXC_BAD_ACCESS / KERN_INVALID_ADDRESS'
     assert state.assertion == ''
@@ -112,7 +112,7 @@ def test_linux_with_cfi(res_path):
     assert state.thread_count == 1
     assert state.requesting_thread == 0
     assert state.timestamp == 1505305040L
-    assert state.crash_time == datetime(2017, 9, 13, 14, 17, 20)
+    assert state.crash_time == datetime(2017, 9, 13, 12, 17, 20)
     assert state.crash_address == 0  # memory address: *(0x0) = 0;
     assert state.crash_reason == 'SIGSEGV'
     assert state.assertion == ''


### PR DESCRIPTION
Exposes all attributes except exploitability:

- requesting_thread: u32
- time_date_stamp: **u64** (was u32)
- crash_reason: String
- crash_address: u64
- assertion: String
- system_info:
    - os: String
    - os_short: String
    - os_version: String
    - cpu: String
    - cpu_info: String
    - cpu_count: u32
- *exploitability: enum* (not implemented)

Fixes #11 