### PR TITLE
feat(demangle): Support symbols from Objective C++ code

### DIFF
--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -317,31 +317,32 @@ impl Language {
     pub fn name(&self) -> &'static str {
         use Language::*;
         match *self {
-            Language::Unknown | Language::__Max => "unknown",
-            Language::C => "c",
-            Language::Cpp => "cpp",
-            Language::D => "d",
-            Language::Go => "go",
-            Language::ObjC => "objc",
-            Language::ObjCpp => "objcpp",
-            Language::Rust => "rust",
-            Language::Swift => "swift",
+            Unknown | __Max => "unknown",
+            C => "c",
+            Cpp => "cpp",
+            D => "d",
+            Go => "go",
+            ObjC => "objc",
+            ObjCpp => "objcpp",
+            Rust => "rust",
+            Swift => "swift",
         }
     }
 }
 
 impl fmt::Display for Language {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Language::*;
         write!(f, "{}", match *self {
-            Language::Unknown | Language::__Max => "unknown",
-            Language::C => "C",
-            Language::Cpp => "C++",
-            Language::D => "D",
-            Language::Go => "Go",
-            Language::ObjC => "Objective-C",
-            Language::ObjCpp => "Objective-C++",
-            Language::Rust => "Rust",
-            Language::Swift => "Swift",
+            Unknown | __Max => "unknown",
+            C => "C",
+            Cpp => "C++",
+            D => "D",
+            Go => "Go",
+            ObjC => "Objective-C",
+            ObjCpp => "Objective-C++",
+            Rust => "Rust",
+            Swift => "Swift",
         })
     }
 }

--- a/demangle/src/lib.rs
+++ b/demangle/src/lib.rs
@@ -214,11 +214,12 @@ impl<'a> Symbol<'a> {
 
     /// Demangles a symbol with the given options.
     pub fn demangle(&self, opts: &DemangleOptions) -> Result<Option<String>> {
+        use Language::*;
         match self.language() {
-            Some(Language::ObjC) => Ok(Some(self.mangled.to_string())),
-            Some(Language::Rust) => try_demangle_rust(self.mangled, opts),
-            Some(Language::Cpp) => try_demangle_cpp(self.mangled, opts),
-            Some(Language::Swift) => try_demangle_swift(self.mangled, opts),
+            Some(ObjC) => Ok(Some(self.mangled.to_string())),
+            Some(Rust) => try_demangle_rust(self.mangled, opts),
+            Some(Cpp) => try_demangle_cpp(self.mangled, opts),
+            Some(Swift) => try_demangle_swift(self.mangled, opts),
             _ => Ok(None),
         }
     }

--- a/demangle/tests/basic.rs
+++ b/demangle/tests/basic.rs
@@ -28,6 +28,18 @@ fn test_rust_demangle() {
 }
 
 #[test]
+fn test_objcpp_cpp_demangle() {
+    let sym = Symbol::with_language("_ZN4base24MessagePumpNSApplication5DoRunEPNS_11MessagePump8DelegateE", Language::ObjCpp);
+    assert_eq!(sym.to_string(), "base::MessagePumpNSApplication::DoRun");
+}
+
+#[test]
+fn test_objcpp_objc_demangle() {
+    let sym = Symbol::with_language("+[KSCrashReportFilterObjectForKey filterWithKey:allowNotFound:]", Language::ObjCpp);
+    assert_eq!(sym.to_string(), "+[KSCrashReportFilterObjectForKey filterWithKey:allowNotFound:]");
+}
+
+#[test]
 fn test_cpp_demangle() {
     assert_mangle("_Z28JS_GetPropertyDescriptorByIdP9JSContextN2JS6HandleIP8JSObjectEENS2_I4jsidEENS1_13MutableHandleINS1_18PropertyDescriptorEEE",
                   Some("JS_GetPropertyDescriptorById"), DemangleOptions {


### PR DESCRIPTION
Objective C++ can contain both Objective C and C++ code, and thus contains
both mangled versions. When `Language::ObjCpp` is explicitly passed when
constructing the symbol, we need to use the heuristic do differenciate and
use the right demangler.

This fixes the remaining known issues for Electron crashes.