### PR TITLE
feat(debuginfo): Extend Object interface for debug information

### DIFF
--- a/cabi/include/symbolic.h
+++ b/cabi/include/symbolic.h
@@ -359,9 +359,19 @@ void symbolic_object_free(SymbolicObject *so);
 SymbolicStr symbolic_object_get_arch(const SymbolicObject *so);
 
 /*
+ * Returns the object class
+ */
+SymbolicStr symbolic_object_get_debug_kind(const SymbolicObject *so);
+
+/*
  * Returns the object kind
  */
 SymbolicStr symbolic_object_get_kind(const SymbolicObject *so);
+
+/*
+ * Returns the object type
+ */
+SymbolicStr symbolic_object_get_type(const SymbolicObject *so);
 
 /*
  * Returns the UUID of an object.

--- a/cabi/src/common.rs
+++ b/cabi/src/common.rs
@@ -18,7 +18,7 @@ ffi_fn! {
 ffi_fn! {
     /// Checks if an architecture is known.
     unsafe fn symbolic_arch_from_macho(arch: &SymbolicMachoArch) -> Result<SymbolicStr> {
-        Ok(SymbolicStr::new(Arch::from_mach(arch.cputype, arch.cpusubtype).map(|x| x.name())?))
+        Ok(SymbolicStr::new(Arch::from_mach(arch.cputype, arch.cpusubtype).name()))
     }
 }
 

--- a/cabi/src/debuginfo.rs
+++ b/cabi/src/debuginfo.rs
@@ -4,7 +4,7 @@ use std::os::raw::c_char;
 use std::ffi::CStr;
 
 use symbolic_common::ByteView;
-use symbolic_debuginfo::{Object, FatObject};
+use symbolic_debuginfo::{FatObject, Object};
 
 use core::{SymbolicStr, SymbolicUuid};
 
@@ -89,6 +89,30 @@ ffi_fn! {
     {
         let o = so as *mut Object<'static>;
         Ok(SymbolicStr::new((*o).kind().name()))
+    }
+}
+
+ffi_fn! {
+    /// Returns the object type
+    unsafe fn symbolic_object_get_type(so: *const SymbolicObject)
+        -> Result<SymbolicStr>
+    {
+        let o = so as *mut Object<'static>;
+        Ok(SymbolicStr::new((*o).class().name()))
+    }
+}
+
+ffi_fn! {
+    /// Returns the object class
+    unsafe fn symbolic_object_get_debug_kind(so: *const SymbolicObject)
+        -> Result<SymbolicStr>
+    {
+        let o = so as *mut Object<'static>;
+        Ok(if let Some(kind) = (*o).debug_kind() {
+            SymbolicStr::new(kind.name())
+        } else {
+            SymbolicStr::default()
+        })
     }
 }
 

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -92,9 +92,9 @@ impl Arch {
 
     /// Constructs an architecture from mach CPU types
     #[cfg(feature = "with_objects")]
-    pub fn from_mach(cputype: u32, cpusubtype: u32) -> Result<Arch> {
+    pub fn from_mach(cputype: u32, cpusubtype: u32) -> Arch {
         use goblin::mach::constants::cputype::*;
-        Ok(match (cputype, cpusubtype) {
+        match (cputype, cpusubtype) {
             (CPU_TYPE_I386, CPU_SUBTYPE_I386_ALL) => Arch::X86,
             (CPU_TYPE_X86_64, CPU_SUBTYPE_X86_64_ALL) => Arch::X86_64,
             (CPU_TYPE_X86_64, CPU_SUBTYPE_X86_64_H) => Arch::X86_64h,
@@ -112,10 +112,8 @@ impl Arch {
             (CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7EM) => Arch::ArmV7em,
             (CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_ALL) => Arch::Ppc,
             (CPU_TYPE_POWERPC64, CPU_SUBTYPE_POWERPC_ALL) => Arch::Ppc64,
-            _ => {
-                return Err(ErrorKind::Parse("unknown architecture").into());
-            }
-        })
+            _ => Arch::Unknown,
+        }
     }
 
     /// Returns the macho arch for this arch.
@@ -149,9 +147,9 @@ impl Arch {
 
     /// Constructs an architecture from ELF flags
     #[cfg(feature = "with_objects")]
-    pub fn from_elf(machine: u16) -> Result<Arch> {
+    pub fn from_elf(machine: u16) -> Arch {
         use goblin::elf::header::*;
-        Ok(match machine {
+        match machine {
             EM_386 => Arch::X86,
             EM_X86_64 => Arch::X86_64,
             EM_AARCH64 => Arch::Arm64,
@@ -166,23 +164,21 @@ impl Arch {
             EM_ARM => Arch::Arm,
             EM_PPC => Arch::Ppc,
             EM_PPC64 => Arch::Ppc64,
-            _ => return Err(ErrorKind::Parse("unknown architecture").into()),
-        })
+            _ => Arch::Unknown,
+        }
     }
 
     /// Constructs an architecture from ELF flags
     #[cfg(feature = "with_objects")]
-    pub fn from_breakpad(string: &str) -> Result<Arch> {
+    pub fn from_breakpad(string: &str) -> Arch {
         use Arch::*;
-        Ok(match string {
+        match string {
             "x86" => X86,
             "x86_64" => X86_64,
             "ppc" => Ppc,
             "ppc64" => Ppc64,
-            _ => {
-                return Err(ErrorKind::NotFound("Unknown architecture for Breakpad").into());
-            }
-        })
+            _ => Unknown,
+        }
     }
 
     /// Parses an architecture from a string.
@@ -309,20 +305,20 @@ impl Language {
 
     /// Converts a DWARF language tag into a supported language.
     #[cfg(feature="with_dwarf")]
-    pub fn from_dwarf_lang(lang: gimli::DwLang) -> Option<Language> {
+    pub fn from_dwarf_lang(lang: gimli::DwLang) -> Language {
         match lang {
             gimli::DW_LANG_C | gimli::DW_LANG_C11 |
-            gimli::DW_LANG_C89 | gimli::DW_LANG_C99 => Some(Language::C),
+            gimli::DW_LANG_C89 | gimli::DW_LANG_C99 => Language::C,
             gimli::DW_LANG_C_plus_plus | gimli::DW_LANG_C_plus_plus_03 |
             gimli::DW_LANG_C_plus_plus_11 |
-            gimli::DW_LANG_C_plus_plus_14 => Some(Language::Cpp),
-            gimli::DW_LANG_D => Some(Language::D),
-            gimli::DW_LANG_Go => Some(Language::Go),
-            gimli::DW_LANG_ObjC => Some(Language::ObjC),
-            gimli::DW_LANG_ObjC_plus_plus => Some(Language::ObjCpp),
-            gimli::DW_LANG_Rust => Some(Language::Rust),
-            gimli::DW_LANG_Swift => Some(Language::Swift),
-            _ => None,
+            gimli::DW_LANG_C_plus_plus_14 => Language::Cpp,
+            gimli::DW_LANG_D => Language::D,
+            gimli::DW_LANG_Go => Language::Go,
+            gimli::DW_LANG_ObjC => Language::ObjC,
+            gimli::DW_LANG_ObjC_plus_plus => Language::ObjCpp,
+            gimli::DW_LANG_Rust => Language::Rust,
+            gimli::DW_LANG_Swift => Language::Swift,
+            _ => Language::Unknown,
         }
     }
 

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -506,6 +506,21 @@ impl ObjectClass {
     }
 
     #[cfg(feature = "with_objects")]
+    pub fn from_elf_full(elf_type: u16, has_interpreter: bool) -> ObjectClass {
+        let class = ObjectClass::from_elf(elf_type);
+
+        // When stripping debug information into a separate file with objcopy,
+        // the eh_type field still reads ET_EXEC. However, the interpreter is
+        // removed. Since an executable without interpreter does not make any
+        // sense, we assume ``Debug`` in this case.
+        if class == ObjectClass::Executable && !has_interpreter {
+            ObjectClass::Debug
+        } else {
+            class
+        }
+    }
+
+    #[cfg(feature = "with_objects")]
     pub fn to_elf(&self) -> Result<u16> {
         use goblin::elf::header::*;
         use ObjectClass::*;

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -139,6 +139,7 @@ impl Arch {
             Arch::ArmV7m => (CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7M),
             Arch::ArmV7em => (CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7EM),
             Arch::Ppc => (CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_ALL),
+            Arch::Ppc64 => (CPU_TYPE_POWERPC64, CPU_SUBTYPE_POWERPC_ALL),
             _ => {
                 return Err(ErrorKind::NotFound("Unknown architecture for macho").into());
             }
@@ -163,6 +164,8 @@ impl Arch {
             // http://code.metager.de/source/xref/gnu/src/binutils/readelf.c#11282
             // https://stackoverflow.com/a/20556156/4228225
             EM_ARM => Arch::Arm,
+            EM_PPC => Arch::Ppc,
+            EM_PPC64 => Arch::Ppc64,
             _ => return Err(ErrorKind::Parse("unknown architecture").into()),
         })
     }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -6,7 +6,7 @@ use gimli;
 
 use errors::{ErrorKind, Result};
 
-/// Represents endianess.
+/// Represents endianness.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub enum Endianness {
     Little,

--- a/debuginfo/src/breakpad.rs
+++ b/debuginfo/src/breakpad.rs
@@ -89,7 +89,7 @@ fn test_parse_error() {
 
 /// Provides access to information in a breakpad file
 #[derive(Debug)]
-pub struct BreakpadSym {
+pub(crate) struct BreakpadSym {
     id: BreakpadId,
     arch: Arch,
 }

--- a/debuginfo/src/breakpad.rs
+++ b/debuginfo/src/breakpad.rs
@@ -1,11 +1,96 @@
+use std::fmt;
+
 use uuid::Uuid;
 
 use symbolic_common::{Arch, ErrorKind, Result};
 
+/// Unique identifier of a Breakpad code module
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
+pub struct BreakpadId {
+    uuid: Uuid,
+    age: u32,
+}
+
+impl BreakpadId {
+    /// Parses a `BreakpadId` from a 33 character `String`
+    pub fn parse(input: &str) -> Result<BreakpadId> {
+        if input.len() != 33 {
+            return Err(ErrorKind::Parse("Invalid input string length").into());
+        }
+
+        let uuid = Uuid::parse_str(&input[..32]).map_err(|_| ErrorKind::Parse("UUID parse error"))?;
+        let age = u32::from_str_radix(&input[32..], 16)?;
+        Ok(BreakpadId { uuid, age })
+    }
+
+    /// Constructs a `BreakpadId` from its `uuid`
+    pub fn from_uuid(uuid: Uuid) -> BreakpadId {
+        Self::from_parts(uuid, 0)
+    }
+
+    /// Constructs a `BreakpadId` from its `uuid` and `age` parts
+    pub fn from_parts(uuid: Uuid, age: u32) -> BreakpadId {
+        BreakpadId { uuid, age }
+    }
+
+    /// Returns the UUID part of the code module's debug_identifier
+    pub fn uuid(&self) -> Uuid {
+        self.uuid
+    }
+
+    /// Returns the age part of the code module's debug identifier
+    ///
+    /// On Windows, this is an incrementing counter to identify the build.
+    /// On all other platforms, this value will always be zero.
+    pub fn age(&self) -> u32 {
+        self.age
+    }
+}
+
+impl fmt::Display for BreakpadId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let uuid = self.uuid.simple().to_string().to_uppercase();
+        write!(f, "{}{:X}", uuid, self.age)
+    }
+}
+
+impl Into<String> for BreakpadId {
+    fn into(self) -> String {
+        self.to_string()
+    }
+}
+
+#[test]
+fn test_parse() {
+    assert_eq!(
+        BreakpadId::parse("DFB8E43AF2423D73A453AEB6A777EF75A").unwrap(),
+        BreakpadId {
+            uuid: Uuid::parse_str("DFB8E43AF2423D73A453AEB6A777EF75").unwrap(),
+            age: 10,
+        }
+    );
+}
+
+#[test]
+fn test_to_string() {
+    let id = BreakpadId {
+        uuid: Uuid::parse_str("DFB8E43AF2423D73A453AEB6A777EF75").unwrap(),
+        age: 10,
+    };
+
+    assert_eq!(id.to_string(), "DFB8E43AF2423D73A453AEB6A777EF75A");
+}
+
+#[test]
+fn test_parse_error() {
+    assert!(BreakpadId::parse("DFB8E43AF2423D73A").is_err());
+}
+
+
 /// Provides access to information in a breakpad file
 #[derive(Debug)]
 pub struct BreakpadSym {
-    uuid: Uuid,
+    id: BreakpadId,
     arch: Arch,
 }
 
@@ -37,19 +122,24 @@ impl BreakpadSym {
             None => return Err(ErrorKind::BadBreakpadSym("Missing breakpad uuid").into()),
         };
 
-        let uuid = match Uuid::parse_str(&uuid_hex[0..32]) {
+        let id = match BreakpadId::parse(&uuid_hex[0..33]) {
             Ok(uuid) => uuid,
             Err(_) => return Err(ErrorKind::Parse("Invalid breakpad uuid").into()),
         };
 
         Ok(BreakpadSym {
-            uuid: uuid,
+            id: id,
             arch: Arch::from_breakpad(arch.as_ref())?,
         })
     }
 
+    pub fn id(&self) -> BreakpadId {
+        self.id
+    }
+
     pub fn uuid(&self) -> Uuid {
-        self.uuid
+        // TODO: To avoid collisions, this should hash the age in
+        self.id().uuid()
     }
 
     pub fn arch(&self) -> Arch {

--- a/debuginfo/src/breakpad.rs
+++ b/debuginfo/src/breakpad.rs
@@ -1,8 +1,11 @@
 use std::fmt;
+use std::str::FromStr;
 
 use uuid::Uuid;
 
-use symbolic_common::{Arch, ErrorKind, Result};
+use symbolic_common::{Arch, Error, ErrorKind, ObjectKind, Result};
+
+use object::Object;
 
 /// Unique identifier of a Breakpad code module
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
@@ -86,6 +89,85 @@ fn test_parse_error() {
     assert!(BreakpadId::parse("DFB8E43AF2423D73A").is_err());
 }
 
+pub enum BreakpadRecord<'input> {
+    Module(BreakpadModuleRecord<'input>),
+    File(BreakpadFileRecord<'input>),
+    Function(BreakpadFuncRecord<'input>),
+    Line(BreakpadLineRecord),
+    Public(BreakpadPublicRecord<'input>),
+    Stack,
+}
+
+pub struct BreakpadModuleRecord<'input> {
+    pub arch: Arch,
+    pub uuid: Uuid,
+    pub name: &'input [u8],
+}
+
+impl<'input> fmt::Debug for BreakpadModuleRecord<'input> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("BreakpadModuleRecord")
+            .field("arch", &self.arch)
+            .field("uuid", &self.uuid)
+            .field("name", &String::from_utf8_lossy(self.name))
+            .finish()
+    }
+}
+
+pub struct BreakpadFileRecord<'input> {
+    pub id: u16,
+    pub name: &'input [u8],
+}
+
+impl<'input> fmt::Debug for BreakpadFileRecord<'input> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("BreakpadFileRecord")
+            .field("id", &self.id)
+            .field("name", &String::from_utf8_lossy(self.name))
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub struct BreakpadLineRecord {
+    pub address: u64,
+    pub line: u64,
+    pub file_id: u16,
+}
+
+pub struct BreakpadFuncRecord<'input> {
+    pub address: u64,
+    pub size: u64,
+    pub name: &'input [u8],
+    pub lines: Vec<BreakpadLineRecord>,
+}
+
+impl<'input> fmt::Debug for BreakpadFuncRecord<'input> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("BreakpadFuncRecord")
+            .field("address", &self.address)
+            .field("size", &self.size)
+            .field("name", &String::from_utf8_lossy(self.name))
+            .field("lines", &self.lines)
+            .finish()
+    }
+}
+
+pub struct BreakpadPublicRecord<'input> {
+    pub address: u64,
+    pub size: u64,
+    pub name: &'input [u8],
+}
+
+impl<'input> fmt::Debug for BreakpadPublicRecord<'input> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("BreakpadPublicRecord")
+            .field("address", &self.address)
+            .field("size", &self.size)
+            .field("name", &String::from_utf8_lossy(self.name))
+            .finish()
+    }
+}
 
 /// Provides access to information in a breakpad file
 #[derive(Debug)]
@@ -145,4 +227,299 @@ impl BreakpadSym {
     pub fn arch(&self) -> Arch {
         self.arch
     }
+}
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+enum IterState {
+    Started,
+    Reading,
+    Function,
+}
+
+pub struct BreakpadRecords<'data> {
+    lines: Box<Iterator<Item = &'data [u8]> + 'data>,
+    state: IterState,
+}
+
+impl<'data> BreakpadRecords<'data> {
+    fn from_bytes(bytes: &'data [u8]) -> BreakpadRecords<'data> {
+        BreakpadRecords {
+            lines: Box::new(bytes.split(|b| *b == b'\n')),
+            state: IterState::Started,
+        }
+    }
+
+    fn parse(&mut self, line: &'data [u8]) -> Result<BreakpadRecord<'data>> {
+        let mut words = line.splitn(2, |b| *b == b' ');
+        let magic = words.next().unwrap_or(b"");
+        let record = words.next().unwrap_or(b"");
+
+        match magic {
+            b"MODULE" => {
+                if self.state != IterState::Started {
+                    return Err(ErrorKind::BadBreakpadSym("unexpected module header").into());
+                }
+
+                self.state = IterState::Reading;
+                parse_module(record)
+            }
+            b"FILE" => {
+                self.state = IterState::Reading;
+                parse_file(record)
+            }
+            b"FUNC" => {
+                self.state = IterState::Function;
+                parse_func(record)
+            }
+            b"STACK" => {
+                self.state = IterState::Reading;
+                parse_stack(record)
+            }
+            b"PUBLIC" => {
+                self.state = IterState::Reading;
+                parse_public(record)
+            }
+            _ => {
+                if self.state == IterState::Function {
+                    // Pass the whole line down as there is no magic
+                    parse_line(line)
+                } else {
+                    // No known magic and we don't expect a line record
+                    Err(ErrorKind::BadBreakpadSym("unexpected line record").into())
+                }
+            }
+        }
+    }
+}
+
+impl<'data> Iterator for BreakpadRecords<'data> {
+    type Item = Result<BreakpadRecord<'data>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(next) = self.lines.next() {
+            let len = next.len();
+            let line = if len > 0 && next[len - 1] == b'\r' {
+                &next[0..len - 1]
+            } else {
+                next
+            };
+
+            if line.len() > 0 {
+                return Some(self.parse(line));
+            }
+        }
+
+        None
+    }
+}
+
+pub trait BreakpadData {
+    fn has_breakpad_data(&self) -> bool;
+    fn breakpad_records<'input>(&'input self) -> BreakpadRecords<'input>;
+}
+
+impl<'data> BreakpadData for Object<'data> {
+    fn has_breakpad_data(&self) -> bool {
+        self.kind() == ObjectKind::Breakpad
+    }
+
+    fn breakpad_records<'input>(&'input self) -> BreakpadRecords<'input> {
+        BreakpadRecords::from_bytes(self.as_bytes())
+    }
+}
+
+/// Parses a breakpad MODULE record
+///
+/// Syntax: "MODULE operatingsystem architecture id name"
+/// Example: "MODULE Linux x86 D3096ED481217FD4C16B29CD9BC208BA0 firefox-bin"
+/// see https://github.com/google/breakpad/blob/master/docs/symbol_files.md#module-records
+fn parse_module<'data>(line: &'data [u8]) -> Result<BreakpadRecord<'data>> {
+    // if self.module.is_some() {
+    //     return Err(ErrorKind::BadBreakpadSym("Multiple MODULE records not supported").into());
+    // }
+
+    let mut record = line.splitn(4, |b| *b == b' ');
+
+    // Skip "os" field
+    record.next();
+
+    let arch = match record.next() {
+        Some(word) => String::from_utf8_lossy(word),
+        None => return Err(ErrorKind::BadBreakpadSym("missing module arch").into()),
+    };
+
+    let uuid_hex = match record.next() {
+        Some(word) => String::from_utf8_lossy(word),
+        None => return Err(ErrorKind::BadBreakpadSym("missing module uuid").into()),
+    };
+
+    let uuid = match Uuid::parse_str(&uuid_hex[0..32]) {
+        Ok(uuid) => uuid,
+        Err(_) => return Err(ErrorKind::Parse("invalid breakpad uuid").into()),
+    };
+
+    let name = match record.next() {
+        Some(word) => word,
+        None => return Err(ErrorKind::BadBreakpadSym("missing module name").into()),
+    };
+
+    Ok(BreakpadRecord::Module(BreakpadModuleRecord {
+        name: name,
+        arch: Arch::from_breakpad(&arch)?,
+        uuid: uuid,
+    }))
+}
+
+/// Parses a breakpad FILE record
+///
+/// Syntax: "FILE number name"
+/// Example: "FILE 2 /home/jimb/mc/in/browser/app/nsBrowserApp.cpp"
+/// see https://github.com/google/breakpad/blob/master/docs/symbol_files.md#file-records
+fn parse_file<'data>(line: &'data [u8]) -> Result<BreakpadRecord<'data>> {
+    let mut record = line.splitn(2, |b| *b == b' ');
+
+    let id = match record.next() {
+        Some(text) => u16::from_str(&String::from_utf8_lossy(text))
+            .map_err(|e| Error::with_chain(e, "invalid file id"))?,
+        None => return Err(ErrorKind::Parse("missing file ID").into()),
+    };
+
+    let name = match record.next() {
+        Some(text) => text,
+        None => return Err(ErrorKind::Parse("missing file name").into()),
+    };
+
+    Ok(BreakpadRecord::File(BreakpadFileRecord {
+        id: id,
+        name: name,
+    }))
+}
+
+/// Parses a breakpad FUNC record
+///
+/// Syntax: "FUNC [m] address size parameter_size name"
+/// Example: "FUNC m c184 30 0 nsQueryInterfaceWithError::operator()(nsID const&, void**) const"
+/// see https://github.com/google/breakpad/blob/master/docs/symbol_files.md#func-records
+fn parse_func<'data>(line: &'data [u8]) -> Result<BreakpadRecord<'data>> {
+    // Strip the optional "m" parameter; it has no meaning to us
+    let line = if line.starts_with(b"m ") {
+        &line[2..]
+    } else {
+        line
+    };
+    let mut record = line.splitn(4, |b| *b == b' ');
+
+    let address = match record.next() {
+        Some(text) => u64::from_str_radix(&String::from_utf8_lossy(text), 16)
+            .map_err(|e| Error::with_chain(e, "invalid function address"))?,
+        None => return Err(ErrorKind::Parse("missing function address").into()),
+    };
+
+    let size = match record.next() {
+        Some(text) => u64::from_str_radix(&String::from_utf8_lossy(text), 16)
+            .map_err(|e| Error::with_chain(e, "invalid function size"))?,
+        None => return Err(ErrorKind::Parse("missing function size").into()),
+    };
+
+    // Skip the parameter_size field
+    record.next();
+
+    let name = match record.next() {
+        Some(text) => text,
+        None => return Err(ErrorKind::Parse("missing function name").into()),
+    };
+
+    Ok(BreakpadRecord::Function(BreakpadFuncRecord {
+        address: address,
+        size: size,
+        name: name,
+        lines: vec![],
+    }))
+}
+
+/// Parses a breakpad STACK record
+///
+/// Can either be a STACK WIN record...
+/// Syntax: "STACK WIN type rva code_size prologue_size epilogue_size parameter_size saved_register_size local_size max_stack_size has_program_string program_string_OR_allocates_base_pointer"
+/// Example: "STACK WIN 4 2170 14 1 0 0 0 0 0 1 $eip 4 + ^ = $esp $ebp 8 + = $ebp $ebp ^ ="
+/// see https://github.com/google/breakpad/blob/master/docs/symbol_files.md#stack-win-records
+///
+/// ... or a STACK CFI record
+/// Syntax: "STACK CFI INIT address size register1: expression1 register2: expression2 ..."
+/// Example: "STACK CFI INIT 804c4b0 40 .cfa: $esp 4 + $eip: .cfa 4 - ^"
+/// see https://github.com/google/breakpad/blob/master/docs/symbol_files.md#stack-cfi-records
+fn parse_stack<'data>(_line: &'data [u8]) -> Result<BreakpadRecord<'data>> {
+    // Ignored
+    Ok(BreakpadRecord::Stack)
+}
+
+/// Parses a breakpad PUBLIC record
+///
+/// Syntax: "PUBLIC [m] address parameter_size name"
+/// Example: "PUBLIC m 2160 0 Public2_1"
+/// see https://github.com/google/breakpad/blob/master/docs/symbol_files.md#public-records
+fn parse_public<'data>(line: &'data [u8]) -> Result<BreakpadRecord<'data>> {
+    // Strip the optional "m" parameter; it has no meaning to us
+    let line = if line.starts_with(b"m ") {
+        &line[2..]
+    } else {
+        line
+    };
+    let mut record = line.splitn(4, |b| *b == b' ');
+
+    let address = match record.next() {
+        Some(text) => u64::from_str_radix(&String::from_utf8_lossy(text), 16)
+            .map_err(|e| Error::with_chain(e, "invalid symbol address"))?,
+        None => return Err(ErrorKind::Parse("missing symbol address").into()),
+    };
+
+    // Skip the parameter_size field
+    record.next();
+
+    let name = match record.next() {
+        Some(text) => text,
+        None => return Err(ErrorKind::Parse("missing function name").into()),
+    };
+
+    Ok(BreakpadRecord::Public(BreakpadPublicRecord {
+        address: address,
+        size: 0, // will be computed with the next PUBLIC record
+        name: name,
+    }))
+}
+
+/// Parses a breakpad line record (after funcs)
+///
+/// Syntax: "address size line filenum"
+/// Example: "c184 7 59 4"
+/// see https://github.com/google/breakpad/blob/master/docs/symbol_files.md#line-records
+fn parse_line<'data>(line: &'data [u8]) -> Result<BreakpadRecord<'data>> {
+    let mut record = line.splitn(4, |b| *b == b' ');
+
+    let address = match record.next() {
+        Some(text) => u64::from_str_radix(&String::from_utf8_lossy(text), 16)
+            .map_err(|e| Error::with_chain(e, "invalid line address"))?,
+        None => return Err(ErrorKind::Parse("Missing line address").into()),
+    };
+
+    // Skip the size field
+    record.next();
+
+    let line_number = match record.next() {
+        Some(text) => u64::from_str(&String::from_utf8_lossy(text))
+            .map_err(|e| Error::with_chain(e, "invalid line number"))?,
+        None => return Err(ErrorKind::Parse("Missing line number").into()),
+    };
+
+    let file_id = match record.next() {
+        Some(text) => u16::from_str(&String::from_utf8_lossy(text))
+            .map_err(|e| Error::with_chain(e, "invalid line file id"))?,
+        None => return Err(ErrorKind::Parse("missing line file id").into()),
+    };
+
+    Ok(BreakpadRecord::Line(BreakpadLineRecord {
+        address: address,
+        line: line_number,
+        file_id: file_id,
+    }))
 }

--- a/debuginfo/src/breakpad.rs
+++ b/debuginfo/src/breakpad.rs
@@ -1,0 +1,58 @@
+use uuid::Uuid;
+
+use symbolic_common::{Arch, ErrorKind, Result};
+
+/// Provides access to information in a breakpad file
+#[derive(Debug)]
+pub struct BreakpadSym {
+    uuid: Uuid,
+    arch: Arch,
+}
+
+impl BreakpadSym {
+    /// Parses a breakpad file header
+    ///
+    /// Example:
+    /// ```
+    /// MODULE mac x86_64 13DA2547B1D53AF99F55ED66AF0C7AF70 Electron Framework
+    /// ```
+    pub fn parse(bytes: &[u8]) -> Result<BreakpadSym> {
+        let mut words = bytes.splitn(5, |b| *b == b' ');
+
+        match words.next() {
+            Some(b"MODULE") => (),
+            _ => return Err(ErrorKind::BadBreakpadSym("Invalid breakpad magic").into()),
+        };
+
+        // Operating system not needed
+        words.next();
+
+        let arch = match words.next() {
+            Some(word) => String::from_utf8_lossy(word),
+            None => return Err(ErrorKind::BadBreakpadSym("Missing breakpad arch").into()),
+        };
+
+        let uuid_hex = match words.next() {
+            Some(word) => String::from_utf8_lossy(word),
+            None => return Err(ErrorKind::BadBreakpadSym("Missing breakpad uuid").into()),
+        };
+
+        let uuid = match Uuid::parse_str(&uuid_hex[0..32]) {
+            Ok(uuid) => uuid,
+            Err(_) => return Err(ErrorKind::Parse("Invalid breakpad uuid").into()),
+        };
+
+        Ok(BreakpadSym {
+            uuid: uuid,
+            arch: Arch::from_breakpad(arch.as_ref())?,
+        })
+    }
+
+    pub fn uuid(&self) -> Uuid {
+        self.uuid
+    }
+
+    pub fn arch(&self) -> Arch {
+        self.arch
+    }
+}

--- a/debuginfo/src/breakpad.rs
+++ b/debuginfo/src/breakpad.rs
@@ -211,7 +211,7 @@ impl BreakpadSym {
 
         Ok(BreakpadSym {
             id: id,
-            arch: Arch::from_breakpad(arch.as_ref())?,
+            arch: Arch::from_breakpad(arch.as_ref()),
         })
     }
 
@@ -365,7 +365,7 @@ fn parse_module<'data>(line: &'data [u8]) -> Result<BreakpadRecord<'data>> {
 
     Ok(BreakpadRecord::Module(BreakpadModuleRecord {
         name: name,
-        arch: Arch::from_breakpad(&arch)?,
+        arch: Arch::from_breakpad(&arch),
         uuid: uuid,
     }))
 }

--- a/debuginfo/src/dwarf.rs
+++ b/debuginfo/src/dwarf.rs
@@ -95,14 +95,14 @@ impl DwarfSection {
 
 /// Gives access to a section in a dwarf file.
 #[derive(Eq, PartialEq, Debug, Clone)]
-pub struct DwarfSectionData<'a> {
+pub struct DwarfSectionData<'data> {
     section: DwarfSection,
-    data: &'a [u8],
+    data: &'data [u8],
     offset: u64,
 }
 
-impl<'a> DwarfSectionData<'a> {
-    pub fn new(section: DwarfSection, data: &'a [u8], offset: u64) -> DwarfSectionData<'a> {
+impl<'data> DwarfSectionData<'data> {
+    pub fn new(section: DwarfSection, data: &'data [u8], offset: u64) -> DwarfSectionData<'data> {
         DwarfSectionData {
             section: section,
             data: data,
@@ -111,7 +111,7 @@ impl<'a> DwarfSectionData<'a> {
     }
 
     /// Return the section as bytes
-    pub fn as_bytes(&self) -> &'a [u8] {
+    pub fn as_bytes(&self) -> &'data [u8] {
         self.data
     }
 
@@ -126,11 +126,11 @@ impl<'a> DwarfSectionData<'a> {
     }
 }
 
-fn read_elf_dwarf_section<'a>(
-    elf: &elf::Elf<'a>,
-    data: &'a [u8],
+fn read_elf_dwarf_section<'data>(
+    elf: &elf::Elf<'data>,
+    data: &'data [u8],
     sect: DwarfSection,
-) -> Option<DwarfSectionData<'a>> {
+) -> Option<DwarfSectionData<'data>> {
     let section_name = sect.elf_name();
 
     for header in &elf.section_headers {
@@ -145,10 +145,10 @@ fn read_elf_dwarf_section<'a>(
     None
 }
 
-fn read_macho_dwarf_section<'a>(
-    macho: &mach::MachO<'a>,
+fn read_macho_dwarf_section<'data>(
+    macho: &mach::MachO<'data>,
     sect: DwarfSection,
-) -> Option<DwarfSectionData<'a>> {
+) -> Option<DwarfSectionData<'data>> {
     let dwarf_segment = if sect == DwarfSection::EhFrame {
         "__TEXT"
     } else {

--- a/debuginfo/src/lib.rs
+++ b/debuginfo/src/lib.rs
@@ -5,8 +5,10 @@ extern crate goblin;
 #[macro_use] extern crate symbolic_common;
 #[macro_use] extern crate if_chain;
 
+mod breakpad;
 mod object;
 mod dwarf;
 
+pub use breakpad::*;
 pub use object::*;
 pub use dwarf::*;

--- a/debuginfo/src/lib.rs
+++ b/debuginfo/src/lib.rs
@@ -1,14 +1,18 @@
 //! Abstraction for reading debug info files.
 
-extern crate uuid;
 extern crate goblin;
-#[macro_use] extern crate symbolic_common;
-#[macro_use] extern crate if_chain;
+#[macro_use]
+extern crate if_chain;
+#[macro_use]
+extern crate symbolic_common;
+extern crate uuid;
 
 mod breakpad;
-mod object;
 mod dwarf;
+mod object;
+mod symbols;
 
 pub use breakpad::*;
 pub use object::*;
 pub use dwarf::*;
+pub use symbols::*;

--- a/debuginfo/src/object.rs
+++ b/debuginfo/src/object.rs
@@ -120,7 +120,9 @@ impl<'bytes> Object<'bytes> {
     pub fn class(&self) -> ObjectClass {
         match self.target {
             ObjectTarget::Breakpad(..) => ObjectClass::Debug,
-            ObjectTarget::Elf(ref elf) => ObjectClass::from_elf(elf.header.e_type),
+            ObjectTarget::Elf(ref elf) => {
+                ObjectClass::from_elf_full(elf.header.e_type, elf.interpreter.is_some())
+            }
             ObjectTarget::MachOSingle(macho) => ObjectClass::from_mach(macho.header.filetype),
             ObjectTarget::MachOFat(_, ref macho) => ObjectClass::from_mach(macho.header.filetype),
         }

--- a/debuginfo/src/object.rs
+++ b/debuginfo/src/object.rs
@@ -6,7 +6,7 @@ use goblin::{elf, mach, Hint};
 use uuid::Uuid;
 
 use symbolic_common::{Arch, ByteView, ByteViewHandle, DebugKind, Endianness, ErrorKind,
-                      ObjectKind, Result};
+                      ObjectKind, ObjectClass, Result};
 
 use breakpad::BreakpadSym;
 
@@ -105,6 +105,16 @@ impl<'bytes> Object<'bytes> {
                 let bytes = self.fat_bytes;
                 &bytes[arch.offset as usize..(arch.offset + arch.size) as usize]
             }
+        }
+    }
+
+    /// Returns the desiganted use of the object file and hints at its contents.
+    pub fn class(&self) -> ObjectClass {
+        match self.target {
+            ObjectTarget::Breakpad(..) => ObjectClass::Debug,
+            ObjectTarget::Elf(ref elf) => ObjectClass::from_elf(elf.header.e_type),
+            ObjectTarget::MachOSingle(macho) => ObjectClass::from_mach(macho.header.filetype),
+            ObjectTarget::MachOFat(_, ref macho) => ObjectClass::from_mach(macho.header.filetype),
         }
     }
 

--- a/debuginfo/src/object.rs
+++ b/debuginfo/src/object.rs
@@ -79,12 +79,10 @@ impl<'a> Object<'a> {
         }
     }
 
-    /// True if little endian, false if not.
-    /// TODO: Should return Option<Endianness>
-    /// TODO: Should be renamed to "endianness"
-    pub fn endianess(&self) -> Endianness {
+    /// True if little endian, false if not
+    pub fn endianness(&self) -> Endianness {
         let little = match self.target {
-            ObjectTarget::Breakpad(..) => true,
+            ObjectTarget::Breakpad(..) => return Endianness::default(),
             ObjectTarget::Elf(ref elf) => elf.little_endian,
             ObjectTarget::MachOSingle(macho) => macho.little_endian,
             ObjectTarget::MachOFat(_, ref macho) => macho.little_endian,
@@ -150,7 +148,7 @@ impl<'a> fmt::Debug for Object<'a> {
             .field("uuid", &self.uuid())
             .field("arch", &self.arch)
             .field("vmaddr", &self.vmaddr().unwrap_or(0))
-            .field("endianess", &self.endianess())
+            .field("endianness", &self.endianness())
             .field("kind", &self.kind())
             .finish()
     }

--- a/debuginfo/src/symbols.rs
+++ b/debuginfo/src/symbols.rs
@@ -1,0 +1,126 @@
+use std::collections::{BTreeMap, HashSet};
+use std::iter::Peekable;
+use std::slice::Iter as SliceIter;
+
+use goblin::mach;
+
+use symbolic_common::{ErrorKind, Result};
+
+use object::{Object, ObjectTarget};
+
+pub trait SymbolTable {
+    fn symbols(&self) -> Result<Symbols>;
+}
+
+impl<'a> SymbolTable for Object<'a> {
+    fn symbols(&self) -> Result<Symbols> {
+        match self.target {
+            ObjectTarget::MachOSingle(macho) => get_macho_symbols(macho),
+            ObjectTarget::MachOFat(_, ref macho) => get_macho_symbols(macho),
+            _ => Err(ErrorKind::MissingDebugInfo("symbol table not implemented").into()),
+        }
+    }
+}
+
+/// Gives access to symbols in a symbol table.
+pub struct Symbols<'a> {
+    // note: if we need elf here later, we can move this into an internal wrapper
+    macho_symbols: Option<&'a mach::symbols::Symbols<'a>>,
+    symbol_list: Vec<(u64, u32)>,
+}
+
+impl<'a> Symbols<'a> {
+    pub fn lookup(&self, addr: u64) -> Result<Option<(u64, u32, &'a str)>> {
+        let idx = match self.symbol_list.binary_search_by_key(&addr, |&x| x.0) {
+            Ok(idx) => idx,
+            Err(0) => return Ok(None),
+            Err(next_idx) => next_idx - 1,
+        };
+        let (sym_addr, sym_id) = self.symbol_list[idx];
+
+        let sym_len = self.symbol_list
+            .get(idx + 1)
+            .map(|next| next.0 - sym_addr)
+            .unwrap_or(!0);
+
+        let symbols = self.macho_symbols.unwrap();
+        let (symbol, _) = symbols.get(sym_id as usize)?;
+        Ok(Some((sym_addr, sym_len as u32, try_strip_symbol(symbol))))
+    }
+
+    pub fn iter(&'a self) -> SymbolIterator<'a> {
+        SymbolIterator {
+            symbols: self,
+            iter: self.symbol_list.iter().peekable(),
+        }
+    }
+}
+
+/// An iterator over a contained symbol table.
+pub struct SymbolIterator<'a> {
+    // note: if we need elf here later, we can move this into an internal wrapper
+    symbols: &'a Symbols<'a>,
+    iter: Peekable<SliceIter<'a, (u64, u32)>>,
+}
+
+impl<'a> Iterator for SymbolIterator<'a> {
+    type Item = Result<(u64, u32, &'a str)>;
+
+    fn next(&mut self) -> Option<Result<(u64, u32, &'a str)>> {
+        if let Some(&(addr, id)) = self.iter.next() {
+            Some(if let Some(ref mo) = self.symbols.macho_symbols {
+                let sym = try_strip_symbol(itry!(mo.get(id as usize).map(|x| x.0)));
+                if let Some(&&(next_addr, _)) = self.iter.peek() {
+                    Ok((addr, (next_addr - addr) as u32, sym))
+                } else {
+                    Ok((addr, !0, sym))
+                }
+            } else {
+                Err(ErrorKind::Internal("out of range for symbol iteration").into())
+            })
+        } else {
+            None
+        }
+    }
+}
+
+fn get_macho_symbols<'a>(macho: &'a mach::MachO) -> Result<Symbols<'a>> {
+    let mut sections = HashSet::new();
+    let mut idx = 0;
+
+    for segment in &macho.segments {
+        for section_rv in segment {
+            let (section, _) = section_rv?;
+            let name = section.name()?;
+            if name == "__stubs" || name == "__text" {
+                sections.insert(idx);
+            }
+            idx += 1;
+        }
+    }
+
+    // build an ordered map of the symbols
+    let mut symbol_map = BTreeMap::new();
+    for (id, sym_rv) in macho.symbols().enumerate() {
+        let (_, nlist) = sym_rv?;
+        if nlist.get_type() == mach::symbols::N_SECT
+            && nlist.n_sect != (mach::symbols::NO_SECT as usize)
+            && sections.contains(&(nlist.n_sect - 1))
+        {
+            symbol_map.insert(nlist.n_value, id as u32);
+        }
+    }
+
+    Ok(Symbols {
+        macho_symbols: macho.symbols.as_ref(),
+        symbol_list: symbol_map.into_iter().collect(),
+    })
+}
+
+fn try_strip_symbol(s: &str) -> &str {
+    if s.starts_with("_") {
+        &s[1..]
+    } else {
+        s
+    }
+}

--- a/minidump/src/cfi.rs
+++ b/minidump/src/cfi.rs
@@ -21,7 +21,7 @@ impl<W: Write> BreakpadAsciiCfiWriter<W> {
     }
 
     pub fn process(&mut self, object: &Object) -> Result<()> {
-        let endianness = object.endianess();
+        let endianness = object.endianness();
 
         if let Some(section) = object.get_dwarf_section(DwarfSection::EhFrame) {
             let frame = EhFrame::new(section.as_bytes(), endianness);

--- a/minidump/src/cfi.rs
+++ b/minidump/src/cfi.rs
@@ -7,7 +7,7 @@ use gimli::{self, BaseAddresses, CfaRule, CieOrFde, DebugFrame, EhFrame, FrameDe
 
 use symbolic_common::{Arch, Result};
 use symbolic_common::ErrorKind::MissingDebugInfo;
-use symbolic_debuginfo::{DwarfSection, Object};
+use symbolic_debuginfo::{DwarfData, DwarfSection, Object};
 
 use registers::get_register_name;
 

--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -81,6 +81,16 @@ class Object(RustObject):
         """The object kind."""
         return str(decode_str(self._methodcall(lib.symbolic_object_get_kind)))
 
+    @property
+    def type(self):
+        """The object type."""
+        return str(decode_str(self._methodcall(lib.symbolic_object_get_type)))
+
+    @property
+    def debug_kind(self):
+        """The kind of debug information in this object."""
+        return str(decode_str(self._methodcall(lib.symbolic_object_get_debug_kind)))
+
     def make_symcache(self):
         """Creates a symcache from the object."""
         return SymCache._from_objptr(self._methodcall(

--- a/symcache/src/breakpad.rs
+++ b/symcache/src/breakpad.rs
@@ -1,81 +1,6 @@
-use std::fmt;
-use std::str::FromStr;
-
-use uuid::Uuid;
-
-use symbolic_common::{Arch, Error, ErrorKind, Result};
-use symbolic_debuginfo::Object;
-
-pub struct BreakpadModuleRecord<'input> {
-    pub arch: Arch,
-    pub uuid: Uuid,
-    pub name: &'input [u8],
-}
-
-impl<'input> fmt::Debug for BreakpadModuleRecord<'input> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("BreakpadModuleRecord")
-            .field("arch", &self.arch)
-            .field("uuid", &self.uuid)
-            .field("name", &String::from_utf8_lossy(self.name))
-            .finish()
-    }
-}
-
-pub struct BreakpadFileRecord<'input> {
-    pub id: u16,
-    pub name: &'input [u8],
-}
-
-impl<'input> fmt::Debug for BreakpadFileRecord<'input> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("BreakpadFileRecord")
-            .field("id", &self.id)
-            .field("name", &String::from_utf8_lossy(self.name))
-            .finish()
-    }
-}
-
-#[derive(Debug)]
-pub struct BreakpadLineRecord {
-    pub address: u64,
-    pub line: u64,
-    pub file_id: u16,
-}
-
-pub struct BreakpadFuncRecord<'input> {
-    pub address: u64,
-    pub size: u64,
-    pub name: &'input [u8],
-    pub lines: Vec<BreakpadLineRecord>,
-}
-
-impl<'input> fmt::Debug for BreakpadFuncRecord<'input> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("BreakpadFuncRecord")
-            .field("address", &self.address)
-            .field("size", &self.size)
-            .field("name", &String::from_utf8_lossy(self.name))
-            .field("lines", &self.lines)
-            .finish()
-    }
-}
-
-pub struct BreakpadPublicRecord<'input> {
-    pub address: u64,
-    pub size: u64,
-    pub name: &'input [u8],
-}
-
-impl<'input> fmt::Debug for BreakpadPublicRecord<'input> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("BreakpadPublicRecord")
-            .field("address", &self.address)
-            .field("size", &self.size)
-            .field("name", &String::from_utf8_lossy(self.name))
-            .finish()
-    }
-}
+use symbolic_common::{ErrorKind, Result};
+use symbolic_debuginfo::{BreakpadData, BreakpadFileRecord, BreakpadFuncRecord,
+                         BreakpadModuleRecord, BreakpadPublicRecord, BreakpadRecord, Object};
 
 #[derive(Debug)]
 pub struct BreakpadInfo<'input> {
@@ -94,7 +19,7 @@ impl<'input> BreakpadInfo<'input> {
             syms: vec![],
         };
 
-        info.parse(object.as_bytes())?;
+        info.parse(object)?;
         Ok(info)
     }
 
@@ -110,269 +35,36 @@ impl<'input> BreakpadInfo<'input> {
         self.syms.as_slice()
     }
 
-    fn parse(&mut self, bytes: &'input [u8]) -> Result<()> {
-        let lines = bytes.split(|b| *b == b'\n').map(|line| {
-            let len = line.len();
-            if len > 0 && line[len - 1] == b'\r' {
-                &line[0..len-1]
-            } else {
-                line
-            }
-        });
+    fn parse(&mut self, object: &'input Object) -> Result<()> {
+        let mut records = object.breakpad_records();
+        while let Some(Ok(record)) = records.next() {
+            match record {
+                BreakpadRecord::Module(m) => self.module = Some(m),
+                BreakpadRecord::File(f) => self.files.push(f),
+                BreakpadRecord::Function(f) => self.funcs.push(f),
+                BreakpadRecord::Line(l) => {
+                    let func = match self.funcs.last_mut() {
+                        Some(func) => func,
+                        None => {
+                            return Err(ErrorKind::BadBreakpadSym("Unexpected line record").into());
+                        }
+                    };
 
-        let mut in_func = false;
-        for line in lines {
-            let mut words = line.splitn(2, |b| *b == b' ');
-            let magic = words.next().unwrap_or(b"");
-            let record = words.next().unwrap_or(b"");
-
-            match magic {
-                b"MODULE" => {
-                    self.parse_module(record)?;
-                    in_func = false;
+                    func.lines.push(l);
                 }
-                b"FILE" => {
-                    self.parse_file(record)?;
-                    in_func = false;
-                }
-                b"FUNC" => {
-                    self.parse_func(record)?;
-                    in_func = true;
-                }
-                b"STACK" => {
-                    self.parse_stack(record)?;
-                    in_func = false;
-                }
-                b"PUBLIC" => {
-                    self.parse_public(record)?;
-                    in_func = false;
-                }
-                b"" => {
-                    // Ignore empty lines
-                }
-                _ => {
-                    if !in_func {
-                        // No known magic and we don't expect a line record
-                        return Err(ErrorKind::BadBreakpadSym("unexpected line record").into());
+                BreakpadRecord::Public(p) => {
+                    if let Some(last_rec) = self.syms.last_mut() {
+                        // The last PUBLIC record's size can now be computed
+                        last_rec.size = p.address.saturating_sub(last_rec.address);
                     }
 
-                    // Pass the whole line down as there is no magic
-                    self.parse_line(line)?;
+                    self.syms.push(p);
+                }
+                BreakpadRecord::Stack => {
+                    // not relevant
                 }
             }
         }
-
-        Ok(())
-    }
-
-    /// Parses a breakpad MODULE record
-    ///
-    /// Syntax: "MODULE operatingsystem architecture id name"
-    /// Example: "MODULE Linux x86 D3096ED481217FD4C16B29CD9BC208BA0 firefox-bin"
-    /// see https://github.com/google/breakpad/blob/master/docs/symbol_files.md#module-records
-    fn parse_module(&mut self, line: &'input [u8]) -> Result<()> {
-        if self.module.is_some() {
-            return Err(ErrorKind::BadBreakpadSym("Multiple MODULE records not supported").into());
-        }
-
-        let mut record = line.splitn(4, |b| *b == b' ');
-
-        // Skip "os" field
-        record.next();
-
-        let arch = match record.next() {
-            Some(word) => String::from_utf8_lossy(word),
-            None => return Err(ErrorKind::BadBreakpadSym("missing module arch").into()),
-        };
-
-        let uuid_hex = match record.next() {
-            Some(word) => String::from_utf8_lossy(word),
-            None => return Err(ErrorKind::BadBreakpadSym("missing module uuid").into()),
-        };
-
-        let uuid = match Uuid::parse_str(&uuid_hex[0..32]) {
-            Ok(uuid) => uuid,
-            Err(_) => return Err(ErrorKind::Parse("invalid breakpad uuid").into()),
-        };
-
-        let name = match record.next() {
-            Some(word) => word,
-            None => return Err(ErrorKind::BadBreakpadSym("missing module name").into()),
-        };
-
-        self.module = Some(BreakpadModuleRecord {
-            name: name,
-            arch: Arch::from_breakpad(&arch)?,
-            uuid: uuid,
-        });
-
-        Ok(())
-    }
-
-    /// Parses a breakpad FILE record
-    ///
-    /// Syntax: "FILE number name"
-    /// Example: "FILE 2 /home/jimb/mc/in/browser/app/nsBrowserApp.cpp"
-    /// see https://github.com/google/breakpad/blob/master/docs/symbol_files.md#file-records
-    fn parse_file(&mut self, line: &'input [u8]) -> Result<()> {
-        let mut record = line.splitn(2, |b| *b == b' ');
-
-        let id = match record.next() {
-            Some(text) => u16::from_str(&String::from_utf8_lossy(text))
-                .map_err(|e| Error::with_chain(e, "invalid file id"))?,
-            None => return Err(ErrorKind::Parse("missing file ID").into()),
-        };
-
-        let name = match record.next() {
-            Some(text) => text,
-            None => return Err(ErrorKind::Parse("missing file name").into()),
-        };
-
-        self.files.push(BreakpadFileRecord { id: id, name: name });
-        Ok(())
-    }
-
-    /// Parses a breakpad FUNC record
-    ///
-    /// Syntax: "FUNC [m] address size parameter_size name"
-    /// Example: "FUNC m c184 30 0 nsQueryInterfaceWithError::operator()(nsID const&, void**) const"
-    /// see https://github.com/google/breakpad/blob/master/docs/symbol_files.md#func-records
-    fn parse_func(&mut self, line: &'input [u8]) -> Result<()> {
-        // Strip the optional "m" parameter; it has no meaning to us
-        let line = if line.starts_with(b"m ") {
-            &line[2..]
-        } else {
-            line
-        };
-        let mut record = line.splitn(4, |b| *b == b' ');
-
-        let address = match record.next() {
-            Some(text) => u64::from_str_radix(&String::from_utf8_lossy(text), 16)
-                .map_err(|e| Error::with_chain(e, "invalid function address"))?,
-            None => return Err(ErrorKind::Parse("missing function address").into()),
-        };
-
-        let size = match record.next() {
-            Some(text) => u64::from_str_radix(&String::from_utf8_lossy(text), 16)
-                .map_err(|e| Error::with_chain(e, "invalid function size"))?,
-            None => return Err(ErrorKind::Parse("missing function size").into()),
-        };
-
-        // Skip the parameter_size field
-        record.next();
-
-        let name = match record.next() {
-            Some(text) => text,
-            None => return Err(ErrorKind::Parse("missing function name").into()),
-        };
-
-        self.funcs.push(BreakpadFuncRecord {
-            address: address,
-            size: size,
-            name: name,
-            lines: vec![],
-        });
-
-        Ok(())
-    }
-
-    /// Parses a breakpad STACK record
-    ///
-    /// Can either be a STACK WIN record...
-    /// Syntax: "STACK WIN type rva code_size prologue_size epilogue_size parameter_size saved_register_size local_size max_stack_size has_program_string program_string_OR_allocates_base_pointer"
-    /// Example: "STACK WIN 4 2170 14 1 0 0 0 0 0 1 $eip 4 + ^ = $esp $ebp 8 + = $ebp $ebp ^ ="
-    /// see https://github.com/google/breakpad/blob/master/docs/symbol_files.md#stack-win-records
-    ///
-    /// ... or a STACK CFI record
-    /// Syntax: "STACK CFI INIT address size register1: expression1 register2: expression2 ..."
-    /// Example: "STACK CFI INIT 804c4b0 40 .cfa: $esp 4 + $eip: .cfa 4 - ^"
-    /// see https://github.com/google/breakpad/blob/master/docs/symbol_files.md#stack-cfi-records
-    fn parse_stack(&mut self, _line: &'input [u8]) -> Result<()> {
-        // Ignored
-        Ok(())
-    }
-
-    /// Parses a breakpad PUBLIC record
-    ///
-    /// Syntax: "PUBLIC [m] address parameter_size name"
-    /// Example: "PUBLIC m 2160 0 Public2_1"
-    /// see https://github.com/google/breakpad/blob/master/docs/symbol_files.md#public-records
-    fn parse_public(&mut self, line: &'input [u8]) -> Result<()> {
-        // Strip the optional "m" parameter; it has no meaning to us
-        let line = if line.starts_with(b"m ") {
-            &line[2..]
-        } else {
-            line
-        };
-        let mut record = line.splitn(4, |b| *b == b' ');
-
-        let address = match record.next() {
-            Some(text) => u64::from_str_radix(&String::from_utf8_lossy(text), 16)
-                .map_err(|e| Error::with_chain(e, "invalid symbol address"))?,
-            None => return Err(ErrorKind::Parse("missing symbol address").into()),
-        };
-
-        // Skip the parameter_size field
-        record.next();
-
-        let name = match record.next() {
-            Some(text) => text,
-            None => return Err(ErrorKind::Parse("missing function name").into()),
-        };
-
-        if let Some(last_rec) = self.syms.last_mut() {
-            // The last PUBLIC record's size can now be computed
-            last_rec.size = address.saturating_sub(last_rec.address);
-        }
-
-        self.syms.push(BreakpadPublicRecord {
-            address: address,
-            size: 0, // will be computed with the next PUBLIC record
-            name: name,
-        });
-
-        Ok(())
-    }
-
-    /// Parses a breakpad line record (after funcs)
-    ///
-    /// Syntax: "address size line filenum"
-    /// Example: "c184 7 59 4"
-    /// see https://github.com/google/breakpad/blob/master/docs/symbol_files.md#line-records
-    fn parse_line(&mut self, line: &'input [u8]) -> Result<()> {
-        let func = match self.funcs.last_mut() {
-            Some(func) => func,
-            None => return Err(ErrorKind::BadBreakpadSym("Unexpected line record").into()),
-        };
-
-        let mut record = line.splitn(4, |b| *b == b' ');
-
-        let address = match record.next() {
-            Some(text) => u64::from_str_radix(&String::from_utf8_lossy(text), 16)
-                .map_err(|e| Error::with_chain(e, "invalid line address"))?,
-            None => return Err(ErrorKind::Parse("Missing line address").into()),
-        };
-
-        // Skip the size field
-        record.next();
-
-        let line_number = match record.next() {
-            Some(text) => u64::from_str(&String::from_utf8_lossy(text))
-                .map_err(|e| Error::with_chain(e, "invalid line number"))?,
-            None => return Err(ErrorKind::Parse("Missing line number").into()),
-        };
-
-        let file_id = match record.next() {
-            Some(text) => u16::from_str(&String::from_utf8_lossy(text))
-                .map_err(|e| Error::with_chain(e, "invalid line file id"))?,
-            None => return Err(ErrorKind::Parse("missing line file id").into()),
-        };
-
-        func.lines.push(BreakpadLineRecord {
-            address: address,
-            line: line_number,
-            file_id: file_id,
-        });
 
         Ok(())
     }

--- a/symcache/src/dwarf.rs
+++ b/symcache/src/dwarf.rs
@@ -5,7 +5,7 @@ use std::mem;
 use std::sync::Arc;
 
 use symbolic_common::{Endianness, Error, ErrorKind, Language, Result, ResultExt};
-use symbolic_debuginfo::{DwarfSection, Object, Symbols};
+use symbolic_debuginfo::{DwarfData, DwarfSection, Object, Symbols};
 
 use fallible_iterator::FallibleIterator;
 use lru_cache::LruCache;

--- a/symcache/src/dwarf.rs
+++ b/symcache/src/dwarf.rs
@@ -319,7 +319,7 @@ impl<'input> Unit<'input> {
                 lines: vec![],
                 comp_dir: self.comp_dir.map(|x| x.buf()).unwrap_or(b""),
                 lang: self.language
-                    .and_then(|lang| Language::from_dwarf_lang(lang))
+                    .map(|lang| Language::from_dwarf_lang(lang))
                     .unwrap_or(Language::Unknown),
             };
 

--- a/symcache/src/dwarf.rs
+++ b/symcache/src/dwarf.rs
@@ -48,7 +48,7 @@ impl<'input> DwarfInfo<'input> {
                         &[]
                     }
                 };
-                gimli::$sect::new(sect, obj.endianess())
+                gimli::$sect::new(sect, obj.endianness())
             }}
         }
 

--- a/symcache/src/writer.rs
+++ b/symcache/src/writer.rs
@@ -10,7 +10,7 @@ use fnv::{FnvHashMap, FnvHashSet};
 use num;
 
 use symbolic_common::{DebugKind, Error, ErrorKind, Language, Result, ResultExt};
-use symbolic_debuginfo::{Object, SymbolIterator, Symbols};
+use symbolic_debuginfo::{Object, SymbolIterator, Symbols, SymbolTable};
 
 use breakpad::BreakpadInfo;
 use cache::SYMCACHE_MAGIC;


### PR DESCRIPTION
This PR aims to clean up `FatObject` and `Object` handling by separating concerns and streamlining the behavior of different methods. More specifically:

 - Symbol and dwarf handling have moved to separate traits. They can be used by importing `symbolic_debuginfo::{DwarfData, SymbolTable}`. The main reason for this is easier feature flagging and a clearer code structure. The C-ABI doesn't export any of these functions yet, but could use the traits, too.
 - Most of Breakpad parsing has moved from `symcache` to `debuginfo`. This mostly concerns the low-level parser for records in ASCII symbols, implemented as iterator. Also, Breakpad module IDs (uuid+age) are represented by their own type `BreakpadId` which provides a convert back to UUID. For now, this simply discards the age -- but in future we could also hash the age in.
 - Improved `DebugKind`: Objects now check whether they **actually** contain debug information -- by looking for specific sections in their headers -- and return an `Option<DebugKind>`. There is a default implementation in `Object::debug_kind()` that selects the preferred debug kind for an object, but it is also possible to query for each kind separately using the respective trait (e.g. `Object::has_dwarf_data()`).
 - Added the concept of `ObjectClass`: Regardless of the physical container, each object either represents an executable, relocatable, library, etc. This is exposed via `Object::class()` for the lack of a better name. The method is also smart about ELF and can distinguish between (potentially stripped) executables and the corresponding debugging information. Note that this property is exported to python as `@property Object.type()`.
 - Parsing `Arch`, `Language` and `ObjectClass` from ELF/MachO now never returns a `Result` but directly the enum's Unknown/Other variant. The reason for this is to be more graceful about unsupported but valid values in those symbol files. We generally do not want to crash in a case where we don't care about all unimplemented variations. In the current code this resulted in no change. As an alternative, it would be possible to always return `Option<_>` and explicitly remove the Unknown/Other variant from these enums. 
 - Some minor fixes, like corrected spelling of the `endianness` method and missing PowerPC conversions for ELF/MachO.