### PR TITLE
ref(debuginfo): Make FatObjects iterable by default

### DIFF
--- a/symcache/examples/symcache-debug.rs
+++ b/symcache/examples/symcache-debug.rs
@@ -19,7 +19,6 @@ fn err(msg: &str) -> Box<Error> {
     Box::new(io::Error::new(io::ErrorKind::Other, msg))
 }
 
-
 fn execute(matches: &ArgMatches) -> Result<(), Box<Error>> {
     let symcache;
 
@@ -31,7 +30,8 @@ fn execute(matches: &ArgMatches) -> Result<(), Box<Error>> {
         };
         let byteview = ByteView::from_path(&file_path)?;
         let fat_obj = FatObject::parse(byteview)?;
-        let objects = fat_obj.objects()?;
+        let objects_result: Result<Vec<_>, _> = fat_obj.objects().collect();
+        let objects = objects_result?;
         if arch == Arch::Unknown && objects.len() != 1 {
             println!("Contained architectures:");
             for obj in objects {


### PR DESCRIPTION
- Adds a public `Objects` iterator
 - Makes `FatObject::objects()` return an iterator by default
 - Adapts the example in `symbolic_symcache`

Note that `FatObject::objects()` is not used in the CABI but only in Rust.
An iterator is therefore way more idiomatic and will save the vector allocation
in most cases. The example also shows, how to neatly collect the values into a
vector or any other data structure using `FromIterator for Result`.

`Objects::size_hint` and `Objects::count` are implemented for performance. The 
other methods are left the same, but if necessary we could also implement `nth`, 
`skip` etc...