### PR TITLE
ref(debuginfo): Refactor the symbols trait

### DIFF
--- a/debuginfo/src/lib.rs
+++ b/debuginfo/src/lib.rs
@@ -3,7 +3,6 @@
 extern crate goblin;
 #[macro_use]
 extern crate if_chain;
-#[macro_use]
 extern crate symbolic_common;
 extern crate uuid;
 

--- a/debuginfo/src/symbols.rs
+++ b/debuginfo/src/symbols.rs
@@ -68,12 +68,13 @@ impl<'data> SymbolsInternal<'data> {
 
                 // The length is only calculated if `next` is specified and does
                 // not result in an error. Otherwise, errors here are swallowed.
+                let addr = nlist.n_value;
                 let len = next.and_then(|index| symbols.get(index).ok())
-                    .map(|(_, nlist)| nlist.n_value);
+                    .map(|(_, nlist)| nlist.n_value - addr);
 
                 Symbol {
                     name: stripped.as_bytes(),
-                    addr: nlist.n_value,
+                    addr: addr,
                     len: len,
                 }
             }
@@ -94,7 +95,7 @@ type IndexMapping = (u64, usize);
 /// `Symbols::lookup` instead.
 pub struct SymbolIterator<'data, 'sym>
 where
-    'data: 'sym
+    'data: 'sym,
 {
     symbols: &'sym Symbols<'data>,
     iter: Peekable<slice::Iter<'sym, IndexMapping>>,

--- a/debuginfo/src/symbols.rs
+++ b/debuginfo/src/symbols.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
-use std::iter::Peekable;
-use std::slice::Iter as SliceIter;
+use std::fmt;
+use std::iter::{IntoIterator, Peekable};
+use std::slice;
 
 use goblin::mach;
 
@@ -8,119 +9,194 @@ use symbolic_common::{ErrorKind, Result};
 
 use object::{Object, ObjectTarget};
 
+/// A single symbol
+#[derive(Clone, Copy)]
+pub struct Symbol<'data> {
+    /// Binary string value of the symbol
+    pub name: &'data [u8],
+    /// Address of this symbol
+    pub addr: u64,
+    /// Presumed length of the symbol
+    pub len: Option<u64>,
+}
+
+impl<'a> fmt::Debug for Symbol<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Symbol")
+            .field("name", &String::from_utf8_lossy(self.name))
+            .field("addr", &self.addr)
+            .field("len", &self.len)
+            .finish()
+    }
+}
+
+/// Internal wrapper around certain symbol table implementations
+#[derive(Clone, Copy, Debug)]
+enum SymbolsInternal<'data> {
+    MachO(&'data mach::symbols::Symbols<'data>),
+}
+
+impl<'data> SymbolsInternal<'data> {
+    /// Returns the symbol at the given index
+    ///
+    /// To compute the presumed length of a symbol, pass the index of the
+    /// logically next symbol (i.e. the one with the next greater address).
+    pub fn get(&self, index: usize, next: Option<usize>) -> Result<Option<Symbol<'data>>> {
+        Ok(Some(match *self {
+            SymbolsInternal::MachO(symbols) => {
+                let (name, nlist) = symbols.get(index)?;
+
+                let stripped = if name.starts_with("_") {
+                    &name[1..]
+                } else {
+                    name
+                };
+
+                // The length is only calculated if `next` is specified and does
+                // not result in an error. Otherwise, errors here are swallowed.
+                let len = next.and_then(|index| symbols.get(index).ok())
+                    .map(|(_, nlist)| nlist.n_value);
+
+                Symbol {
+                    name: stripped.as_bytes(),
+                    addr: nlist.n_value,
+                    len: len,
+                }
+            }
+        }))
+    }
+}
+
+/// Internal type used to map addresses to symbol indices
+///
+/// `mapping.0`: The address of a symbol
+/// `mapping.1`: The index of a symbol in the symbol list
+type IndexMapping = (u64, usize);
+
+/// An iterator over `Symbol`s in a symbol table
+///
+/// Can be obtained via `SymbolTable::symbols`. This is primarily intended for
+/// consuming all symbols in an object file. To lookup single symbols, use
+/// `Symbols::lookup` instead.
+pub struct SymbolIterator<'data, 'sym>
+where
+    'data: 'sym
+{
+    symbols: &'sym Symbols<'data>,
+    iter: Peekable<slice::Iter<'sym, IndexMapping>>,
+}
+
+impl<'data, 'sym> Iterator for SymbolIterator<'data, 'sym> {
+    type Item = Result<Symbol<'data>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let index = match self.iter.next() {
+            Some(map) => map.1,
+            None => return None,
+        };
+
+        let next = self.iter.peek().map(|mapping| mapping.1);
+        match self.symbols.internal.get(index, next) {
+            Ok(Some(symbol)) => Some(Ok(symbol)),
+            Ok(None) => None,
+            Err(err) => Some(Err(err)),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+}
+
+/// Provides access to `Symbol`s of an `Object`
+///
+/// It allows to either lookup single symbols with `Symbols::lookup` or iterate
+/// them using `Symbols::into_iter`. Use `SymbolTable::lookup` on an `Object` to
+/// retrieve the symbols.
+pub struct Symbols<'data> {
+    internal: SymbolsInternal<'data>,
+    mappings: Vec<IndexMapping>,
+}
+
+impl<'data> Symbols<'data> {
+    /// Creates a `Symbols` wrapper for MachO
+    fn from_macho(macho: &'data mach::MachO) -> Result<Symbols<'data>> {
+        let macho_symbols = match macho.symbols {
+            Some(ref symbols) => symbols,
+            None => return Err(ErrorKind::MissingDebugInfo("symbol table missing").into()),
+        };
+
+        let mut sections = HashSet::new();
+        let mut section_index = 0;
+
+        // Cache section indices that we are interested in
+        for segment in &macho.segments {
+            for section_rv in segment {
+                let (section, _) = section_rv?;
+                let name = section.name()?;
+                if name == "__stubs" || name == "__text" {
+                    sections.insert(section_index);
+                }
+                section_index += 1;
+            }
+        }
+
+        // Build an ordered map of only symbols we are interested in
+        let mut symbol_map = BTreeMap::new();
+        for (symbol_index, symbol_result) in macho.symbols().enumerate() {
+            let (_, nlist) = symbol_result?;
+            let in_valid_section = nlist.get_type() == mach::symbols::N_SECT
+                && nlist.n_sect != (mach::symbols::NO_SECT as usize)
+                && sections.contains(&(nlist.n_sect - 1));
+
+            if in_valid_section {
+                symbol_map.insert(nlist.n_value, symbol_index);
+            }
+        }
+
+        Ok(Symbols {
+            internal: SymbolsInternal::MachO(macho_symbols),
+            mappings: symbol_map.into_iter().collect(),
+        })
+    }
+
+    /// Searches for a single `Symbol` inside the symbol table
+    pub fn lookup(&self, addr: u64) -> Result<Option<Symbol<'data>>> {
+        let found = match self.mappings.binary_search_by_key(&addr, |&x| x.0) {
+            Ok(idx) => idx,
+            Err(0) => return Ok(None),
+            Err(next_idx) => next_idx - 1,
+        };
+
+        let index = self.mappings[found].1;
+        let next = self.mappings.get(found + 1).map(|mapping| mapping.1);
+        self.internal.get(index, next)
+    }
+
+    pub fn iter<'sym>(&'sym self) -> SymbolIterator<'data, 'sym> {
+        SymbolIterator {
+            symbols: self,
+            iter: self.mappings.iter().peekable(),
+        }
+    }
+}
+
+/// Gives access to the symbol table of an `Object` file
 pub trait SymbolTable {
+    /// Returns the symbols of this `Object`
     fn symbols(&self) -> Result<Symbols>;
 }
 
 impl<'data> SymbolTable for Object<'data> {
     fn symbols(&self) -> Result<Symbols> {
         match self.target {
-            ObjectTarget::MachOSingle(macho) => get_macho_symbols(macho),
-            ObjectTarget::MachOFat(_, ref macho) => get_macho_symbols(macho),
-            _ => Err(ErrorKind::MissingDebugInfo("symbol table not implemented").into()),
+            ObjectTarget::MachOSingle(macho) => Symbols::from_macho(macho),
+            ObjectTarget::MachOFat(_, ref macho) => Symbols::from_macho(macho),
+            _ => Err(ErrorKind::Internal("symbol table not implemented").into()),
         }
-    }
-}
-
-/// Gives access to symbols in a symbol table.
-pub struct Symbols<'data> {
-    // note: if we need elf here later, we can move this into an internal wrapper
-    macho_symbols: Option<&'data mach::symbols::Symbols<'data>>,
-    symbol_list: Vec<(u64, u32)>,
-}
-
-impl<'data> Symbols<'data> {
-    pub fn lookup(&self, addr: u64) -> Result<Option<(u64, u32, &'data str)>> {
-        let idx = match self.symbol_list.binary_search_by_key(&addr, |&x| x.0) {
-            Ok(idx) => idx,
-            Err(0) => return Ok(None),
-            Err(next_idx) => next_idx - 1,
-        };
-        let (sym_addr, sym_id) = self.symbol_list[idx];
-
-        let sym_len = self.symbol_list
-            .get(idx + 1)
-            .map(|next| next.0 - sym_addr)
-            .unwrap_or(!0);
-
-        let symbols = self.macho_symbols.unwrap();
-        let (symbol, _) = symbols.get(sym_id as usize)?;
-        Ok(Some((sym_addr, sym_len as u32, try_strip_symbol(symbol))))
-    }
-
-    pub fn iter(&'data self) -> SymbolIterator<'data> {
-        SymbolIterator {
-            symbols: self,
-            iter: self.symbol_list.iter().peekable(),
-        }
-    }
-}
-
-/// An iterator over a contained symbol table.
-pub struct SymbolIterator<'data> {
-    // note: if we need elf here later, we can move this into an internal wrapper
-    symbols: &'data Symbols<'data>,
-    iter: Peekable<SliceIter<'data, (u64, u32)>>,
-}
-
-impl<'data> Iterator for SymbolIterator<'data> {
-    type Item = Result<(u64, u32, &'data str)>;
-
-    fn next(&mut self) -> Option<Result<(u64, u32, &'data str)>> {
-        if let Some(&(addr, id)) = self.iter.next() {
-            Some(if let Some(ref mo) = self.symbols.macho_symbols {
-                let sym = try_strip_symbol(itry!(mo.get(id as usize).map(|x| x.0)));
-                if let Some(&&(next_addr, _)) = self.iter.peek() {
-                    Ok((addr, (next_addr - addr) as u32, sym))
-                } else {
-                    Ok((addr, !0, sym))
-                }
-            } else {
-                Err(ErrorKind::Internal("out of range for symbol iteration").into())
-            })
-        } else {
-            None
-        }
-    }
-}
-
-fn get_macho_symbols<'data>(macho: &'data mach::MachO) -> Result<Symbols<'data>> {
-    let mut sections = HashSet::new();
-    let mut idx = 0;
-
-    for segment in &macho.segments {
-        for section_rv in segment {
-            let (section, _) = section_rv?;
-            let name = section.name()?;
-            if name == "__stubs" || name == "__text" {
-                sections.insert(idx);
-            }
-            idx += 1;
-        }
-    }
-
-    // build an ordered map of the symbols
-    let mut symbol_map = BTreeMap::new();
-    for (id, sym_rv) in macho.symbols().enumerate() {
-        let (_, nlist) = sym_rv?;
-        if nlist.get_type() == mach::symbols::N_SECT
-            && nlist.n_sect != (mach::symbols::NO_SECT as usize)
-            && sections.contains(&(nlist.n_sect - 1))
-        {
-            symbol_map.insert(nlist.n_value, id as u32);
-        }
-    }
-
-    Ok(Symbols {
-        macho_symbols: macho.symbols.as_ref(),
-        symbol_list: symbol_map.into_iter().collect(),
-    })
-}
-
-fn try_strip_symbol(s: &str) -> &str {
-    if s.starts_with("_") {
-        &s[1..]
-    } else {
-        s
     }
 }

--- a/debuginfo/src/symbols.rs
+++ b/debuginfo/src/symbols.rs
@@ -12,15 +12,29 @@ use object::{Object, ObjectTarget};
 /// A single symbol
 #[derive(Clone, Copy)]
 pub struct Symbol<'data> {
-    /// Binary string value of the symbol
-    pub name: &'data [u8],
-    /// Address of this symbol
-    pub addr: u64,
-    /// Presumed length of the symbol
-    pub len: Option<u64>,
+    name: &'data [u8],
+    addr: u64,
+    len: Option<u64>,
 }
 
-impl<'a> fmt::Debug for Symbol<'a> {
+impl<'data> Symbol<'data> {
+    /// Binary string value of the symbol
+    pub fn name(&self) -> &'data [u8] {
+        self.name
+    }
+
+    /// Address of this symbol
+    pub fn addr(&self) -> u64 {
+        self.addr
+    }
+
+    /// Presumed length of the symbol
+    pub fn len(&self) -> Option<u64> {
+        self.len
+    }
+}
+
+impl<'data> fmt::Debug for Symbol<'data> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Symbol")
             .field("name", &String::from_utf8_lossy(self.name))

--- a/symcache/src/dwarf.rs
+++ b/symcache/src/dwarf.rs
@@ -301,9 +301,9 @@ impl<'input> Unit<'input> {
                 if !inline;
                 if let Some(symbols) = symbols;
                 if let Some(symbol) = symbols.lookup(ranges[0].begin)?;
-                if symbol.addr + symbol.len.unwrap_or(!0) <= ranges[ranges.len() - 1].end;
+                if symbol.addr() + symbol.len().unwrap_or(!0) <= ranges[ranges.len() - 1].end;
                 then {
-                    Some(symbol.name)
+                    Some(symbol.name())
                 } else {
                     // fall back to dwarf info
                     self.resolve_function_name(info, entry)?

--- a/symcache/src/dwarf.rs
+++ b/symcache/src/dwarf.rs
@@ -300,10 +300,10 @@ impl<'input> Unit<'input> {
             let func_name = if_chain! {
                 if !inline;
                 if let Some(symbols) = symbols;
-                if let Some((sym_addr, sym_len, symbol)) = symbols.lookup(ranges[0].begin)?;
-                if sym_addr + (sym_len as u64) <= ranges[ranges.len() - 1].end;
+                if let Some(symbol) = symbols.lookup(ranges[0].begin)?;
+                if symbol.addr + symbol.len.unwrap_or(!0) <= ranges[ranges.len() - 1].end;
                 then {
-                    Some(symbol.as_bytes())
+                    Some(symbol.name)
                 } else {
                     // fall back to dwarf info
                     self.resolve_function_name(info, entry)?

--- a/symcache/src/dwarf.rs
+++ b/symcache/src/dwarf.rs
@@ -301,7 +301,8 @@ impl<'input> Unit<'input> {
                 if !inline;
                 if let Some(symbols) = symbols;
                 if let Some(symbol) = symbols.lookup(ranges[0].begin)?;
-                if symbol.addr() + symbol.len().unwrap_or(!0) <= ranges[ranges.len() - 1].end;
+                if let Some(len) = symbol.len();
+                if symbol.addr() + len <= ranges[ranges.len() - 1].end;
                 then {
                     Some(symbol.name())
                 } else {

--- a/symcache/src/writer.rs
+++ b/symcache/src/writer.rs
@@ -253,7 +253,6 @@ impl<W: Write> SymCacheWriter<W> {
     ) -> Result<()> {
         while let Some(&Ok(symbol)) = symbol_iter.peek() {
             let sym_addr = symbol.addr() - vmaddr;
-            let sym_len = symbol.len().unwrap_or(!0);
 
             // skip forward until we hit a relevant symbol
             if *last_addr != !0 && sym_addr < *last_addr {
@@ -262,9 +261,9 @@ impl<W: Write> SymCacheWriter<W> {
             }
 
             if (*last_addr == !0 || sym_addr >= *last_addr) && sym_addr < cur_addr {
-                self.write_simple_function(sym_addr, sym_len, symbol.name())?;
+                self.write_simple_function(sym_addr, symbol.len().unwrap_or(!0), symbol.name())?;
                 symbol_iter.next();
-                *last_addr = sym_addr + sym_len;
+                *last_addr = sym_addr + symbol.len().unwrap_or(1);
             } else {
                 break;
             }

--- a/symcache/src/writer.rs
+++ b/symcache/src/writer.rs
@@ -232,9 +232,9 @@ impl<W: Write> SymCacheWriter<W> {
     }
 
     fn write_symbol_table(&mut self, symbols: SymbolIterator, vmaddr: u64) -> Result<()> {
-        for sym_rv in symbols {
-            let (func_addr, len, symbol) = sym_rv?;
-            self.write_simple_function(func_addr - vmaddr, len, symbol)?;
+        for symbol_result in symbols {
+            let func = symbol_result?;
+            self.write_simple_function(func.addr - vmaddr, func.len.unwrap_or(!0), func.name)?;
         }
 
         self.header.data_source = DataSource::SymbolTable as u8;
@@ -251,8 +251,9 @@ impl<W: Write> SymCacheWriter<W> {
         vmaddr: u64,
         symbol_iter: &mut Peekable<SymbolIterator>,
     ) -> Result<()> {
-        while let Some(&Ok((mut sym_addr, sym_len, sym))) = symbol_iter.peek() {
-            sym_addr -= vmaddr;
+        while let Some(&Ok(symbol)) = symbol_iter.peek() {
+            let sym_addr = symbol.addr - vmaddr;
+            let sym_len = symbol.len.unwrap_or(!0);
 
             // skip forward until we hit a relevant symbol
             if *last_addr != !0 && sym_addr < *last_addr {
@@ -261,9 +262,9 @@ impl<W: Write> SymCacheWriter<W> {
             }
 
             if (*last_addr == !0 || sym_addr >= *last_addr) && sym_addr < cur_addr {
-                self.write_simple_function(sym_addr, sym_len, sym)?;
+                self.write_simple_function(sym_addr, sym_len, symbol.name)?;
                 symbol_iter.next();
-                *last_addr = sym_addr + sym_len as u64;
+                *last_addr = sym_addr + sym_len;
             } else {
                 break;
             }
@@ -271,7 +272,7 @@ impl<W: Write> SymCacheWriter<W> {
         Ok(())
     }
 
-    fn write_simple_function<S>(&mut self, func_addr: u64, len: u32, symbol: S) -> Result<()>
+    fn write_simple_function<S>(&mut self, func_addr: u64, len: u64, symbol: S) -> Result<()>
     where
         S: AsRef<[u8]>,
     {
@@ -315,7 +316,7 @@ impl<W: Write> SymCacheWriter<W> {
             // Write all symbols that are not defined in info.functions()
             while syms.peek().map_or(false, |s| s.address < function.address) {
                 let symbol = syms.next().unwrap();
-                self.write_simple_function(symbol.address, symbol.size as u32, symbol.name)?;
+                self.write_simple_function(symbol.address, symbol.size, symbol.name)?;
             }
 
             // Skip symbols that are also defined in info.functions()
@@ -325,7 +326,7 @@ impl<W: Write> SymCacheWriter<W> {
             }
 
             let func_id = self.func_records.len();
-            self.write_simple_function(function.address, function.size as u32, function.name)?;
+            self.write_simple_function(function.address, function.size, function.name)?;
 
             if function.lines.is_empty() {
                 continue;
@@ -359,7 +360,7 @@ impl<W: Write> SymCacheWriter<W> {
 
         // Flush out all remaining symbols from the symbol table (PUBLIC records)
         for symbol in syms {
-            self.write_simple_function(symbol.address, symbol.size as u32, symbol.name)?;
+            self.write_simple_function(symbol.address, symbol.size, symbol.name)?;
         }
 
         self.header.data_source = DataSource::BreakpadSym as u8;
@@ -371,8 +372,9 @@ impl<W: Write> SymCacheWriter<W> {
     }
 
     fn write_dwarf_info(&mut self, info: &DwarfInfo, symbols: Option<Symbols>) -> Result<()> {
-        let mut range_buf = Vec::new();
         let symbols = symbols.as_ref();
+
+        let mut range_buf = Vec::new();
         let mut symbol_iter = symbols.map(|x| x.iter().peekable());
         let mut last_addr = !0;
         let mut addrs = FnvHashSet::default();

--- a/symcache/src/writer.rs
+++ b/symcache/src/writer.rs
@@ -234,7 +234,7 @@ impl<W: Write> SymCacheWriter<W> {
     fn write_symbol_table(&mut self, symbols: SymbolIterator, vmaddr: u64) -> Result<()> {
         for symbol_result in symbols {
             let func = symbol_result?;
-            self.write_simple_function(func.addr - vmaddr, func.len.unwrap_or(!0), func.name)?;
+            self.write_simple_function(func.addr() - vmaddr, func.len().unwrap_or(!0), func.name())?;
         }
 
         self.header.data_source = DataSource::SymbolTable as u8;
@@ -252,8 +252,8 @@ impl<W: Write> SymCacheWriter<W> {
         symbol_iter: &mut Peekable<SymbolIterator>,
     ) -> Result<()> {
         while let Some(&Ok(symbol)) = symbol_iter.peek() {
-            let sym_addr = symbol.addr - vmaddr;
-            let sym_len = symbol.len.unwrap_or(!0);
+            let sym_addr = symbol.addr() - vmaddr;
+            let sym_len = symbol.len().unwrap_or(!0);
 
             // skip forward until we hit a relevant symbol
             if *last_addr != !0 && sym_addr < *last_addr {
@@ -262,7 +262,7 @@ impl<W: Write> SymCacheWriter<W> {
             }
 
             if (*last_addr == !0 || sym_addr >= *last_addr) && sym_addr < cur_addr {
-                self.write_simple_function(sym_addr, sym_len, symbol.name)?;
+                self.write_simple_function(sym_addr, sym_len, symbol.name())?;
                 symbol_iter.next();
                 *last_addr = sym_addr + sym_len;
             } else {


### PR DESCRIPTION
 - Returns a `Symbol` struct instead of unnamed enum
 - Properly abstracts MachO/ELF
 - Adds missing documentation
 - Took way to long to implement