### PR TITLE
feat(py): Turn on backtraces even for regular errors

### DIFF
--- a/cabi/include/symbolic.h
+++ b/cabi/include/symbolic.h
@@ -277,6 +277,11 @@ SymbolicStr symbolic_demangle_no_args(const SymbolicStr *ident, const SymbolicSt
 void symbolic_err_clear();
 
 /*
+ * Returns the panic information as string.
+ */
+SymbolicStr symbolic_err_get_backtrace();
+
+/*
  * Returns the last error code.
  *
  * If there is no error, 0 is returned.
@@ -290,11 +295,6 @@ SymbolicErrorCode symbolic_err_get_last_code();
  * that needs to be freed with `symbolic_str_free`.
  */
 SymbolicStr symbolic_err_get_last_message();
-
-/*
- * Returns the panic information as string.
- */
-SymbolicStr symbolic_err_get_panic_info();
 
 /*
  * Frees the given fat object.

--- a/py/symbolic/common.py
+++ b/py/symbolic/common.py
@@ -1,3 +1,4 @@
+import os
 from symbolic._lowlevel import lib, ffi
 from symbolic._compat import string_types, int_types
 from symbolic.utils import rustcall, encode_str, decode_str
@@ -11,7 +12,8 @@ __all__ = ['arch_is_known', 'arch_from_macho', 'arch_to_macho',
 ignore_arch_exc = (exceptions.NotFound, exceptions.Parse)
 
 
-# Make sure we init the lib
+# Make sure we init the lib and turn on rust backtraces
+os.environ['RUST_BACKTRACE'] = '1'
 ffi.init_once(lib.symbolic_init, 'init')
 
 

--- a/py/symbolic/exceptions.py
+++ b/py/symbolic/exceptions.py
@@ -13,12 +13,12 @@ class SymbolicError(Exception):
     def __init__(self, msg):
         Exception.__init__(self)
         self.message = msg
-        self.panic_info = None
+        self.rust_info = None
 
     def __str__(self):
         rv = self.message
-        if self.panic_info is not None:
-            return u'%s\n\n%s' % (rv, self.panic_info)
+        if self.rust_info is not None:
+            return u'%s\n\n%s' % (rv, self.rust_info)
         return rv
 
 

--- a/py/symbolic/utils.py
+++ b/py/symbolic/utils.py
@@ -81,9 +81,9 @@ def rustcall(func, *args):
     msg = lib.symbolic_err_get_last_message()
     cls = exceptions_by_code.get(err, SymbolicError)
     exc = cls(decode_str(msg))
-    panic_info = decode_str(lib.symbolic_err_get_panic_info())
-    if panic_info:
-        exc.panic_info = panic_info
+    backtrace = decode_str(lib.symbolic_err_get_backtrace())
+    if backtrace:
+        exc.rust_info = backtrace
     raise exc
 
 


### PR DESCRIPTION
This enables backtraces even for regular errors which should help us
figure out where stuff breaks in production.