### PR TITLE
feat(py): Support processing minidumps in memory

### DIFF
--- a/cabi/include/symbolic.h
+++ b/cabi/include/symbolic.h
@@ -385,6 +385,14 @@ SymbolicUuid symbolic_object_get_uuid(const SymbolicObject *so);
 SymbolicProcessState *symbolic_process_minidump(const char *path, const SymbolicFrameInfoMap *smap);
 
 /*
+ * Processes a minidump with optional CFI information and returns the state
+ * of the process at the time of the crash
+ */
+SymbolicProcessState *symbolic_process_minidump_buffer(const char *buffer,
+                                                       size_t length,
+                                                       const SymbolicFrameInfoMap *smap);
+
+/*
  * Frees a process state object
  */
 void symbolic_process_state_free(SymbolicProcessState *sstate);

--- a/py/symbolic/minidump.py
+++ b/py/symbolic/minidump.py
@@ -155,6 +155,17 @@ class ProcessState(RustObject):
         return ProcessState._from_objptr(
             rustcall(lib.symbolic_process_minidump, encode_path(path), frame_infos_ptr))
 
+    @classmethod
+    def from_minidump_buffer(cls, buffer, frame_infos=None):
+        """Processes a minidump and get the state of the crashed process"""
+        frame_infos_ptr = frame_infos._objptr if frame_infos is not None else ffi.NULL
+        return ProcessState._from_objptr(rustcall(
+            lib.symbolic_process_minidump_buffer,
+            ffi.from_buffer(buffer),
+            len(buffer),
+            frame_infos_ptr,
+        ))
+
     @property
     def requesting_thread(self):
         """The index of the thread that requested a dump be written in the


### PR DESCRIPTION
Needed in sentry in case uploades are handled as `InMemoryUploadedFiles`.