### PR TITLE
feat(cabi): Expose frame's code modules to python

### DIFF
--- a/cabi/include/symbolic.h
+++ b/cabi/include/symbolic.h
@@ -183,11 +183,22 @@ typedef struct {
 } SymbolicSystemInfo;
 
 /*
+ * Carries information about a code module loaded into the process during the crash
+ */
+typedef struct {
+  SymbolicUuid uuid;
+  uint64_t addr;
+  uint64_t size;
+  SymbolicStr name;
+} SymbolicCodeModule;
+
+/*
  * Contains the absolute instruction address and image information of a stack frame
  */
 typedef struct {
   uint64_t instruction;
   SymbolicFrameTrust trust;
+  SymbolicCodeModule module;
 } SymbolicStackFrame;
 
 /*
@@ -198,16 +209,6 @@ typedef struct {
   SymbolicStackFrame *frames;
   size_t frame_count;
 } SymbolicCallStack;
-
-/*
- * Carries information about a code module loaded into the process during the crash
- */
-typedef struct {
-  SymbolicUuid uuid;
-  uint64_t addr;
-  uint64_t size;
-  SymbolicStr name;
-} SymbolicCodeModule;
 
 /*
  * State of a crashed process

--- a/cabi/src/minidump.rs
+++ b/cabi/src/minidump.rs
@@ -41,9 +41,7 @@ pub struct SymbolicCodeModule {
 pub struct SymbolicStackFrame {
     pub instruction: u64,
     pub trust: SymbolicFrameTrust,
-    // pub image_uuid: SymbolicUuid,
-    // pub image_addr: u64,
-    // pub image_size: u64,
+    pub module: SymbolicCodeModule,
 }
 
 /// Represents a thread of the process state which holds a list of stack frames
@@ -153,9 +151,7 @@ unsafe fn map_stack_frame(frame: &StackFrame) -> SymbolicStackFrame {
     SymbolicStackFrame {
         instruction: frame.instruction(),
         trust: mem::transmute(frame.trust()),
-        // image_uuid: map_uuid(&frame.module().map_or(Uuid::nil(), |m| m.id().uuid())),
-        // image_addr: frame.module().map_or(0, |m| m.base_address()),
-        // image_size: frame.module().map_or(0, |m| m.size()),
+        module: frame.module().map_or(mem::zeroed(), |m| map_code_module(m)),
     }
 }
 

--- a/py/symbolic/minidump.py
+++ b/py/symbolic/minidump.py
@@ -70,6 +70,16 @@ class StackFrame(RustObject):
         """The confidence with with the instruction pointer was retrieved"""
         return FrameTrust.by_value[self._objptr.trust]
 
+    @property
+    def module(self):
+        """The code module that defines code for this frame"""
+        module = CodeModule._from_objptr(self._objptr.module, shared=True)
+        if not module.uuid.int and not module.addr and not module.size:
+            return None
+
+        attached_refs[module] = self
+        return module
+
 
 class CallStack(RustObject):
     """A thread of the crashed process"""


### PR DESCRIPTION
This is needed so we can initialize more stack trace information in Sentry when creating the initial event. Otherwise, symbolication will leave the module name empty.

The code module is inlined directly into the frame, which substantially increases its size but makes handling it easier. An other option would have been to store a pointer into the `ProcessState.modules`.

Note that modules are **optional**. If a frame has no module associated, its memory is zeroed out. The python code checks this by looking at the `uuid`, `address` and `size` fields together. 