### PR TITLE
fix(debuginfo): Parse INFO records in breakpad symbols

### DIFF
--- a/debuginfo/src/breakpad.rs
+++ b/debuginfo/src/breakpad.rs
@@ -95,6 +95,7 @@ pub enum BreakpadRecord<'input> {
     Function(BreakpadFuncRecord<'input>),
     Line(BreakpadLineRecord),
     Public(BreakpadPublicRecord<'input>),
+    Info(&'input [u8]),
     Stack,
 }
 
@@ -278,6 +279,10 @@ impl<'data> BreakpadRecords<'data> {
             b"PUBLIC" => {
                 self.state = IterState::Reading;
                 parse_public(record)
+            }
+            b"INFO" => {
+                self.state = IterState::Reading;
+                parse_info(record)
             }
             _ => {
                 if self.state == IterState::Function {
@@ -496,6 +501,15 @@ fn parse_public<'data>(line: &'data [u8]) -> Result<BreakpadRecord<'data>> {
         size: 0, // will be computed with the next PUBLIC record
         name: name,
     }))
+}
+
+/// Parses a breakpad INFO record
+///
+/// Syntax: "INFO text"
+/// Example: "INFO CODE_ID C22813AC7D101E2FF2598697023E1F28"
+/// no documentation available
+fn parse_info<'data>(line: &'data [u8]) -> Result<BreakpadRecord<'data>> {
+    Ok(BreakpadRecord::Info(line))
 }
 
 /// Parses a breakpad line record (after funcs)

--- a/symcache/src/breakpad.rs
+++ b/symcache/src/breakpad.rs
@@ -37,8 +37,8 @@ impl<'input> BreakpadInfo<'input> {
 
     fn parse(&mut self, object: &'input Object) -> Result<()> {
         let mut records = object.breakpad_records();
-        while let Some(Ok(record)) = records.next() {
-            match record {
+        while let Some(record) = records.next() {
+            match record? {
                 BreakpadRecord::Module(m) => self.module = Some(m),
                 BreakpadRecord::File(f) => self.files.push(f),
                 BreakpadRecord::Function(f) => self.funcs.push(f),
@@ -59,6 +59,9 @@ impl<'input> BreakpadInfo<'input> {
                     }
 
                     self.syms.push(p);
+                }
+                BreakpadRecord::Info(_) => {
+                    // not relevant
                 }
                 BreakpadRecord::Stack => {
                     // not relevant


### PR DESCRIPTION
Adds support to parse `INFO` records in Breakpad ASCII symbols. Also, breakpad to symcache conversion silently swallowed errors.
