### PR TITLE
feat(minidump): Separate version and build number

### DIFF
--- a/cabi/include/symbolic.h
+++ b/cabi/include/symbolic.h
@@ -177,6 +177,7 @@ typedef struct {
 typedef struct {
   SymbolicStr os_name;
   SymbolicStr os_version;
+  SymbolicStr os_build;
   SymbolicStr cpu_family;
   SymbolicStr cpu_info;
   uint32_t cpu_count;

--- a/cabi/src/minidump.rs
+++ b/cabi/src/minidump.rs
@@ -65,6 +65,7 @@ impl Drop for SymbolicCallStack {
 pub struct SymbolicSystemInfo {
     pub os_name: SymbolicStr,
     pub os_version: SymbolicStr,
+    pub os_build: SymbolicStr,
     pub cpu_family: SymbolicStr,
     pub cpu_info: SymbolicStr,
     pub cpu_count: u32,
@@ -170,6 +171,7 @@ unsafe fn map_system_info(info: &SystemInfo) -> SymbolicSystemInfo {
     SymbolicSystemInfo {
         os_name: SymbolicStr::from_string(info.os_name()),
         os_version: SymbolicStr::from_string(info.os_version()),
+        os_build: SymbolicStr::from_string(info.os_build()),
         cpu_family: SymbolicStr::from_string(info.cpu_family()),
         cpu_info: SymbolicStr::from_string(info.cpu_info()),
         cpu_count: info.cpu_count(),

--- a/minidump/Cargo.toml
+++ b/minidump/Cargo.toml
@@ -17,6 +17,8 @@ build = "build.rs"
 [dependencies]
 gimli = "0.15"
 goblin = "0.0"
+lazy_static = "1.0"
+regex = "0.2"
 symbolic-common = { version = "2.0.2", path = "../common" }
 symbolic-debuginfo = { version = "2.0.2", path = "../debuginfo" }
 uuid = { version = "0.5", features = ["use_std"] }

--- a/minidump/src/lib.rs
+++ b/minidump/src/lib.rs
@@ -1,6 +1,9 @@
 //! Provides minidump support.
 extern crate gimli;
 extern crate goblin;
+#[macro_use]
+extern crate lazy_static;
+extern crate regex;
 extern crate uuid;
 
 extern crate symbolic_common;

--- a/minidump/src/processor.rs
+++ b/minidump/src/processor.rs
@@ -6,11 +6,17 @@ use std::ffi::CString;
 use std::marker::PhantomData;
 use std::hash::{Hash, Hasher};
 use std::os::raw::{c_char, c_void};
+
+use regex::Regex;
 use uuid::Uuid;
 
 use symbolic_common::{ByteView, ErrorKind, Result};
 
 use utils;
+
+lazy_static! {
+    static ref LINUX_BUILD_RE: Regex = Regex::new(r"^Linux ([^ ]+) (.*) \w+ [^ ]+$").unwrap();
+}
 
 extern "C" {
     fn code_module_base_address(module: *const CodeModule) -> u64;
@@ -378,14 +384,49 @@ impl SystemInfo {
         }
     }
 
-    /// A string identifying the version of the operating system, such as
-    /// "5.1.2600 Service Pack 2" or "10.4.8 8L2127".  If the dump does not
-    /// contain this information, this field will be empty.
-    pub fn os_version(&self) -> String {
-        unsafe {
+    /// Strings identifying the version and build number of the operating
+    /// system.  If the dump does not contain either information, the component
+    /// will be empty.
+    ///
+    /// Tries to parse the version number from the build if it is not apparent
+    /// from the version string.
+    pub fn os_parts(&self) -> (String, String) {
+        let string = unsafe {
             let ptr = system_info_os_version(self);
             utils::ptr_to_string(ptr)
+        };
+
+        let mut parts = string.splitn(2, ' ');
+        let version = parts.next().unwrap_or("0.0.0");
+        let build = parts.next().unwrap_or("");
+
+        if version == "0.0.0" {
+            // Try to parse the Linux build string. Breakpad and Crashpad run
+            // `uname -srvmo` to generate it. This roughtly resembles:
+            // "Linux [version] [build...] [arch] Linux/GNU"
+            if let Some(captures) = LINUX_BUILD_RE.captures(&build) {
+                let version = captures.get(1).unwrap(); // uname -r portion
+                let build = captures.get(2).unwrap();   // uname -v portion
+                return (version.as_str().into(), build.as_str().into());
+            }
         }
+
+        (version.into(), build.into())
+    }
+
+    /// A string identifying the version of the operating system, such as
+    /// "5.1.2600" or "10.4.8".  The version will be formatted as three-
+    /// component semantic version.  If the dump does not contain this
+    /// information, this field will contain "0.0.0".
+    pub fn os_version(&self) -> String {
+        self.os_parts().0
+    }
+
+    /// A string identifying the build of the operating system, such as
+    /// "Service Pack 2" or "8L2127".  If the dump does not contain this
+    /// information, this field will be empty.
+    pub fn os_build(&self) -> String {
+        self.os_parts().1
     }
 
     /// A string identifying the basic CPU family, such as "x86" or "ppc".

--- a/minidump/src/processor.rs
+++ b/minidump/src/processor.rs
@@ -15,7 +15,7 @@ use symbolic_common::{ByteView, ErrorKind, Result};
 use utils;
 
 lazy_static! {
-    static ref LINUX_BUILD_RE: Regex = Regex::new(r"^Linux ([^ ]+) (.*) \w+ [^ ]+$").unwrap();
+    static ref LINUX_BUILD_RE: Regex = Regex::new(r"^Linux ([^ ]+) (.*) \w+(?: GNU/Linux)?$").unwrap();
 }
 
 extern "C" {

--- a/py/symbolic/minidump.py
+++ b/py/symbolic/minidump.py
@@ -126,9 +126,17 @@ class SystemInfo(RustObject):
     @property
     def os_version(self):
         """A string identifying the version of the operating system, such as
-        "5.1.2600 Service Pack 2" or "10.4.8 8L2127".  If the dump does not
-        contain this information, this field will be empty."""
+        "5.1.2600" or "10.4.8".  The version will be formatted as three-
+        component semantic version.  If the dump does not contain this
+        information, this field will contain "0.0.0"."""
         return decode_str(self._objptr.os_version)
+
+    @property
+    def os_build(self):
+        """A string identifying the build of the operating system, such as
+        "Service Pack 2" or "8L2127".  If the dump does not contain this
+        information, this field will be empty."""
+        return decode_str(self._objptr.os_build)
 
     @property
     def cpu_family(self):

--- a/py/tests/test_minidump.py
+++ b/py/tests/test_minidump.py
@@ -19,7 +19,8 @@ def test_macos_without_cfi(res_path):
 
     info = state.system_info
     assert info.os_name == 'Mac OS X'
-    assert info.os_version == '10.12.6 16G29'
+    assert info.os_version == '10.12.6'
+    assert info.os_build == '16G29'
     assert info.cpu_family == 'amd64'
     assert info.cpu_info == 'family 6 model 70 stepping 1'
     assert info.cpu_count == 8
@@ -53,7 +54,8 @@ def test_linux_without_cfi(res_path):
 
     info = state.system_info
     assert info.os_name == 'Linux'
-    assert info.os_version == '0.0.0 Linux 4.9.46-moby #1 SMP Thu Sep 7 02:53:42 UTC 2017 x86_64'
+    assert info.os_version == '4.9.46-moby'
+    assert info.os_build == '#1 SMP Thu Sep 7 02:53:42 UTC 2017'
     assert info.cpu_family == 'amd64'
     assert info.cpu_info == 'family 6 model 70 stepping 1'
     assert info.cpu_count == 4
@@ -91,7 +93,8 @@ def test_macos_with_cfi(res_path):
 
     info = state.system_info
     assert info.os_name == 'Mac OS X'
-    assert info.os_version == '10.12.6 16G29'
+    assert info.os_version == '10.12.6'
+    assert info.os_build == '16G29'
     assert info.cpu_family == 'amd64'
     assert info.cpu_info == 'family 6 model 70 stepping 1'
     assert info.cpu_count == 8
@@ -129,7 +132,8 @@ def test_linux_with_cfi(res_path):
 
     info = state.system_info
     assert info.os_name == 'Linux'
-    assert info.os_version == '0.0.0 Linux 4.9.46-moby #1 SMP Thu Sep 7 02:53:42 UTC 2017 x86_64'
+    assert info.os_version == '4.9.46-moby'
+    assert info.os_build == '#1 SMP Thu Sep 7 02:53:42 UTC 2017'
     assert info.cpu_family == 'amd64'
     assert info.cpu_info == 'family 6 model 70 stepping 1'
     assert info.cpu_count == 4


### PR DESCRIPTION
Splits the `os_version` string from minidump into the version and build information. 

On Linux, the version number is often times `0.0.0` while the build contains information obtained via `uname -srvmo`. This includes the architecture, linux kernel version and build version of the distribution. For now, the `uname -r` (kernel release) is used as `version` and `uname -v` (kernel version) as build.

Note that `uname -r` contains version numbers like "4.10.0-42-generic". This currently breaks in Sentry but will be fixed in the PR introducing Linux symbolication support.