### PR TITLE
fix(symcache): Add line address and improve code docs

### DIFF
--- a/cabi/include/symbolic.h
+++ b/cabi/include/symbolic.h
@@ -154,6 +154,7 @@ typedef struct {
  */
 typedef struct {
   uint64_t sym_addr;
+  uint64_t line_addr;
   uint64_t instr_addr;
   uint32_t line;
   SymbolicStr lang;

--- a/cabi/src/symcache.rs
+++ b/cabi/src/symcache.rs
@@ -19,6 +19,7 @@ pub struct SymbolicSymCache;
 #[repr(C)]
 pub struct SymbolicLineInfo {
     pub sym_addr: u64,
+    pub line_addr: u64,
     pub instr_addr: u64,
     pub line: u32,
     pub lang: SymbolicStr,
@@ -163,6 +164,7 @@ ffi_fn! {
         for line_info in vec {
             items.push(SymbolicLineInfo {
                 sym_addr: line_info.sym_addr(),
+                line_addr: line_info.line_addr(),
                 instr_addr: line_info.instr_addr(),
                 line: line_info.line(),
                 lang: SymbolicStr::new(line_info.lang().name()),

--- a/examples/minidump_stackwalk.rs
+++ b/examples/minidump_stackwalk.rs
@@ -177,7 +177,7 @@ fn print_state(state: &ProcessState, symcaches: &SymCaches, crashed_only: bool) 
                             info.function_name(),
                             info.filename(),
                             info.line(),
-                            info.instr_addr() - info.sym_addr(),
+                            info.instr_addr() - info.line_addr(),
                         );
 
                         if i + 1 < line_infos.len() {

--- a/py/symbolic/symcache.py
+++ b/py/symbolic/symcache.py
@@ -23,8 +23,9 @@ SYMCACHE_LATEST_VERSION = rustcall(
 class LineInfo(object):
 
     def __init__(self, sym_addr, instr_addr, line, lang, symbol,
-                 filename=None, base_dir=None, comp_dir=None):
+                 line_addr=None, filename=None, base_dir=None, comp_dir=None):
         self.sym_addr = sym_addr
+        self.line_addr = line_addr
         self.instr_addr = instr_addr
         self.line = line
         self.lang = lang
@@ -135,6 +136,7 @@ class SymCache(RustObject):
                 sym = rv.items[idx]
                 matches.append(LineInfo(
                     sym_addr=sym.sym_addr,
+                    line_addr=sym.line_addr,
                     instr_addr=sym.instr_addr,
                     line=sym.line,
                     lang=decode_str(sym.lang),

--- a/symcache/src/cache.rs
+++ b/symcache/src/cache.rs
@@ -513,7 +513,7 @@ impl<'a> SymCache<'a> {
         }
     }
 
-    fn build_symbol(&'a self, fun: &'a FuncRecord, addr: u64,
+    fn build_line_info(&'a self, fun: &'a FuncRecord, addr: u64,
                     inner_sym: Option<&LineInfo<'a>>) -> Result<LineInfo<'a>> {
         let (line, filename, base_dir) = match self.run_to_line(fun, addr)? {
             Some((file_record, line)) => {
@@ -593,7 +593,7 @@ impl<'a> SymCache<'a> {
         let mut rv = vec![];
 
         // what we hit directly
-        rv.push(self.build_symbol(&fun, addr, None)?);
+        rv.push(self.build_line_info(&fun, addr, None)?);
 
         // inlined outer parts
         while let Some(parent_id) = fun.parent(func_id) {
@@ -601,7 +601,7 @@ impl<'a> SymCache<'a> {
             fun = &funcs[parent_id];
             func_id = parent_id;
             let symbol = {
-                self.build_symbol(&fun, outer_addr, Some(&rv[rv.len() - 1]))?
+                self.build_line_info(&fun, outer_addr, Some(&rv[rv.len() - 1]))?
             };
             rv.push(symbol);
         }


### PR DESCRIPTION
This PR exposes the instruction address at which a source line starts via `LineInfo`. 

While the docs of `LineInfo::sym_addr()` suggested this, it is actually returning the first instruction of the function. Instead, a new function `LineInfo::line_addr()` now returns this value. This change was made in commit 36f0759 (_feat(symcache): Add line address to LineInfo_).

The other commits expose this change to python or improve the general documentation of the `SymCache`.
