### PR TITLE
fix(minidump): Use original return addresses

### DIFF
--- a/cabi/include/symbolic.h
+++ b/cabi/include/symbolic.h
@@ -198,6 +198,7 @@ typedef struct {
  * Contains the absolute instruction address and image information of a stack frame
  */
 typedef struct {
+  uint64_t return_address;
   uint64_t instruction;
   SymbolicFrameTrust trust;
   SymbolicCodeModule module;

--- a/cabi/src/common.rs
+++ b/cabi/src/common.rs
@@ -67,7 +67,7 @@ ffi_fn! {
     unsafe fn symbolic_arch_ip_reg_name(arch: *const SymbolicStr) -> Result<SymbolicStr> {
         Ok(SymbolicStr::new(
             Arch::parse((*arch).as_str())?
-                .ip_reg_name()
+                .ip_register_name()
                 .ok_or(ErrorKind::NotFound("ip reg unknown for architecture"))?))
     }
 }

--- a/cabi/src/symcache.rs
+++ b/cabi/src/symcache.rs
@@ -206,7 +206,7 @@ ffi_fn! {
             signal: if (*ii).signal == 0 { None } else { Some((*ii).signal) },
             ip_reg: if (*ii).ip_reg == 0 { None } else { Some((*ii).ip_reg) },
         };
-        Ok(real_ii.find_best_instruction())
+        Ok(real_ii.caller_address())
     }
 }
 

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -280,12 +280,25 @@ impl Arch {
     }
 
     /// The name of the IP register if known.
-    pub fn ip_reg_name(&self) -> Option<&'static str> {
+    pub fn ip_register_name(&self) -> Option<&'static str> {
         match self.cpu_family() {
             CpuFamily::Intel32 => Some("eip"),
             CpuFamily::Intel64 => Some("rip"),
             CpuFamily::Arm32 | CpuFamily::Arm64 => Some("pc"),
-            _ => None,
+            CpuFamily::Ppc32 | CpuFamily::Ppc64 => Some("srr0"),
+            CpuFamily::Unknown => None,
+        }
+    }
+
+    /// Returns instruction alignment if fixed.
+    pub fn instruction_alignment(&self) -> Option<u64> {
+        match self.cpu_family() {
+            CpuFamily::Arm32 => Some(2),
+            CpuFamily::Arm64 => Some(4),
+            CpuFamily::Ppc32 => Some(4),
+            CpuFamily::Ppc64 => Some(8),
+            CpuFamily::Intel32 | CpuFamily::Intel64 => None,
+            CpuFamily::Unknown => None,
         }
     }
 }

--- a/minidump/cpp/data_structures.cpp
+++ b/minidump/cpp/data_structures.cpp
@@ -140,6 +140,14 @@ stack_frame_t *const *call_stack_frames(const call_stack_t *stack,
     return reinterpret_cast<stack_frame_t *const *>(frames->data());
 }
 
+uint64_t stack_frame_return_address(const stack_frame_t *frame) {
+    if (frame == nullptr) {
+        return 0;
+    }
+
+    return stack_frame_t::cast(frame)->ReturnAddress();
+}
+
 uint64_t stack_frame_instruction(const stack_frame_t *frame) {
     if (frame == nullptr) {
         return 0;

--- a/minidump/cpp/data_structures.h
+++ b/minidump/cpp/data_structures.h
@@ -1,9 +1,9 @@
 #ifndef SENTRY_DATA_STRUCTURES_H
 #define SENTRY_DATA_STRUCTURES_H
 
+#include <cstdbool>
 #include <cstddef>
 #include <cstdint>
-#include <cstdbool>
 
 #ifdef __cplusplus
 extern "C" {
@@ -125,6 +125,11 @@ uint32_t call_stack_thread_id(const call_stack_t *stack);
 /// in the size_out parameter.
 stack_frame_t *const *call_stack_frames(const call_stack_t *stack,
                                         size_t *size_out);
+
+// Return the actual return address, as saved on the stack or in a
+// register. See the comments for 'stack_frameinstruction', below,
+// for details.
+uint64_t stack_frame_return_address(const stack_frame_t *frame);
 
 /// Returns the program counter location as an absolute virtual address.
 ///

--- a/py/symbolic/minidump.py
+++ b/py/symbolic/minidump.py
@@ -61,6 +61,11 @@ class StackFrame(RustObject):
     __dealloc_func__ = None
 
     @property
+    def return_address(self):
+        """The frame's return address as saved in registers or on the stack"""
+        return self._objptr.return_address
+
+    @property
     def instruction(self):
         """The frame's program counter location as absolute virtual address"""
         return self._objptr.instruction

--- a/py/tests/test_minidump.py
+++ b/py/tests/test_minidump.py
@@ -32,6 +32,7 @@ def test_macos_without_cfi(res_path):
     frame = thread.get_frame(1)
     assert frame.trust == 'scan'
     assert frame.instruction == 4329952133
+    assert frame.return_address == 4329952134
 
     mid = uuid.UUID("3f58bc3d-eabe-3361-b5fb-52a676298598")
     module = next(module for module in state.modules() if module.uuid == mid)
@@ -67,6 +68,7 @@ def test_linux_without_cfi(res_path):
     frame = thread.get_frame(1)
     assert frame.trust == 'scan'
     assert frame.instruction == 4202617
+    assert frame.return_address == 4202618
 
     mid = uuid.UUID("d2554cdb-9261-36c4-b976-6a086583b9b5")
     module = next(module for module in state.modules() if module.uuid == mid)
@@ -106,6 +108,7 @@ def test_macos_with_cfi(res_path):
     frame = thread.get_frame(1)
     assert frame.trust == 'cfi'
     assert frame.instruction == 4329952133
+    assert frame.return_address == 4329952134
 
     mid = uuid.UUID("3f58bc3d-eabe-3361-b5fb-52a676298598")
     module = next(module for module in state.modules() if module.uuid == mid)
@@ -145,6 +148,7 @@ def test_linux_with_cfi(res_path):
     frame = thread.get_frame(1)
     assert frame.trust == 'cfi'
     assert frame.instruction == 4202617
+    assert frame.return_address == 4202618
 
     mid = uuid.UUID("d2554cdb-9261-36c4-b976-6a086583b9b5")
     module = next(module for module in state.modules() if module.uuid == mid)

--- a/symcache/src/heuristics.rs
+++ b/symcache/src/heuristics.rs
@@ -4,8 +4,13 @@ const SIGILL: u32 = 4;
 const SIGBUS: u32 = 10;
 const SIGSEGV: u32 = 11;
 
-
-/// Helper to determine best instructions.
+/// Helper to work with instruction addresses.
+///
+/// The most useful function is `InstructionInfo::caller_address` which applies
+/// some heuristics to determine the call site of a function call based on the
+/// return address. See `InstructionInfo::caller_address` for more information.
+///
+/// See https://goo.gl/g17EAn for detailed information on this topic.
 pub struct InstructionInfo {
     /// The address of the instruction we want to use as a base.
     pub addr: u64,
@@ -13,56 +18,99 @@ pub struct InstructionInfo {
     pub arch: Arch,
     /// This is true if the frame is the cause of the crash.
     pub crashing_frame: bool,
-    /// If a signal is know that triggers the crash, it can be stored here.
+    /// If a signal is known that triggers the crash, it can be stored here.
     pub signal: Option<u32>,
     /// The optional value of the IP register.
     pub ip_reg: Option<u64>,
 }
 
 impl InstructionInfo {
-    /// Returns true if the signal indicates a crash.
-    pub fn is_crash_signal(&self) -> bool {
-        match self.signal {
-            Some(SIGILL) | Some(SIGBUS) | Some(SIGSEGV) => true,
-            _ => false
+    /// Tries to resolve the start address of the current instruction.
+    ///
+    /// For architectures without fixed alignment (such as Intel with variable
+    /// instruction lengths), this will return the same address. Otherwise, the
+    /// address is aligned to the architecture's instruction alignment.
+    pub fn aligned_address(&self) -> u64 {
+        if let Some(alignment) = self.arch.instruction_alignment() {
+            self.addr - (self.addr % alignment)
+        } else {
+            self.addr
         }
     }
 
     /// Return the previous instruction to the current one if we can
     /// determine this for the current architecture.
-    pub fn get_previous_instruction(&self) -> Option<u64> {
-        match self.arch.cpu_family() {
-            CpuFamily::Arm64 => Some(self.addr - (self.addr % 4) - 4),
-            CpuFamily::Arm32 => Some(self.addr - (self.addr % 2) - 2),
-            _ => None
+    /// Returns the instruction preceding the current one.
+    ///
+    /// For known architectures, this will return the start address of the
+    /// instruction immediately before the current one in the machine code.
+    /// This is likely the instruction that was just executed or that called
+    /// a function returning at the current address.
+    ///
+    /// For unknown architectures or those using variable instruction size, the
+    /// exact start address cannot be determined. Instead, an address *within*
+    /// the preceding instruction will be returned. For this reason, the return
+    /// value of this function should be considered an upper bound.
+    pub fn previous_address(&self) -> u64 {
+        self.aligned_address() - self.arch.instruction_alignment().unwrap_or(1)
+    }
+
+    /// Returns whether the application attempted to jump to an invalid,
+    /// privileged or misaligned address. This indicates, that certain
+    /// adjustments should be made on the caller instruction address.
+    pub fn is_crash_signal(&self) -> bool {
+        match self.signal {
+            Some(SIGILL) | Some(SIGBUS) | Some(SIGSEGV) => true,
+            _ => false,
         }
+    }
+
+    /// Determines whether the given address should be adjusted to resolve the
+    /// call site of a stack frame.
+    ///
+    /// This generally applies to all frames except the crashing / suspended
+    /// frame. However, if the process crashed with an illegal instruction,
+    /// even the top-most frame needs to be adjusted to account for the signal
+    /// handler.
+    pub fn should_adjust_caller(&self) -> bool {
+        // All frames other than the crashing frame (or suspended frame for
+        // other threads) report the return address. This address (generally)
+        // points to the instruction after the function call. Therefore, we
+        // need to adjust the caller address for these frames.
+        if !self.crashing_frame {
+            return true;
+        }
+
+        // The crashing frame usually contains the actual register contents,
+        // which points to the exact instruction that crashed and must not be
+        // adjusted. A notable exception to this is if we crashed with one of
+        // the crash signals.
+        // TODO: Document reason of this
+        if let Some(ip) = self.ip_reg {
+            if ip != self.addr && self.is_crash_signal() {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// Give the information in the instruction info this returns the
     /// most accurate instruction.
-    pub fn find_best_instruction(&self) -> u64 {
-        let mut prev = false;
-
-        if !self.crashing_frame {
-            prev = true;
-        } else if let Some(ip) = self.ip_reg {
-            if ip != self.addr && self.is_crash_signal() {
-                prev = true;
-            }
-        }
-
-        round_to_instruction_end(if prev {
-            self.get_previous_instruction().unwrap_or(self.addr.saturating_sub(1))
+    pub fn caller_address(&self) -> u64 {
+        let addr = if self.should_adjust_caller() {
+            self.previous_address()
         } else {
-            self.addr
-        }, self.arch)
-    }
-}
+            self.aligned_address()
+        };
 
-fn round_to_instruction_end(addr: u64, arch: Arch) -> u64 {
-    match arch.cpu_family() {
-        CpuFamily::Arm64 => addr - (addr % 4) + 3,
-        CpuFamily::Arm32 => addr - (addr % 2) + 1,
-        _ => addr
+        // For some crashes on ARM, the aligned address resolved to the wrong
+        // symbol.
+        // TODO: Document details for this
+        match self.arch.cpu_family() {
+            CpuFamily::Arm32 => addr + 1,
+            CpuFamily::Arm64 => addr + 3,
+            _ => addr,
+        }
     }
 }


### PR DESCRIPTION
This PR tries to expose the original return addresses from stack frames without Breakpad's instruction heuristics. It allows us to apply our own heuristics defined in `symcache/heuristics` from Sentry. On the bottom line, Sentry no longer has to distinguish between minidump stacktraces and KSCrash stacktraces to perform correct symbolication.

### Getting the correct return address

The first issue was to obtain the actual return address from the process state. Breakpad defines the following interface for stack frames:

```
struct StackFrame {
  // Return the actual return address, as saved on the stack or in a
  // register. See the comments for 'instruction', below, for details.
  virtual uint64_t ReturnAddress() const { return instruction; }

  // The program counter location as an absolute virtual address.
  // - [Except for the first frame], this address is within the instruction that
  //   caused execution to branch to this frame's callee [...]
  uint64_t instruction;
}
```

This suggests that Breakpad tries to infer the caller address and saves it in `instruction` while returning the original return address with `ReturnAddress`. However, this default implementation simply returns `instruction` which already looks like a source for errors. In fact, it is not overridden for `ARM` and `ARM64`: The `instruction` field is offset by `-2` and `-4` respectively, so `ReturnAddress()` does not return the original value. 

For this reason, our implementation of `StackFrame::return_address` in Rust compensates this difference. 

### Instruction heuristics

The heuristics inside `symcache/src/heuristics.rs` have been refactored to be more clear about what they do and why. Semantics should not have changed. Notable changes are:

 - `Arch::instruction_alignment` now centralizes all alignment-related operations
 - All logic whether a frame's instruction should be adjusted now lives in `should_adjust_caller`
 - Public helper methods `aligned_address` and `previous_address` use the above to navigate instructions
 - Renamed `find_best_instruction` to `caller_address` (only in Rust) to be more specific about what the method actually does
 - Added detailed comments about the reasoning behind the manipulations, as this is a fragile yet important piece of code.

Based on [this document](https://opensource.plausible.coop/wiki/display/PLCR/Automated+Crash+Report+Analysis), however, I am still not quite clear about two parts. Also, we do not seem to apply the [two Link Register Heuristics](https://opensource.plausible.coop/wiki/display/PLCR/Automated+Crash+Report+Analysis#AutomatedCrashReportAnalysis-FixingtheIssue.1) for ARM.

### Final remarks

 - Sentry must must use `return_address` over `instruction` to get frames' addresses when building events from minidumps. This can be implemented after the next release of `symbolic`.
 - With CFI (which was never present on KSCrash), some of these heuristics should probably be turned off. Sentry is not using the `FrameTrust` field yet, but it should probably pass it to the heuristics. This might require a change to the frame interface in Sentry.
 - We do not yet have any test dumps to verify these heuristics or the quality of stack traces
 - We still need a way to read register values from the process state and add them to events
