### PR TITLE
fix(debuginfo): Compute correct UUID for ELF binaries

### DIFF
--- a/debuginfo/Cargo.toml
+++ b/debuginfo/Cargo.toml
@@ -17,7 +17,6 @@ as Mach-O or ELF.
 [dependencies]
 gimli = "0.15"
 goblin = "0.0"
-if_chain = "0.1"
 lazy_static = "1.0"
 memmap = "0.5"
 regex = "0.2"

--- a/debuginfo/src/dwarf.rs
+++ b/debuginfo/src/dwarf.rs
@@ -1,12 +1,15 @@
 use goblin::{elf, mach};
 
 use object::{Object, ObjectTarget};
+use elf::{find_elf_section, has_elf_section};
+use mach::{find_mach_section, has_mach_segment};
 
+/// Provides access to DWARF debugging information in object files
 pub trait DwarfData {
-    /// Checks whether this object contains DWARF infos.
+    /// Checks whether this object contains DWARF infos
     fn has_dwarf_data(&self) -> bool;
 
-    /// Loads a specific dwarf section if its in the file.
+    /// Loads a specific dwarf section if its in the file
     fn get_dwarf_section<'input>(
         &'input self,
         section: DwarfSection,
@@ -19,15 +22,19 @@ impl<'input> DwarfData for Object<'input> {
             // We assume an ELF contains debug information if it still contains
             // the debug_info section. The file utility uses a similar mechanism,
             // except that it checks for the ".symtab" section instead.
-            ObjectTarget::Elf(ref elf) => has_elf_section(elf, DwarfSection::DebugInfo),
+            ObjectTarget::Elf(ref elf) => has_elf_section(
+                elf,
+                elf::section_header::SHT_PROGBITS,
+                DwarfSection::DebugInfo.elf_name(),
+            ),
 
             // MachO generally stores debug information in the "__DWARF" segment,
             // so we simply check if it is present. The only exception to this
             // rule is call frame information (CFI), which is stored in the __TEXT
             // segment of the executable. This, however, requires more specific
             // logic anyway, so we ignore this here.
-            ObjectTarget::MachOSingle(ref macho) => has_macho_segment(macho, "__DWARF"),
-            ObjectTarget::MachOFat(_, ref macho) => has_macho_segment(macho, "__DWARF"),
+            ObjectTarget::MachOSingle(ref macho) => has_mach_segment(macho, "__DWARF"),
+            ObjectTarget::MachOFat(_, ref macho) => has_mach_segment(macho, "__DWARF"),
 
             // We do not support DWARF in any other object targets
             _ => false,
@@ -40,14 +47,14 @@ impl<'input> DwarfData for Object<'input> {
     ) -> Option<DwarfSectionData<'data>> {
         match self.target {
             ObjectTarget::Elf(ref elf) => read_elf_dwarf_section(elf, self.as_bytes(), section),
-            ObjectTarget::MachOSingle(ref macho) => read_macho_dwarf_section(macho, section),
-            ObjectTarget::MachOFat(_, ref macho) => read_macho_dwarf_section(macho, section),
+            ObjectTarget::MachOSingle(ref macho) => read_mach_dwarf_section(macho, section),
+            ObjectTarget::MachOFat(_, ref macho) => read_mach_dwarf_section(macho, section),
             _ => None,
         }
     }
 }
 
-/// Represents the name of the section.
+/// Represents the name of the section
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
 pub enum DwarfSection {
     EhFrame,
@@ -116,7 +123,7 @@ impl DwarfSection {
     }
 }
 
-/// Gives access to a section in a dwarf file.
+/// Gives access to a section in a dwarf file
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub struct DwarfSectionData<'data> {
     section: DwarfSection,
@@ -133,92 +140,38 @@ impl<'data> DwarfSectionData<'data> {
         }
     }
 
-    /// Return the section as bytes
+    /// Return the section data as bytes
     pub fn as_bytes(&self) -> &'data [u8] {
         self.data
     }
 
-    /// Get the offset
+    /// Get the absolute file offset
     pub fn offset(&self) -> u64 {
         self.offset
     }
 
-    /// Get the section
+    /// Get the section name
     pub fn section(&self) -> DwarfSection {
         self.section
     }
 }
 
+/// Reads a single `DwarfSection` from an ELF object file
 fn read_elf_dwarf_section<'data>(
     elf: &elf::Elf<'data>,
     data: &'data [u8],
     sect: DwarfSection,
 ) -> Option<DwarfSectionData<'data>> {
-    let section_name = sect.elf_name();
-
-    for header in &elf.section_headers {
-        if let Some(Ok(name)) = elf.shdr_strtab.get(header.sh_name) {
-            if name == section_name {
-                let sec_data = &data[header.sh_offset as usize..][..header.sh_size as usize];
-                return Some(DwarfSectionData::new(sect, sec_data, header.sh_offset));
-            }
-        }
-    }
-
-    None
+    let sh_type = elf::section_header::SHT_PROGBITS;
+    find_elf_section(elf, data, sh_type, sect.elf_name())
+        .map(|section| DwarfSectionData::new(sect, section.data, section.header.sh_offset))
 }
 
-fn read_macho_dwarf_section<'data>(
+/// Reads a single `DwarfSection` from Mach object file
+fn read_mach_dwarf_section<'data>(
     macho: &mach::MachO<'data>,
     sect: DwarfSection,
 ) -> Option<DwarfSectionData<'data>> {
-    let dwarf_segment = if sect == DwarfSection::EhFrame {
-        "__TEXT"
-    } else {
-        "__DWARF"
-    };
-
-    let dwarf_section_name = sect.macho_name();
-    for segment in &macho.segments {
-        if_chain! {
-            if let Ok(seg) = segment.name();
-            if dwarf_segment == seg;
-            then {
-                for section in segment {
-                    if_chain! {
-                        if let Ok((section, data)) = section;
-                        if let Ok(name) = section.name();
-                        if name == dwarf_section_name;
-                        then {
-                            return Some(DwarfSectionData::new(sect, data, section.offset as u64));
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    None
-}
-
-fn has_elf_section(elf: &elf::Elf, section: DwarfSection) -> bool {
-    for header in &elf.section_headers {
-        if let Some(Ok(name)) = elf.shdr_strtab.get(header.sh_name) {
-            if name == section.elf_name() {
-                return true;
-            }
-        }
-    }
-
-    false
-}
-
-fn has_macho_segment(macho: &mach::MachO, name: &str) -> bool {
-    for segment in &macho.segments {
-        if segment.name().map(|seg| seg == name).unwrap_or(false) {
-            return true;
-        }
-    }
-
-    false
+    find_mach_section(macho, sect.macho_name())
+        .map(|section| DwarfSectionData::new(sect, section.data, section.header.offset as u64))
 }

--- a/debuginfo/src/elf.rs
+++ b/debuginfo/src/elf.rs
@@ -1,0 +1,185 @@
+use std::cmp;
+
+use goblin::elf;
+use uuid::Uuid;
+
+const UUID_SIZE: usize = 16;
+const PAGE_SIZE: usize = 4096;
+
+/// A section inside an ELF binary
+pub struct ElfSection<'elf, 'data> {
+    pub header: &'elf elf::SectionHeader,
+    pub data: &'data [u8],
+}
+
+/// Locates and reads a section in an ELF binary
+pub fn find_elf_section<'elf, 'data>(
+    elf: &'elf elf::Elf,
+    data: &'data [u8],
+    sh_type: u32,
+    name: &str,
+) -> Option<ElfSection<'elf, 'data>> {
+    for header in &elf.section_headers {
+        if header.sh_type != sh_type {
+            continue;
+        }
+
+        if let Some(Ok(section_name)) = elf.shdr_strtab.get(header.sh_name) {
+            if section_name != name {
+                continue;
+            }
+
+            let offset = header.sh_offset as usize;
+            let size = header.sh_size as usize;
+            return Some(ElfSection {
+                header: header,
+                data: &data[offset..][..size],
+            });
+        }
+    }
+
+    None
+}
+
+/// Checks whether an ELF binary contains a section
+///
+/// This is useful to determine whether the binary contains certain information
+/// without loading its section data.
+pub fn has_elf_section(elf: &elf::Elf, sh_type: u32, name: &str) -> bool {
+    for header in &elf.section_headers {
+        if header.sh_type != sh_type {
+            continue;
+        }
+
+        if let Some(Ok(section_name)) = elf.shdr_strtab.get(header.sh_name) {
+            if section_name == name {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+/// Locates and reads a `Note` within a note section
+///
+/// The note iterator can either be obtained from a PT_NOTE program header entry
+/// or a SHT_NOTE section. Both data contents look identical.
+fn find_elf_note<'data>(
+    mut notes: elf::note::NoteIterator<'data>,
+    n_type: u32,
+) -> Option<&'data [u8]> {
+    while let Some(Ok(note)) = notes.next() {
+        if note.n_type == n_type {
+            return Some(note.desc);
+        }
+    }
+
+    None
+}
+
+/// Searches for a GNU build identifier node in an ELF file
+///
+/// Depending on the compiler and linker, the build ID can be declared in a
+/// NT_GNU_BUILD_ID program header entry, the ".note.gnu.build-id" section, or
+/// even both.
+fn find_build_id<'data>(elf: &elf::Elf, data: &'data [u8]) -> Option<&'data [u8]> {
+    // First, search the PT_NOTE program header entries for a NT_GNU_BUILD_ID.
+    // We swallow all errors during this process and simply fall back to the
+    // next method below. Since lld generates two PT_NOTEs, we cannot rely on
+    // `Elf::iter_notes` and have to walk all headers manually.
+    for phdr in &elf.program_headers {
+        if phdr.p_type != elf::program_header::PT_NOTE {
+            continue;
+        }
+
+        let offset = phdr.p_offset as usize;
+        let mut notes = elf::note::NoteIterator {
+            data,
+            offset,
+            size: offset + phdr.p_filesz as usize,
+            ctx: (phdr.p_align as usize, elf.ctx),
+        };
+
+        if let Some(note) = find_elf_note(notes, elf::note::NT_GNU_BUILD_ID) {
+            return Some(note);
+        }
+    }
+
+    // Next, load the SHT_NOTE section called ".note.gnu.build-id". It contains
+    // the same data as the PT_NOTE program header. Again, swallow all errors
+    // and fall through if reading the section is not possible.
+    let sh_type = elf::section_header::SHT_NOTE;
+    if let Some(section) = find_elf_section(elf, data, sh_type, ".note.gnu.build-id") {
+        let offset = section.header.sh_offset as usize;
+        let mut notes = elf::note::NoteIterator {
+            data,
+            offset,
+            size: offset + section.header.sh_size as usize,
+            ctx: (section.header.sh_addralign as usize, elf.ctx),
+        };
+
+        if let Some(note) = find_elf_note(notes, elf::note::NT_GNU_BUILD_ID) {
+            return Some(note);
+        }
+    }
+
+    None
+}
+
+/// Converts an ELF object identifier into a `Uuid`
+///
+/// The identifier data is first truncated or extended to match 16 byte size of
+/// Uuids. If the data is declared in little endian, the first three Uuid fields
+/// are flipped to match the big endian expected by the breakpad processor.
+fn create_elf_uuid(identifier: &[u8], little_endian: bool) -> Option<Uuid> {
+    // Make sure that we have exactly UUID_SIZE bytes available
+    let mut data = [0 as u8; UUID_SIZE];
+    let len = cmp::min(identifier.len(), UUID_SIZE);
+    data[0..len].copy_from_slice(&identifier[0..len]);
+
+    if little_endian {
+        // The file ELF file targets a little endian architecture. Convert to
+        // network byte order (big endian) to match the Breakpad processor's
+        // expectations. For big endian object files, this is not needed.
+        data[0..4].reverse(); // uuid field 1
+        data[4..6].reverse(); // uuid field 2
+        data[6..8].reverse(); // uuid field 3
+    }
+
+    Uuid::from_bytes(&data).ok()
+}
+
+/// Tries to obtain the object UUID of an ELF object.
+///
+/// As opposed to Mach-O, ELF does not specify a unique ID for object files in
+/// its header. Compilers and linkers usually add either `SHT_NOTE` sections or
+/// `PT_NOTE` program header elements for this purpose.
+///
+/// If neither of the above are present, this function will hash the first page
+/// of the `.text` section (program code) to synthesize a unique ID. This is
+/// likely not a valid UUID since was generated off a hash value.
+///
+/// If all of the above fails, the UUID will be `None`.
+pub fn get_elf_uuid(elf: &elf::Elf, data: &[u8]) -> Option<Uuid> {
+    // Search for a GNU build identifier node in the program headers or the
+    // build ID section. If errors occur during this process, fall through
+    // silently to the next method.
+    if let Some(identifier) = find_build_id(elf, data) {
+        return create_elf_uuid(identifier, elf.little_endian);
+    }
+
+    // We were not able to locate the build ID, so fall back to hashing the
+    // first page of the ".text" (program code) section. This algorithm XORs
+    // 16-byte chunks directly into a UUID buffer.
+    if let Some(section) = find_elf_section(elf, data, elf::section_header::SHT_PROGBITS, ".text") {
+        let mut hash = [0; UUID_SIZE];
+        for i in 0..cmp::min(section.data.len(), PAGE_SIZE) {
+            hash[i % UUID_SIZE] ^= section.data[i];
+        }
+
+        return create_elf_uuid(&hash, elf.little_endian);
+    }
+
+    None
+}

--- a/debuginfo/src/elf.rs
+++ b/debuginfo/src/elf.rs
@@ -84,7 +84,7 @@ fn find_build_id<'data>(elf: &elf::Elf<'data>, data: &'data [u8]) -> Option<&'da
     // In that case, search for a note section (SHT_NOTE). We are looking for a
     // note within the ".note.gnu.build-id" section. Again, swallow all errors
     // and fall through if reading the section is not possible.
-    if let Some(mut notes) = elf.iter_note_sections(data) {
+    if let Some(mut notes) = elf.iter_note_sections(data, Some(".note.gnu.build-id")) {
         while let Some(Ok(note)) = notes.next() {
             if note.n_type == elf::note::NT_GNU_BUILD_ID {
                 return Some(note.desc);

--- a/debuginfo/src/lib.rs
+++ b/debuginfo/src/lib.rs
@@ -2,8 +2,6 @@
 
 extern crate goblin;
 #[macro_use]
-extern crate if_chain;
-#[macro_use]
 extern crate lazy_static;
 extern crate regex;
 extern crate symbolic_common;
@@ -11,6 +9,8 @@ extern crate uuid;
 
 mod breakpad;
 mod dwarf;
+mod elf;
+mod mach;
 mod object;
 mod symbols;
 

--- a/debuginfo/src/mach.rs
+++ b/debuginfo/src/mach.rs
@@ -1,0 +1,98 @@
+use goblin::mach;
+use uuid::Uuid;
+
+use symbolic_common::Result;
+
+/// A segment inside a Mach object file containing multiple sections
+type MachSegment<'mach, 'data> = &'mach mach::segment::Segment<'data>;
+
+/// A section inside a Mach object file
+pub struct MachSection<'data> {
+    // The header struct
+    pub header: mach::segment::Section,
+    // The raw data
+    pub data: &'data [u8],
+}
+
+/// Locates and reads a segment in a Mach object file
+pub fn find_mach_segment<'mach, 'data>(
+    mach: &'mach mach::MachO<'data>,
+    name: &str,
+) -> Option<MachSegment<'mach, 'data>> {
+    for segment in &mach.segments {
+        if segment.name().map(|seg| seg == name).unwrap_or(false) {
+            return Some(segment);
+        }
+    }
+
+    None
+}
+
+/// Checks whether a Mach object file contains a segment
+///
+/// This is useful to determine whether the object contains certain information
+/// without iterating over all section headers and loading their data.
+pub fn has_mach_segment(mach: &mach::MachO, name: &str) -> bool {
+    find_mach_segment(mach, name).is_some()
+}
+
+/// Locates and reads a section in a Mach object file
+///
+/// Depending on its name, the segment will be loaded from either the `"__TEXT"`
+/// or the `"__DWARF"` segment.
+pub fn find_mach_section<'data>(
+    mach: &mach::MachO<'data>,
+    name: &str,
+) -> Option<MachSection<'data>> {
+    let segment_name = match name {
+        "__eh_frame" => "__TEXT",
+        _ => "__DWARF",
+    };
+
+    let segment = match find_mach_segment(mach, segment_name) {
+        Some(segment) => segment,
+        None => return None,
+    };
+
+    for section in segment {
+        if let Ok((header, data)) = section {
+            if header.name().map(|sec| sec == name).unwrap_or(false) {
+                return Some(MachSection { header, data });
+            }
+        }
+    }
+
+    None
+}
+
+/// Checks whether a Mach object file contains a section
+///
+/// Depending on its name, the section will searched in the `"__TEXT"` or the
+/// `"__DWARF"` segment. This is useful to determine whether the object contains
+/// certain information without iterating over all section headers and loading
+/// their data.
+pub fn has_mach_section(mach: &mach::MachO, name: &str) -> bool {
+    find_mach_section(mach, name).is_some()
+}
+
+/// Resolves the UUID from Mach object load commands
+pub fn get_mach_uuid(macho: &mach::MachO) -> Option<Uuid> {
+    for cmd in &macho.load_commands {
+        if let mach::load_command::CommandVariant::Uuid(ref uuid_cmd) = cmd.command {
+            return Uuid::from_bytes(&uuid_cmd.uuid).ok();
+        }
+    }
+
+    None
+}
+
+/// Loads the virtual memory address of this object's __TEXT (code) segment
+pub fn get_mach_vmaddr(macho: &mach::MachO) -> Result<u64> {
+    for seg in &macho.segments {
+        if seg.name()? == "__TEXT" {
+            return Ok(seg.vmaddr);
+        }
+    }
+
+    Ok(0)
+}

--- a/debuginfo/src/object.rs
+++ b/debuginfo/src/object.rs
@@ -9,7 +9,7 @@ use symbolic_common::{Arch, ByteView, ByteViewHandle, DebugKind, Endianness, Err
 
 use breakpad::BreakpadSym;
 use dwarf::DwarfData;
-use elf::get_elf_uuid;
+use elf::{get_elf_uuid, get_elf_vmaddr};
 use mach::{get_mach_uuid, get_mach_vmaddr};
 
 /// Contains type specific data of `Object`s
@@ -69,7 +69,7 @@ impl<'bytes> Object<'bytes> {
         use ObjectTarget::*;
         match self.target {
             Breakpad(..) => Ok(0),
-            Elf(..) => Ok(0),
+            Elf(elf) => get_elf_vmaddr(elf),
             MachOSingle(macho) => get_mach_vmaddr(macho),
             MachOFat(_, ref macho) => get_mach_vmaddr(macho),
         }

--- a/debuginfo/src/object.rs
+++ b/debuginfo/src/object.rs
@@ -68,6 +68,7 @@ impl<'bytes> Object<'bytes> {
     pub fn vmaddr(&self) -> Result<u64> {
         use ObjectTarget::*;
         match self.target {
+            // Breakpad accounts for the vmaddr when dumping symbols
             Breakpad(..) => Ok(0),
             Elf(elf) => get_elf_vmaddr(elf),
             MachOSingle(macho) => get_mach_vmaddr(macho),


### PR DESCRIPTION
This PR fixes some issues with ELF processing and refactors some format-specific code into its own helper modules.

### Build ID Algorithm

This algorithm computes a UUID for the ELF binary. The previous way to use `e_ident` in the ELF header is simply wrong, as `e_ident` is no identifier by any means but rather a collection of magic and flags. For obvious reasons, we try to closely resemble what Breakpad is doing:

1. Determine the build identifier:
    1. First, try to locate a `NT_GNU_BUILD_ID` in one of the `PT_NOTE` program header entries
    2. Otherwise, locate the above note in the contents of the `".note.gnu.build-id"` section
    3. If the above does not work, take the entire `".text"` section (the program code) and XOR it into a 16 byte buffer
2. Strip or extend the buffer obtained above to exactly 16 bytes
3. Interpret the above as 4-field UUID: `(u32, u16, u16, [u8; 8])`
4. If the target architecture is little endian, flip the first three fields into big endian

### Load Address

We previously assumed the load address is always `0x0`, which is completely wrong for executables. In that case, the load address is the start address of the first `PT_LOAD` segment.

Note: We refer to the load address as `vmaddr` (virtual memory address) internally, as we prefer Mach speak.

### Refactoring

To structure the above code better, all ELF-related utility functions have been moved to an internal `elf` module which exports functions like `find_elf_section` or `get_elf_uuid`. In the same way, all Mach-O related helpers have been moved to the `mach` module.

The `find_*_section` now always return a structure with reference to the section header and the data. For now, I've decided not to expose these functions publicly, but they are for sure candidates for the public API. There might be a follow-up PR with further refactoring of the code structure here.

### Dependencies

This PR makes use of `goblin::note::NoteIterator` to parse the contents of note sections. The easiest way to create an instance was to expose the internal `Elf.ctx` field for now. However, I don't really like this solution and might change this before creating a PR with `goblin`.