### PR TITLE
fix(cabi): Report correct backtraces for panics

### DIFF
--- a/cabi/Cargo.toml
+++ b/cabi/Cargo.toml
@@ -26,7 +26,6 @@ lto = true
 
 [dependencies]
 uuid = "0"
-backtrace = "0"
 symbolic-common = { version = "2.0.4", path = "../common", features = ["with_dwarf", "with_objects", "with_sourcemaps"] }
 symbolic-demangle = { version = "2.0.4", path = "../demangle" }
 symbolic-debuginfo = { version = "2.0.4", path = "../debuginfo" }

--- a/cabi/src/lib.rs
+++ b/cabi/src/lib.rs
@@ -7,7 +7,6 @@ extern crate symbolic_sourcemap;
 extern crate symbolic_proguard;
 extern crate symbolic_minidump;
 extern crate uuid;
-extern crate backtrace;
 
 #[macro_use] mod utils;
 


### PR DESCRIPTION
Backports some work conducted on the cabi crate: Fixes backtraces for panics and improves rendering of backtraces. In both cases, `error_chain` is used to create an error including a backtrace and stored in `LAST_ERROR`.

**Panic Backtrace**
```
Panic: panic: thread 'unnamed' panicked with 'this should panic' at /Users/jauer/Coding/symbolic/common/src/byteview.rs:68

stacktrace:
       0x10799eff9 std::panicking::try::do_call::hce186e5269aa29d7 (.llvm.F576D645)
       0x1079b7cc0 symbolic::utils::landingpad::h9e547e03fcd0c5e5
       0x1079a9e54 symbolic_symcache_from_path
    0x7fff5088cf63 ffi_call_unix64
    0x7fff5088d77b ffi_call
                   [205 python frames omitted]
```

**Error Backtrace**
```
Io: No such file or directory (os error 2)

stacktrace:
       0x101a66a55 symbolic_common::byteview::ByteView::from_path::h86257803c7e93187
       0x101a5613c std::panicking::try::do_call::hce186e5269aa29d7 (.llvm.F576D645)
       0x101a71880 symbolic::utils::landingpad::h9e547e03fcd0c5e5
       0x101a60f04 symbolic_symcache_from_path
    0x7fff5088cf63 ffi_call_unix64
    0x7fff5088d77b ffi_call
                   [202 python frames omitted]
```

**Explanation**

In the old implementation, the panic hook in`set_panic_hook` computed a backtrace and stored it in `LAST_BACKTRACE`. Then, `landingpad` created `ErrorKind::Panic` and passed it to `notify_err`. However, errors from `error_chain` always contain backtraces, so the previously computed backtrace in `LAST_BACKTRACE` was overwritten again by `err.backtrace()`.

Furthermore, the serialization in `symbolic_err_get_backtrace` always dropped `6` frames, which is too much in case of error results. A typical backtrace from error results looks like:

```
0  backtrace::backtrace::trace
1  error_chain::make_backtrace      
--------------------------------------   <  drop until here
2  [frames from symbolic]
3  std::panicking::try::do_call
4  symbolic::utils::landingpad
5  [symbolic FFI wrapper]
--------------------------------------   <  omit after this
5  [ffi call and python]
```

In contrast, backtraces from panics look like:

```
0  backtrace::backtrace::trace
1  error_chain::make_backtrace
2  symbolic::utils::set_panic_hook
3  std::panicking::rust_panic_with_hook
4  std::panicking::begin_panic
--------------------------------------   <  drop until here
5  [frames from symbolic]
6  std::panicking::try::do_call
7  symbolic::utils::landingpad
8  [symbolic FFI wrapper]
--------------------------------------   <  omit after this
9  [ffi call and python]
```