### PR TITLE
ref: Fix and streamline object identifiers

### DIFF
--- a/debuginfo/src/breakpad.rs
+++ b/debuginfo/src/breakpad.rs
@@ -5,89 +5,7 @@ use uuid::Uuid;
 
 use symbolic_common::{Arch, Error, ErrorKind, ObjectKind, Result};
 
-use object::{FatObject, Object};
-
-/// Unique identifier of a Breakpad code module
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
-pub struct BreakpadId {
-    uuid: Uuid,
-    age: u32,
-}
-
-impl BreakpadId {
-    /// Parses a `BreakpadId` from a 33 character `String`
-    pub fn parse(input: &str) -> Result<BreakpadId> {
-        if input.len() != 33 {
-            return Err(ErrorKind::Parse("Invalid input string length").into());
-        }
-
-        let uuid = Uuid::parse_str(&input[..32]).map_err(|_| ErrorKind::Parse("UUID parse error"))?;
-        let age = u32::from_str_radix(&input[32..], 16)?;
-        Ok(BreakpadId { uuid, age })
-    }
-
-    /// Constructs a `BreakpadId` from its `uuid`
-    pub fn from_uuid(uuid: Uuid) -> BreakpadId {
-        Self::from_parts(uuid, 0)
-    }
-
-    /// Constructs a `BreakpadId` from its `uuid` and `age` parts
-    pub fn from_parts(uuid: Uuid, age: u32) -> BreakpadId {
-        BreakpadId { uuid, age }
-    }
-
-    /// Returns the UUID part of the code module's debug_identifier
-    pub fn uuid(&self) -> Uuid {
-        self.uuid
-    }
-
-    /// Returns the age part of the code module's debug identifier
-    ///
-    /// On Windows, this is an incrementing counter to identify the build.
-    /// On all other platforms, this value will always be zero.
-    pub fn age(&self) -> u32 {
-        self.age
-    }
-}
-
-impl fmt::Display for BreakpadId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let uuid = self.uuid.simple().to_string().to_uppercase();
-        write!(f, "{}{:X}", uuid, self.age)
-    }
-}
-
-impl Into<String> for BreakpadId {
-    fn into(self) -> String {
-        self.to_string()
-    }
-}
-
-#[test]
-fn test_parse() {
-    assert_eq!(
-        BreakpadId::parse("DFB8E43AF2423D73A453AEB6A777EF75A").unwrap(),
-        BreakpadId {
-            uuid: Uuid::parse_str("DFB8E43AF2423D73A453AEB6A777EF75").unwrap(),
-            age: 10,
-        }
-    );
-}
-
-#[test]
-fn test_to_string() {
-    let id = BreakpadId {
-        uuid: Uuid::parse_str("DFB8E43AF2423D73A453AEB6A777EF75").unwrap(),
-        age: 10,
-    };
-
-    assert_eq!(id.to_string(), "DFB8E43AF2423D73A453AEB6A777EF75A");
-}
-
-#[test]
-fn test_parse_error() {
-    assert!(BreakpadId::parse("DFB8E43AF2423D73A").is_err());
-}
+use object::{FatObject, Object, ObjectId};
 
 pub enum BreakpadRecord<'input> {
     Module(BreakpadModuleRecord<'input>),
@@ -173,7 +91,7 @@ impl<'input> fmt::Debug for BreakpadPublicRecord<'input> {
 /// Provides access to information in a breakpad file
 #[derive(Debug)]
 pub(crate) struct BreakpadSym {
-    id: BreakpadId,
+    id: ObjectId,
     arch: Arch,
 }
 
@@ -205,7 +123,7 @@ impl BreakpadSym {
             None => return Err(ErrorKind::BadBreakpadSym("Missing breakpad uuid").into()),
         };
 
-        let id = match BreakpadId::parse(&uuid_hex[0..33]) {
+        let id = match ObjectId::parse(&uuid_hex[0..33]) {
             Ok(uuid) => uuid,
             Err(_) => return Err(ErrorKind::Parse("Invalid breakpad uuid").into()),
         };
@@ -216,7 +134,7 @@ impl BreakpadSym {
         })
     }
 
-    pub fn id(&self) -> BreakpadId {
+    pub fn id(&self) -> ObjectId {
         self.id
     }
 

--- a/debuginfo/src/object.rs
+++ b/debuginfo/src/object.rs
@@ -12,6 +12,60 @@ use dwarf::DwarfData;
 use elf::{get_elf_uuid, get_elf_vmaddr};
 use mach::{get_mach_uuid, get_mach_vmaddr};
 
+/// Unique identifier for `Object` files and their debug information.
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
+pub struct ObjectId {
+    uuid: Uuid,
+    age: u32,
+}
+
+impl ObjectId {
+    /// Parses a `ObjectId` from a formatted `String`.
+    ///
+    /// The string must be between 33 and 40 characters long and consist of:
+    /// 1. A 32 character uppercase hex representation of the UUID field
+    /// 2. A 1-8 character lowercase hex representation of the u32 age field
+    pub fn parse(input: &str) -> Result<ObjectId> {
+        if input.len() < 33 || input.len() > 40 {
+            return Err(ErrorKind::Parse("Invalid input string length").into());
+        }
+
+        let uuid = Uuid::parse_str(&input[..32]).map_err(|_| ErrorKind::Parse("UUID parse error"))?;
+        let age = u32::from_str_radix(&input[32..], 16)?;
+        Ok(ObjectId { uuid, age })
+    }
+
+    /// Constructs a `ObjectId` from its `uuid`.
+    pub fn from_uuid(uuid: Uuid) -> ObjectId {
+        Self::from_parts(uuid, 0)
+    }
+
+    /// Constructs a `ObjectId` from its `uuid` and `age` parts.
+    pub fn from_parts(uuid: Uuid, age: u32) -> ObjectId {
+        ObjectId { uuid, age }
+    }
+
+    /// Returns the UUID part of the code module's debug_identifier.
+    pub fn uuid(&self) -> Uuid {
+        self.uuid
+    }
+
+    /// Returns the age part of the code module's debug identifier.
+    ///
+    /// On Windows, this is an incrementing counter to identify the build.
+    /// On all other platforms, this value will always be zero.
+    pub fn age(&self) -> u32 {
+        self.age
+    }
+}
+
+impl fmt::Display for ObjectId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let uuid = self.uuid.simple().to_string().to_uppercase();
+        write!(f, "{}{:x}", uuid, self.age)
+    }
+}
+
 /// Contains type specific data of `Object`s
 pub(crate) enum ObjectTarget<'bytes> {
     Breakpad(&'bytes BreakpadSym),
@@ -285,5 +339,62 @@ impl<'bytes> FatObject<'bytes> {
     /// Returns a iterator over object variants in this fat object.
     pub fn objects(&'bytes self) -> Objects<'bytes> {
         Objects::new(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_short() {
+        assert_eq!(
+            ObjectId::parse("DFB8E43AF2423D73A453AEB6A777EF75a").unwrap(),
+            ObjectId {
+                uuid: Uuid::parse_str("DFB8E43AF2423D73A453AEB6A777EF75").unwrap(),
+                age: 10,
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_long() {
+        assert_eq!(
+            ObjectId::parse("DFB8E43AF2423D73A453AEB6A777EF75feedface").unwrap(),
+            ObjectId {
+                uuid: Uuid::parse_str("DFB8E43AF2423D73A453AEB6A777EF75").unwrap(),
+                age: 4277009102,
+            }
+        );
+    }
+
+    #[test]
+    fn test_to_string_short() {
+        let id = ObjectId {
+            uuid: Uuid::parse_str("DFB8E43AF2423D73A453AEB6A777EF75").unwrap(),
+            age: 10,
+        };
+
+        assert_eq!(id.to_string(), "DFB8E43AF2423D73A453AEB6A777EF75a");
+    }
+
+    #[test]
+    fn test_to_string_long() {
+        let id = ObjectId {
+            uuid: Uuid::parse_str("DFB8E43AF2423D73A453AEB6A777EF75").unwrap(),
+            age: 4277009102,
+        };
+
+        assert_eq!(id.to_string(), "DFB8E43AF2423D73A453AEB6A777EF75feedface");
+    }
+
+    #[test]
+    fn test_parse_error_short() {
+        assert!(ObjectId::parse("DFB8E43AF2423D73A453AEB6A777EF75").is_err());
+    }
+
+    #[test]
+    fn test_parse_error_long() {
+        assert!(ObjectId::parse("DFB8E43AF2423D73A453AEB6A777EF75feedface1").is_err())
     }
 }

--- a/minidump/Cargo.toml
+++ b/minidump/Cargo.toml
@@ -21,7 +21,6 @@ lazy_static = "1.0"
 regex = "0.2"
 symbolic-common = { version = "2.0.4", path = "../common" }
 symbolic-debuginfo = { version = "2.0.4", path = "../debuginfo" }
-uuid = { version = "0.5", features = ["use_std"] }
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }

--- a/minidump/src/lib.rs
+++ b/minidump/src/lib.rs
@@ -4,7 +4,6 @@ extern crate goblin;
 #[macro_use]
 extern crate lazy_static;
 extern crate regex;
-extern crate uuid;
 
 extern crate symbolic_common;
 extern crate symbolic_debuginfo;


### PR DESCRIPTION
This PR removes duplicate code for handling Breakpad identifiers and also allows all valid Breakpad debug identifers of up to 40 characters. Previously, only 33 characters were allowed. Last, `Display` has been update to render the `age` field in lowercase hex instead of uppercase.

The new common type is called `ObjectId`. This PR is meant as a first step to transition to the new ID system. However, since the concept has not been finalized, it cannot be used in place of UUIDs to identify `Object`s yet.

In the end, we might need to transition back to a separate `ObjectId` and `CodeModuleId`, but for now it's easier this way. In the meanwhile, the type is aliased in `symbolic_minidump`.

**Note**: This is a breaking change to the public API (`symbolic_debuginfo::BreakpadId` -> `symbolic_debuginfo::ObjectId`), but I'm not intending to major bump :)