### PR TITLE
feat(debuginfo): Use the new ObjectId for objects

### DIFF
--- a/cabi/include/symbolic.h
+++ b/cabi/include/symbolic.h
@@ -174,6 +174,14 @@ typedef struct {
 } SymbolicLookupResult;
 
 /*
+ * Unique identifier for Objects.
+ */
+typedef struct {
+  SymbolicUuid uuid;
+  uint32_t age;
+} SymbolicObjectId;
+
+/*
  * OS and CPU information
  */
 typedef struct {
@@ -392,6 +400,8 @@ SymbolicStr symbolic_object_get_arch(const SymbolicObject *so);
  * Returns the object class
  */
 SymbolicStr symbolic_object_get_debug_kind(const SymbolicObject *so);
+
+SymbolicObjectId symbolic_object_get_id(const SymbolicObject *so);
 
 /*
  * Returns the object kind

--- a/cabi/src/core.rs
+++ b/cabi/src/core.rs
@@ -72,6 +72,18 @@ pub struct SymbolicUuid {
     pub data: [u8; 16]
 }
 
+impl Default for SymbolicUuid {
+    fn default() -> SymbolicUuid {
+        Uuid::nil().into()
+    }
+}
+
+impl From<Uuid> for SymbolicUuid {
+    fn from(uuid: Uuid) -> SymbolicUuid {
+        unsafe { mem::transmute(*uuid.as_bytes()) }
+    }
+}
+
 /// Indicates the error that ocurred
 #[repr(u32)]
 pub enum SymbolicErrorCode {
@@ -230,7 +242,7 @@ pub unsafe extern "C" fn symbolic_err_get_backtrace() -> SymbolicStr {
                         }
 
                         if done {
-                            write!(&mut out, "\n{:18} [{} python frames omitted]", "", frames.len() - i);
+                            write!(&mut out, "\n{:18} [{} python frames omitted]", "", frames.len() - i).ok();
                             break;
                         }
                     }

--- a/cabi/src/debuginfo.rs
+++ b/cabi/src/debuginfo.rs
@@ -1,4 +1,3 @@
-use std::mem;
 use std::ptr;
 use std::os::raw::c_char;
 use std::ffi::CStr;
@@ -67,7 +66,7 @@ ffi_fn! {
     unsafe fn symbolic_object_get_arch(so: *const SymbolicObject)
         -> Result<SymbolicStr>
     {
-        let o = so as *mut Object<'static>;
+        let o = so as *const Object<'static>;
         Ok(SymbolicStr::new((*o).arch().name()))
     }
 }
@@ -77,8 +76,8 @@ ffi_fn! {
     unsafe fn symbolic_object_get_uuid(so: *const SymbolicObject)
         -> Result<SymbolicUuid>
     {
-        let o = so as *mut Object<'static>;
-        Ok(mem::transmute(*(*o).uuid().unwrap_or(Uuid::nil()).as_bytes()))
+        let o = so as *const Object<'static>;
+        Ok((*o).uuid().unwrap_or_default().into())
     }
 }
 
@@ -87,7 +86,7 @@ ffi_fn! {
     unsafe fn symbolic_object_get_kind(so: *const SymbolicObject)
         -> Result<SymbolicStr>
     {
-        let o = so as *mut Object<'static>;
+        let o = so as *const Object<'static>;
         Ok(SymbolicStr::new((*o).kind().name()))
     }
 }
@@ -107,7 +106,7 @@ ffi_fn! {
     unsafe fn symbolic_object_get_debug_kind(so: *const SymbolicObject)
         -> Result<SymbolicStr>
     {
-        let o = so as *mut Object<'static>;
+        let o = so as *const Object<'static>;
         Ok(if let Some(kind) = (*o).debug_kind() {
             SymbolicStr::new(kind.name())
         } else {

--- a/cabi/src/minidump.rs
+++ b/cabi/src/minidump.rs
@@ -97,11 +97,6 @@ impl Drop for SymbolicProcessState {
     }
 }
 
-/// Maps a native UUID to the FFI type
-unsafe fn map_uuid(uuid: &Uuid) -> SymbolicUuid {
-    mem::transmute(*uuid.as_bytes())
-}
-
 /// Creates a packed array of mapped FFI elements from a slice
 unsafe fn map_slice<T, S, F>(items: &[T], mut mapper: F) -> (*mut S, usize)
 where
@@ -141,7 +136,7 @@ where
 /// Maps a `CodeModule` to its FFI type
 unsafe fn map_code_module(module: &CodeModule) -> SymbolicCodeModule {
     SymbolicCodeModule {
-        uuid: map_uuid(&module.id().uuid()),
+        uuid: module.id().uuid().into(),
         addr: module.base_address(),
         size: module.size(),
         name: SymbolicStr::from_string(module.code_file()),

--- a/cabi/src/proguard.rs
+++ b/cabi/src/proguard.rs
@@ -1,4 +1,3 @@
-use std::mem;
 use std::slice;
 use std::os::raw::c_char;
 use std::ffi::CStr;
@@ -47,12 +46,12 @@ ffi_fn! {
 }
 
 ffi_fn! {
-    /// Returns the UUID 
+    /// Returns the UUID
     unsafe fn symbolic_proguardmappingview_get_uuid(spmv: *mut SymbolicProguardMappingView)
         -> Result<SymbolicUuid>
     {
         let pmv = spmv as *mut ProguardMappingView<'static>;
-        Ok(mem::transmute((*pmv).uuid()))
+        Ok((*pmv).uuid().into())
     }
 }
 

--- a/cabi/src/symcache.rs
+++ b/cabi/src/symcache.rs
@@ -3,8 +3,6 @@ use std::slice;
 use std::os::raw::c_char;
 use std::ffi::CStr;
 
-use uuid::Uuid;
-
 use symbolic_debuginfo::Object;
 use symbolic_symcache::{SymCache, InstructionInfo, SYMCACHE_LATEST_VERSION};
 use symbolic_common::{ByteView, Arch};
@@ -125,7 +123,7 @@ ffi_fn! {
     /// Returns the architecture of the symcache.
     unsafe fn symbolic_symcache_get_uuid(scache: *const SymbolicSymCache) -> Result<SymbolicUuid> {
         let cache = scache as *mut SymCache<'static>;
-        Ok(mem::transmute(*(*cache).uuid().unwrap_or(Uuid::nil()).as_bytes()))
+        Ok((*cache).uuid().unwrap_or_default().into())
     }
 }
 

--- a/debuginfo/src/breakpad.rs
+++ b/debuginfo/src/breakpad.rs
@@ -88,7 +88,7 @@ impl<'input> fmt::Debug for BreakpadPublicRecord<'input> {
     }
 }
 
-/// Provides access to information in a breakpad file
+/// Provides access to information in a breakpad file.
 #[derive(Debug)]
 pub(crate) struct BreakpadSym {
     id: ObjectId,
@@ -96,7 +96,7 @@ pub(crate) struct BreakpadSym {
 }
 
 impl BreakpadSym {
-    /// Parses a breakpad file header
+    /// Parses a breakpad file header.
     ///
     /// Example:
     /// ```
@@ -136,11 +136,6 @@ impl BreakpadSym {
 
     pub fn id(&self) -> ObjectId {
         self.id
-    }
-
-    pub fn uuid(&self) -> Uuid {
-        // TODO: To avoid collisions, this should hash the age in
-        self.id().uuid()
     }
 
     pub fn arch(&self) -> Arch {

--- a/debuginfo/src/mach.rs
+++ b/debuginfo/src/mach.rs
@@ -81,7 +81,9 @@ pub fn has_mach_section(mach: &mach::MachO, name: &str) -> bool {
 pub fn get_mach_id(macho: &mach::MachO) -> Option<ObjectId> {
     for cmd in &macho.load_commands {
         if let mach::load_command::CommandVariant::Uuid(ref uuid_cmd) = cmd.command {
-            return Uuid::from_bytes(&uuid_cmd.uuid).ok().map(ObjectId::from_uuid);
+            return Uuid::from_bytes(&uuid_cmd.uuid)
+                .ok()
+                .map(ObjectId::from_uuid);
         }
     }
 

--- a/debuginfo/src/object.rs
+++ b/debuginfo/src/object.rs
@@ -13,7 +13,7 @@ use elf::{get_elf_id, get_elf_vmaddr};
 use mach::{get_mach_id, get_mach_vmaddr};
 
 /// Unique identifier for `Object` files and their debug information.
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
+#[derive(Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
 pub struct ObjectId {
     uuid: Uuid,
     age: u32,

--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -62,6 +62,20 @@ class FatObject(RustObject):
         return rv
 
 
+class ObjectId(object):
+    """Unique identifier for Objects and their debug information."""
+
+    def __init__(self, data):
+        self.uuid = decode_uuid(data.uuid)
+        self.age = data.age
+
+    def __repr__(self):
+        return '<ObjectId %s %s>' % (
+            self.uuid,
+            self.age,
+        )
+
+
 class Object(RustObject):
     __dealloc_func__ = lib.symbolic_object_free
 
@@ -72,8 +86,13 @@ class Object(RustObject):
         return str(decode_str(self._methodcall(lib.symbolic_object_get_arch)))
 
     @property
+    def id(self):
+        """The unique ID of the object."""
+        return ObjectId(self._methodcall(lib.symbolic_object_get_id))
+
+    @property
     def uuid(self):
-        """The UUID of the object."""
+        """The UUID of the object. Use object.id() instead."""
         return decode_uuid(self._methodcall(lib.symbolic_object_get_uuid))
 
     @property


### PR DESCRIPTION
This PR adds the previously introduced `ObjectId` type (UUID + age) to `Objects` and exposes it via the C-ABI to Python.

Also performs some cleanup in the C-ABI to reduce duplicated code to convert `Uuid` into `SymbolicUuid`.

Since the ObjectId proposal still has not been finalized, the `ObjectId` type is still subject to change and will not be used for the object lookup in Sentry.