### PR TITLE
fix(debuginfo): Match Apple's hidden symbols correctly

### DIFF
--- a/debuginfo/src/symbols.rs
+++ b/debuginfo/src/symbols.rs
@@ -11,7 +11,7 @@ use symbolic_common::{ErrorKind, Name, Result};
 use object::{Object, ObjectTarget};
 
 lazy_static! {
-    static ref HIDDEN_SYMBOL_RE: Regex = Regex::new("__hidden#\\d+").unwrap();
+    static ref HIDDEN_SYMBOL_RE: Regex = Regex::new("__?hidden#\\d+_").unwrap();
 }
 
 /// A single symbol


### PR DESCRIPTION
This was definitely broken in previous releases and also in `sentry-cli` since we migrated to `symbolic`. Since our symbol iterator strips the first `"_"` in the symbol name, the regular expression never matched.

Also adding a trailing `"_"`, as hidden symbols seem to have this. @mitsuhiko can you confirm?