### PR TITLE
make setup.py work in OpenBSD

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -1,11 +1,11 @@
 import os
 import re
+import sys
 import atexit
 import shutil
 import zipfile
 import tempfile
 import subprocess
-import platform
 from setuptools import setup, find_packages
 from distutils.command.sdist import sdist
 
@@ -75,7 +75,7 @@ def build_native(spec):
     )
 
     rtld_flags = ['NOW']
-    rtld_flags.append('NODELETE') if platform.system() == 'Darwin' else None
+    rtld_flags.append('NODELETE') if sys.platform == 'darwin' else None
     spec.add_cffi_module(
         module_path='symbolic._lowlevel',
         dylib=lambda: build.find_dylib('symbolic', in_path='target/%s' % target),

--- a/py/setup.py
+++ b/py/setup.py
@@ -75,7 +75,7 @@ def build_native(spec):
     )
 
     rtld_flags = ['NOW']
-    rtld_flags.append('NODELETE') if platform.system() != 'OpenBSD' else None
+    rtld_flags.append('NODELETE') if platform.system() == 'Darwin' else None
     spec.add_cffi_module(
         module_path='symbolic._lowlevel',
         dylib=lambda: build.find_dylib('symbolic', in_path='target/%s' % target),

--- a/py/setup.py
+++ b/py/setup.py
@@ -75,7 +75,8 @@ def build_native(spec):
     )
 
     rtld_flags = ['NOW']
-    rtld_flags.append('NODELETE') if sys.platform == 'darwin' else None
+    if sys.platform == 'darwin':
+        rtld_flags.append('NODELETE')
     spec.add_cffi_module(
         module_path='symbolic._lowlevel',
         dylib=lambda: build.find_dylib('symbolic', in_path='target/%s' % target),

--- a/py/setup.py
+++ b/py/setup.py
@@ -5,6 +5,7 @@ import shutil
 import zipfile
 import tempfile
 import subprocess
+import platform
 from setuptools import setup, find_packages
 from distutils.command.sdist import sdist
 
@@ -73,11 +74,13 @@ def build_native(spec):
         path=rust_path
     )
 
+    rtld_flags = ['NOW']
+    rtld_flags.append('NODELETE') if platform.system() != 'OpenBSD' else None
     spec.add_cffi_module(
         module_path='symbolic._lowlevel',
         dylib=lambda: build.find_dylib('symbolic', in_path='target/%s' % target),
         header_filename=lambda: build.find_header('symbolic.h', in_path='include'),
-        rtld_flags=['NOW', 'NODELETE']
+        rtld_flags=rtld_flags
     )
 
 


### PR DESCRIPTION
The RTLD_NODELETE flag is not supported by the dlopen implementation on OpenBSD. Because of this, we need to exclude this flag from the installation as milksnake will throw an exception when trying to install.