### PR TITLE
feat: Implement serde traits for common types

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -22,10 +22,13 @@ goblin = { version = "0.0.14", optional = true }
 memmap = "0.6.2"
 owning_ref = "0.3.3"
 scroll = { version = "0.8.0", optional = true }
+serde = { version = "1.0.33", optional = true }
+serde_plain = { version = "0.3.0", optional = true }
 sourcemap = { version = "2.2.0", optional = true }
 
 [features]
 default = []
 with_dwarf = ["gimli"]
 with_objects = ["goblin", "scroll"]
+with_serde = ["serde", "serde_plain"]
 with_sourcemaps = ["sourcemap"]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -14,6 +14,11 @@ extern crate memmap;
 extern crate owning_ref;
 #[cfg(feature = "with_objects")]
 extern crate scroll;
+#[cfg(feature = "with_serde")]
+extern crate serde;
+#[macro_use]
+#[cfg(feature = "with_serde")]
+extern crate serde_plain;
 #[cfg(feature = "with_sourcemaps")]
 extern crate sourcemap;
 

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -319,6 +319,12 @@ impl str::FromStr for Arch {
     }
 }
 
+#[cfg(feature = "with_serde")]
+derive_deserialize_from_str!(Arch, "Arch");
+
+#[cfg(feature = "with_serde")]
+derive_serialize_from_display!(Arch);
+
 /// Supported programming languages for demangling
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone)]
 #[repr(u32)]
@@ -429,6 +435,12 @@ impl str::FromStr for Language {
     }
 }
 
+#[cfg(feature = "with_serde")]
+derive_deserialize_from_str!(Language, "Language");
+
+#[cfg(feature = "with_serde")]
+derive_serialize_from_display!(Language);
+
 /// Represents a potentially mangled symbol
 #[derive(Debug, Eq, PartialEq, Hash)]
 pub struct Name<'a> {
@@ -538,6 +550,12 @@ impl str::FromStr for ObjectKind {
         })
     }
 }
+
+#[cfg(feature = "with_serde")]
+derive_deserialize_from_str!(ObjectKind, "ObjectKind");
+
+#[cfg(feature = "with_serde")]
+derive_serialize_from_display!(ObjectKind);
 
 /// Represents the designated use of the object file and hints at its contents.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone)]
@@ -698,6 +716,12 @@ impl str::FromStr for ObjectClass {
     }
 }
 
+#[cfg(feature = "with_serde")]
+derive_deserialize_from_str!(ObjectClass, "ObjectClass");
+
+#[cfg(feature = "with_serde")]
+derive_serialize_from_display!(ObjectClass);
+
 /// Represents the kind of debug information inside an object.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone)]
 pub enum DebugKind {
@@ -738,3 +762,9 @@ impl str::FromStr for DebugKind {
         DebugKind::parse(string)
     }
 }
+
+#[cfg(feature = "with_serde")]
+derive_deserialize_from_str!(DebugKind, "DebugKind");
+
+#[cfg(feature = "with_serde")]
+derive_serialize_from_display!(DebugKind);

--- a/debuginfo/Cargo.toml
+++ b/debuginfo/Cargo.toml
@@ -18,5 +18,11 @@ as Mach-O or ELF.
 goblin = "0.0.14"
 lazy_static = "1.0.0"
 regex = "0.2.10"
+serde = { version = "1.0.33", optional = true }
+serde_plain = { version = "0.3.0", optional = true }
 symbolic-common = { path = "../common", version = "2.0.7", features = ["with_objects", "with_dwarf"] }
 uuid = "0.6.1"
+
+[features]
+default = []
+with_serde = ["serde", "serde_plain"]

--- a/debuginfo/src/id.rs
+++ b/debuginfo/src/id.rs
@@ -123,6 +123,12 @@ impl From<(Uuid, u64)> for ObjectId {
     }
 }
 
+#[cfg(feature = "with_serde")]
+derive_deserialize_from_str!(ObjectId, "ObjectId");
+
+#[cfg(feature = "with_serde")]
+derive_serialize_from_display!(ObjectId);
+
 /// Wrapper around `ObjectId` for Breakpad formatting.
 ///
 /// **Example:**

--- a/debuginfo/src/lib.rs
+++ b/debuginfo/src/lib.rs
@@ -4,6 +4,11 @@ extern crate goblin;
 #[macro_use]
 extern crate lazy_static;
 extern crate regex;
+#[cfg(feature = "with_serde")]
+extern crate serde;
+#[macro_use]
+#[cfg(feature = "with_serde")]
+extern crate serde_plain;
 extern crate symbolic_common;
 extern crate uuid;
 

--- a/minidump/Cargo.toml
+++ b/minidump/Cargo.toml
@@ -18,9 +18,15 @@ build = "build.rs"
 gimli = "0.15.0"
 lazy_static = "1.0.0"
 regex = "0.2.10"
+serde = { version = "1.0.33", optional = true }
+serde_plain = { version = "0.3.0", optional = true }
 symbolic-common = { version = "2.0.7", path = "../common" }
 symbolic-debuginfo = { version = "2.0.7", path = "../debuginfo" }
 uuid = "0.6.1"
 
 [build-dependencies]
 cc = { version = "1.0.8", features = ["parallel"] }
+
+[features]
+default = []
+with_serde = ["serde", "serde_plain"]

--- a/minidump/src/lib.rs
+++ b/minidump/src/lib.rs
@@ -3,6 +3,11 @@ extern crate gimli;
 #[macro_use]
 extern crate lazy_static;
 extern crate regex;
+#[cfg(feature = "with_serde")]
+extern crate serde;
+#[macro_use]
+#[cfg(feature = "with_serde")]
+extern crate serde_plain;
 extern crate uuid;
 
 extern crate symbolic_common;

--- a/minidump/src/processor.rs
+++ b/minidump/src/processor.rs
@@ -136,6 +136,12 @@ impl str::FromStr for CodeModuleId {
     }
 }
 
+#[cfg(feature = "with_serde")]
+derive_deserialize_from_str!(CodeModuleId, "CodeModuleId");
+
+#[cfg(feature = "with_serde")]
+derive_serialize_from_display!(CodeModuleId);
+
 /// Carries information about a code module loaded into the process during the
 /// crash. The `debug_identifier` uniquely identifies this module.
 #[repr(C)]


### PR DESCRIPTION
This primarily allows to derive `Serialize` and `Serialize` for types containing these types, as required by Sentry CLI. 