### PR TITLE
fix(py): Fix id_from_breakpad implementation

### DIFF
--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -3,7 +3,7 @@ from weakref import WeakValueDictionary
 
 from symbolic._compat import itervalues, range_type
 from symbolic._lowlevel import lib, ffi
-from symbolic.utils import RustObject, rustcall, decode_str, attached_refs
+from symbolic.utils import RustObject, rustcall, decode_str, encode_str, attached_refs
 from symbolic.common import parse_addr, arch_is_known, arch_from_macho
 from symbolic.symcache import SymCache
 from symbolic.minidump import CfiCache

--- a/py/tests/test_debug.py
+++ b/py/tests/test_debug.py
@@ -1,6 +1,15 @@
-from symbolic import arch_from_macho, arch_to_macho
+from symbolic import arch_from_macho, arch_to_macho, id_from_breakpad
 
 
 def test_macho_cpu_names():
     assert arch_from_macho(12, 9) == 'armv7'
     tup = arch_to_macho('arm64')
+
+
+def test_id_from_breakpad():
+    assert id_from_breakpad(
+        'DFB8E43AF2423D73A453AEB6A777EF750') == 'dfb8e43a-f242-3d73-a453-aeb6a777ef75'
+    assert id_from_breakpad(
+        'DFB8E43AF2423D73A453AEB6A777EF75a') == 'dfb8e43a-f242-3d73-a453-aeb6a777ef75-a'
+    assert id_from_breakpad(
+        'DFB8E43AF2423D73A453AEB6A777EF75feedface') == 'dfb8e43a-f242-3d73-a453-aeb6a777ef75-feedface'


### PR DESCRIPTION
`encode_str` wasn't imported and there were no tests.