### PR TITLE
ref(minidump): Make CodeModuleIds optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
       script: make wheel
       before_install: HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade node
       env: DEPLOY=mac-wheel
-      osx_image: xcode6.4
+      osx_image: xcode7.3
     - os: linux
       script: make wheel-manylinux IMAGE=quay.io/pypa/manylinux1_x86_64
       env: DEPLOY=linux-x86_64-wheel

--- a/cabi/src/minidump.rs
+++ b/cabi/src/minidump.rs
@@ -136,7 +136,7 @@ where
 /// Maps a `CodeModule` to its FFI type
 unsafe fn map_code_module(module: &CodeModule) -> SymbolicCodeModule {
     SymbolicCodeModule {
-        id: module.id().to_string().into(),
+        id: module.id().map(|id| id.to_string().into()).unwrap_or_default(),
         addr: module.base_address(),
         size: module.size(),
         name: SymbolicStr::from_string(module.code_file()),

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -72,7 +72,8 @@ pub enum Arch {
     Arm64V8,
     Ppc,
     Ppc64,
-    #[doc(hidden)] __Max,
+    #[doc(hidden)]
+    __Max,
 }
 
 impl Default for Arch {
@@ -338,7 +339,8 @@ pub enum Language {
     ObjCpp,
     Rust,
     Swift,
-    #[doc(hidden)] __Max,
+    #[doc(hidden)]
+    __Max,
 }
 
 impl Language {

--- a/minidump/src/processor.rs
+++ b/minidump/src/processor.rs
@@ -148,8 +148,8 @@ pub struct CodeModule(c_void);
 
 impl CodeModule {
     /// Returns the unique identifier of this `CodeModule`.
-    pub fn id(&self) -> CodeModuleId {
-        CodeModuleId::from_str(&self.debug_identifier()).unwrap()
+    pub fn id(&self) -> Option<CodeModuleId> {
+        CodeModuleId::from_str(&self.debug_identifier()).ok()
     }
 
     /// Returns the base address of this code module as it was loaded by the

--- a/minidump/tests/snapshots/process_state_linux.txt
+++ b/minidump/tests/snapshots/process_state_linux.txt
@@ -21,12 +21,14 @@ ProcessState {
                     trust: Context,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 4194304,
                             size: 106496,
                             code_file: "/work/linux/build/crash",
@@ -42,12 +44,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("451a38b5-0679-79d2-0738-22a5ceb24c4b"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("451a38b5-0679-79d2-0738-22a5ceb24c4b"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 139986944249856,
                             size: 1835008,
                             code_file: "/lib/x86_64-linux-gnu/libc-2.23.so",
@@ -63,12 +67,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("451a38b5-0679-79d2-0738-22a5ceb24c4b"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("451a38b5-0679-79d2-0738-22a5ceb24c4b"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 139986944249856,
                             size: 1835008,
                             code_file: "/lib/x86_64-linux-gnu/libc-2.23.so",
@@ -90,12 +96,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("59627b5d-2255-a375-c17b-d4c3fd05f5a6"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("59627b5d-2255-a375-c17b-d4c3fd05f5a6"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 139986956304384,
                             size: 155648,
                             code_file: "/lib/x86_64-linux-gnu/ld-2.23.so",
@@ -111,12 +119,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 4194304,
                             size: 106496,
                             code_file: "/work/linux/build/crash",
@@ -132,12 +142,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 4194304,
                             size: 106496,
                             code_file: "/work/linux/build/crash",
@@ -153,12 +165,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("451a38b5-0679-79d2-0738-22a5ceb24c4b"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("451a38b5-0679-79d2-0738-22a5ceb24c4b"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 139986944249856,
                             size: 1835008,
                             code_file: "/lib/x86_64-linux-gnu/libc-2.23.so",
@@ -174,12 +188,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 4194304,
                             size: 106496,
                             code_file: "/work/linux/build/crash",
@@ -195,12 +211,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 4194304,
                             size: 106496,
                             code_file: "/work/linux/build/crash",
@@ -216,12 +234,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 4194304,
                             size: 106496,
                             code_file: "/work/linux/build/crash",
@@ -237,12 +257,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 4194304,
                             size: 106496,
                             code_file: "/work/linux/build/crash",
@@ -258,12 +280,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 4194304,
                             size: 106496,
                             code_file: "/work/linux/build/crash",
@@ -279,12 +303,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 4194304,
                             size: 106496,
                             code_file: "/work/linux/build/crash",
@@ -306,12 +332,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 4194304,
                             size: 106496,
                             code_file: "/work/linux/build/crash",
@@ -333,12 +361,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 4194304,
                             size: 106496,
                             code_file: "/work/linux/build/crash",

--- a/minidump/tests/snapshots/process_state_macos.txt
+++ b/minidump/tests/snapshots/process_state_macos.txt
@@ -21,12 +21,14 @@ ProcessState {
                     trust: Context,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("67e9247c-814e-392b-a027-dbde6748fcbf"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("67e9247c-814e-392b-a027-dbde6748fcbf"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 4458131456,
                             size: 69632,
                             code_file: "/Users/travis/build/getsentry/breakpad-tools/macos/build/./crash",
@@ -42,12 +44,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("67e9247c-814e-392b-a027-dbde6748fcbf"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("67e9247c-814e-392b-a027-dbde6748fcbf"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 4458131456,
                             size: 69632,
                             code_file: "/Users/travis/build/getsentry/breakpad-tools/macos/build/./crash",
@@ -63,12 +67,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("9b2ac56d-107c-3541-a127-9094a751f2c9"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("9b2ac56d-107c-3541-a127-9094a751f2c9"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 140737084547072,
                             size: 24576,
                             code_file: "/usr/lib/system/libdyld.dylib",
@@ -84,12 +90,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("9b2ac56d-107c-3541-a127-9094a751f2c9"),
-                                    appendix: 0
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("9b2ac56d-107c-3541-a127-9094a751f2c9"),
+                                        appendix: 0
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 140737084547072,
                             size: 24576,
                             code_file: "/usr/lib/system/libdyld.dylib",

--- a/minidump/tests/snapshots/process_state_windows.txt
+++ b/minidump/tests/snapshots/process_state_windows.txt
@@ -21,12 +21,14 @@ ProcessState {
                     trust: Context,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("3249d99d-0c40-4931-8610-f4e4fb0b6936"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("3249d99d-0c40-4931-8610-f4e4fb0b6936"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 2752512,
                             size: 36864,
                             code_file: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe",
@@ -42,12 +44,14 @@ ProcessState {
                     trust: FP,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("3249d99d-0c40-4931-8610-f4e4fb0b6936"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("3249d99d-0c40-4931-8610-f4e4fb0b6936"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 2752512,
                             size: 36864,
                             code_file: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe",
@@ -63,12 +67,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("ae131c67-27a7-4fa1-9916-b5a4aef41190"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("ae131c67-27a7-4fa1-9916-b5a4aef41190"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 1971388416,
                             size: 790528,
                             code_file: "C:\\Windows\\System32\\rpcrt4.dll",
@@ -90,12 +96,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("aec7ef2f-df4b-4642-a471-4c3e5fe8760a"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("aec7ef2f-df4b-4642-a471-4c3e5fe8760a"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 1891041280,
                             size: 151552,
                             code_file: "C:\\Windows\\System32\\dbgcore.dll",
@@ -117,12 +125,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("ae131c67-27a7-4fa1-9916-b5a4aef41190"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("ae131c67-27a7-4fa1-9916-b5a4aef41190"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 1971388416,
                             size: 790528,
                             code_file: "C:\\Windows\\System32\\rpcrt4.dll",
@@ -138,12 +148,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("3249d99d-0c40-4931-8610-f4e4fb0b6936"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("3249d99d-0c40-4931-8610-f4e4fb0b6936"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 2752512,
                             size: 36864,
                             code_file: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe",
@@ -159,12 +171,14 @@ ProcessState {
                     trust: Scan,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("3249d99d-0c40-4931-8610-f4e4fb0b6936"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("3249d99d-0c40-4931-8610-f4e4fb0b6936"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 2752512,
                             size: 36864,
                             code_file: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe",
@@ -180,12 +194,14 @@ ProcessState {
                     trust: FP,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("d3474559-96f7-47d6-bf43-c176b2171e68"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("d3474559-96f7-47d6-bf43-c176b2171e68"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 1963261952,
                             size: 917504,
                             code_file: "C:\\Windows\\System32\\kernel32.dll",
@@ -201,12 +217,14 @@ ProcessState {
                     trust: FP,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 1997996032,
                             size: 1585152,
                             code_file: "C:\\Windows\\System32\\ntdll.dll",
@@ -222,12 +240,14 @@ ProcessState {
                     trust: FP,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 1997996032,
                             size: 1585152,
                             code_file: "C:\\Windows\\System32\\ntdll.dll",
@@ -248,12 +268,14 @@ ProcessState {
                     trust: Context,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 1997996032,
                             size: 1585152,
                             code_file: "C:\\Windows\\System32\\ntdll.dll",
@@ -269,12 +291,14 @@ ProcessState {
                     trust: FP,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("d3474559-96f7-47d6-bf43-c176b2171e68"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("d3474559-96f7-47d6-bf43-c176b2171e68"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 1963261952,
                             size: 917504,
                             code_file: "C:\\Windows\\System32\\kernel32.dll",
@@ -290,12 +314,14 @@ ProcessState {
                     trust: FP,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 1997996032,
                             size: 1585152,
                             code_file: "C:\\Windows\\System32\\ntdll.dll",
@@ -311,12 +337,14 @@ ProcessState {
                     trust: FP,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 1997996032,
                             size: 1585152,
                             code_file: "C:\\Windows\\System32\\ntdll.dll",
@@ -337,12 +365,14 @@ ProcessState {
                     trust: Context,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 1997996032,
                             size: 1585152,
                             code_file: "C:\\Windows\\System32\\ntdll.dll",
@@ -358,12 +388,14 @@ ProcessState {
                     trust: FP,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("d3474559-96f7-47d6-bf43-c176b2171e68"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("d3474559-96f7-47d6-bf43-c176b2171e68"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 1963261952,
                             size: 917504,
                             code_file: "C:\\Windows\\System32\\kernel32.dll",
@@ -379,12 +411,14 @@ ProcessState {
                     trust: FP,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 1997996032,
                             size: 1585152,
                             code_file: "C:\\Windows\\System32\\ntdll.dll",
@@ -400,12 +434,14 @@ ProcessState {
                     trust: FP,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 1997996032,
                             size: 1585152,
                             code_file: "C:\\Windows\\System32\\ntdll.dll",
@@ -426,12 +462,14 @@ ProcessState {
                     trust: Context,
                     module: Some(
                         CodeModule {
-                            id: CodeModuleId {
-                                inner: DebugId {
-                                    uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
-                                    appendix: 1
+                            id: Some(
+                                CodeModuleId {
+                                    inner: DebugId {
+                                        uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
+                                        appendix: 1
+                                    }
                                 }
-                            },
+                            ),
                             base_address: 1997996032,
                             size: 1585152,
                             code_file: "C:\\Windows\\System32\\ntdll.dll",

--- a/minidump/tests/snapshots/referenced_modules_linux.txt
+++ b/minidump/tests/snapshots/referenced_modules_linux.txt
@@ -1,11 +1,13 @@
 {
     CodeModule {
-        id: CodeModuleId {
-            inner: DebugId {
-                uuid: Uuid("451a38b5-0679-79d2-0738-22a5ceb24c4b"),
-                appendix: 0
+        id: Some(
+            CodeModuleId {
+                inner: DebugId {
+                    uuid: Uuid("451a38b5-0679-79d2-0738-22a5ceb24c4b"),
+                    appendix: 0
+                }
             }
-        },
+        ),
         base_address: 139986944249856,
         size: 1835008,
         code_file: "/lib/x86_64-linux-gnu/libc-2.23.so",
@@ -14,12 +16,14 @@
         debug_identifier: "451A38B5067979D2073822A5CEB24C4B0"
     },
     CodeModule {
-        id: CodeModuleId {
-            inner: DebugId {
-                uuid: Uuid("59627b5d-2255-a375-c17b-d4c3fd05f5a6"),
-                appendix: 0
+        id: Some(
+            CodeModuleId {
+                inner: DebugId {
+                    uuid: Uuid("59627b5d-2255-a375-c17b-d4c3fd05f5a6"),
+                    appendix: 0
+                }
             }
-        },
+        ),
         base_address: 139986956304384,
         size: 155648,
         code_file: "/lib/x86_64-linux-gnu/ld-2.23.so",
@@ -28,12 +32,14 @@
         debug_identifier: "59627B5D2255A375C17BD4C3FD05F5A60"
     },
     CodeModule {
-        id: CodeModuleId {
-            inner: DebugId {
-                uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
-                appendix: 0
+        id: Some(
+            CodeModuleId {
+                inner: DebugId {
+                    uuid: Uuid("c0bcc3f1-9827-fe65-3058-404b2831d9e6"),
+                    appendix: 0
+                }
             }
-        },
+        ),
         base_address: 4194304,
         size: 106496,
         code_file: "/work/linux/build/crash",

--- a/minidump/tests/snapshots/referenced_modules_macos.txt
+++ b/minidump/tests/snapshots/referenced_modules_macos.txt
@@ -1,11 +1,13 @@
 {
     CodeModule {
-        id: CodeModuleId {
-            inner: DebugId {
-                uuid: Uuid("67e9247c-814e-392b-a027-dbde6748fcbf"),
-                appendix: 0
+        id: Some(
+            CodeModuleId {
+                inner: DebugId {
+                    uuid: Uuid("67e9247c-814e-392b-a027-dbde6748fcbf"),
+                    appendix: 0
+                }
             }
-        },
+        ),
         base_address: 4458131456,
         size: 69632,
         code_file: "/Users/travis/build/getsentry/breakpad-tools/macos/build/./crash",
@@ -14,12 +16,14 @@
         debug_identifier: "67E9247C814E392BA027DBDE6748FCBF0"
     },
     CodeModule {
-        id: CodeModuleId {
-            inner: DebugId {
-                uuid: Uuid("9b2ac56d-107c-3541-a127-9094a751f2c9"),
-                appendix: 0
+        id: Some(
+            CodeModuleId {
+                inner: DebugId {
+                    uuid: Uuid("9b2ac56d-107c-3541-a127-9094a751f2c9"),
+                    appendix: 0
+                }
             }
-        },
+        ),
         base_address: 140737084547072,
         size: 24576,
         code_file: "/usr/lib/system/libdyld.dylib",

--- a/minidump/tests/snapshots/referenced_modules_windows.txt
+++ b/minidump/tests/snapshots/referenced_modules_windows.txt
@@ -1,11 +1,13 @@
 {
     CodeModule {
-        id: CodeModuleId {
-            inner: DebugId {
-                uuid: Uuid("3249d99d-0c40-4931-8610-f4e4fb0b6936"),
-                appendix: 1
+        id: Some(
+            CodeModuleId {
+                inner: DebugId {
+                    uuid: Uuid("3249d99d-0c40-4931-8610-f4e4fb0b6936"),
+                    appendix: 1
+                }
             }
-        },
+        ),
         base_address: 2752512,
         size: 36864,
         code_file: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe",
@@ -14,12 +16,14 @@
         debug_identifier: "3249D99D0C4049318610F4E4FB0B69361"
     },
     CodeModule {
-        id: CodeModuleId {
-            inner: DebugId {
-                uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
-                appendix: 1
+        id: Some(
+            CodeModuleId {
+                inner: DebugId {
+                    uuid: Uuid("971f98e5-ce60-41ff-b2d7-235bbeb34578"),
+                    appendix: 1
+                }
             }
-        },
+        ),
         base_address: 1997996032,
         size: 1585152,
         code_file: "C:\\Windows\\System32\\ntdll.dll",
@@ -28,12 +32,14 @@
         debug_identifier: "971F98E5CE6041FFB2D7235BBEB345781"
     },
     CodeModule {
-        id: CodeModuleId {
-            inner: DebugId {
-                uuid: Uuid("ae131c67-27a7-4fa1-9916-b5a4aef41190"),
-                appendix: 1
+        id: Some(
+            CodeModuleId {
+                inner: DebugId {
+                    uuid: Uuid("ae131c67-27a7-4fa1-9916-b5a4aef41190"),
+                    appendix: 1
+                }
             }
-        },
+        ),
         base_address: 1971388416,
         size: 790528,
         code_file: "C:\\Windows\\System32\\rpcrt4.dll",
@@ -42,12 +48,14 @@
         debug_identifier: "AE131C6727A74FA19916B5A4AEF411901"
     },
     CodeModule {
-        id: CodeModuleId {
-            inner: DebugId {
-                uuid: Uuid("aec7ef2f-df4b-4642-a471-4c3e5fe8760a"),
-                appendix: 1
+        id: Some(
+            CodeModuleId {
+                inner: DebugId {
+                    uuid: Uuid("aec7ef2f-df4b-4642-a471-4c3e5fe8760a"),
+                    appendix: 1
+                }
             }
-        },
+        ),
         base_address: 1891041280,
         size: 151552,
         code_file: "C:\\Windows\\System32\\dbgcore.dll",
@@ -56,12 +64,14 @@
         debug_identifier: "AEC7EF2FDF4B4642A4714C3E5FE8760A1"
     },
     CodeModule {
-        id: CodeModuleId {
-            inner: DebugId {
-                uuid: Uuid("d3474559-96f7-47d6-bf43-c176b2171e68"),
-                appendix: 1
+        id: Some(
+            CodeModuleId {
+                inner: DebugId {
+                    uuid: Uuid("d3474559-96f7-47d6-bf43-c176b2171e68"),
+                    appendix: 1
+                }
             }
-        },
+        ),
         base_address: 1963261952,
         size: 917504,
         code_file: "C:\\Windows\\System32\\kernel32.dll",

--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -121,7 +121,8 @@ class ObjectRef(object):
         # not a real address but why handle it differently
         self.size = parse_addr(data['image_size'])
         self.vmaddr = data.get('image_vmaddr')
-        self.id = normalize_debug_id(data.get('id') or data.get('uuid') or '')
+        self.id = normalize_debug_id(
+            data.get('id') or data.get('uuid') or None)
         if data.get('arch') is not None and arch_is_known(data['arch']):
             self.arch = data['arch']
         elif data.get('cpu_type') is not None \
@@ -182,6 +183,9 @@ class ObjectLookup(object):
 
 def id_from_breakpad(breakpad_id):
     """Converts a Breakpad CodeModuleId to DebugId"""
+    if breakpad_id is None:
+        return None
+
     s = encode_str(breakpad_id)
     id = rustcall(lib.symbolic_id_from_breakpad, s)
     return decode_str(id)
@@ -189,6 +193,9 @@ def id_from_breakpad(breakpad_id):
 
 def normalize_debug_id(debug_id):
     """Normalizes a debug identifier to default representation"""
+    if debug_id is None:
+        return None
+
     s = encode_str(debug_id)
     id = rustcall(lib.symbolic_normalize_debug_id, s)
     return decode_str(id)

--- a/py/symbolic/minidump.py
+++ b/py/symbolic/minidump.py
@@ -39,7 +39,7 @@ class CodeModule(RustObject):
     @property
     def id(self):
         """ID of the loaded module containing the instruction"""
-        return decode_str(self._objptr.id)
+        return decode_str(self._objptr.id) or None
 
     @property
     def addr(self):

--- a/py/tests/test_debug.py
+++ b/py/tests/test_debug.py
@@ -1,4 +1,4 @@
-from symbolic import arch_from_macho, arch_to_macho, id_from_breakpad
+from symbolic import arch_from_macho, arch_to_macho, id_from_breakpad, normalize_debug_id
 
 
 def test_macho_cpu_names():
@@ -13,3 +13,18 @@ def test_id_from_breakpad():
         'DFB8E43AF2423D73A453AEB6A777EF75a') == 'dfb8e43a-f242-3d73-a453-aeb6a777ef75-a'
     assert id_from_breakpad(
         'DFB8E43AF2423D73A453AEB6A777EF75feedface') == 'dfb8e43a-f242-3d73-a453-aeb6a777ef75-feedface'
+    assert id_from_breakpad(None) == None
+
+
+def test_normalize_debug_id():
+    assert normalize_debug_id(
+        'dfb8e43a-f242-3d73-a453-aeb6a777ef75') == 'dfb8e43a-f242-3d73-a453-aeb6a777ef75'
+    assert normalize_debug_id(
+        'dfb8e43a-f242-3d73-a453-aeb6a777ef75-a') == 'dfb8e43a-f242-3d73-a453-aeb6a777ef75-a'
+    assert normalize_debug_id(
+        'dfb8e43af2423d73a453aeb6a777ef75-a') == 'dfb8e43a-f242-3d73-a453-aeb6a777ef75-a'
+    assert normalize_debug_id(
+        'DFB8E43AF2423D73A453AEB6A777EF750') == 'dfb8e43a-f242-3d73-a453-aeb6a777ef75'
+    assert normalize_debug_id(
+        'DFB8E43AF2423D73A453AEB6A777EF75a') == 'dfb8e43a-f242-3d73-a453-aeb6a777ef75-a'
+    assert normalize_debug_id(None) == None

--- a/symcache/src/types.rs
+++ b/symcache/src/types.rs
@@ -121,7 +121,8 @@ pub enum DataSource {
     Dwarf,
     SymbolTable,
     BreakpadSym,
-    #[doc(hidden)] __Max,
+    #[doc(hidden)]
+    __Max,
 }
 
 impl DataSource {


### PR DESCRIPTION
Breakpad can return `""` as `debug_identifier` in certain instances. We make the `id()` return value optional to prevent a `panic`:

```rust
pub fn id(&self) -> Option<CodeModuleId> {
    CodeModuleId::from_str(&self.debug_identifier()).ok()
}
```

Python returns `None` in this case. Minor fixes in sentry needed to support this. 

Fixes [SENTRY-5P5](https://sentry.io/sentry/sentry/issues/429475080)