### PR TITLE
feat: Create features for every top-level crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 [workspace]
 
 [features]
-default = []
+default = ["debuginfo"]
 debuginfo = ["symbolic-debuginfo"]
 demangle = ["symbolic-demangle"]
 minidump = ["debuginfo", "symbolic-minidump"]
@@ -52,8 +52,8 @@ walkdir = "2.1.4"
 
 [[example]]
 name = "minidump_stackwalk"
-required-features = ["debuginfo", "minidump", "symcache"]
+required-features = ["minidump", "symcache"]
 
 [[example]]
 name = "symcache_debug"
-required-features = ["debuginfo", "symcache"]
+required-features = ["symcache"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,25 +24,36 @@ exclude = [
 
 [features]
 default = []
-with_dwarf = ["symbolic-common/with_dwarf"]
-with_objects = ["symbolic-common/with_objects"]
+debuginfo = ["symbolic-debuginfo"]
+demangle = ["symbolic-demangle"]
+minidump = ["debuginfo", "symbolic-minidump"]
+proguard = ["symbolic-proguard"]
+sourcemap = ["symbolic-sourcemap"]
+symcache = ["debuginfo", "demangle", "symbolic-symcache"]
 with_serde = [
     "symbolic-common/with_serde",
     "symbolic-debuginfo/with_serde",
     "symbolic-minidump/with_serde"
 ]
-with_sourcemaps = ["symbolic-common/with_sourcemaps"]
 
 [dependencies]
 symbolic-common = { version = "4.0.0", path = "common" }
-symbolic-demangle = { version = "4.0.0", path = "demangle" }
-symbolic-minidump = { version = "4.0.0", path = "minidump" }
-symbolic-proguard = { version = "4.0.0", path = "proguard" }
-symbolic-sourcemap = { version = "4.0.0", path = "sourcemap" }
-symbolic-symcache = { version = "4.0.0", path = "symcache" }
-symbolic-debuginfo = { version = "4.0.0", path = "debuginfo" }
+symbolic-debuginfo = { version = "4.0.0", path = "debuginfo", optional = true }
+symbolic-demangle = { version = "4.0.0", path = "demangle", optional = true }
+symbolic-minidump = { version = "4.0.0", path = "minidump", optional = true }
+symbolic-proguard = { version = "4.0.0", path = "proguard", optional = true }
+symbolic-sourcemap = { version = "4.0.0", path = "sourcemap", optional = true }
+symbolic-symcache = { version = "4.0.0", path = "symcache", optional = true }
 
 [dev-dependencies]
 clap = "2.31.2"
 failure = "0.1.1"
 walkdir = "2.1.4"
+
+[[example]]
+name = "minidump_stackwalk"
+required-features = ["debuginfo", "minidump", "symcache"]
+
+[[example]]
+name = "symcache_debug"
+required-features = ["debuginfo", "symcache"]

--- a/cabi/Cargo.toml
+++ b/cabi/Cargo.toml
@@ -28,4 +28,4 @@ lto = true
 uuid = "0.6.3"
 failure = "0.1.1"
 failure_derive = "0.1.1"
-symbolic = { version = "4.0.0", path = "..", features = ["with_dwarf", "with_objects", "with_sourcemaps"] }
+symbolic = { version = "4.0.0", path = "..", features = ["debuginfo", "demangle", "minidump", "proguard", "sourcemap", "symcache"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,22 +7,34 @@
 #[doc(hidden)]
 pub extern crate symbolic_common;
 #[doc(hidden)]
+#[cfg(feature = "debuginfo")]
 pub extern crate symbolic_debuginfo;
 #[doc(hidden)]
+#[cfg(feature = "demangle")]
 pub extern crate symbolic_demangle;
 #[doc(hidden)]
+#[cfg(feature = "minidump")]
 pub extern crate symbolic_minidump;
 #[doc(hidden)]
+#[cfg(feature = "proguard")]
 pub extern crate symbolic_proguard;
 #[doc(hidden)]
+#[cfg(feature = "sourcemap")]
 pub extern crate symbolic_sourcemap;
 #[doc(hidden)]
+#[cfg(feature = "symcache")]
 pub extern crate symbolic_symcache;
 
-pub use symbolic_proguard as proguard;
-pub use symbolic_sourcemap as sourcemap;
-pub use symbolic_demangle as demangle;
-pub use symbolic_minidump as minidump;
-pub use symbolic_symcache as symcache;
-pub use symbolic_debuginfo as debuginfo;
 pub use symbolic_common as common;
+#[cfg(feature = "debuginfo")]
+pub use symbolic_debuginfo as debuginfo;
+#[cfg(feature = "demangle")]
+pub use symbolic_demangle as demangle;
+#[cfg(feature = "minidump")]
+pub use symbolic_minidump as minidump;
+#[cfg(feature = "proguard")]
+pub use symbolic_proguard as proguard;
+#[cfg(feature = "sourcemap")]
+pub use symbolic_sourcemap as sourcemap;
+#[cfg(feature = "symcache")]
+pub use symbolic_symcache as symcache;


### PR DESCRIPTION
Introduces features for every top-level crate. Since `common` is always needed, there is no feature for that. In additon, each feature might have dependencies on other features:

- `debuginfo`: none
- `demangle`: none
- `minidump`: `debuginfo`
- `proguard`: none
- `sourcemap`: none
- `symcache`: `debuginfo`, `demangle`
- `with_serde`: activates inside `common`, `debuginfo` and `minidump`