### PR TITLE
feat(minidump): Expose all loaded modules to python

### DIFF
--- a/cabi/src/minidump.rs
+++ b/cabi/src/minidump.rs
@@ -221,8 +221,7 @@ unsafe fn map_system_info(info: &SystemInfo) -> SymbolicSystemInfo {
 unsafe fn map_process_state(state: &ProcessState) -> SymbolicProcessState {
     let arch = state.system_info().cpu_arch();
     let (threads, thread_count) = map_slice(state.threads(), |s| map_call_stack(s, arch));
-    let (modules, module_count) =
-        map_iter(state.referenced_modules().iter(), |m| map_code_module(m));
+    let (modules, module_count) = map_iter(state.modules().iter(), |m| map_code_module(m));
 
     SymbolicProcessState {
         requesting_thread: state.requesting_thread(),

--- a/minidump/cpp/data_structures.cpp
+++ b/minidump/cpp/data_structures.cpp
@@ -34,6 +34,27 @@ call_stack_t *const *process_state_threads(process_state_t *state,
     return reinterpret_cast<call_stack_t *const *>(threads->data());
 }
 
+const code_module_t **process_state_modules(process_state_t *state,
+                                            size_t *size_out) {
+    if (state == nullptr) {
+        return nullptr;
+    }
+
+    auto *modules = process_state_t::cast(state)->modules();
+    unsigned int size = modules->module_count();
+
+    const code_module_t **buffer = new const code_module_t *[size];
+    for (unsigned int i = 0; i < size; i++) {
+        buffer[i] = code_module_t::cast(modules->GetModuleAtIndex(i));
+    }
+
+    if (size_out != nullptr) {
+        *size_out = size;
+    }
+
+    return buffer;
+}
+
 int32_t process_state_requesting_thread(const process_state_t *state) {
     if (state == nullptr) {
         return -1;
@@ -515,4 +536,10 @@ char *code_module_debug_identifier(const code_module_t *module) {
     }
 
     return string_from(code_module_t::cast(module)->debug_identifier());
+}
+
+void code_modules_delete(code_module_t **modules) {
+    if (modules != nullptr) {
+        delete modules;
+    }
 }

--- a/minidump/cpp/data_structures.cpp
+++ b/minidump/cpp/data_structures.cpp
@@ -494,7 +494,7 @@ regval_t *stack_frame_registers(const stack_frame_t *frame,
 
 void regval_delete(regval_t *regval) {
     if (regval != nullptr) {
-        delete regval;
+        delete[] regval;
     }
 }
 
@@ -540,6 +540,6 @@ char *code_module_debug_identifier(const code_module_t *module) {
 
 void code_modules_delete(code_module_t **modules) {
     if (modules != nullptr) {
-        delete modules;
+        delete[] modules;
     }
 }

--- a/minidump/cpp/data_structures.h
+++ b/minidump/cpp/data_structures.h
@@ -50,6 +50,11 @@ void process_state_delete(process_state_t *state);
 call_stack_t *const *process_state_threads(process_state_t *state,
                                            size_t *size_out);
 
+/// Returns an owned pointer to a list of loaded code modules in the minidump.
+/// The number of modules is returned in the size_out parameter.
+const code_module_t **process_state_modules(process_state_t *state,
+                                            size_t *size_out);
+
 /// The index of the thread that requested a dump be written in the
 /// threads vector.  If a dump was produced as a result of a crash, this
 /// will point to the thread that crashed.  If the dump was produced as
@@ -226,6 +231,9 @@ char *code_module_debug_file(const code_module_t *module);
 ///
 /// The return value is an owning pointer. Release memory with string_delete.
 char *code_module_debug_identifier(const code_module_t *module);
+
+/// Releases memory of a code modules list. Assumes ownership of the pointer.
+void code_modules_delete(code_module_t **modules);
 
 #ifdef __cplusplus
 }

--- a/minidump/tests/snapshots/process_state_linux.txt
+++ b/minidump/tests/snapshots/process_state_linux.txt
@@ -380,5 +380,135 @@ ProcessState {
                 }
             ]
         }
+    ],
+    modules: [
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "c0bcc3f1-9827-fe65-3058-404b2831d9e6",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 4194304,
+            size: 106496,
+            code_file: "/work/linux/build/crash",
+            code_identifier: "f1c3bcc0279865fe3058404b2831d9e64135386c",
+            debug_file: "/work/linux/build/crash",
+            debug_identifier: "C0BCC3F19827FE653058404B2831D9E60"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "e45db8df-af2d-09fd-640c-8fe377d572de",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 139986941067264,
+            size: 1081344,
+            code_file: "/lib/x86_64-linux-gnu/libm-2.23.so",
+            code_identifier: "dfb85de42daffd09640c8fe377d572de3e168920",
+            debug_file: "/lib/x86_64-linux-gnu/libm-2.23.so",
+            debug_identifier: "E45DB8DFAF2D09FD640C8FE377D572DE0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "451a38b5-0679-79d2-0738-22a5ceb24c4b",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 139986944249856,
+            size: 1835008,
+            code_file: "/lib/x86_64-linux-gnu/libc-2.23.so",
+            code_identifier: "b5381a457906d279073822a5ceb24c4bfef94ddb",
+            debug_file: "/lib/x86_64-linux-gnu/libc-2.23.so",
+            debug_identifier: "451A38B5067979D2073822A5CEB24C4B0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "e20a2268-5dc6-c165-b6aa-a12fa6765a6e",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 139986948222976,
+            size: 90112,
+            code_file: "/lib/x86_64-linux-gnu/libgcc_s.so.1",
+            code_identifier: "68220ae2c65d65c1b6aaa12fa6765a6ec2f5f434",
+            debug_file: "/lib/x86_64-linux-gnu/libgcc_s.so.1",
+            debug_identifier: "E20A22685DC6C165B6AAA12FA6765A6E0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "81c893cb-9b92-3c52-01ac-ef171b52d526",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 139986950410240,
+            size: 1515520,
+            code_file: "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21",
+            code_identifier: "cb93c881929b523c01acef171b52d5261f026029",
+            debug_file: "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21",
+            debug_identifier: "81C893CB9B923C5201ACEF171B52D5260"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "23e017ce-2254-fc65-11d9-bc8f534bb4f0",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 139986954088448,
+            size: 98304,
+            code_file: "/lib/x86_64-linux-gnu/libpthread-2.23.so",
+            code_identifier: "ce17e023542265fc11d9bc8f534bb4f070493d30",
+            debug_file: "/lib/x86_64-linux-gnu/libpthread-2.23.so",
+            debug_identifier: "23E017CE2254FC6511D9BC8F534BB4F00"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "59627b5d-2255-a375-c17b-d4c3fd05f5a6",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 139986956304384,
+            size: 155648,
+            code_file: "/lib/x86_64-linux-gnu/ld-2.23.so",
+            code_identifier: "5d7b6259552275a3c17bd4c3fd05f5a6bf40caa5",
+            debug_file: "/lib/x86_64-linux-gnu/ld-2.23.so",
+            debug_identifier: "59627B5D2255A375C17BD4C3FD05F5A60"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "75185f6c-04b9-b48f-b8df-d832e74ad31a",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140734719004672,
+            size: 8192,
+            code_file: "linux-gate.so",
+            code_identifier: "6c5f1875b9048fb4b8dfd832e74ad31a9aafb38f",
+            debug_file: "linux-gate.so",
+            debug_identifier: "75185F6C04B9B48FB8DFD832E74AD31A0"
+        }
     ]
 }

--- a/minidump/tests/snapshots/process_state_macos.txt
+++ b/minidump/tests/snapshots/process_state_macos.txt
@@ -109,5 +109,695 @@ ProcessState {
                 }
             ]
         }
+    ],
+    modules: [
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "67e9247c-814e-392b-a027-dbde6748fcbf",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 4458131456,
+            size: 69632,
+            code_file: "/Users/travis/build/getsentry/breakpad-tools/macos/build/./crash",
+            code_identifier: "id",
+            debug_file: "crash",
+            debug_identifier: "67E9247C814E392BA027DBDE6748FCBF0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "36385a3a-60d3-32db-bf55-c6d8931a7aa6",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140736719339520,
+            size: 4800512,
+            code_file: "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation",
+            code_identifier: "id",
+            debug_file: "CoreFoundation",
+            debug_identifier: "36385A3A60D332DBBF55C6D8931A7AA60"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "84a04d24-0e60-3810-a8c0-90a65e2df61a",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737059020800,
+            size: 8192,
+            code_file: "/usr/lib/libDiagnosticMessagesClient.dylib",
+            code_identifier: "id",
+            debug_file: "libDiagnosticMessagesClient.dylib",
+            debug_identifier: "84A04D240E603810A8C090A65E2DF61A0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "f18ac1e7-c6f1-34b1-8069-be571b3231d4",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737061376000,
+            size: 8192,
+            code_file: "/usr/lib/libSystem.B.dylib",
+            code_identifier: "id",
+            debug_file: "libSystem.B.dylib",
+            debug_identifier: "F18AC1E7C6F134B18069BE571B3231D40"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "0b43bb5d-e6eb-3464-8de9-b41ac8ed9d1c",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737063157760,
+            size: 356352,
+            code_file: "/usr/lib/libc++.1.dylib",
+            code_identifier: "id",
+            debug_file: "libc++.1.dylib",
+            debug_identifier: "0B43BB5DE6EB34648DE9B41AC8ED9D1C0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "bc271ad3-831b-362a-9da7-e8c51f285fe4",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737063514112,
+            size: 172032,
+            code_file: "/usr/lib/libc++abi.dylib",
+            code_identifier: "id",
+            debug_file: "libc++abi.dylib",
+            debug_identifier: "BC271AD3831B362A9DA7E8C51F285FE40"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "ccd2ed24-3071-383b-925d-8d763bb12a6f",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737069191168,
+            size: 2252800,
+            code_file: "/usr/lib/libicucore.A.dylib",
+            code_identifier: "id",
+            debug_file: "libicucore.A.dylib",
+            debug_identifier: "CCD2ED243071383B925D8D763BB12A6F0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "4df3c25c-52c2-3f01-a3ef-0d9d53a73c1c",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737075171328,
+            size: 4022272,
+            code_file: "/usr/lib/libobjc.A.dylib",
+            code_identifier: "id",
+            debug_file: "libobjc.A.dylib",
+            debug_identifier: "4DF3C25C52C23F01A3EF0D9D53A73C1C0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "46e3ffa2-4328-327a-8d34-a03e20bffb8e",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737083535360,
+            size: 73728,
+            code_file: "/usr/lib/libz.1.dylib",
+            code_identifier: "id",
+            debug_file: "libz.1.dylib",
+            debug_identifier: "46E3FFA24328327A8D34A03E20BFFB8E0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "093a4dab-8385-3d47-a350-e20cb7ccf7bf",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737083666432,
+            size: 20480,
+            code_file: "/usr/lib/system/libcache.dylib",
+            code_identifier: "id",
+            debug_file: "libcache.dylib",
+            debug_identifier: "093A4DAB83853D47A350E20CB7CCF7BF0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "8a64d1b0-c70e-385c-92f0-e669079fda90",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737083686912,
+            size: 45056,
+            code_file: "/usr/lib/system/libcommonCrypto.dylib",
+            code_identifier: "id",
+            debug_file: "libcommonCrypto.dylib",
+            debug_identifier: "8A64D1B0C70E385C92F0E669079FDA900"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "55d47421-772a-32ab-b529-1a46c2f43b4d",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737083731968,
+            size: 32768,
+            code_file: "/usr/lib/system/libcompiler_rt.dylib",
+            code_identifier: "id",
+            debug_file: "libcompiler_rt.dylib",
+            debug_identifier: "55D47421772A32ABB5291A46C2F43B4D0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "819bea3c-df11-3e3d-a1a1-5a51c5bf1961",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737083764736,
+            size: 36864,
+            code_file: "/usr/lib/system/libcopyfile.dylib",
+            code_identifier: "id",
+            debug_file: "libcopyfile.dylib",
+            debug_identifier: "819BEA3CDF113E3DA1A15A51C5BF19610"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "65d7165e-2e71-335d-a2d6-33f78e2df0c1",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737083801600,
+            size: 540672,
+            code_file: "/usr/lib/system/libcorecrypto.dylib",
+            code_identifier: "id",
+            debug_file: "libcorecrypto.dylib",
+            debug_identifier: "65D7165E2E71335DA2D633F78E2DF0C10"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "6582bad6-ed27-3b30-b620-90b1c5a4ae3c",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737084342272,
+            size: 204800,
+            code_file: "/usr/lib/system/libdispatch.dylib",
+            code_identifier: "id",
+            debug_file: "libdispatch.dylib",
+            debug_identifier: "6582BAD6ED273B30B62090B1C5A4AE3C0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "9b2ac56d-107c-3541-a127-9094a751f2c9",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737084547072,
+            size: 24576,
+            code_file: "/usr/lib/system/libdyld.dylib",
+            code_identifier: "id",
+            debug_file: "libdyld.dylib",
+            debug_identifier: "9B2AC56D107C3541A1279094A751F2C90"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "7aa011a9-dc21-3488-bf73-3b5b14d1fdd6",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737084571648,
+            size: 4096,
+            code_file: "/usr/lib/system/libkeymgr.dylib",
+            code_identifier: "id",
+            debug_file: "libkeymgr.dylib",
+            debug_identifier: "7AA011A9DC213488BF733B5B14D1FDD60"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "b856abd2-896e-3de0-b2c8-146a6af8e2a7",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737084628992,
+            size: 4096,
+            code_file: "/usr/lib/system/liblaunch.dylib",
+            code_identifier: "id",
+            debug_file: "liblaunch.dylib",
+            debug_identifier: "B856ABD2896E3DE0B2C8146A6AF8E2A70"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "17d5d855-f6c3-3b04-b680-e9bf02ef8aed",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737084633088,
+            size: 24576,
+            code_file: "/usr/lib/system/libmacho.dylib",
+            code_identifier: "id",
+            debug_file: "libmacho.dylib",
+            debug_identifier: "17D5D855F6C33B04B680E9BF02EF8AED0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "12448cc2-378e-35f3-be33-9dc395a5b970",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737084657664,
+            size: 12288,
+            code_file: "/usr/lib/system/libquarantine.dylib",
+            code_identifier: "id",
+            debug_file: "libquarantine.dylib",
+            debug_identifier: "12448CC2378E35F3BE339DC395A5B9700"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "38d4cb9c-10cd-30d3-8b7b-a515ec75fe85",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737084669952,
+            size: 8192,
+            code_file: "/usr/lib/system/libremovefile.dylib",
+            code_identifier: "id",
+            debug_file: "libremovefile.dylib",
+            debug_identifier: "38D4CB9C10CD30D38B7BA515EC75FE850"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "096e4228-3b7c-30a6-8b13-ec909a64499a",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737084678144,
+            size: 102400,
+            code_file: "/usr/lib/system/libsystem_asl.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_asl.dylib",
+            debug_identifier: "096E42283B7C30A68B13EC909A64499A0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "10dc5404-73ab-35b3-a277-a8afecb476eb",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737084780544,
+            size: 4096,
+            code_file: "/usr/lib/system/libsystem_blocks.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_blocks.dylib",
+            debug_identifier: "10DC540473AB35B3A277A8AFECB476EB0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "e5ae5244-7d0c-36ac-8bb6-c7ae7ea52a4b",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737084784640,
+            size: 581632,
+            code_file: "/usr/lib/system/libsystem_c.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_c.dylib",
+            debug_identifier: "E5AE52447D0C36AC8BB6C7AE7EA52A4B0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "becc01a2-ca8d-31e6-bcdf-d452965fa976",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737085366272,
+            size: 16384,
+            code_file: "/usr/lib/system/libsystem_configuration.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_configuration.dylib",
+            debug_identifier: "BECC01A2CA8D31E6BCDFD452965FA9760"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "7d26de79-b424-3450-85e1-f7fab32714ab",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737085382656,
+            size: 16384,
+            code_file: "/usr/lib/system/libsystem_coreservices.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_coreservices.dylib",
+            debug_identifier: "7D26DE79B424345085E1F7FAB32714AB0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "ec6fcf07-dcfb-3a03-9cc9-6dd3709974c6",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737085399040,
+            size: 102400,
+            code_file: "/usr/lib/system/libsystem_coretls.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_coretls.dylib",
+            debug_identifier: "EC6FCF07DCFB3A039CC96DD3709974C60"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "cc960215-0b1b-3822-a13a-3dde96fa796f",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737085501440,
+            size: 28672,
+            code_file: "/usr/lib/system/libsystem_dnssd.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_dnssd.dylib",
+            debug_identifier: "CC9602150B1B3822A13A3DDE96FA796F0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "611db84c-bf70-3f92-8702-b9f28a900920",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737085530112,
+            size: 172032,
+            code_file: "/usr/lib/system/libsystem_info.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_info.dylib",
+            debug_identifier: "611DB84CBF703F928702B9F28A9009200"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "34b1f16c-bc9c-3c5f-9045-0cae91cb5914",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737085702144,
+            size: 143360,
+            code_file: "/usr/lib/system/libsystem_kernel.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_kernel.dylib",
+            debug_identifier: "34B1F16CBC9C3C5F90450CAE91CB59140"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "86d499b5-bbdc-3d3b-8a4e-97ae8e6672a4",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737085845504,
+            size: 294912,
+            code_file: "/usr/lib/system/libsystem_m.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_m.dylib",
+            debug_identifier: "86D499B5BBDC3D3B8A4E97AE8E6672A40"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "a3d15f17-99a6-3367-8c7e-4280e8619c95",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737086140416,
+            size: 126976,
+            code_file: "/usr/lib/system/libsystem_malloc.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_malloc.dylib",
+            debug_identifier: "A3D15F1799A633678C7E4280E8619C950"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "369d0221-56ca-3c3e-9ede-94b41cae77b7",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737086267392,
+            size: 368640,
+            code_file: "/usr/lib/system/libsystem_network.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_network.dylib",
+            debug_identifier: "369D022156CA3C3E9EDE94B41CAE77B70"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "b021f2b3-8a75-3633-abb0-fc012b8e9b0c",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737086636032,
+            size: 40960,
+            code_file: "/usr/lib/system/libsystem_networkextension.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_networkextension.dylib",
+            debug_identifier: "B021F2B38A753633ABB0FC012B8E9B0C0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "b8160190-a069-3b3a-bdf6-2aa408221fae",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737086676992,
+            size: 40960,
+            code_file: "/usr/lib/system/libsystem_notify.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_notify.dylib",
+            debug_identifier: "B8160190A0693B3ABDF62AA408221FAE0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "897462fd-b318-321b-a554-e61982630f7e",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737086717952,
+            size: 36864,
+            code_file: "/usr/lib/system/libsystem_platform.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_platform.dylib",
+            debug_identifier: "897462FDB318321BA554E61982630F7E0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "b8fb5e20-3295-39e2-b5eb-b464d1d4b104",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737086754816,
+            size: 45056,
+            code_file: "/usr/lib/system/libsystem_pthread.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_pthread.dylib",
+            debug_identifier: "B8FB5E20329539E2B5EBB464D1D4B1040"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "4b92ec49-acd0-36ae-b07a-a2b8152eaf9d",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737086799872,
+            size: 16384,
+            code_file: "/usr/lib/system/libsystem_sandbox.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_sandbox.dylib",
+            debug_identifier: "4B92EC49ACD036AEB07AA2B8152EAF9D0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "f78b847b-3565-3e4b-98a6-f7ad40392e2d",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737086816256,
+            size: 8192,
+            code_file: "/usr/lib/system/libsystem_secinit.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_secinit.dylib",
+            debug_identifier: "F78B847B35653E4B98A6F7AD40392E2D0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "3390e07c-c1ce-348f-adbd-2c5440b45eaa",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737086824448,
+            size: 32768,
+            code_file: "/usr/lib/system/libsystem_symptoms.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_symptoms.dylib",
+            debug_identifier: "3390E07CC1CE348FADBD2C5440B45EAA0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "ac63a7fe-50d9-3a30-96e6-f6b7ff16e465",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737086857216,
+            size: 81920,
+            code_file: "/usr/lib/system/libsystem_trace.dylib",
+            code_identifier: "id",
+            debug_file: "libsystem_trace.dylib",
+            debug_identifier: "AC63A7FE50D93A3096E6F6B7FF16E4650"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "3d50d8a8-c460-334d-a519-2da841102c6b",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737086939136,
+            size: 24576,
+            code_file: "/usr/lib/system/libunwind.dylib",
+            code_identifier: "id",
+            debug_file: "libunwind.dylib",
+            debug_identifier: "3D50D8A8C460334DA5192DA841102C6B0"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "bf896df0-d8e9-31a8-a4b3-01120bfeee52",
+                        appendix: 0
+                    }
+                }
+            ),
+            base_address: 140737086963712,
+            size: 172032,
+            code_file: "/usr/lib/system/libxpc.dylib",
+            code_identifier: "id",
+            debug_file: "libxpc.dylib",
+            debug_identifier: "BF896DF0D8E931A8A4B301120BFEEE520"
+        }
     ]
 }

--- a/minidump/tests/snapshots/process_state_windows.txt
+++ b/minidump/tests/snapshots/process_state_windows.txt
@@ -481,5 +481,279 @@ ProcessState {
                 }
             ]
         }
+    ],
+    modules: [
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "3249d99d-0c40-4931-8610-f4e4fb0b6936",
+                        appendix: 1
+                    }
+                }
+            ),
+            base_address: 2752512,
+            size: 36864,
+            code_file: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.exe",
+            code_identifier: "5AB380779000",
+            debug_file: "C:\\projects\\breakpad-tools\\windows\\Release\\crash.pdb",
+            debug_identifier: "3249D99D0C4049318610F4E4FB0B69361"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "9c2a902b-6fdf-40ad-8308-588a41d572a0",
+                        appendix: 1
+                    }
+                }
+            ),
+            base_address: 1887764480,
+            size: 1331200,
+            code_file: "C:\\Windows\\System32\\dbghelp.dll",
+            code_identifier: "57898E12145000",
+            debug_file: "dbghelp.pdb",
+            debug_identifier: "9C2A902B6FDF40AD8308588A41D572A01"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "bf5257f7-8c26-43dd-9bb7-901625e1136a",
+                        appendix: 1
+                    }
+                }
+            ),
+            base_address: 1889140736,
+            size: 442368,
+            code_file: "C:\\Windows\\System32\\msvcp140.dll",
+            code_identifier: "589ABC846c000",
+            debug_file: "msvcp140.i386.pdb",
+            debug_identifier: "BF5257F78C2643DD9BB7901625E1136A1"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "8daf7773-372f-460a-af38-944e193f7e33",
+                        appendix: 1
+                    }
+                }
+            ),
+            base_address: 1889599488,
+            size: 598016,
+            code_file: "C:\\Windows\\System32\\apphelp.dll",
+            code_identifier: "57898EEB92000",
+            debug_file: "apphelp.pdb",
+            debug_identifier: "8DAF7773372F460AAF38944E193F7E331"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "aec7ef2f-df4b-4642-a471-4c3e5fe8760a",
+                        appendix: 1
+                    }
+                }
+            ),
+            base_address: 1891041280,
+            size: 151552,
+            code_file: "C:\\Windows\\System32\\dbgcore.dll",
+            code_identifier: "57898DAB25000",
+            debug_file: "dbgcore.pdb",
+            debug_identifier: "AEC7EF2FDF4B4642A4714C3E5FE8760A1"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "0ed80a50-ecda-472b-86a4-eb6c833f8e1b",
+                        appendix: 1
+                    }
+                }
+            ),
+            base_address: 1892024320,
+            size: 81920,
+            code_file: "C:\\Windows\\System32\\VCRUNTIME140.dll",
+            code_identifier: "589ABC7714000",
+            debug_file: "vcruntime140.i386.pdb",
+            debug_identifier: "0ED80A50ECDA472B86A4EB6C833F8E1B1"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "147c51fb-7ca1-408f-85b5-285f2ad6f9c5",
+                        appendix: 1
+                    }
+                }
+            ),
+            base_address: 1941569536,
+            size: 40960,
+            code_file: "C:\\Windows\\System32\\CRYPTBASE.dll",
+            code_identifier: "57899141a000",
+            debug_file: "cryptbase.pdb",
+            debug_identifier: "147C51FB7CA1408F85B5285F2AD6F9C51"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "51e432b1-0450-4b19-8ed1-6d4335f9f543",
+                        appendix: 1
+                    }
+                }
+            ),
+            base_address: 1941635072,
+            size: 126976,
+            code_file: "C:\\Windows\\System32\\sspicli.dll",
+            code_identifier: "59BF30E31f000",
+            debug_file: "wsspicli.pdb",
+            debug_identifier: "51E432B104504B198ED16D4335F9F5431"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "0c799483-b549-417d-8433-4331852031fe",
+                        appendix: 1
+                    }
+                }
+            ),
+            base_address: 1942421504,
+            size: 487424,
+            code_file: "C:\\Windows\\System32\\advapi32.dll",
+            code_identifier: "5A49BB7677000",
+            debug_file: "advapi32.pdb",
+            debug_identifier: "0C799483B549417D84334331852031FE1"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "6f6409b3-d520-43c7-9b2f-62e00bfe761c",
+                        appendix: 1
+                    }
+                }
+            ),
+            base_address: 1942945792,
+            size: 778240,
+            code_file: "C:\\Windows\\System32\\msvcrt.dll",
+            code_identifier: "57899155be000",
+            debug_file: "msvcrt.pdb",
+            debug_identifier: "6F6409B3D52043C79B2F62E00BFE761C1"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "6f6a05dd-0a80-478b-a419-9b88703bf75b",
+                        appendix: 1
+                    }
+                }
+            ),
+            base_address: 1950679040,
+            size: 266240,
+            code_file: "C:\\Windows\\System32\\sechost.dll",
+            code_identifier: "598942C741000",
+            debug_file: "sechost.pdb",
+            debug_identifier: "6F6A05DD0A80478BA4199B88703BF75B1"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "d3474559-96f7-47d6-bf43-c176b2171e68",
+                        appendix: 1
+                    }
+                }
+            ),
+            base_address: 1963261952,
+            size: 917504,
+            code_file: "C:\\Windows\\System32\\kernel32.dll",
+            code_identifier: "590285E9e0000",
+            debug_file: "wkernel32.pdb",
+            debug_identifier: "D347455996F747D6BF43C176B2171E681"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "287b19c3-9209-4a2b-bb8f-bcc37f411b11",
+                        appendix: 1
+                    }
+                }
+            ),
+            base_address: 1964179456,
+            size: 368640,
+            code_file: "C:\\Windows\\System32\\bcryptPrimitives.dll",
+            code_identifier: "59B0DF8F5a000",
+            debug_file: "bcryptprimitives.pdb",
+            debug_identifier: "287B19C392094A2BBB8FBCC37F411B111"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "ae131c67-27a7-4fa1-9916-b5a4aef41190",
+                        appendix: 1
+                    }
+                }
+            ),
+            base_address: 1971388416,
+            size: 790528,
+            code_file: "C:\\Windows\\System32\\rpcrt4.dll",
+            code_identifier: "5A49BB75c1000",
+            debug_file: "wrpcrt4.pdb",
+            debug_identifier: "AE131C6727A74FA19916B5A4AEF411901"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "6bedcbce-0a3a-40e9-8040-81c2c8c6cc2f",
+                        appendix: 1
+                    }
+                }
+            ),
+            base_address: 1972305920,
+            size: 917504,
+            code_file: "C:\\Windows\\System32\\ucrtbase.dll",
+            code_identifier: "59BF2B5Ae0000",
+            debug_file: "ucrtbase.pdb",
+            debug_identifier: "6BEDCBCE0A3A40E9804081C2C8C6CC2F1"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "8462294a-c645-402d-ac82-a4e95f61ddf9",
+                        appendix: 1
+                    }
+                }
+            ),
+            base_address: 1994063872,
+            size: 1708032,
+            code_file: "C:\\Windows\\System32\\KERNELBASE.dll",
+            code_identifier: "59BF2BCF1a1000",
+            debug_file: "wkernelbase.pdb",
+            debug_identifier: "8462294AC645402DAC82A4E95F61DDF91"
+        },
+        CodeModule {
+            id: Some(
+                CodeModuleId {
+                    inner: DebugId {
+                        uuid: "971f98e5-ce60-41ff-b2d7-235bbeb34578",
+                        appendix: 1
+                    }
+                }
+            ),
+            base_address: 1997996032,
+            size: 1585152,
+            code_file: "C:\\Windows\\System32\\ntdll.dll",
+            code_identifier: "59B0D8F3183000",
+            debug_file: "wntdll.pdb",
+            debug_identifier: "971F98E5CE6041FFB2D7235BBEB345781"
+        }
     ]
 }


### PR DESCRIPTION
This PR exposes all loaded code modules in python's `ProcessState.modules` function as opposed to only referenced ones. This will allow us to do proper CFI walking in Sentry.