### PR TITLE
fix(cabi): Map errors correctly after failure upgrade

### DIFF
--- a/cabi/src/core.rs
+++ b/cabi/src/core.rs
@@ -169,7 +169,7 @@ pub enum SymbolicErrorCode {
 impl SymbolicErrorCode {
     /// This maps all errors that can possibly happen.
     pub fn from_error(error: &Error) -> SymbolicErrorCode {
-        for cause in error.iter_causes() {
+        for cause in error.iter_chain() {
             if let Some(_) = cause.downcast_ref::<Panic>() {
                 return SymbolicErrorCode::Panic;
             }
@@ -328,7 +328,7 @@ pub unsafe extern "C" fn symbolic_err_get_last_message() -> SymbolicStr {
     LAST_ERROR.with(|e| {
         if let Some(ref err) = *e.borrow() {
             let mut msg = err.to_string();
-            for cause in err.iter_causes().skip(1) {
+            for cause in err.iter_causes() {
                 write!(&mut msg, "\n  caused by: {}", cause).ok();
             }
             SymbolicStr::from_string(msg)

--- a/examples/object_debug.rs
+++ b/examples/object_debug.rs
@@ -13,7 +13,7 @@ use symbolic::debuginfo::FatObject;
 fn print_error(error: Error) {
     println!("Error: {}", error);
 
-    for cause in error.iter_causes().skip(1) {
+    for cause in error.iter_causes() {
         println!("   caused by {}", cause);
     }
 }


### PR DESCRIPTION
This bug was introduced after upgrading to a recent `failure` version (see https://github.com/rust-lang-nursery/failure/pull/252)