### PR TITLE
feat: Add MSVC demangling support

### DIFF
--- a/cabi/Cargo.lock
+++ b/cabi/Cargo.lock
@@ -153,7 +153,7 @@ name = "failure_derive"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -327,6 +327,14 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "msvc-demangler"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,7 +437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -456,7 +464,7 @@ name = "quote"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -562,7 +570,7 @@ name = "scroll_derive"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -702,6 +710,7 @@ version = "5.3.0"
 dependencies = [
  "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpp_demangle 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "msvc-demangler 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "symbolic-common 5.3.0",
 ]
@@ -774,7 +783,7 @@ name = "syn"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -784,7 +793,7 @@ name = "syn"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -802,7 +811,7 @@ name = "synstructure"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -955,6 +964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memmap 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "46f3c7359028b31999287dae4e5047ddfe90a23b7dca2282ce759b491080c99b"
 "checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
+"checksum msvc-demangler 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7ba0f00b401e37f2ded22c395bfac67f65a8bbe3779759dbc6b2913967f4164"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db"
 "checksum num-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3eceac7784c5dc97c2d6edf30259b4e153e6e2b42b3c85e9a6e9f45d06caef6e"
@@ -968,7 +978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-"checksum proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)" = "ffe022fb8c8bd254524b0b3305906c1921fa37a84a644e29079a9e62200c3901"
+"checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
 "checksum proguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4429ecff47016f5d2810877d2ba727aa94e7e422c7b5367da752a46f464979a1"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"

--- a/demangle/Cargo.toml
+++ b/demangle/Cargo.toml
@@ -16,6 +16,7 @@ build = "build.rs"
 
 [dependencies]
 cpp_demangle = "0.2.12"
+msvc-demangler = "0.6.0"
 rustc-demangle = "0.1.9"
 symbolic-common = { version = "5.3.0", path = "../common" }
 

--- a/demangle/tests/cpp.rs
+++ b/demangle/tests/cpp.rs
@@ -1,6 +1,6 @@
 //! C++ Itanium Demangling Tests
 //! We use cpp_demangle under the hood which runs the libiberty test suite
-//! Still, we run some tests here -- also to prepare for MSVC.
+//! Still, we run some basic regression tests here to detect demangling differences.
 
 extern crate symbolic_common;
 extern crate symbolic_demangle;

--- a/demangle/tests/msvc.rs
+++ b/demangle/tests/msvc.rs
@@ -1,0 +1,55 @@
+//! MSVC C++ Demangling Tests
+//! We use msvc_demangler under the hood which runs its own test suite.
+//! Tests here make it easier to detect regressions.
+
+extern crate symbolic_common;
+extern crate symbolic_demangle;
+mod utils;
+
+use symbolic_common::types::Language;
+use utils::assert_demangle;
+
+// These symbols were extracted from electron.exe.pdb
+// https://github.com/electron/electron/releases/download/v2.0.11/electron-v2.0.11-win32-x64-pdb.zip
+
+// NOTE: msvc_demangler cannot demangle without qualifiers and argument lists yet.
+
+#[test]
+fn test_operator_delete() {
+    assert_demangle(
+        Language::Cpp,
+        "??3@YAXPEAX@Z",
+        Some("void __cdecl operator delete(void*)"),
+        Some("void __cdecl operator delete(void*)"),
+    );
+}
+
+#[test]
+fn test_method() {
+    assert_demangle(
+        Language::Cpp,
+        "?LoadV8Snapshot@V8Initializer@gin@@SAXXZ",
+        Some("public: static void __cdecl gin::V8Initializer::LoadV8Snapshot(void)"),
+        Some("public: static void __cdecl gin::V8Initializer::LoadV8Snapshot(void)"),
+    );
+}
+
+#[test]
+fn test_operator() {
+    assert_demangle(
+        Language::Cpp,
+        "??9@YA_NAEBVGURL@@0@Z",
+        Some("bool __cdecl operator!=(class GURL const&,class GURL const&)"),
+        Some("bool __cdecl operator!=(class GURL const&,class GURL const&)"),
+    );
+}
+
+#[test]
+fn test_anonymous_namespace() {
+    assert_demangle(
+        Language::Cpp,
+        "??_GAtomSandboxedRenderFrameObserver@?A0x77c58568@atom@@UEAAPEAXI@Z",
+        Some("public: virtual void* __cdecl atom::`anonymous namespace`::AtomSandboxedRenderFrameObserver::`scalar deleting destructor'(unsigned int)"),
+        Some("public: virtual void* __cdecl atom::`anonymous namespace`::AtomSandboxedRenderFrameObserver::`scalar deleting destructor'(unsigned int)"),
+    );
+}


### PR DESCRIPTION
Adds support for demangling MSVC symbols. This will be needed to support PDBs.

Ref #72 