### PR TITLE
fix(debuginfo): Skip empty MachO sections

### DIFF
--- a/debuginfo/src/elf.rs
+++ b/debuginfo/src/elf.rs
@@ -32,6 +32,14 @@ pub fn find_elf_section<'elf, 'data>(
             }
 
             let offset = header.sh_offset as usize;
+            if offset == 0 {
+                // We're defensive here. On darwin, dsymutil leaves phantom section headers while
+                // stripping their data from the file by setting their offset to 0. We know that no
+                // section can start at an absolute file offset of zero, so we can safely skip them
+                // in case similar things happen on linux.
+                return None;
+            }
+
             let size = header.sh_size as usize;
             return Some(ElfSection {
                 header,


### PR DESCRIPTION
MacOS dsyms contain phantom sections with an `offset` of `0`. These sections do not actually exist in the file, which is why we need to skip them. Previously we assumed they are valid and read bad data. 