### PR TITLE
feat(debuginfo): Extract object features and expose them to python

### DIFF
--- a/cabi/include/symbolic.h
+++ b/cabi/include/symbolic.h
@@ -181,6 +181,14 @@ typedef struct {
 } SymbolicLookupResult;
 
 /*
+ * A list of object features.
+ */
+typedef struct {
+  SymbolicStr *data;
+  uintptr_t len;
+} SymbolicObjectFeatures;
+
+/*
  * OS and CPU information in a minidump.
  */
 typedef struct {
@@ -416,6 +424,8 @@ void symbolic_lookup_result_free(SymbolicLookupResult *slr);
  */
 SymbolicStr symbolic_normalize_debug_id(const SymbolicStr *sid);
 
+void symbolic_object_features_free(SymbolicObjectFeatures *f);
+
 /*
  * Frees an object returned from a fat object.
  */
@@ -430,6 +440,8 @@ SymbolicStr symbolic_object_get_arch(const SymbolicObject *so);
  * Returns the kind of debug data contained in this object file, if any (e.g. DWARF).
  */
 SymbolicStr symbolic_object_get_debug_kind(const SymbolicObject *so);
+
+SymbolicObjectFeatures symbolic_object_get_features(const SymbolicObject *so);
 
 /*
  * Returns the debug identifier of the object.

--- a/debuginfo/Cargo.toml
+++ b/debuginfo/Cargo.toml
@@ -25,6 +25,9 @@ uuid = "0.7.1"
 failure = "0.1.2"
 failure_derive = "0.1.2"
 
+[dev-dependencies]
+symbolic-testutils = { version = "5.3.0", path = "../testutils" }
+
 [features]
 default = []
 with_serde = ["serde", "serde_plain"]

--- a/debuginfo/src/features.rs
+++ b/debuginfo/src/features.rs
@@ -1,0 +1,104 @@
+use std::collections::BTreeSet;
+use std::fmt;
+
+use dwarf::{DwarfData, DwarfSection};
+use object::{Object, ObjectTarget};
+
+fn has_dwarf_unwind_info(object: &Object) -> bool {
+    object.get_dwarf_section(DwarfSection::EhFrame).is_some()
+        || object.get_dwarf_section(DwarfSection::DebugFrame).is_some()
+}
+
+fn has_breakpad_record(object: &Object, record: &[u8]) -> bool {
+    for line in object.as_bytes().split(|b| *b == b'\n') {
+        if line.starts_with(record) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn has_breakpad_debug_info(object: &Object) -> bool {
+    has_breakpad_record(object, b"FUNC")
+}
+
+fn has_breakpad_unwind_info(object: &Object) -> bool {
+    has_breakpad_record(object, b"STACK")
+}
+
+/// A debug feature of an `Object` file.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum ObjectFeature {
+    /// This object contains debug information. It can be used to symbolicate crashes.
+    DebugInfo,
+
+    /// This object contains unwind information. It can be used to improve stack walking on stack
+    /// memory.
+    UnwindInfo,
+}
+
+impl fmt::Display for ObjectFeature {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ObjectFeature::DebugInfo => write!(f, "debug"),
+            ObjectFeature::UnwindInfo => write!(f, "unwind"),
+        }
+    }
+}
+
+/// Inspects features of `Object` files.
+pub trait DebugFeatures {
+    /// Checks whether this object file contains processable debug information.
+    fn has_debug_info(&self) -> bool;
+
+    /// Checks whether this object contains processable unwind information (CFI).
+    fn has_unwind_info(&self) -> bool;
+
+    /// Checks whether this object has a given feature.
+    fn has_feature(&self, tag: ObjectFeature) -> bool;
+
+    /// Returns all features of this object.
+    fn features(&self) -> BTreeSet<ObjectFeature>;
+}
+
+impl<'a> DebugFeatures for Object<'a> {
+    fn has_debug_info(&self) -> bool {
+        match self.target {
+            ObjectTarget::Elf(..) => self.has_dwarf_data(),
+            ObjectTarget::MachOSingle(..) => self.has_dwarf_data(),
+            ObjectTarget::MachOFat(..) => self.has_dwarf_data(),
+            ObjectTarget::Breakpad(..) => has_breakpad_debug_info(self),
+        }
+    }
+
+    fn has_unwind_info(&self) -> bool {
+        match self.target {
+            ObjectTarget::Elf(..) => has_dwarf_unwind_info(self),
+            ObjectTarget::MachOSingle(..) => has_dwarf_unwind_info(self),
+            ObjectTarget::MachOFat(..) => has_dwarf_unwind_info(self),
+            ObjectTarget::Breakpad(..) => has_breakpad_unwind_info(self),
+        }
+    }
+
+    fn has_feature(&self, tag: ObjectFeature) -> bool {
+        match tag {
+            ObjectFeature::DebugInfo => self.has_debug_info(),
+            ObjectFeature::UnwindInfo => self.has_unwind_info(),
+        }
+    }
+
+    fn features(&self) -> BTreeSet<ObjectFeature> {
+        let mut features = BTreeSet::new();
+
+        if self.has_feature(ObjectFeature::DebugInfo) {
+            features.insert(ObjectFeature::DebugInfo);
+        }
+
+        if self.has_feature(ObjectFeature::UnwindInfo) {
+            features.insert(ObjectFeature::UnwindInfo);
+        }
+
+        features
+    }
+}

--- a/debuginfo/src/lib.rs
+++ b/debuginfo/src/lib.rs
@@ -15,12 +15,14 @@ extern crate uuid;
 mod breakpad;
 mod dwarf;
 mod elf;
+mod features;
 mod mach;
 mod object;
 mod symbols;
 
 pub use breakpad::*;
 pub use dwarf::*;
+pub use features::*;
 pub use object::*;
 #[deprecated]
 pub use symbolic_common::types::{BreakpadFormat, DebugId, ParseDebugIdError};

--- a/debuginfo/src/symbols.rs
+++ b/debuginfo/src/symbols.rs
@@ -252,6 +252,9 @@ impl<'data> Symbols<'data> {
 
 /// Gives access to the symbol table of an `Object` file.
 pub trait SymbolTable {
+    /// Checks whether this object contains DWARF infos.
+    fn has_symbols(&self) -> bool;
+
     /// Returns the symbols of this `Object`.
     ///
     /// If the symbol table has been stripped from the object, `None` is returned. In case a symbol
@@ -261,6 +264,16 @@ pub trait SymbolTable {
 }
 
 impl<'data> SymbolTable for Object<'data> {
+    fn has_symbols(&self) -> bool {
+        match self.target {
+            ObjectTarget::MachOSingle(macho) => macho.symbols.is_some(),
+            ObjectTarget::MachOFat(_, ref macho) => macho.symbols.is_some(),
+            // We don't support symbols for these yet
+            ObjectTarget::Elf(..) => false,
+            ObjectTarget::Breakpad(..) => false,
+        }
+    }
+
     fn symbols(&self) -> Result<Option<Symbols>, ObjectError> {
         match self.target {
             ObjectTarget::MachOSingle(macho) => Symbols::from_macho(macho),

--- a/debuginfo/tests/test_features.rs
+++ b/debuginfo/tests/test_features.rs
@@ -33,7 +33,10 @@ fn test_features_elf_dbg() {
 
     assert_eq!(
         object.features(),
-        [ObjectFeature::DebugInfo].iter().cloned().collect()
+        [ObjectFeature::SymbolTable, ObjectFeature::DebugInfo]
+            .iter()
+            .cloned()
+            .collect()
     );
 }
 
@@ -48,7 +51,10 @@ fn test_features_mach_bin() {
 
     assert_eq!(
         object.features(),
-        [ObjectFeature::UnwindInfo].iter().cloned().collect()
+        [ObjectFeature::SymbolTable, ObjectFeature::UnwindInfo]
+            .iter()
+            .cloned()
+            .collect()
     );
 }
 

--- a/debuginfo/tests/test_features.rs
+++ b/debuginfo/tests/test_features.rs
@@ -33,10 +33,7 @@ fn test_features_elf_dbg() {
 
     assert_eq!(
         object.features(),
-        [ObjectFeature::SymbolTable, ObjectFeature::DebugInfo]
-            .iter()
-            .cloned()
-            .collect()
+        [ObjectFeature::DebugInfo].iter().cloned().collect()
     );
 }
 
@@ -71,7 +68,10 @@ fn test_features_mach_dbg() {
 
     assert_eq!(
         object.features(),
-        [ObjectFeature::DebugInfo].iter().cloned().collect()
+        [ObjectFeature::SymbolTable, ObjectFeature::DebugInfo]
+            .iter()
+            .cloned()
+            .collect()
     );
 }
 

--- a/debuginfo/tests/test_features.rs
+++ b/debuginfo/tests/test_features.rs
@@ -1,0 +1,88 @@
+extern crate symbolic_common;
+extern crate symbolic_debuginfo;
+extern crate symbolic_testutils;
+
+use symbolic_common::byteview::ByteView;
+use symbolic_debuginfo::{DebugFeatures, FatObject, ObjectFeature};
+use symbolic_testutils::fixture_path;
+
+#[test]
+fn test_features_elf_bin() {
+    let buffer = ByteView::from_path(fixture_path("linux/crash")).expect("Could not open file");
+    let fat = FatObject::parse(buffer).expect("Could not create an object");
+    let object = fat
+        .get_object(0)
+        .expect("Could not get the first object")
+        .expect("Missing object");
+
+    assert_eq!(
+        object.features(),
+        [ObjectFeature::UnwindInfo].iter().cloned().collect()
+    );
+}
+
+#[test]
+fn test_features_elf_dbg() {
+    let buffer =
+        ByteView::from_path(fixture_path("linux/crash.debug")).expect("Could not open file");
+    let fat = FatObject::parse(buffer).expect("Could not create an object");
+    let object = fat
+        .get_object(0)
+        .expect("Could not get the first object")
+        .expect("Missing object");
+
+    assert_eq!(
+        object.features(),
+        [ObjectFeature::DebugInfo].iter().cloned().collect()
+    );
+}
+
+#[test]
+fn test_features_mach_bin() {
+    let buffer = ByteView::from_path(fixture_path("macos/crash")).expect("Could not open file");
+    let fat = FatObject::parse(buffer).expect("Could not create an object");
+    let object = fat
+        .get_object(0)
+        .expect("Could not get the first object")
+        .expect("Missing object");
+
+    assert_eq!(
+        object.features(),
+        [ObjectFeature::UnwindInfo].iter().cloned().collect()
+    );
+}
+
+#[test]
+fn test_features_mach_dbg() {
+    let buffer = ByteView::from_path(fixture_path(
+        "macos/crash.dSYM/Contents/Resources/DWARF/crash",
+    )).expect("Could not open file");
+    let fat = FatObject::parse(buffer).expect("Could not create an object");
+    let object = fat
+        .get_object(0)
+        .expect("Could not get the first object")
+        .expect("Missing object");
+
+    assert_eq!(
+        object.features(),
+        [ObjectFeature::DebugInfo].iter().cloned().collect()
+    );
+}
+
+#[test]
+fn test_features_breakpad() {
+    let buffer = ByteView::from_path(fixture_path("macos/crash.sym")).expect("Could not open file");
+    let fat = FatObject::parse(buffer).expect("Could not create an object");
+    let object = fat
+        .get_object(0)
+        .expect("Could not get the first object")
+        .expect("Missing object");
+
+    assert_eq!(
+        object.features(),
+        [ObjectFeature::DebugInfo, ObjectFeature::UnwindInfo]
+            .iter()
+            .cloned()
+            .collect()
+    );
+}

--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -99,10 +99,8 @@ class Object(RustObject):
     @property
     def features(self):
         """The list of features offered by this debug file."""
-        features = set()
         struct = self._methodcall(lib.symbolic_object_get_features)
-        for i in range(0, struct.len):
-            features.add(decode_str(struct.data[i]))
+        features = set(decode_str(struct.data[i]) for i in range(0, struct.len))
         rustcall(lib.symbolic_object_features_free, ffi.addressof(struct))
         return frozenset(features)
 

--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -96,6 +96,16 @@ class Object(RustObject):
         """The kind of debug information in this object."""
         return str(decode_str(self._methodcall(lib.symbolic_object_get_debug_kind)))
 
+    @property
+    def features(self):
+        """The list of features offered by this debug file."""
+        features = set()
+        struct = self._methodcall(lib.symbolic_object_get_features)
+        for i in range(0, struct.len):
+            features.add(decode_str(struct.data[i]))
+        rustcall(lib.symbolic_object_features_free, ffi.addressof(struct))
+        return frozenset(features)
+
     def make_symcache(self):
         """Creates a symcache from the object."""
         return SymCache._from_objptr(self._methodcall(

--- a/py/tests/test_debug.py
+++ b/py/tests/test_debug.py
@@ -14,6 +14,13 @@ def test_object_features_mac(res_path):
     assert obj.features == set(['symtab', 'debug'])
 
 
+def test_object_features_linux(res_path):
+    binary_path = os.path.join(res_path, 'minidump', 'crash_linux')
+    fat = FatObject.from_path(binary_path)
+    obj = fat.get_object(arch="x86_64")
+    assert obj.features == set(['debug', 'unwind'])
+
+
 def test_id_from_breakpad():
     assert id_from_breakpad(
         'DFB8E43AF2423D73A453AEB6A777EF750') == 'dfb8e43a-f242-3d73-a453-aeb6a777ef75'

--- a/py/tests/test_debug.py
+++ b/py/tests/test_debug.py
@@ -6,12 +6,12 @@ def test_object_features_mac(res_path):
     binary_path = os.path.join(res_path, 'minidump', 'crash_macos')
     fat = FatObject.from_path(binary_path)
     obj = fat.get_object(arch="x86_64")
-    assert obj.features == set(['unwind'])
+    assert obj.features == set(['symtab', 'unwind'])
 
     binary_path = os.path.join(res_path, 'minidump', 'crash_macos.dSYM', 'Contents', 'Resources', 'DWARF', 'crash_macos')
     fat = FatObject.from_path(binary_path)
     obj = fat.get_object(arch="x86_64")
-    assert obj.features == set(['debug'])
+    assert obj.features == set(['symtab', 'debug'])
 
 
 def test_id_from_breakpad():

--- a/py/tests/test_debug.py
+++ b/py/tests/test_debug.py
@@ -1,4 +1,17 @@
-from symbolic import arch_from_macho, id_from_breakpad, normalize_debug_id
+import os
+from symbolic import FatObject, arch_from_macho, id_from_breakpad, normalize_debug_id
+
+
+def test_object_features_mac(res_path):
+    binary_path = os.path.join(res_path, 'minidump', 'crash_macos')
+    fat = FatObject.from_path(binary_path)
+    obj = fat.get_object(arch="x86_64")
+    assert obj.features == set(['unwind'])
+
+    binary_path = os.path.join(res_path, 'minidump', 'crash_macos.dSYM', 'Contents', 'Resources', 'DWARF', 'crash_macos')
+    fat = FatObject.from_path(binary_path)
+    obj = fat.get_object(arch="x86_64")
+    assert obj.features == set(['debug'])
 
 
 def test_id_from_breakpad():


### PR DESCRIPTION
This PR adds a function `Object::features()` that returns the different pieces of information contained in an object file, such as unwind info and debug info. Features are an abstract concept that can be used to determine whether an object file is suitable input to certain operations, such as symbolication or stack walking.

The list of features is kept to a minimum for now, but can be extended with more entries later depending on relevant use cases.

Based on https://github.com/getsentry/symbolic/pull/90