### PR TITLE
feat: Add an explicit type for CFI caches

### DIFF
--- a/cabi/include/symbolic.h
+++ b/cabi/include/symbolic.h
@@ -30,6 +30,7 @@ enum SymbolicErrorCode {
   SYMBOLIC_ERROR_CODE_CFI_ERROR_BAD_DEBUG_INFO = 3003,
   SYMBOLIC_ERROR_CODE_CFI_ERROR_UNSUPPORTED_ARCH = 3004,
   SYMBOLIC_ERROR_CODE_CFI_ERROR_WRITE_ERROR = 3005,
+  SYMBOLIC_ERROR_CODE_CFI_ERROR_BAD_FILE_MAGIC = 3006,
   SYMBOLIC_ERROR_CODE_PROCESS_MINIDUMP_ERROR_MINIDUMP_NOT_FOUND = 4001,
   SYMBOLIC_ERROR_CODE_PROCESS_MINIDUMP_ERROR_NO_MINIDUMP_HEADER = 4002,
   SYMBOLIC_ERROR_CODE_PROCESS_MINIDUMP_ERROR_NO_THREAD_LIST = 4003,
@@ -66,6 +67,11 @@ enum SymbolicFrameTrust {
   SYMBOLIC_FRAME_TRUST_CONTEXT,
 };
 typedef uint32_t SymbolicFrameTrust;
+
+/*
+ * Represents a symbolic CFI cache.
+ */
+typedef struct SymbolicCfiCache SymbolicCfiCache;
 
 /*
  * A potential multi arch object.
@@ -125,11 +131,6 @@ typedef struct {
   uint32_t cputype;
   uint32_t cpusubtype;
 } SymbolicMachoArch;
-
-typedef struct {
-  uint8_t *bytes;
-  uintptr_t len;
-} SymbolicCfiCache;
 
 /*
  * Represents an instruction info.
@@ -313,12 +314,34 @@ SymbolicStr symbolic_arch_to_breakpad(const SymbolicStr *arch);
 void symbolic_cfi_cache_free(SymbolicCfiCache *scache);
 
 /*
- * Extracts call frame information (CFI) from an Object in ASCII format.
- *
- * To use this, create a `SymbolicFrameInfoMap` and pass it CFI for referenced modules during
- * minidump processing to receive improved stack traces.
+ * Extracts call frame information (CFI) from an Object.
  */
 SymbolicCfiCache *symbolic_cfi_cache_from_object(const SymbolicObject *sobj);
+
+/*
+ * Loads a CFI cache from the given path.
+ */
+SymbolicCfiCache *symbolic_cfi_cache_from_path(const char *path);
+
+/*
+ * Returns a pointer to the raw buffer of the CFI cache.
+ */
+const uint8_t *symbolic_cfi_cache_get_bytes(const SymbolicCfiCache *scache);
+
+/*
+ * Returns the size of the raw buffer of the CFI cache.
+ */
+uintptr_t symbolic_cfi_cache_get_size(const SymbolicCfiCache *scache);
+
+/*
+ * Returns the file format version of the CFI cache.
+ */
+uint32_t symbolic_cfi_cache_get_version(const SymbolicCfiCache *scache);
+
+/*
+ * Returns the latest CFI cache version.
+ */
+uint32_t symbolic_cfi_cache_latest_version(void);
 
 /*
  * Demangles a given identifier.
@@ -388,7 +411,7 @@ SymbolicFatObject *symbolic_fatobject_open(const char *path);
 uint64_t symbolic_find_best_instruction(const SymbolicInstructionInfo *ii);
 
 /*
- * Adds CFI for a code module specified by the `sid` argument.
+ * Adds the CfiCache for a module specified by the `sid` argument.
  */
 void symbolic_frame_info_map_add(const SymbolicFrameInfoMap *smap,
                                  const SymbolicStr *sid,
@@ -670,7 +693,7 @@ bool symbolic_symcache_has_file_info(const SymbolicSymCache *scache);
 bool symbolic_symcache_has_line_info(const SymbolicSymCache *scache);
 
 /*
- * Returns the version of the cache file.
+ * Returns the latest symcache version.
  */
 uint32_t symbolic_symcache_latest_file_format_version(void);
 

--- a/cabi/include/symbolic.h
+++ b/cabi/include/symbolic.h
@@ -311,37 +311,37 @@ SymbolicStr symbolic_arch_to_breakpad(const SymbolicStr *arch);
 /*
  * Releases memory held by an unmanaged `SymbolicCfiCache` instance.
  */
-void symbolic_cfi_cache_free(SymbolicCfiCache *scache);
+void symbolic_cficache_free(SymbolicCfiCache *scache);
 
 /*
  * Extracts call frame information (CFI) from an Object.
  */
-SymbolicCfiCache *symbolic_cfi_cache_from_object(const SymbolicObject *sobj);
+SymbolicCfiCache *symbolic_cficache_from_object(const SymbolicObject *sobj);
 
 /*
  * Loads a CFI cache from the given path.
  */
-SymbolicCfiCache *symbolic_cfi_cache_from_path(const char *path);
+SymbolicCfiCache *symbolic_cficache_from_path(const char *path);
 
 /*
  * Returns a pointer to the raw buffer of the CFI cache.
  */
-const uint8_t *symbolic_cfi_cache_get_bytes(const SymbolicCfiCache *scache);
+const uint8_t *symbolic_cficache_get_bytes(const SymbolicCfiCache *scache);
 
 /*
  * Returns the size of the raw buffer of the CFI cache.
  */
-uintptr_t symbolic_cfi_cache_get_size(const SymbolicCfiCache *scache);
+uintptr_t symbolic_cficache_get_size(const SymbolicCfiCache *scache);
 
 /*
  * Returns the file format version of the CFI cache.
  */
-uint32_t symbolic_cfi_cache_get_version(const SymbolicCfiCache *scache);
+uint32_t symbolic_cficache_get_version(const SymbolicCfiCache *scache);
 
 /*
  * Returns the latest CFI cache version.
  */
-uint32_t symbolic_cfi_cache_latest_version(void);
+uint32_t symbolic_cficache_latest_version(void);
 
 /*
  * Demangles a given identifier.

--- a/cabi/src/core.rs
+++ b/cabi/src/core.rs
@@ -138,6 +138,7 @@ pub enum SymbolicErrorCode {
     CfiErrorBadDebugInfo = 3003,
     CfiErrorUnsupportedArch = 3004,
     CfiErrorWriteError = 3005,
+    CfiErrorBadFileMagic = 3006,
 
     // symbolic::minidump::processor
     ProcessMinidumpErrorMinidumpNotFound = 4001,
@@ -224,6 +225,7 @@ impl SymbolicErrorCode {
                     CfiErrorKind::BadDebugInfo => SymbolicErrorCode::CfiErrorBadDebugInfo,
                     CfiErrorKind::UnsupportedArch => SymbolicErrorCode::CfiErrorUnsupportedArch,
                     CfiErrorKind::WriteError => SymbolicErrorCode::CfiErrorWriteError,
+                    CfiErrorKind::BadFileMagic => SymbolicErrorCode::CfiErrorBadFileMagic,
                 };
             }
 

--- a/cabi/src/minidump.rs
+++ b/cabi/src/minidump.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 
 use symbolic::common::{byteview::ByteView, types::Arch};
 use symbolic::debuginfo::Object;
-use symbolic::minidump::cfi::AsciiCfiWriter;
+use symbolic::minidump::cfi::{CfiCache, CFICACHE_LATEST_VERSION};
 use symbolic::minidump::processor::{
     CallStack, CodeModule, CodeModuleId, FrameInfoMap, ProcessState, RegVal, StackFrame, SystemInfo,
 };
@@ -247,7 +247,7 @@ ffi_fn! {
 }
 
 ffi_fn! {
-    /// Adds CFI for a code module specified by the `sid` argument.
+    /// Adds the CfiCache for a module specified by the `sid` argument.
     unsafe fn symbolic_frame_info_map_add(
         smap: *const SymbolicFrameInfoMap,
         sid: *const SymbolicStr,
@@ -255,9 +255,10 @@ ffi_fn! {
     ) -> Result<()> {
         let map = smap as *mut FrameInfoMap<'static>;
         let byteview = ByteView::from_path(CStr::from_ptr(path).to_str()?)?;
+        let cache = CfiCache::from_bytes(byteview)?;
         let id = CodeModuleId::from_str((*sid).as_str())?;
 
-        (*map).insert(id, byteview);
+        (*map).insert(id, cache);
         Ok(())
     }
 }
@@ -322,42 +323,49 @@ ffi_fn! {
     }
 }
 
-#[repr(C)]
-pub struct SymbolicCfiCache {
-    pub bytes: *mut u8,
-    pub len: usize,
-}
+/// Represents a symbolic CFI cache.
+pub struct SymbolicCfiCache;
 
-impl Drop for SymbolicCfiCache {
-    fn drop(&mut self) {
-        unsafe {
-            Vec::from_raw_parts(self.bytes, self.len, self.len);
-        }
+ffi_fn! {
+    /// Extracts call frame information (CFI) from an Object.
+    unsafe fn symbolic_cfi_cache_from_object(
+        sobj: *const SymbolicObject,
+    ) -> Result<*mut SymbolicCfiCache> {
+        let cache = CfiCache::from_object(&*(sobj as *const Object))?;
+        Ok(Box::into_raw(Box::new(cache)) as *mut SymbolicCfiCache)
     }
 }
 
 ffi_fn! {
-    /// Extracts call frame information (CFI) from an Object in ASCII format.
-    ///
-    /// To use this, create a `SymbolicFrameInfoMap` and pass it CFI for referenced modules during
-    /// minidump processing to receive improved stack traces.
-    unsafe fn symbolic_cfi_cache_from_object(
-        sobj: *const SymbolicObject,
-    ) -> Result<*mut SymbolicCfiCache> {
-        let mut buffer = vec![] as Vec<u8>;
+    /// Loads a CFI cache from the given path.
+    unsafe fn symbolic_cfi_cache_from_path(path: *const c_char) -> Result<*mut SymbolicCfiCache> {
+        let byteview = ByteView::from_path(CStr::from_ptr(path).to_str()?)?;
+        let cache = CfiCache::from_bytes(byteview)?;
+        Ok(Box::into_raw(Box::new(cache)) as *mut SymbolicCfiCache)
+    }
+}
 
-        {
-            let mut writer = AsciiCfiWriter::new(&mut buffer);
-            writer.process(&*(sobj as *const Object))?;
-        }
+ffi_fn! {
+    /// Returns the file format version of the CFI cache.
+    unsafe fn symbolic_cfi_cache_get_version(scache: *const SymbolicCfiCache) -> Result<u32> {
+        let cache = scache as *const CfiCache<'static>;
+        Ok((*cache).version())
+    }
+}
 
-        buffer.shrink_to_fit();
-        let bytes = mem::transmute(buffer.as_ptr());
-        let len = buffer.len();
-        mem::forget(buffer);
+ffi_fn! {
+    /// Returns a pointer to the raw buffer of the CFI cache.
+    unsafe fn symbolic_cfi_cache_get_bytes(scache: *const SymbolicCfiCache) -> Result<*const u8> {
+        let cache = scache as *const CfiCache<'static>;
+        Ok((*cache).as_slice().as_ptr())
+    }
+}
 
-        let scache = SymbolicCfiCache { bytes, len };
-        Ok(Box::into_raw(Box::new(scache)))
+ffi_fn! {
+    /// Returns the size of the raw buffer of the CFI cache.
+    unsafe fn symbolic_cfi_cache_get_size(scache: *const SymbolicCfiCache) -> Result<usize> {
+        let cache = scache as *const CfiCache<'static>;
+        Ok((*cache).as_slice().len())
     }
 }
 
@@ -365,7 +373,15 @@ ffi_fn! {
     /// Releases memory held by an unmanaged `SymbolicCfiCache` instance.
     unsafe fn symbolic_cfi_cache_free(scache: *mut SymbolicCfiCache) {
         if !scache.is_null() {
-            Box::from_raw(scache);
+            let cache = scache as *mut CfiCache<'static>;
+            Box::from_raw(cache);
         }
+    }
+}
+
+ffi_fn! {
+    /// Returns the latest CFI cache version.
+    unsafe fn symbolic_cfi_cache_latest_version() -> Result<u32> {
+        Ok(CFICACHE_LATEST_VERSION)
     }
 }

--- a/cabi/src/minidump.rs
+++ b/cabi/src/minidump.rs
@@ -328,7 +328,7 @@ pub struct SymbolicCfiCache;
 
 ffi_fn! {
     /// Extracts call frame information (CFI) from an Object.
-    unsafe fn symbolic_cfi_cache_from_object(
+    unsafe fn symbolic_cficache_from_object(
         sobj: *const SymbolicObject,
     ) -> Result<*mut SymbolicCfiCache> {
         let cache = CfiCache::from_object(&*(sobj as *const Object))?;
@@ -338,7 +338,7 @@ ffi_fn! {
 
 ffi_fn! {
     /// Loads a CFI cache from the given path.
-    unsafe fn symbolic_cfi_cache_from_path(path: *const c_char) -> Result<*mut SymbolicCfiCache> {
+    unsafe fn symbolic_cficache_from_path(path: *const c_char) -> Result<*mut SymbolicCfiCache> {
         let byteview = ByteView::from_path(CStr::from_ptr(path).to_str()?)?;
         let cache = CfiCache::from_bytes(byteview)?;
         Ok(Box::into_raw(Box::new(cache)) as *mut SymbolicCfiCache)
@@ -347,7 +347,7 @@ ffi_fn! {
 
 ffi_fn! {
     /// Returns the file format version of the CFI cache.
-    unsafe fn symbolic_cfi_cache_get_version(scache: *const SymbolicCfiCache) -> Result<u32> {
+    unsafe fn symbolic_cficache_get_version(scache: *const SymbolicCfiCache) -> Result<u32> {
         let cache = scache as *const CfiCache<'static>;
         Ok((*cache).version())
     }
@@ -355,7 +355,7 @@ ffi_fn! {
 
 ffi_fn! {
     /// Returns a pointer to the raw buffer of the CFI cache.
-    unsafe fn symbolic_cfi_cache_get_bytes(scache: *const SymbolicCfiCache) -> Result<*const u8> {
+    unsafe fn symbolic_cficache_get_bytes(scache: *const SymbolicCfiCache) -> Result<*const u8> {
         let cache = scache as *const CfiCache<'static>;
         Ok((*cache).as_slice().as_ptr())
     }
@@ -363,7 +363,7 @@ ffi_fn! {
 
 ffi_fn! {
     /// Returns the size of the raw buffer of the CFI cache.
-    unsafe fn symbolic_cfi_cache_get_size(scache: *const SymbolicCfiCache) -> Result<usize> {
+    unsafe fn symbolic_cficache_get_size(scache: *const SymbolicCfiCache) -> Result<usize> {
         let cache = scache as *const CfiCache<'static>;
         Ok((*cache).as_slice().len())
     }
@@ -371,7 +371,7 @@ ffi_fn! {
 
 ffi_fn! {
     /// Releases memory held by an unmanaged `SymbolicCfiCache` instance.
-    unsafe fn symbolic_cfi_cache_free(scache: *mut SymbolicCfiCache) {
+    unsafe fn symbolic_cficache_free(scache: *mut SymbolicCfiCache) {
         if !scache.is_null() {
             let cache = scache as *mut CfiCache<'static>;
             Box::from_raw(cache);
@@ -381,7 +381,7 @@ ffi_fn! {
 
 ffi_fn! {
     /// Returns the latest CFI cache version.
-    unsafe fn symbolic_cfi_cache_latest_version() -> Result<u32> {
+    unsafe fn symbolic_cficache_latest_version() -> Result<u32> {
         Ok(CFICACHE_LATEST_VERSION)
     }
 }

--- a/cabi/src/symcache.rs
+++ b/cabi/src/symcache.rs
@@ -1,7 +1,7 @@
-use std::mem;
-use std::slice;
-use std::os::raw::c_char;
 use std::ffi::CStr;
+use std::mem;
+use std::os::raw::c_char;
+use std::slice;
 
 use symbolic::common::{byteview::ByteView, types::Arch};
 use symbolic::debuginfo::Object;
@@ -96,7 +96,7 @@ ffi_fn! {
     ///
     /// The internal buffer is exactly `symbolic_symcache_get_size` bytes long.
     unsafe fn symbolic_symcache_get_bytes(scache: *const SymbolicSymCache) -> Result<*const u8> {
-        let cache = scache as *mut SymCache<'static>;
+        let cache = scache as *const SymCache<'static>;
         Ok((*cache).as_bytes().as_ptr())
     }
 }
@@ -104,7 +104,7 @@ ffi_fn! {
 ffi_fn! {
     /// Returns the size in bytes of the symcache.
     unsafe fn symbolic_symcache_get_size(scache: *const SymbolicSymCache) -> Result<usize> {
-        let cache = scache as *mut SymCache<'static>;
+        let cache = scache as *const SymCache<'static>;
         Ok((*cache).size())
     }
 }
@@ -112,7 +112,7 @@ ffi_fn! {
 ffi_fn! {
     /// Returns the architecture of the symcache.
     unsafe fn symbolic_symcache_get_arch(scache: *const SymbolicSymCache) -> Result<SymbolicStr> {
-        let cache = scache as *mut SymCache<'static>;
+        let cache = scache as *const SymCache<'static>;
         Ok(SymbolicStr::new((*cache).arch()?.name()))
     }
 }
@@ -120,7 +120,7 @@ ffi_fn! {
 ffi_fn! {
     /// Returns the architecture of the symcache.
     unsafe fn symbolic_symcache_get_id(scache: *const SymbolicSymCache) -> Result<SymbolicStr> {
-        let cache = scache as *mut SymCache<'static>;
+        let cache = scache as *const SymCache<'static>;
         Ok((*cache).id().map(|id| id.to_string()).unwrap_or_default().into())
     }
 }
@@ -128,7 +128,7 @@ ffi_fn! {
 ffi_fn! {
     /// Returns true if the symcache has line infos.
     unsafe fn symbolic_symcache_has_line_info(scache: *const SymbolicSymCache) -> Result<bool> {
-        let cache = scache as *mut SymCache<'static>;
+        let cache = scache as *const SymCache<'static>;
         Ok((*cache).has_line_info()?)
     }
 }
@@ -136,7 +136,7 @@ ffi_fn! {
 ffi_fn! {
     /// Returns true if the symcache has file infos.
     unsafe fn symbolic_symcache_has_file_info(scache: *const SymbolicSymCache) -> Result<bool> {
-        let cache = scache as *mut SymCache<'static>;
+        let cache = scache as *const SymCache<'static>;
         Ok((*cache).has_file_info()?)
     }
 }
@@ -146,7 +146,7 @@ ffi_fn! {
     unsafe fn symbolic_symcache_file_format_version(
         scache: *const SymbolicSymCache,
     ) -> Result<u32> {
-        let cache = scache as *mut SymCache<'static>;
+        let cache = scache as *const SymCache<'static>;
         Ok((*cache).file_format_version()?)
     }
 }
@@ -209,7 +209,7 @@ ffi_fn! {
 }
 
 ffi_fn! {
-    /// Returns the version of the cache file.
+    /// Returns the latest symcache version.
     unsafe fn symbolic_symcache_latest_file_format_version() -> Result<u32> {
         Ok(SYMCACHE_LATEST_VERSION)
     }

--- a/examples/minidump_stackwalk.rs
+++ b/examples/minidump_stackwalk.rs
@@ -13,7 +13,7 @@ use walkdir::WalkDir;
 use symbolic::common::byteview::ByteView;
 use symbolic::common::types::{Arch, ObjectKind};
 use symbolic::debuginfo::{FatObject, Object};
-use symbolic::minidump::cfi::AsciiCfiWriter;
+use symbolic::minidump::cfi::CfiCache;
 use symbolic::minidump::processor::{CodeModuleId, FrameInfoMap, ProcessState, StackFrame};
 use symbolic::symcache::{InstructionInfo, LineInfo, SymCache};
 
@@ -86,8 +86,8 @@ where
 {
     collect_referenced_objects(path, state, |object| {
         // Silently skip all debug symbols without CFI
-        Ok(match AsciiCfiWriter::transform(&object) {
-            Ok(buffer) => Some(ByteView::from_vec(buffer)),
+        Ok(match CfiCache::from_object(&object) {
+            Ok(cficache) => Some(cficache),
             Err(_) => None,
         })
     })

--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -109,10 +109,10 @@ class Object(RustObject):
         return SymCache._from_objptr(self._methodcall(
             lib.symbolic_symcache_from_object))
 
-    def make_cfi_cache(self):
-        """Creates a cfi cache from the object."""
+    def make_cficache(self):
+        """Creates a cficache from the object."""
         return CfiCache._from_objptr(self._methodcall(
-            lib.symbolic_cfi_cache_from_object))
+            lib.symbolic_cficache_from_object))
 
     def __repr__(self):
         return '<Object %s %r>' % (

--- a/py/symbolic/minidump.py
+++ b/py/symbolic/minidump.py
@@ -323,23 +323,23 @@ class FrameInfoMap(RustObject):
 
 
 # the most recent version for the CFI cache file format.
-SYMCACHE_LATEST_VERSION = rustcall(lib.symbolic_cfi_cache_latest_version)
+SYMCACHE_LATEST_VERSION = rustcall(lib.symbolic_cficache_latest_version)
 
 
 class CfiCache(RustObject):
     """A cache for call frame information (CFI) to improve native stackwalking"""
-    __dealloc_func__ = lib.symbolic_cfi_cache_free
+    __dealloc_func__ = lib.symbolic_cficache_free
 
     @classmethod
     def from_path(cls, path):
         """Loads a symcache from a file via mmap."""
         return cls._from_objptr(
-            rustcall(lib.symbolic_cfi_cache_from_path, encode_path(path)))
+            rustcall(lib.symbolic_cficache_from_path, encode_path(path)))
 
     @property
     def version(self):
         """Version of the file format."""
-        return self._methodcall(lib.symbolic_cfi_cache_get_version)
+        return self._methodcall(lib.symbolic_cficache_get_version)
 
     @property
     def is_latest_file_format(self):
@@ -348,8 +348,8 @@ class CfiCache(RustObject):
 
     def open_stream(self):
         """Returns a stream to read files from the internal buffer."""
-        buf = self._methodcall(lib.symbolic_cfi_cache_get_bytes)
-        size = self._methodcall(lib.symbolic_cfi_cache_get_size)
+        buf = self._methodcall(lib.symbolic_cficache_get_bytes)
+        size = self._methodcall(lib.symbolic_cficache_get_size)
         return io.BufferedReader(CacheReader(ffi.buffer(buf, size), self))
 
         buf = ffi.buffer(self._objptr.bytes, self._objptr.len)

--- a/py/symbolic/minidump.py
+++ b/py/symbolic/minidump.py
@@ -332,9 +332,15 @@ class CfiCache(RustObject):
 
     @classmethod
     def from_path(cls, path):
-        """Loads a symcache from a file via mmap."""
+        """Loads a cficache from a file via mmap."""
         return cls._from_objptr(
             rustcall(lib.symbolic_cficache_from_path, encode_path(path)))
+
+    @classmethod
+    def from_object(cls, obj):
+        """Creates a cficache from the given object."""
+        return cls._from_objptr(
+            rustcall(lib.symbolic_cficache_from_object, obj._get_objptr()))
 
     @property
     def version(self):

--- a/py/symbolic/minidump.py
+++ b/py/symbolic/minidump.py
@@ -9,8 +9,8 @@ from symbolic._lowlevel import lib, ffi
 from symbolic.utils import RustObject, rustcall, attached_refs, encode_path, \
     encode_str, decode_str, CacheReader
 
-__all__ = ['CallStack', 'FrameInfoMap',
-           'FrameTrust', 'ProcessState', 'StackFrame']
+__all__ = ['CallStack', 'FrameInfoMap', 'FrameTrust', 'ProcessState',
+           'StackFrame', 'CfiCache']
 
 
 def _make_frame_trust():

--- a/py/symbolic/minidump.py
+++ b/py/symbolic/minidump.py
@@ -322,8 +322,8 @@ class FrameInfoMap(RustObject):
                          encode_str(id), encode_path(path))
 
 
-# the most recent version for the CFI cache file format.
-SYMCACHE_LATEST_VERSION = rustcall(lib.symbolic_cficache_latest_version)
+# The most recent version for the CFI cache file format
+CFICACHE_LATEST_VERSION = rustcall(lib.symbolic_cficache_latest_version)
 
 
 class CfiCache(RustObject):
@@ -343,14 +343,14 @@ class CfiCache(RustObject):
             rustcall(lib.symbolic_cficache_from_object, obj._get_objptr()))
 
     @property
-    def version(self):
+    def file_format_version(self):
         """Version of the file format."""
         return self._methodcall(lib.symbolic_cficache_get_version)
 
     @property
     def is_latest_file_format(self):
         """Returns true if this is the latest file format."""
-        return self.version >= CFICACHE_LATEST_VERSION
+        return self.file_format_version >= CFICACHE_LATEST_VERSION
 
     def open_stream(self):
         """Returns a stream to read files from the internal buffer."""

--- a/py/symbolic/symcache.py
+++ b/py/symbolic/symcache.py
@@ -80,6 +80,12 @@ class SymCache(RustObject):
             rustcall(lib.symbolic_symcache_from_path, encode_path(path)))
 
     @classmethod
+    def from_object(cls, obj):
+        """Creates a symcache from the given object."""
+        return cls._from_objptr(
+            rustcall(lib.symbolic_symcache_from_object, obj._get_objptr()))
+
+    @classmethod
     def from_bytes(cls, data):
         """Loads a symcache from a file via mmap."""
         return cls._from_objptr(

--- a/py/tests/test_minidump.py
+++ b/py/tests/test_minidump.py
@@ -182,11 +182,11 @@ def test_linux_with_cfi(res_path):
     assert module.name == '/breakpad/examples/target/crash_linux'
 
 
-def test_macos_cfi_cache(res_path):
+def test_macos_cficache(res_path):
     binary_path = os.path.join(res_path, 'minidump', 'crash_macos')
     fat = FatObject.from_path(binary_path)
     obj = fat.get_object(arch="x86_64")
-    cache = obj.make_cfi_cache()
+    cache = obj.make_cficache()
 
     sym_path = os.path.join(res_path, 'minidump', 'crash_macos.sym')
     with cache.open_stream() as sym_cache:
@@ -194,11 +194,11 @@ def test_macos_cfi_cache(res_path):
             assert sym_cache.read() == sym_file.read()
 
 
-def test_linux_cfi_cache(res_path):
+def test_linux_cficache(res_path):
     binary_path = os.path.join(res_path, 'minidump', 'crash_linux')
     fat = FatObject.from_path(binary_path)
     obj = fat.get_object(arch="x86_64")
-    cache = obj.make_cfi_cache()
+    cache = obj.make_cficache()
 
     sym_path = os.path.join(res_path, 'minidump', 'crash_linux.sym')
     with cache.open_stream() as sym_cache:

--- a/symcache/src/cache.rs
+++ b/symcache/src/cache.rs
@@ -22,7 +22,7 @@ use utils::common_join_path;
 use writer;
 
 /// The magic file preamble to identify symcache files.
-pub const SYMCACHE_MAGIC: [u8; 4] = [b'S', b'Y', b'M', b'C'];
+pub const SYMCACHE_MAGIC: [u8; 4] = *b"SYMC";
 
 /// The latest version of the file format.
 pub const SYMCACHE_LATEST_VERSION: u32 = 2;


### PR DESCRIPTION
Adds an explicit type `CfiCache`. It is versioned similar to `SymCache`, can be created from objects and can be written and read from files. 

Strictly speaking, this is a breaking change. Since we never used CfiCaches in the past, however, there is no need to perform a major bump.