### PR TITLE
 build: Switch to breakpad fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "minidump/third_party/breakpad"]
 	path = minidump/third_party/breakpad
-	url = https://chromium.googlesource.com/breakpad/breakpad
+	url = https://github.com/getsentry/breakpad
 [submodule "minidump/third_party/lss"]
 	path = minidump/third_party/lss
 	url = https://chromium.googlesource.com/linux-syscall-support

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "minidump/third_party/breakpad"]
 	path = minidump/third_party/breakpad
 	url = https://github.com/getsentry/breakpad
+	shallow = true
 [submodule "minidump/third_party/lss"]
 	path = minidump/third_party/lss
 	url = https://chromium.googlesource.com/linux-syscall-support

--- a/py/tests/test_minidump.py
+++ b/py/tests/test_minidump.py
@@ -110,7 +110,7 @@ def test_macos_with_cfi(res_path):
 
     thread = state.get_thread(0)
     assert thread.thread_id == 775
-    assert thread.frame_count == 3
+    assert thread.frame_count == 9
 
     frame = thread.get_frame(1)
     assert frame.trust == 'cfi'
@@ -160,7 +160,7 @@ def test_linux_with_cfi(res_path):
 
     thread = state.get_thread(0)
     assert thread.thread_id == 133
-    assert thread.frame_count == 8
+    assert thread.frame_count == 5
 
     frame = thread.get_frame(1)
     assert frame.trust == 'cfi'


### PR DESCRIPTION
Updates the breakpad submodule to our fork with a small patch. Also makes the submodule shallow which should speed up cloning and the initial build.