### PR TITLE
fix(py): Fix object lookup by address

### DIFF
--- a/debuginfo/src/lib.rs
+++ b/debuginfo/src/lib.rs
@@ -24,6 +24,6 @@ pub use crate::breakpad::*;
 pub use crate::dwarf::*;
 pub use crate::features::*;
 pub use crate::object::*;
+pub use crate::symbols::*;
 #[deprecated]
 pub use symbolic_common::types::{BreakpadFormat, DebugId, ParseDebugIdError};
-pub use crate::symbols::*;

--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -178,10 +178,10 @@ class ObjectLookup(object):
         """Given an instruction address this locates the image this address
         is contained in.
         """
-        idx = bisect.bisect_left(self._addresses, parse_addr(addr))
+        idx = bisect.bisect_right(self._addresses, parse_addr(addr))
         if idx > 0:
             rv = self._by_addr[self._addresses[idx - 1]]
-            if not rv.size or addr < rv.addr + rv.size:
+            if not rv.size or parse_addr(addr) < rv.addr + rv.size:
                 return rv
 
     def get_object(self, id):

--- a/py/tests/test_debug.py
+++ b/py/tests/test_debug.py
@@ -1,5 +1,6 @@
 import os
-from symbolic import FatObject, arch_from_macho, id_from_breakpad, normalize_debug_id
+
+from symbolic import ObjectLookup, FatObject, arch_from_macho, id_from_breakpad, normalize_debug_id
 
 
 def test_object_features_mac(res_path):
@@ -43,3 +44,21 @@ def test_normalize_debug_id():
     assert normalize_debug_id(
         'DFB8E43AF2423D73A453AEB6A777EF75a') == 'dfb8e43a-f242-3d73-a453-aeb6a777ef75-a'
     assert normalize_debug_id(None) == None
+
+
+def test_find_object():
+    lookup = ObjectLookup([{
+        'uuid': 'dfb8e43a-f242-3d73-a453-aeb6a777ef75',
+        'image_addr': '0x1000',
+        'image_size': 1024,
+    }])
+
+    from pprint import pprint
+    pprint(lookup._addresses)
+
+    assert lookup.find_object('0x1000') is not None
+    assert lookup.find_object(4096) is not None
+    assert lookup.find_object(5119) is not None
+
+    assert lookup.find_object(4095) is None
+    assert lookup.find_object(5120) is None


### PR DESCRIPTION
Fixes two major issues in object lookup: `ObjectLookup.find_object(instruction_addr)`

 - We missed modules when we passed the image_addr as instruction_addr
 - If the address passed in was a hex string, we skipped the symbol