### PR TITLE
fix(symcache): Skip inlined children of dead code DIEs

### DIFF
--- a/symcache/src/dwarf.rs
+++ b/symcache/src/dwarf.rs
@@ -360,13 +360,14 @@ impl<'input> Unit<'input> {
                 continue;
             }
 
-            if funcs.is_empty() {
-                return Err(ConversionError("could not find root function").into());
-            }
+            // An inlined function must always have a parent. An empty list of funcs indicates
+            // invalid debug information.
+            let mut node = funcs
+                .last_mut()
+                .ok_or(ConversionError("could not find inline parent function"))?;
 
             // Search the inner-most parent function from the inlines tree. At
             // the very bottom we will attach to that parent as inline function.
-            let mut node = funcs.last_mut().unwrap();
             while { &node }
                 .inlines
                 .last()


### PR DESCRIPTION
This fixes the _"could not find root function"_ error for some debug symbols. We did not take into account that LTO might remove code for a function that leaves behind a surrogate DIE with inlined children that might have ranges attached. In that case, we tried to attach them to a non-existing parent function.