### PR TITLE
fix(minidump): Check for missing modules list

### DIFF
--- a/minidump/cpp/data_structures.cpp
+++ b/minidump/cpp/data_structures.cpp
@@ -41,8 +41,11 @@ const code_module_t **process_state_modules(process_state_t *state,
     }
 
     auto *modules = process_state_t::cast(state)->modules();
-    unsigned int size = modules->module_count();
+    if (modules == nullptr) {
+        return nullptr;
+    }
 
+    unsigned int size = modules->module_count();
     const code_module_t **buffer = new const code_module_t *[size];
     for (unsigned int i = 0; i < size; i++) {
         buffer[i] = code_module_t::cast(modules->GetModuleAtIndex(i));


### PR DESCRIPTION
It appears that breakpad actually does not set the modules pointer if there are no modules in a minidump. This lead to a null dereference segfault.

I did a quick scan over other information that we read, but this is the only unchecked case where a null value is possible.