### PR TITLE
fix(debuginfo): Only consider executable program headers for ELF

### DIFF
--- a/debuginfo/src/elf.rs
+++ b/debuginfo/src/elf.rs
@@ -203,7 +203,7 @@ pub fn get_elf_vmaddr(elf: &elf::Elf<'_>) -> u64 {
     // and dynamic libraries (e_type == ET_DYN), this address will
     // normally be zero.
     for phdr in &elf.program_headers {
-        if phdr.p_type == elf::program_header::PT_LOAD {
+        if phdr.p_type == elf::program_header::PT_LOAD && phdr.is_executable() {
             return phdr.p_vaddr;
         }
     }


### PR DESCRIPTION
Some ELF executables and libraries might load data sections via the `PT_LOAD` program header. So far, we've only encountered executable sections in the first load header. Just to be sure, this PR now skips not-executable load headers.

Ref https://github.com/getsentry/sentry-rust/pull/117