### PR TITLE
fix(debuginfo): Workaround for negative Breakpad line numbers

### DIFF
--- a/debuginfo/src/breakpad.rs
+++ b/debuginfo/src/breakpad.rs
@@ -473,7 +473,9 @@ fn parse_line(line: &[u8]) -> Result<BreakpadRecord<'_>, ParseBreakpadError> {
     Ok(BreakpadRecord::Line(BreakpadLineRecord {
         address: u64::from_str_radix(&address, 16)
             .map_err(|_| ParseBreakpadError("invalid line address"))?,
-        line: u64::from_str(&line).map_err(|_| ParseBreakpadError("invalid line number"))?,
+        line: i32::from_str(&line)
+            .map(|line| u64::from(line as u32))
+            .map_err(|_| ParseBreakpadError("invalid line number"))?,
         file_id: u64::from_str(&file_id).map_err(|_| ParseBreakpadError("invalid line file id"))?,
     }))
 }

--- a/debuginfo/src/breakpad.rs
+++ b/debuginfo/src/breakpad.rs
@@ -503,3 +503,18 @@ fn test_parse_line() {
         lines: vec![],
     }));
 }
+
+#[test]
+fn test_parse_negative_line() {
+    let line = b"e0fd10 5 -376 2225";
+    let record = parse_line(line).expect("failed to parse line");
+
+    assert_eq!(
+        record,
+        BreakpadRecord::Line(BreakpadLineRecord {
+            address: 0x00e0_fd10,
+            line: 4_294_966_920, // This is obviously garbage
+            file_id: 2225,
+        })
+    )
+}


### PR DESCRIPTION
Adds a workaround so that we do not reject Breakpad symbols with negative line numbers. 

Negative line records are technically invalid. However, they seem to occur when `dump_syms` is not able to evaluate the DWARF line program correctly. This happens occasionally for user symbols, e.g. [Electron](https://github.com/electron/electron/releases/download/v3.0.13/electron-v3.0.13-linux-x64-symbols.zip).

To handle this case more gracefully, we now just reinterpret line numbers as `i32` and cast them over to `u32`. Breakpad's `dump_syms` internally uses `int` for line numbers, so the value should match. SymCaches will truncate this to `u16::MAX`.

Breakpad's own symbol parser also discards such records as invalid: https://github.com/google/breakpad/blob/79ba6a494fb2097b39f76fe6a4b4b4f407e32a02/src/processor/basic_source_line_resolver_unittest.cc#L632-L635

