### PR TITLE
feat(py): Support updated debug image schema in ObjectLookup

### DIFF
--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -134,13 +134,19 @@ class ObjectRef(object):
         # not a real address but why handle it differently
         self.size = parse_addr(data.get('image_size'))
         self.vmaddr = data.get('image_vmaddr')
+        self.code_id = data.get('code_id')
+        self.code_file = data.get('code_file') or data.get('name')
         self.debug_id = normalize_debug_id(
-            data.get('id') or data.get('uuid') or None)
+            data.get('debug_id') or data.get('id') or data.get('uuid') or None)
+        self.debug_file = data.get('debug_file')
+
         if data.get('arch') is not None and arch_is_known(data['arch']):
             self.arch = data['arch']
         else:
             self.arch = None
-        self.name = data.get('name')
+
+        # Legacy alias for backwards compatibility
+        self.name = self.code_file
 
     def __repr__(self):
         return '<ObjectRef %s %r>' % (

--- a/py/tests/test_debug.py
+++ b/py/tests/test_debug.py
@@ -46,9 +46,62 @@ def test_normalize_debug_id():
     assert normalize_debug_id(None) == None
 
 
-def test_find_object():
+def test_object_ref_legacy_apple():
     lookup = ObjectLookup([{
         'uuid': 'dfb8e43a-f242-3d73-a453-aeb6a777ef75',
+        'image_addr': '0x1000',
+        'image_size': 1024,
+        'name': 'CoreFoundation',
+    }])
+
+    obj = lookup.get_object('dfb8e43a-f242-3d73-a453-aeb6a777ef75')
+    assert obj.name == 'CoreFoundation'
+    assert obj.code_id is None
+    assert obj.code_file == 'CoreFoundation'
+    assert obj.debug_id == 'dfb8e43a-f242-3d73-a453-aeb6a777ef75'
+    assert obj.debug_file is None
+
+
+def test_object_ref_legacy_symbolic():
+    lookup = ObjectLookup([{
+        'id': 'dfb8e43a-f242-3d73-a453-aeb6a777ef75',
+        'image_addr': '0x1000',
+        'image_size': 1024,
+        'name': 'CoreFoundation',
+    }])
+
+    obj = lookup.get_object('dfb8e43a-f242-3d73-a453-aeb6a777ef75')
+    assert obj.name == 'CoreFoundation'
+    assert obj.code_id is None
+    assert obj.code_file == 'CoreFoundation'
+    assert obj.debug_id == 'dfb8e43a-f242-3d73-a453-aeb6a777ef75'
+    assert obj.debug_file is None
+
+
+def test_object_ref():
+    lookup = ObjectLookup([{
+        'code_id': 'DFB8E43A-F242-3D73-A453-AEB6A777EF75',
+        'code_file': 'CoreFoundation',
+        'debug_id': 'dfb8e43a-f242-3d73-a453-aeb6a777ef75',
+        'debug_file': 'CoreFoundation.dSYM',
+        'image_addr': '0x1000',
+        'image_size': 1024,
+    }])
+
+    obj = lookup.get_object('dfb8e43a-f242-3d73-a453-aeb6a777ef75')
+    assert obj.name == 'CoreFoundation'
+    assert obj.code_id == 'DFB8E43A-F242-3D73-A453-AEB6A777EF75'
+    assert obj.code_file == 'CoreFoundation'
+    assert obj.debug_id == 'dfb8e43a-f242-3d73-a453-aeb6a777ef75'
+    assert obj.debug_file == 'CoreFoundation.dSYM'
+
+
+def test_find_object():
+    lookup = ObjectLookup([{
+        'code_id': 'DFB8E43A-F242-3D73-A453-AEB6A777EF75',
+        'code_file': 'CoreFoundation',
+        'debug_id': 'dfb8e43a-f242-3d73-a453-aeb6a777ef75',
+        'debug_file': 'CoreFoundation.dSYM',
         'image_addr': '0x1000',
         'image_size': 1024,
     }])


### PR DESCRIPTION
This prepares a schema change in Sentry regarding native debug images. The `name` attribute on `ObjectRef` was overlooked in the 6.0.0 refactor (see #127). For now, it remains for backwards compatibility as an alias to `code_file`.

**Renamed properties:**

 - `id` -> `debug_id`
 - `name` -> `code_file`

**New optional properties:**

 - `code_id`
 - `debug_file`
