### PR TITLE
feat(py): Expose minidump module's code_id and debug_file

### DIFF
--- a/cabi/include/symbolic.h
+++ b/cabi/include/symbolic.h
@@ -222,10 +222,12 @@ typedef struct {
  * Carries information about a code module loaded into the process during the crash.
  */
 typedef struct {
-  SymbolicStr id;
+  SymbolicStr code_id;
+  SymbolicStr code_file;
+  SymbolicStr debug_id;
+  SymbolicStr debug_file;
   uint64_t addr;
   uint64_t size;
-  SymbolicStr name;
 } SymbolicCodeModule;
 
 /**

--- a/cabi/src/minidump.rs
+++ b/cabi/src/minidump.rs
@@ -43,10 +43,12 @@ pub enum SymbolicFrameTrust {
 /// Carries information about a code module loaded into the process during the crash.
 #[repr(C)]
 pub struct SymbolicCodeModule {
-    pub id: SymbolicStr,
+    pub code_id: SymbolicStr,
+    pub code_file: SymbolicStr,
+    pub debug_id: SymbolicStr,
+    pub debug_file: SymbolicStr,
     pub addr: u64,
     pub size: u64,
-    pub name: SymbolicStr,
 }
 
 /// The CPU register value of a stack frame.
@@ -172,13 +174,15 @@ where
 /// Maps a `CodeModule` to its FFI type.
 unsafe fn map_code_module(module: &CodeModule) -> SymbolicCodeModule {
     SymbolicCodeModule {
-        id: module
+        code_id: module.code_identifier().into(),
+        code_file: module.code_file().into(),
+        debug_id: module
             .id()
             .map(|id| id.to_string().into())
             .unwrap_or_default(),
+        debug_file: module.debug_file().into(),
         addr: module.base_address(),
         size: module.size(),
-        name: SymbolicStr::from_string(module.code_file()),
     }
 }
 
@@ -193,10 +197,12 @@ unsafe fn map_regval(regval: (&str, RegVal)) -> SymbolicRegVal {
 /// Maps a `StackFrame` to its FFI type.
 unsafe fn map_stack_frame(frame: &StackFrame, arch: Arch) -> SymbolicStackFrame {
     let empty_module = SymbolicCodeModule {
-        id: "".into(),
+        code_id: "".into(),
+        code_file: "".into(),
+        debug_id: "".into(),
+        debug_file: "".into(),
         addr: 0,
         size: 0,
-        name: "".into(),
     };
 
     let (registers, register_count) =

--- a/minidump/src/processor.rs
+++ b/minidump/src/processor.rs
@@ -223,12 +223,21 @@ impl CodeModule {
     /// An identifying string used to discriminate between multiple versions and builds of the same
     /// code module.
     ///
-    /// This may contain a UUID, timestamp, version number, or any combination of this or other
-    /// information, in an implementation-defined format.
+    /// The contents of this identifier are implementation defined. GCC generally uses a 40
+    /// character (20 byte) SHA1 checksum of the code. On Windows, this is the program timestamp and
+    /// version number. On macOS, this value is empty.
     pub fn code_identifier(&self) -> String {
-        unsafe {
+        let id = unsafe {
             let ptr = code_module_code_identifier(self);
             utils::ptr_to_string(ptr)
+        };
+
+        // For platforms that do not have explicit code identifiers, the breakpad processor returns
+        // a hardcoded "id". Since this is only a placeholder, return an empty string instead.
+        if id == "id" {
+            String::new()
+        } else {
+            id
         }
     }
 

--- a/minidump/src/processor.rs
+++ b/minidump/src/processor.rs
@@ -198,7 +198,10 @@ impl CodeModule {
     /// Returns the unique identifier of this `CodeModule`, which corresponds to the identifier
     /// returned by [`debug_identifier`](struct.CodeModuleId#method.debug_identifier).
     pub fn id(&self) -> Option<CodeModuleId> {
-        CodeModuleId::from_str(&self.debug_identifier()).ok()
+        match self.debug_identifier().as_str() {
+            "" => None,
+            id => CodeModuleId::from_str(id).ok(),
+        }
     }
 
     /// Returns the base address of this code module as it was loaded by the
@@ -262,9 +265,18 @@ impl CodeModule {
     /// It usually comprises the library's UUID and an age field. On Windows, the age field is a
     /// generation counter, on all other platforms it is mostly zero.
     pub fn debug_identifier(&self) -> String {
-        unsafe {
+        let id = unsafe {
             let ptr = code_module_debug_identifier(self);
             utils::ptr_to_string(ptr)
+        };
+
+        // The breakpad processor sometimes returns only zeros when it cannot determine a debug
+        // identifier, for example from mapped fonts or shared memory regions. Since this is
+        // clearly a garbage value, return an empty string instead.
+        if id == "000000000000000000000000000000000" {
+            String::new()
+        } else {
+            id
         }
     }
 }

--- a/minidump/tests/snapshots/test_processor__process_state_macos.snap
+++ b/minidump/tests/snapshots/test_processor__process_state_macos.snap
@@ -1,6 +1,6 @@
 ---
-created: "2019-02-20T15:42:12.012660Z"
-creator: insta@0.6.3
+created: "2019-03-20T08:50:27.479637Z"
+creator: insta@0.7.1
 source: minidump/tests/test_processor.rs
 expression: "&state"
 ---
@@ -38,7 +38,7 @@ ProcessState {
                             base_address: 4458131456,
                             size: 69632,
                             code_file: "/Users/travis/build/getsentry/breakpad-tools/macos/build/./crash",
-                            code_identifier: "id",
+                            code_identifier: "",
                             debug_file: "crash",
                             debug_identifier: "67E9247C814E392BA027DBDE6748FCBF0"
                         }
@@ -61,7 +61,7 @@ ProcessState {
                             base_address: 4458131456,
                             size: 69632,
                             code_file: "/Users/travis/build/getsentry/breakpad-tools/macos/build/./crash",
-                            code_identifier: "id",
+                            code_identifier: "",
                             debug_file: "crash",
                             debug_identifier: "67E9247C814E392BA027DBDE6748FCBF0"
                         }
@@ -84,7 +84,7 @@ ProcessState {
                             base_address: 140737084547072,
                             size: 24576,
                             code_file: "/usr/lib/system/libdyld.dylib",
-                            code_identifier: "id",
+                            code_identifier: "",
                             debug_file: "libdyld.dylib",
                             debug_identifier: "9B2AC56D107C3541A1279094A751F2C90"
                         }
@@ -107,7 +107,7 @@ ProcessState {
                             base_address: 140737084547072,
                             size: 24576,
                             code_file: "/usr/lib/system/libdyld.dylib",
-                            code_identifier: "id",
+                            code_identifier: "",
                             debug_file: "libdyld.dylib",
                             debug_identifier: "9B2AC56D107C3541A1279094A751F2C90"
                         }
@@ -129,7 +129,7 @@ ProcessState {
             base_address: 4458131456,
             size: 69632,
             code_file: "/Users/travis/build/getsentry/breakpad-tools/macos/build/./crash",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "crash",
             debug_identifier: "67E9247C814E392BA027DBDE6748FCBF0"
         },
@@ -145,7 +145,7 @@ ProcessState {
             base_address: 140736719339520,
             size: 4800512,
             code_file: "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "CoreFoundation",
             debug_identifier: "36385A3A60D332DBBF55C6D8931A7AA60"
         },
@@ -161,7 +161,7 @@ ProcessState {
             base_address: 140737059020800,
             size: 8192,
             code_file: "/usr/lib/libDiagnosticMessagesClient.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libDiagnosticMessagesClient.dylib",
             debug_identifier: "84A04D240E603810A8C090A65E2DF61A0"
         },
@@ -177,7 +177,7 @@ ProcessState {
             base_address: 140737061376000,
             size: 8192,
             code_file: "/usr/lib/libSystem.B.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libSystem.B.dylib",
             debug_identifier: "F18AC1E7C6F134B18069BE571B3231D40"
         },
@@ -193,7 +193,7 @@ ProcessState {
             base_address: 140737063157760,
             size: 356352,
             code_file: "/usr/lib/libc++.1.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libc++.1.dylib",
             debug_identifier: "0B43BB5DE6EB34648DE9B41AC8ED9D1C0"
         },
@@ -209,7 +209,7 @@ ProcessState {
             base_address: 140737063514112,
             size: 172032,
             code_file: "/usr/lib/libc++abi.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libc++abi.dylib",
             debug_identifier: "BC271AD3831B362A9DA7E8C51F285FE40"
         },
@@ -225,7 +225,7 @@ ProcessState {
             base_address: 140737069191168,
             size: 2252800,
             code_file: "/usr/lib/libicucore.A.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libicucore.A.dylib",
             debug_identifier: "CCD2ED243071383B925D8D763BB12A6F0"
         },
@@ -241,7 +241,7 @@ ProcessState {
             base_address: 140737075171328,
             size: 4022272,
             code_file: "/usr/lib/libobjc.A.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libobjc.A.dylib",
             debug_identifier: "4DF3C25C52C23F01A3EF0D9D53A73C1C0"
         },
@@ -257,7 +257,7 @@ ProcessState {
             base_address: 140737083535360,
             size: 73728,
             code_file: "/usr/lib/libz.1.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libz.1.dylib",
             debug_identifier: "46E3FFA24328327A8D34A03E20BFFB8E0"
         },
@@ -273,7 +273,7 @@ ProcessState {
             base_address: 140737083666432,
             size: 20480,
             code_file: "/usr/lib/system/libcache.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libcache.dylib",
             debug_identifier: "093A4DAB83853D47A350E20CB7CCF7BF0"
         },
@@ -289,7 +289,7 @@ ProcessState {
             base_address: 140737083686912,
             size: 45056,
             code_file: "/usr/lib/system/libcommonCrypto.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libcommonCrypto.dylib",
             debug_identifier: "8A64D1B0C70E385C92F0E669079FDA900"
         },
@@ -305,7 +305,7 @@ ProcessState {
             base_address: 140737083731968,
             size: 32768,
             code_file: "/usr/lib/system/libcompiler_rt.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libcompiler_rt.dylib",
             debug_identifier: "55D47421772A32ABB5291A46C2F43B4D0"
         },
@@ -321,7 +321,7 @@ ProcessState {
             base_address: 140737083764736,
             size: 36864,
             code_file: "/usr/lib/system/libcopyfile.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libcopyfile.dylib",
             debug_identifier: "819BEA3CDF113E3DA1A15A51C5BF19610"
         },
@@ -337,7 +337,7 @@ ProcessState {
             base_address: 140737083801600,
             size: 540672,
             code_file: "/usr/lib/system/libcorecrypto.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libcorecrypto.dylib",
             debug_identifier: "65D7165E2E71335DA2D633F78E2DF0C10"
         },
@@ -353,7 +353,7 @@ ProcessState {
             base_address: 140737084342272,
             size: 204800,
             code_file: "/usr/lib/system/libdispatch.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libdispatch.dylib",
             debug_identifier: "6582BAD6ED273B30B62090B1C5A4AE3C0"
         },
@@ -369,7 +369,7 @@ ProcessState {
             base_address: 140737084547072,
             size: 24576,
             code_file: "/usr/lib/system/libdyld.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libdyld.dylib",
             debug_identifier: "9B2AC56D107C3541A1279094A751F2C90"
         },
@@ -385,7 +385,7 @@ ProcessState {
             base_address: 140737084571648,
             size: 4096,
             code_file: "/usr/lib/system/libkeymgr.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libkeymgr.dylib",
             debug_identifier: "7AA011A9DC213488BF733B5B14D1FDD60"
         },
@@ -401,7 +401,7 @@ ProcessState {
             base_address: 140737084628992,
             size: 4096,
             code_file: "/usr/lib/system/liblaunch.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "liblaunch.dylib",
             debug_identifier: "B856ABD2896E3DE0B2C8146A6AF8E2A70"
         },
@@ -417,7 +417,7 @@ ProcessState {
             base_address: 140737084633088,
             size: 24576,
             code_file: "/usr/lib/system/libmacho.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libmacho.dylib",
             debug_identifier: "17D5D855F6C33B04B680E9BF02EF8AED0"
         },
@@ -433,7 +433,7 @@ ProcessState {
             base_address: 140737084657664,
             size: 12288,
             code_file: "/usr/lib/system/libquarantine.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libquarantine.dylib",
             debug_identifier: "12448CC2378E35F3BE339DC395A5B9700"
         },
@@ -449,7 +449,7 @@ ProcessState {
             base_address: 140737084669952,
             size: 8192,
             code_file: "/usr/lib/system/libremovefile.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libremovefile.dylib",
             debug_identifier: "38D4CB9C10CD30D38B7BA515EC75FE850"
         },
@@ -465,7 +465,7 @@ ProcessState {
             base_address: 140737084678144,
             size: 102400,
             code_file: "/usr/lib/system/libsystem_asl.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_asl.dylib",
             debug_identifier: "096E42283B7C30A68B13EC909A64499A0"
         },
@@ -481,7 +481,7 @@ ProcessState {
             base_address: 140737084780544,
             size: 4096,
             code_file: "/usr/lib/system/libsystem_blocks.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_blocks.dylib",
             debug_identifier: "10DC540473AB35B3A277A8AFECB476EB0"
         },
@@ -497,7 +497,7 @@ ProcessState {
             base_address: 140737084784640,
             size: 581632,
             code_file: "/usr/lib/system/libsystem_c.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_c.dylib",
             debug_identifier: "E5AE52447D0C36AC8BB6C7AE7EA52A4B0"
         },
@@ -513,7 +513,7 @@ ProcessState {
             base_address: 140737085366272,
             size: 16384,
             code_file: "/usr/lib/system/libsystem_configuration.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_configuration.dylib",
             debug_identifier: "BECC01A2CA8D31E6BCDFD452965FA9760"
         },
@@ -529,7 +529,7 @@ ProcessState {
             base_address: 140737085382656,
             size: 16384,
             code_file: "/usr/lib/system/libsystem_coreservices.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_coreservices.dylib",
             debug_identifier: "7D26DE79B424345085E1F7FAB32714AB0"
         },
@@ -545,7 +545,7 @@ ProcessState {
             base_address: 140737085399040,
             size: 102400,
             code_file: "/usr/lib/system/libsystem_coretls.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_coretls.dylib",
             debug_identifier: "EC6FCF07DCFB3A039CC96DD3709974C60"
         },
@@ -561,7 +561,7 @@ ProcessState {
             base_address: 140737085501440,
             size: 28672,
             code_file: "/usr/lib/system/libsystem_dnssd.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_dnssd.dylib",
             debug_identifier: "CC9602150B1B3822A13A3DDE96FA796F0"
         },
@@ -577,7 +577,7 @@ ProcessState {
             base_address: 140737085530112,
             size: 172032,
             code_file: "/usr/lib/system/libsystem_info.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_info.dylib",
             debug_identifier: "611DB84CBF703F928702B9F28A9009200"
         },
@@ -593,7 +593,7 @@ ProcessState {
             base_address: 140737085702144,
             size: 143360,
             code_file: "/usr/lib/system/libsystem_kernel.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_kernel.dylib",
             debug_identifier: "34B1F16CBC9C3C5F90450CAE91CB59140"
         },
@@ -609,7 +609,7 @@ ProcessState {
             base_address: 140737085845504,
             size: 294912,
             code_file: "/usr/lib/system/libsystem_m.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_m.dylib",
             debug_identifier: "86D499B5BBDC3D3B8A4E97AE8E6672A40"
         },
@@ -625,7 +625,7 @@ ProcessState {
             base_address: 140737086140416,
             size: 126976,
             code_file: "/usr/lib/system/libsystem_malloc.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_malloc.dylib",
             debug_identifier: "A3D15F1799A633678C7E4280E8619C950"
         },
@@ -641,7 +641,7 @@ ProcessState {
             base_address: 140737086267392,
             size: 368640,
             code_file: "/usr/lib/system/libsystem_network.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_network.dylib",
             debug_identifier: "369D022156CA3C3E9EDE94B41CAE77B70"
         },
@@ -657,7 +657,7 @@ ProcessState {
             base_address: 140737086636032,
             size: 40960,
             code_file: "/usr/lib/system/libsystem_networkextension.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_networkextension.dylib",
             debug_identifier: "B021F2B38A753633ABB0FC012B8E9B0C0"
         },
@@ -673,7 +673,7 @@ ProcessState {
             base_address: 140737086676992,
             size: 40960,
             code_file: "/usr/lib/system/libsystem_notify.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_notify.dylib",
             debug_identifier: "B8160190A0693B3ABDF62AA408221FAE0"
         },
@@ -689,7 +689,7 @@ ProcessState {
             base_address: 140737086717952,
             size: 36864,
             code_file: "/usr/lib/system/libsystem_platform.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_platform.dylib",
             debug_identifier: "897462FDB318321BA554E61982630F7E0"
         },
@@ -705,7 +705,7 @@ ProcessState {
             base_address: 140737086754816,
             size: 45056,
             code_file: "/usr/lib/system/libsystem_pthread.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_pthread.dylib",
             debug_identifier: "B8FB5E20329539E2B5EBB464D1D4B1040"
         },
@@ -721,7 +721,7 @@ ProcessState {
             base_address: 140737086799872,
             size: 16384,
             code_file: "/usr/lib/system/libsystem_sandbox.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_sandbox.dylib",
             debug_identifier: "4B92EC49ACD036AEB07AA2B8152EAF9D0"
         },
@@ -737,7 +737,7 @@ ProcessState {
             base_address: 140737086816256,
             size: 8192,
             code_file: "/usr/lib/system/libsystem_secinit.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_secinit.dylib",
             debug_identifier: "F78B847B35653E4B98A6F7AD40392E2D0"
         },
@@ -753,7 +753,7 @@ ProcessState {
             base_address: 140737086824448,
             size: 32768,
             code_file: "/usr/lib/system/libsystem_symptoms.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_symptoms.dylib",
             debug_identifier: "3390E07CC1CE348FADBD2C5440B45EAA0"
         },
@@ -769,7 +769,7 @@ ProcessState {
             base_address: 140737086857216,
             size: 81920,
             code_file: "/usr/lib/system/libsystem_trace.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libsystem_trace.dylib",
             debug_identifier: "AC63A7FE50D93A3096E6F6B7FF16E4650"
         },
@@ -785,7 +785,7 @@ ProcessState {
             base_address: 140737086939136,
             size: 24576,
             code_file: "/usr/lib/system/libunwind.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libunwind.dylib",
             debug_identifier: "3D50D8A8C460334DA5192DA841102C6B0"
         },
@@ -801,7 +801,7 @@ ProcessState {
             base_address: 140737086963712,
             size: 172032,
             code_file: "/usr/lib/system/libxpc.dylib",
-            code_identifier: "id",
+            code_identifier: "",
             debug_file: "libxpc.dylib",
             debug_identifier: "BF896DF0D8E931A8A4B301120BFEEE520"
         }

--- a/minidump/tests/snapshots/test_processor__referenced_modules_macos.snap
+++ b/minidump/tests/snapshots/test_processor__referenced_modules_macos.snap
@@ -1,6 +1,6 @@
 ---
-created: "2019-02-20T15:42:12.012617Z"
-creator: insta@0.6.3
+created: "2019-03-20T08:50:27.477426Z"
+creator: insta@0.7.1
 source: minidump/tests/test_processor.rs
 expression: "&state.referenced_modules()"
 ---
@@ -17,7 +17,7 @@ expression: "&state.referenced_modules()"
         base_address: 4458131456,
         size: 69632,
         code_file: "/Users/travis/build/getsentry/breakpad-tools/macos/build/./crash",
-        code_identifier: "id",
+        code_identifier: "",
         debug_file: "crash",
         debug_identifier: "67E9247C814E392BA027DBDE6748FCBF0"
     },
@@ -33,7 +33,7 @@ expression: "&state.referenced_modules()"
         base_address: 140737084547072,
         size: 24576,
         code_file: "/usr/lib/system/libdyld.dylib",
-        code_identifier: "id",
+        code_identifier: "",
         debug_file: "libdyld.dylib",
         debug_identifier: "9B2AC56D107C3541A1279094A751F2C90"
     }

--- a/py/tests/test_minidump.py
+++ b/py/tests/test_minidump.py
@@ -37,10 +37,12 @@ def test_macos_without_cfi(res_path):
                                'rsp': '0x00007fff5daa3600'}
 
     mid = '3F58BC3DEABE3361B5FB52A6762985980'
-    module = next(module for module in state.modules() if module.id == mid)
+    module = next(module for module in state.modules() if module.debug_id == mid)
     assert module.addr == 4329947136
     assert module.size == 172032
-    assert module.name == '/Users/jauer/Coding/breakpad/examples/target/crash_macos'
+    assert module.code_id is None
+    assert module.code_file == '/Users/jauer/Coding/breakpad/examples/target/crash_macos'
+    assert module.debug_file == 'crash_macos'
 
 
 def test_linux_without_cfi(res_path):
@@ -76,10 +78,12 @@ def test_linux_without_cfi(res_path):
                                'rsp': '0x00007ffea5979b28'}
 
     mid = 'D2554CDB926136C4B9766A086583B9B50'
-    module = next(module for module in state.modules() if module.id == mid)
+    module = next(module for module in state.modules() if module.debug_id == mid)
     assert module.addr == 4194304
     assert module.size == 196608
-    assert module.name == '/breakpad/examples/target/crash_linux'
+    assert module.code_id == 'db4c55d26192c436b9766a086583b9b5a6d2e271'
+    assert module.code_file == '/breakpad/examples/target/crash_linux'
+    assert module.debug_file == '/breakpad/examples/target/crash_linux'
 
 
 def test_macos_with_cfi(res_path):
@@ -126,10 +130,12 @@ def test_macos_with_cfi(res_path):
                                'rbp': '0x00007fff5daa37c8'}
 
     module = next(module for module in state.modules()
-                  if module.id == module_id)
+                  if module.debug_id == module_id)
     assert module.addr == 4329947136
     assert module.size == 172032
-    assert module.name == '/Users/jauer/Coding/breakpad/examples/target/crash_macos'
+    assert module.code_id is None
+    assert module.code_file == '/Users/jauer/Coding/breakpad/examples/target/crash_macos'
+    assert module.debug_file == 'crash_macos'
 
 
 def test_linux_with_cfi(res_path):
@@ -176,10 +182,12 @@ def test_linux_with_cfi(res_path):
                                'rbp': '0x00007ffea5979ce0'}
 
     module = next(module for module in state.modules()
-                  if module.id == module_id)
+                  if module.debug_id == module_id)
     assert module.addr == 4194304
     assert module.size == 196608
-    assert module.name == '/breakpad/examples/target/crash_linux'
+    assert module.code_id == 'db4c55d26192c436b9766a086583b9b5a6d2e271'
+    assert module.code_file == '/breakpad/examples/target/crash_linux'
+    assert module.debug_file == '/breakpad/examples/target/crash_linux'
 
 
 def test_macos_cficache(res_path):


### PR DESCRIPTION
This exposes the code identifier and debug file name to python. The new interface now is:

- `code_id`: Implementation defined code identifier, if any
- `code_file` (alias `name`): Full path to the code file
- `debug_id` (alias `id`): Contains the normalized debug identifier (in Breakpad format)
- `debug_file`: Name of the debug file, if any

For backwards compatibility, the old attributes have been retained but are marked as deprecated.