### PR TITLE
ref: Switch to updated CodeId signature

### DIFF
--- a/cabi/Cargo.lock
+++ b/cabi/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "debugid"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1211,7 +1211,7 @@ dependencies = [
 name = "symbolic-common"
 version = "6.0.4"
 dependencies = [
- "debugid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "debugid 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1496,7 +1496,7 @@ dependencies = [
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
-"checksum debugid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a5119fdc6563d538d37f492a13799554a73999346347fc7ff2b4a9758d1f72a"
+"checksum debugid 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "143cd6fa7ba77a61118cc1c307fc69dcf83b040db6b9d07b2f90d1e44d0f23dd"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum dmsort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bfc94b97c995cfd2f02fc3972ae0f385cd441b50bb7610b59c7c779d5aec7444"

--- a/cabi/c-tests/object.c
+++ b/cabi/c-tests/object.c
@@ -21,7 +21,7 @@ void test_object_open(void) {
     printf("  debug_id: %.*s\n", (int)debug_id.len, debug_id.data);
 
     assert(code_id.len > 0);
-    assert(strncmp("5AB380779000", code_id.data, code_id.len) == 0);
+    assert(strncmp("5ab380779000", code_id.data, code_id.len) == 0);
     assert(debug_id.len > 0);
     assert(strncmp("3249d99d-0c40-4931-8610-f4e4fb0b6936-1", debug_id.data,
                    debug_id.len) == 0);

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -17,7 +17,7 @@ ProGuard optimized Android apps.
 edition = "2018"
 
 [dependencies]
-debugid = "0.5.0"
+debugid = "0.6.0"
 failure = "0.1.5"
 memmap = "0.7.0"
 stable_deref_trait = "1.1.1"

--- a/debuginfo/src/breakpad.rs
+++ b/debuginfo/src/breakpad.rs
@@ -794,7 +794,7 @@ impl<'d> BreakpadObject<'d> {
         for result in self.info_records() {
             if let Ok(record) = result {
                 if let BreakpadInfoRecord::CodeId { code_id, .. } = record {
-                    return Some(CodeId::new(code_id.into()));
+                    return CodeId::parse_hex(code_id).ok();
                 }
             }
         }

--- a/debuginfo/src/elf.rs
+++ b/debuginfo/src/elf.rs
@@ -62,7 +62,7 @@ impl<'d> ElfObject<'d> {
     /// its header. Compilers and linkers usually add either `SHT_NOTE` sections or
     /// `PT_NOTE` program header elements for this purpose.
     pub fn code_id(&self) -> Option<CodeId> {
-        self.find_build_id().map(|slice| CodeId::from_binary(slice))
+        self.find_build_id().map(|slice| CodeId::from_slice(slice))
     }
 
     /// The debug information identifier of an ELF object.

--- a/debuginfo/src/macho.rs
+++ b/debuginfo/src/macho.rs
@@ -65,8 +65,7 @@ impl<'d> MachObject<'d> {
     /// header. This UUID is generated at compile / link time and is usually unique per compilation.
     pub fn code_id(&self) -> Option<CodeId> {
         let uuid = self.find_uuid()?;
-        let string = format!("{:X}", uuid.to_hyphenated_ref());
-        Some(CodeId::new(string))
+        Some(CodeId::from_slice(&uuid.as_bytes()[..]))
     }
 
     /// The debug information identifier of a MachO file.

--- a/debuginfo/src/pe.rs
+++ b/debuginfo/src/pe.rs
@@ -65,11 +65,15 @@ impl<'d> PeObject<'d> {
         let header = &self.pe.header;
         let optional_header = header.optional_header.as_ref()?;
 
-        let timestamp = header.coff_header.time_date_stamp;
-        let size_of_image = optional_header.windows_fields.size_of_image;
-        let string = format!("{:08X}{:X}", timestamp, size_of_image);
+        let timestamp = header.coff_header.time_date_stamp.to_be_bytes();
+        let size_of_image = optional_header.windows_fields.size_of_image.to_be_bytes();
+        let first_size_byte = size_of_image.iter().position(|x| *x != 0).unwrap_or(3);
 
-        Some(CodeId::new(string))
+        let mut code_id = Vec::with_capacity(8);
+        code_id.extend(&timestamp);
+        code_id.extend(&size_of_image[first_size_byte..]);
+
+        Some(CodeId::from_vec(code_id))
     }
 
     /// The debug information identifier of this PE.

--- a/debuginfo/tests/test_objects.rs
+++ b/debuginfo/tests/test_objects.rs
@@ -69,9 +69,7 @@ fn test_breakpad() -> Result<(), Error> {
     insta::assert_debug_snapshot_matches!(object, @r###"Breakpad(
     BreakpadObject {
         code_id: Some(
-            CodeId(
-                "5AB380779000"
-            )
+            CodeId(5ab380779000)
         ),
         debug_id: DebugId {
             uuid: "3249d99d-0c40-4931-8610-f4e4fb0b6936",
@@ -122,9 +120,7 @@ fn test_elf_executable() -> Result<(), Error> {
     insta::assert_debug_snapshot_matches!(object, @r###"Elf(
     ElfObject {
         code_id: Some(
-            CodeId(
-                "f1c3bcc0279865fe3058404b2831d9e64135386c"
-            )
+            CodeId(f1c3bcc0279865fe3058404b2831d9e64135386c)
         ),
         debug_id: DebugId {
             uuid: "c0bcc3f1-9827-fe65-3058-404b2831d9e6",
@@ -150,9 +146,7 @@ fn test_elf_debug() -> Result<(), Error> {
     insta::assert_debug_snapshot_matches!(object, @r###"Elf(
     ElfObject {
         code_id: Some(
-            CodeId(
-                "f1c3bcc0279865fe3058404b2831d9e64135386c"
-            )
+            CodeId(f1c3bcc0279865fe3058404b2831d9e64135386c)
         ),
         debug_id: DebugId {
             uuid: "c0bcc3f1-9827-fe65-3058-404b2831d9e6",
@@ -202,9 +196,7 @@ fn test_mach_executable() -> Result<(), Error> {
     insta::assert_debug_snapshot_matches!(object, @r###"MachO(
     MachObject {
         code_id: Some(
-            CodeId(
-                "67E9247C-814E-392B-A027-DBDE6748FCBF"
-            )
+            CodeId(67e9247c814e392ba027dbde6748fcbf)
         ),
         debug_id: DebugId {
             uuid: "67e9247c-814e-392b-a027-dbde6748fcbf",
@@ -231,9 +223,7 @@ fn test_mach_dsym() -> Result<(), Error> {
     insta::assert_debug_snapshot_matches!(object, @r###"MachO(
     MachObject {
         code_id: Some(
-            CodeId(
-                "67E9247C-814E-392B-A027-DBDE6748FCBF"
-            )
+            CodeId(67e9247c814e392ba027dbde6748fcbf)
         ),
         debug_id: DebugId {
             uuid: "67e9247c-814e-392b-a027-dbde6748fcbf",
@@ -283,9 +273,7 @@ fn test_pe() -> Result<(), Error> {
     insta::assert_debug_snapshot_matches!(object, @r###"Pe(
     PeObject {
         code_id: Some(
-            CodeId(
-                "5AB380779000"
-            )
+            CodeId(5ab380779000)
         ),
         debug_id: DebugId {
             uuid: "3249d99d-0c40-4931-8610-f4e4fb0b6936",


### PR DESCRIPTION
Updates to the latest version of `debugid` which includes the updated `CodeId` type.