### PR TITLE
feat: Ability to open ByteView from open filehandle

### DIFF
--- a/common/src/byteview.rs
+++ b/common/src/byteview.rs
@@ -79,7 +79,7 @@ impl<'a> ByteView<'a> {
     }
 
     /// Constructs a `ByteView` from an open file handle by memory mapping the file.
-    pub fn from_file(file: File) -> Result<Self, io::Error> {
+    pub fn map_file(file: File) -> Result<Self, io::Error> {
         let backing = match unsafe { Mmap::map(&file) } {
             Ok(mmap) => ByteViewBacking::Mmap(mmap),
             Err(err) => {

--- a/common/src/byteview.rs
+++ b/common/src/byteview.rs
@@ -78,7 +78,7 @@ impl<'a> ByteView<'a> {
         ByteView::from_cow(Cow::Owned(buffer))
     }
 
-    /// Constructs a `ByteView` from an open file handle
+    /// Constructs a `ByteView` from an open file handle by memory mapping the file.
     pub fn from_file(file: File) -> Result<Self, io::Error> {
         let backing = match unsafe { Mmap::map(&file) } {
             Ok(mmap) => ByteViewBacking::Mmap(mmap),

--- a/common/src/byteview.rs
+++ b/common/src/byteview.rs
@@ -113,7 +113,7 @@ impl<'a> ByteView<'a> {
     /// Constructs a `ByteView` from a file path by memory mapping the file.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, io::Error> {
         let file = File::open(path)?;
-        Ok(Self::from_file(file))
+        Self::map_file(file)
     }
 
     /// Returns a slice of the underlying data.

--- a/common/src/byteview.rs
+++ b/common/src/byteview.rs
@@ -113,7 +113,7 @@ impl<'a> ByteView<'a> {
     /// Constructs a `ByteView` from a file path by memory mapping the file.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, io::Error> {
         let file = File::open(path)?;
-        Ok(self.from_file(file))
+        Ok(Self::from_file(file))
     }
 
     /// Returns a slice of the underlying data.


### PR DESCRIPTION
This is useful for opening byteviews from unnamed tempfiles (files that have no hardlink).