### PR TITLE
feat(py): Added size attribute to streams

### DIFF
--- a/py/symbolic/minidump.py
+++ b/py/symbolic/minidump.py
@@ -1,6 +1,5 @@
 """Minidump processing"""
 
-import io
 import shutil
 from datetime import datetime
 import warnings
@@ -8,7 +7,7 @@ import warnings
 from symbolic._compat import range_type
 from symbolic._lowlevel import lib, ffi
 from symbolic.utils import RustObject, rustcall, attached_refs, encode_path, \
-    encode_str, decode_str, SliceReader
+    encode_str, decode_str, make_buffered_slice_reader
 
 __all__ = ['CallStack', 'FrameInfoMap', 'FrameTrust', 'ProcessState',
            'StackFrame', 'CfiCache', 'CFICACHE_LATEST_VERSION']
@@ -377,7 +376,7 @@ class CfiCache(RustObject):
         """Returns a stream to read files from the internal buffer."""
         buf = self._methodcall(lib.symbolic_cficache_get_bytes)
         size = self._methodcall(lib.symbolic_cficache_get_size)
-        return io.BufferedReader(SliceReader(ffi.buffer(buf, size), self))
+        return make_buffered_slice_reader(ffi.buffer(buf, size), self)
 
     def write_to(self, f):
         """Writes the CFI cache into a file object."""

--- a/py/symbolic/unreal.py
+++ b/py/symbolic/unreal.py
@@ -1,11 +1,11 @@
-import io
 import json
 
 from symbolic._lowlevel import lib, ffi
 from symbolic._compat import range_type
 
 from symbolic.minidump import ProcessState
-from symbolic.utils import RustObject, rustcall, decode_str, attached_refs, SliceReader
+from symbolic.utils import RustObject, rustcall, decode_str, attached_refs, \
+    make_buffered_slice_reader
 
 __all__ = ['Unreal4Crash']
 
@@ -78,4 +78,11 @@ class Unreal4CrashFile(RustObject):
         rv = self._methodcall(lib.symbolic_unreal4_crash_file_contents, self.crash._objptr, len_out)
         if rv == ffi.NULL:
             return None
-        return io.BufferedReader(SliceReader(ffi.buffer(rv, len_out[0]), self))
+        return make_buffered_slice_reader(ffi.buffer(rv, len_out[0]), self)
+
+    @property
+    def size(self):
+        """Returns the size of the file in bytes."""
+        len_out = ffi.new('uintptr_t *')
+        self._methodcall(lib.symbolic_unreal4_crash_file_contents, self.crash._objptr, len_out)
+        return len_out[0]

--- a/py/symbolic/utils.py
+++ b/py/symbolic/utils.py
@@ -154,6 +154,10 @@ class SliceReader(io.RawIOBase):
         self.cache = cache
         self.pos = 0
 
+    @property
+    def size(self):
+        return len(self._buffer)
+
     def readable(self):
         return True
 
@@ -167,3 +171,14 @@ class SliceReader(io.RawIOBase):
         buf[:len(rv)] = rv
         self.pos = end
         return len(rv)
+
+
+class PassThroughBufferedReader(io.BufferedReader):
+    __dict__ = ()
+
+    def __getattr__(self, attr):
+        return getattr(self.raw, attr)
+
+
+def make_buffered_slice_reader(buffer, cache):
+    return PassThroughBufferedReader(SliceReader(buffer, cache))

--- a/py/tests/test_unreal.py
+++ b/py/tests/test_unreal.py
@@ -20,7 +20,9 @@ def test_unreal_crash_files(res_path):
         assert len(files[2].open_stream().read()) == 21143
         assert files[3].name == "UE4Minidump.dmp"
         assert files[3].type == "minidump"
-        assert len(files[3].open_stream().read()) == 410700
+        stream = files[3].open_stream()
+        assert stream.size == 410700
+        assert len(stream.read()) == 410700
 
 def test_get_apple_crash_report(res_path):
     path = os.path.join(res_path, 'unreal', 'unreal_crash_apple')


### PR DESCRIPTION
Sentry wants to know the size of a few things before it consumes data from the
stream.  Since we can provide the size here this now adds this attribute which
has the same name (`size`) as we use in Sentry proper (and Django).