### PR TITLE
feat(debuginfo): Expose the PDB filename from PEs

### DIFF
--- a/debuginfo/src/base.rs
+++ b/debuginfo/src/base.rs
@@ -545,6 +545,11 @@ pub trait ObjectLike {
     /// The debug information identifier of this object.
     fn debug_id(&self) -> DebugId;
 
+    /// The filename of the debug companion file.
+    fn debug_file_name(&self) -> Option<Cow<'_, str>> {
+        None
+    }
+
     /// The CPU architecture of this object.
     fn arch(&self) -> Arch;
 

--- a/debuginfo/src/object.rs
+++ b/debuginfo/src/object.rs
@@ -1,5 +1,7 @@
 //! Generic wrappers over various object file formats.
 
+use std::borrow::Cow;
+
 use failure::Fail;
 use goblin::Hint;
 
@@ -187,6 +189,13 @@ impl<'d> Object<'d> {
         match_inner!(self, Object(ref o) => o.debug_id())
     }
 
+    /// The filename of the debug companion file.
+    ///
+    /// For PE files for instane this will be the name of the PDB file that goes with it.
+    pub fn debug_file_name(&self) -> Option<Cow<'_, str>> {
+        match_inner!(self, Object(ref o) => o.debug_file_name())
+    }
+
     /// The CPU architecture of this object.
     pub fn arch(&self) -> Arch {
         match_inner!(self, Object(ref o) => o.arch())
@@ -293,6 +302,10 @@ impl<'d> ObjectLike for Object<'d> {
 
     fn debug_id(&self) -> DebugId {
         self.debug_id()
+    }
+
+    fn debug_file_name(&self) -> Option<Cow<'_, str>> {
+        self.debug_file_name()
     }
 
     fn arch(&self) -> Arch {

--- a/debuginfo/src/pe.rs
+++ b/debuginfo/src/pe.rs
@@ -104,6 +104,17 @@ impl<'d> PeObject<'d> {
             .unwrap_or_default()
     }
 
+    /// The name of the referenced PDB file.
+    pub fn debug_file_name(&self) -> Option<Cow<'_, str>> {
+        self.pe
+            .debug_data
+            .as_ref()
+            .and_then(|debug_data| debug_data.codeview_pdb70_debug_info.as_ref())
+            .map(|debug_info| {
+                String::from_utf8_lossy(&debug_info.filename[..debug_info.filename.len() - 1])
+            })
+    }
+
     /// The CPU architecture of this object, as specified in the COFF header.
     pub fn arch(&self) -> Arch {
         let machine = self.pe.header.coff_header.machine;
@@ -189,6 +200,7 @@ impl fmt::Debug for PeObject<'_> {
         f.debug_struct("PeObject")
             .field("code_id", &self.code_id())
             .field("debug_id", &self.debug_id())
+            .field("debug_file_name", &self.debug_file_name())
             .field("arch", &self.arch())
             .field("kind", &self.kind())
             .field("load_address", &HexFmt(self.load_address()))
@@ -233,6 +245,10 @@ impl<'d> ObjectLike for PeObject<'d> {
 
     fn debug_id(&self) -> DebugId {
         self.debug_id()
+    }
+
+    fn debug_file_name(&self) -> Option<Cow<'_, str>> {
+        self.debug_file_name()
     }
 
     fn arch(&self) -> Arch {

--- a/debuginfo/tests/test_objects.rs
+++ b/debuginfo/tests/test_objects.rs
@@ -279,6 +279,9 @@ fn test_pe_32() -> Result<(), Error> {
             uuid: "3249d99d-0c40-4931-8610-f4e4fb0b6936",
             appendix: 1
         },
+        debug_file_name: Some(
+            "C:\\projects\\breakpad-tools\\windows\\Release\\crash.pdb"
+        ),
         arch: X86,
         kind: Executable,
         load_address: 0x400000,
@@ -305,6 +308,9 @@ fn test_pe_64() -> Result<(), Error> {
             uuid: "f535c5fb-2ae8-4bb8-aa20-6c30be566c5a",
             appendix: 1
         },
+        debug_file_name: Some(
+            "C:\\Users\\sentry\\source\\repos\\CrashWithException\\x64\\Release\\CrashWithException.pdb"
+        ),
         arch: Amd64,
         kind: Executable,
         load_address: 0x140000000,


### PR DESCRIPTION
Since PE files are the definite source of what a PDB is suppose to be called
this exposes this information from the object.  This is only implemented for PE
files as it does not make much sense in other contexts.