### PR TITLE
ref(common): Revert to string-based CodeId

### DIFF
--- a/cabi/Cargo.lock
+++ b/cabi/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "debugid"
-version = "0.6.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1216,7 +1216,7 @@ dependencies = [
 name = "symbolic-common"
 version = "6.1.2"
 dependencies = [
- "debugid 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "debugid 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1501,7 +1501,7 @@ dependencies = [
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
-"checksum debugid 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "143cd6fa7ba77a61118cc1c307fc69dcf83b040db6b9d07b2f90d1e44d0f23dd"
+"checksum debugid 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b52d59e9ccf8f7caf3455d021442ba7b38b8650bb9f581fd9ae4fea10a9eecc6"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum dmsort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bfc94b97c995cfd2f02fc3972ae0f385cd441b50bb7610b59c7c779d5aec7444"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -17,7 +17,7 @@ ProGuard optimized Android apps.
 edition = "2018"
 
 [dependencies]
-debugid = "0.6.0"
+debugid = "0.5.2"
 failure = "0.1.5"
 memmap = "0.7.0"
 stable_deref_trait = "1.1.1"

--- a/debuginfo/src/breakpad.rs
+++ b/debuginfo/src/breakpad.rs
@@ -794,7 +794,7 @@ impl<'d> BreakpadObject<'d> {
         for result in self.info_records() {
             if let Ok(record) = result {
                 if let BreakpadInfoRecord::CodeId { code_id, .. } = record {
-                    return CodeId::parse_hex(code_id).ok();
+                    return Some(CodeId::new(code_id.into()));
                 }
             }
         }

--- a/debuginfo/src/elf.rs
+++ b/debuginfo/src/elf.rs
@@ -62,7 +62,7 @@ impl<'d> ElfObject<'d> {
     /// its header. Compilers and linkers usually add either `SHT_NOTE` sections or
     /// `PT_NOTE` program header elements for this purpose.
     pub fn code_id(&self) -> Option<CodeId> {
-        self.find_build_id().map(|slice| CodeId::from_slice(slice))
+        self.find_build_id().map(|slice| CodeId::from_binary(slice))
     }
 
     /// The debug information identifier of an ELF object.

--- a/debuginfo/src/macho.rs
+++ b/debuginfo/src/macho.rs
@@ -65,7 +65,7 @@ impl<'d> MachObject<'d> {
     /// header. This UUID is generated at compile / link time and is usually unique per compilation.
     pub fn code_id(&self) -> Option<CodeId> {
         let uuid = self.find_uuid()?;
-        Some(CodeId::from_slice(&uuid.as_bytes()[..]))
+        Some(CodeId::from_binary(&uuid.as_bytes()[..]))
     }
 
     /// The debug information identifier of a MachO file.

--- a/debuginfo/src/pe.rs
+++ b/debuginfo/src/pe.rs
@@ -68,15 +68,10 @@ impl<'d> PeObject<'d> {
         let header = &self.pe.header;
         let optional_header = header.optional_header.as_ref()?;
 
-        let timestamp = header.coff_header.time_date_stamp.to_be_bytes();
-        let size_of_image = optional_header.windows_fields.size_of_image.to_be_bytes();
-        let first_size_byte = size_of_image.iter().position(|x| *x != 0).unwrap_or(3);
-
-        let mut code_id = Vec::with_capacity(8);
-        code_id.extend(&timestamp);
-        code_id.extend(&size_of_image[first_size_byte..]);
-
-        Some(CodeId::from_vec(code_id))
+        let timestamp = header.coff_header.time_date_stamp;
+        let size_of_image = optional_header.windows_fields.size_of_image;
+        let string = format!("{:08x}{:x}", timestamp, size_of_image);
+        Some(CodeId::new(string))
     }
 
     /// The debug information identifier of this PE.


### PR DESCRIPTION
`debugid` 0.5.2 is released already.