### PR TITLE
feat(breakpad): Support debug identifiers without age

### DIFF
--- a/debuginfo/src/breakpad.pest
+++ b/debuginfo/src/breakpad.pest
@@ -9,7 +9,7 @@ stack = { stack_cfi | stack_win }
 module = { "MODULE" ~ os ~ arch ~ debug_id ~ name }
 os = @{ ident }
 arch = @{ ident }
-debug_id = @{ ASCII_HEX_DIGIT{33,40} }
+debug_id = @{ ASCII_HEX_DIGIT{32,40} }
 
 // INFO record
 // Example: "INFO CODE_ID C22813AC7D101E2FF2598697023E1F28"


### PR DESCRIPTION
This allows debug identifiers that do not contain an age (i.e. length of 32 characters). To my understanding, this should never be generated by `dump_syms`, yet it happens in production. As `DebugId` can handle this, there is no harm in allowing such identifiers.