### PR TITLE
feat(minidump): Return ProcessStates for minidumps without threads

### DIFF
--- a/minidump/src/processor.rs
+++ b/minidump/src/processor.rs
@@ -701,7 +701,7 @@ impl fmt::Debug for SystemInfo {
 ///
 /// Usually included in `ProcessError` when the file cannot be processed.
 #[repr(u32)]
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ProcessResult {
     /// The dump was processed successfully.
     Ok,
@@ -726,6 +726,19 @@ pub enum ProcessResult {
 
     /// The dump processing was interrupted (not fatal).
     SymbolSupplierInterrupted,
+}
+
+impl ProcessResult {
+    /// Indicates whether the process state is usable.
+    ///
+    /// Depending on the result, the process state might only contain partial information. For a
+    /// full minidump, check for `ProcessResult::Ok` instead.
+    pub fn is_usable(self) -> bool {
+        match self {
+            ProcessResult::Ok | ProcessResult::NoThreadList => true,
+            _ => false,
+        }
+    }
 }
 
 impl fmt::Display for ProcessResult {
@@ -830,7 +843,7 @@ impl<'a> ProcessState<'a> {
             )
         };
 
-        if result == ProcessResult::Ok && !internal.is_null() {
+        if result.is_usable() && !internal.is_null() {
             Ok(ProcessState {
                 internal,
                 _ty: PhantomData,


### PR DESCRIPTION
Returns a `ProcessState` even if the minidump contains no thread list. 

The thread list is retrieved as the last processing step, immediately before symbolication. As such, system information and exception information might still be available. It's better to return this partial process state than fully bailing out.

https://github.com/google/breakpad/blob/d930308bbbfa089a63df67c4f78065604494d39d/src/processor/minidump_processor.cc#L156-L160