### PR TITLE
fix(minidump): Return process states for minidumps without threads

### DIFF
--- a/minidump/cpp/processor.cpp
+++ b/minidump/cpp/processor.cpp
@@ -37,14 +37,10 @@ process_state_t *process_minidump(const char *buffer,
     Minidump minidump(in);
     if (!minidump.Read()) {
         *result_out = google_breakpad::PROCESS_ERROR_MINIDUMP_NOT_FOUND;
-        return nullptr;
-    }
-
-    *result_out = processor.Process(&minidump, state);
-    if (*result_out != google_breakpad::PROCESS_OK) {
         delete state;
         return nullptr;
     }
 
+    *result_out = processor.Process(&minidump, state);
     return process_state_t::cast(state);
 }

--- a/minidump/src/processor.rs
+++ b/minidump/src/processor.rs
@@ -849,6 +849,7 @@ impl<'a> ProcessState<'a> {
                 _ty: PhantomData,
             })
         } else {
+            unsafe { process_state_delete(internal) };
             Err(ProcessMinidumpError(result))
         }
     }


### PR DESCRIPTION
Fix for #144. Also fixes a memory leak if the minidump cannot be opened.

Please review carefully. This is unfortunately hard to test as I cannot reproduce this case and we stopped to store failing minidumps.
