### PR TITLE
fix(debuginfo): Consider all program headers for ELF

### DIFF
--- a/debuginfo/src/elf.rs
+++ b/debuginfo/src/elf.rs
@@ -179,7 +179,7 @@ impl<'d> ElfObject<'d> {
         // and dynamic libraries (e_type == ET_DYN), this address will
         // normally be zero.
         for phdr in &self.elf.program_headers {
-            if phdr.p_type == elf::program_header::PT_LOAD && phdr.is_executable() {
+            if phdr.p_type == elf::program_header::PT_LOAD {
                 return phdr.p_vaddr;
             }
         }

--- a/symcache/src/cache.rs
+++ b/symcache/src/cache.rs
@@ -39,6 +39,11 @@ impl<'a> SymCache<'a> {
         self.header.preamble.version
     }
 
+    /// Returns whether this symcache is the latest version.
+    pub fn is_latest(&self) -> bool {
+        self.version() == format::SYMCACHE_VERSION
+    }
+
     /// The architecture of the symbol file.
     pub fn arch(&self) -> Arch {
         Arch::from_u32(self.header.arch)

--- a/symcache/src/format.rs
+++ b/symcache/src/format.rs
@@ -15,7 +15,7 @@ use crate::error::{SymCacheError, SymCacheErrorKind};
 pub const SYMCACHE_MAGIC: [u8; 4] = *b"SYMC";
 
 /// The latest version of the file format.
-pub const SYMCACHE_VERSION: u32 = 2;
+pub const SYMCACHE_VERSION: u32 = 3;
 
 /// Loads binary data from a segment.
 pub(crate) fn get_slice(data: &[u8], offset: usize, len: usize) -> Result<&[u8], io::Error> {
@@ -322,7 +322,7 @@ impl Header {
             1 => get_record::<HeaderV1>(data, 0)
                 .context(SymCacheErrorKind::BadFileHeader)?
                 .into(),
-            2 => get_record::<HeaderV2>(data, 0)
+            2..=SYMCACHE_VERSION => get_record::<HeaderV2>(data, 0)
                 .context(SymCacheErrorKind::BadFileHeader)?
                 .into(),
             _ => return Err(SymCacheErrorKind::UnsupportedVersion.into()),


### PR DESCRIPTION
This reverts #120. As it turns out, the first `PT_LOAD` segment is always the correct one to use as load address.

This goes along the lines of this change: https://github.com/google/breakpad/commit/3444ed7cf1118f3f288bc6941c8e726f732ad8c6


