### PR TITLE
fix(minidump): Do not emit default CFI for the .ra register

### DIFF
--- a/minidump/src/cfi.rs
+++ b/minidump/src/cfi.rs
@@ -357,15 +357,6 @@ impl<W: Write> AsciiCfiWriter<W> {
                     }
                 }
 
-                // Breakpad STACK CFI records must provide a .ra rule, but DWARF CFI may not
-                // establish any rule for .ra if the return address column is an ordinary register,
-                // and that register holds the return address on entry to the function. So establish
-                // a .ra rule citing the return address register.
-                if !rule_cache.contains_key(&ra) {
-                    let rule = RegisterRule::SameValue::<R>;
-                    written |= Self::write_register_rule(&mut line, info.arch, ra, &rule, ra)?;
-                }
-
                 if written {
                     self.inner
                         .write_all(&line)

--- a/minidump/tests/snapshots/test_cfi__cfi_elf.snap
+++ b/minidump/tests/snapshots/test_cfi__cfi_elf.snap
@@ -1,10 +1,10 @@
 ---
-created: "2019-04-24T14:55:14.510136Z"
-creator: insta@0.7.4
+created: "2019-07-05T18:52:40.332785Z"
+creator: insta@0.8.1
 source: minidump/tests/test_cfi.rs
 expression: cfi
 ---
-STACK CFI INIT 1dc0 2a .cfa: $rsp 8 + .ra: $rip
+STACK CFI INIT 1dc0 2a .cfa: $rsp 8 +
 STACK CFI INIT 1580 370 .cfa: $rsp 16 + .ra: .cfa -8 + ^
 STACK CFI 1586 .cfa: $rsp 24 +
 STACK CFI INIT 1ec0 3b .cfa: $rsp 8 + .ra: .cfa -8 + ^

--- a/py/tests/res/minidump/crash_linux.sym
+++ b/py/tests/res/minidump/crash_linux.sym
@@ -1,4 +1,4 @@
-STACK CFI INIT 1f10 2a .cfa: $rsp 8 + .ra: $rip
+STACK CFI INIT 1f10 2a .cfa: $rsp 8 +
 STACK CFI INIT 1a90 470 .cfa: $rsp 16 + .ra: .cfa -8 + ^
 STACK CFI 1a96 .cfa: $rsp 24 +
 STACK CFI INIT 21d4 3a .cfa: $rsp 8 + .ra: .cfa -8 + ^


### PR DESCRIPTION
Preliminary fix for recursions in stackwalking with CFI on Linux. This no longer emits a default rule for the `.ra` register. The rule was initially introduced to create parity with Breakpad, but turns out to be plain wrong.

There will be a more elaborate fix once `gimli` has been updated.