### PR TITLE
fix: Make tests pass on 3.x again and remove six dependency

### DIFF
--- a/py/symbolic/common.py
+++ b/py/symbolic/common.py
@@ -1,8 +1,7 @@
 import os
-import six
 
 from symbolic._lowlevel import lib, ffi
-from symbolic._compat import string_types, int_types
+from symbolic._compat import string_types, int_types, string_types
 from symbolic.utils import rustcall, encode_str, decode_str
 from symbolic import exceptions
 
@@ -20,7 +19,7 @@ ffi.init_once(lib.symbolic_init, 'init')
 
 def arch_is_known(arch):
     """Checks if an architecture is known."""
-    if not isinstance(arch, six.string_types):
+    if not isinstance(arch, string_types):
         return False
     return rustcall(lib.symbolic_arch_is_known, encode_str(arch))
 
@@ -29,7 +28,7 @@ def normalize_arch(arch):
     """Normalizes an architecture name."""
     if arch is None:
         return None
-    if not isinstance(arch, six.string_types):
+    if not isinstance(arch, string_types):
         raise ValueError('Invalid architecture: expected string')
 
     normalized = rustcall(lib.symbolic_normalize_arch, encode_str(arch))

--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -1,7 +1,7 @@
 import bisect
 from weakref import WeakValueDictionary
 
-from symbolic._compat import itervalues, range_type
+from symbolic._compat import itervalues, range_type, text_type
 from symbolic._lowlevel import lib, ffi
 from symbolic.utils import RustObject, rustcall, decode_str, encode_str, attached_refs
 from symbolic.common import parse_addr, arch_is_known
@@ -25,6 +25,8 @@ class Archive(RustObject):
     @classmethod
     def open(self, path):
         """Opens an archive from a given path."""
+        if isinstance(path, text_type):
+            path = path.encode('utf-8')
         return Archive._from_objptr(
             rustcall(lib.symbolic_archive_open, path))
 

--- a/py/tests/test_minidump.py
+++ b/py/tests/test_minidump.py
@@ -9,7 +9,7 @@ def test_macos_without_cfi(res_path):
     state = ProcessState.from_minidump(path)
     assert state.thread_count == 1
     assert state.requesting_thread == 0
-    assert state.timestamp == 1505305307L
+    assert state.timestamp == 1505305307
     assert state.crashed == True
     assert state.crash_time == datetime(2017, 9, 13, 12, 21, 47)
     assert state.crash_address == 69  # memory address: *(0x45) = 0;
@@ -50,7 +50,7 @@ def test_linux_without_cfi(res_path):
     state = ProcessState.from_minidump(path)
     assert state.thread_count == 1
     assert state.requesting_thread == 0
-    assert state.timestamp == 1505305040L
+    assert state.timestamp == 1505305040
     assert state.crashed == True
     assert state.crash_time == datetime(2017, 9, 13, 12, 17, 20)
     assert state.crash_address == 0  # memory address: *(0x0) = 0;
@@ -97,7 +97,7 @@ def test_macos_with_cfi(res_path):
     state = ProcessState.from_minidump(minidump_path, cfi)
     assert state.thread_count == 1
     assert state.requesting_thread == 0
-    assert state.timestamp == 1505305307L
+    assert state.timestamp == 1505305307
     assert state.crashed == True
     assert state.crash_time == datetime(2017, 9, 13, 12, 21, 47)
     assert state.crash_address == 69  # memory address: *(0x45) = 0;
@@ -149,7 +149,7 @@ def test_linux_with_cfi(res_path):
     state = ProcessState.from_minidump(minidump_path, cfi)
     assert state.thread_count == 1
     assert state.requesting_thread == 0
-    assert state.timestamp == 1505305040L
+    assert state.timestamp == 1505305040
     assert state.crashed == True
     assert state.crash_time == datetime(2017, 9, 13, 12, 17, 20)
     assert state.crash_address == 0  # memory address: *(0x0) = 0;


### PR DESCRIPTION
Fixed some regression in tests that caused them not to work on 3.x and removed a pointless six
dependency which accidentally snuck in.