### PR TITLE
Fix compilation unwder Windows when using MSVC

### DIFF
--- a/demangle/build.rs
+++ b/demangle/build.rs
@@ -14,7 +14,7 @@ fn main() {
             // "vendor/swift/lib/Demangling/Remangler.cpp",
             // "vendor/swift/lib/Demangling/TypeDecoder.cpp",
         ])
-        .flag("-std=c++11")
+        .flag_if_supported("-std=c++11")
         .flag("-DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1")
         .warnings(false)
         .include("vendor/swift/include")

--- a/minidump/build.rs
+++ b/minidump/build.rs
@@ -15,7 +15,7 @@ fn main() {
 
     cc::Build::new()
         .warnings(false)
-        .flag("-Wno-tautological-constant-out-of-range-compare")
+        .flag_if_supported("-Wno-tautological-constant-out-of-range-compare")
         .file("third_party/breakpad/src/third_party/libdisasm/ia32_implicit.c")
         .file("third_party/breakpad/src/third_party/libdisasm/ia32_insn.c")
         .file("third_party/breakpad/src/third_party/libdisasm/ia32_invariant.c")
@@ -35,7 +35,7 @@ fn main() {
     cc::Build::new()
         .cpp(true)
         .warnings(false)
-        .flag("-std=c++11")
+        .flag_if_supported("-std=c++11")
         .include(".")
         .include("third_party/breakpad/src")
         .define("BPLOG_MINIMUM_SEVERITY", "SEVERITY_ERROR")


### PR DESCRIPTION
For "-std=c++11" it is just to disable warnings and for "-Wno-tautological-constant-out-of-range-compare" it's mandatory to be able to compile.