### PR TITLE
feat(sourcebundle): Added callback to skip over files

### DIFF
--- a/debuginfo/src/sourcebundle.rs
+++ b/debuginfo/src/sourcebundle.rs
@@ -854,14 +854,32 @@ where
     /// sources could be resolved. Otherwise, an error is returned if writing the bundle fails.
     ///
     /// This finishes the source bundle and flushes the underlying writer.
-    pub fn write_object<O>(
+    pub fn write_object<O>(self, object: &O, object_name: &str) -> Result<bool, SourceBundleError>
+    where
+        O: ObjectLike,
+        O::Error: Fail,
+    {
+        self.write_object_with_filter(object, object_name, |_| true)
+    }
+
+    /// Writes a single object into the bundle.
+    ///
+    /// Returns `Ok(true)` if any source files were added to the bundle, or `Ok(false)` if no
+    /// sources could be resolved. Otherwise, an error is returned if writing the bundle fails.
+    ///
+    /// This finishes the source bundle and flushes the underlying writer.
+    ///
+    /// Before a file is written a callback is invoked which can return `false` to skip a file.
+    pub fn write_object_with_filter<O, F>(
         mut self,
         object: &O,
         object_name: &str,
+        filter: F,
     ) -> Result<bool, SourceBundleError>
     where
         O: ObjectLike,
         O::Error: Fail,
+        F: Fn(&FileEntry) -> bool,
     {
         let mut files_handled = BTreeSet::new();
         let session = object
@@ -883,7 +901,8 @@ where
                 continue;
             }
 
-            let source = if filename.starts_with('<') && filename.ends_with('>') {
+            let source = if (filename.starts_with('<') && filename.ends_with('>')) || !filter(&file)
+            {
                 None
             } else {
                 File::open(&filename).ok().map(BufReader::new)

--- a/debuginfo/src/sourcebundle.rs
+++ b/debuginfo/src/sourcebundle.rs
@@ -874,12 +874,12 @@ where
         mut self,
         object: &O,
         object_name: &str,
-        filter: F,
+        mut filter: F,
     ) -> Result<bool, SourceBundleError>
     where
         O: ObjectLike,
         O::Error: Fail,
-        F: Fn(&FileEntry) -> bool,
+        F: FnMut(&FileEntry) -> bool,
     {
         let mut files_handled = BTreeSet::new();
         let session = object


### PR DESCRIPTION
This can be used by tools to prevent sources to be added in certain circumstances.