### PR TITLE
fix: Harden macho multi arch parsing code.

### DIFF
--- a/debuginfo/src/macho.rs
+++ b/debuginfo/src/macho.rs
@@ -461,7 +461,11 @@ impl<'d, 'a> Iterator for FatMachObjectIterator<'d, 'a> {
 
         self.remaining -= 1;
         match self.iter.next() {
-            Some(Ok(arch)) => Some(MachObject::parse(arch.slice(self.data))),
+            Some(Ok(arch)) => {
+                let start = (arch.offset as usize).min(self.data.len());
+                let end = ((arch.offset + arch.size) as usize).min(self.data.len());
+                Some(MachObject::parse(&self.data[start..end]))
+            }
             Some(Err(error)) => Some(Err(MachError::BadObject(error))),
             None => None,
         }
@@ -523,7 +527,9 @@ impl<'d> FatMachO<'d> {
             None => return Ok(None),
         };
 
-        MachObject::parse(arch.slice(self.data)).map(Some)
+        let start = (arch.offset as usize).min(self.data.len());
+        let end = ((arch.offset + arch.size) as usize).min(self.data.len());
+        MachObject::parse(&self.data[start..end]).map(Some)
     }
 }
 

--- a/debuginfo/src/object.rs
+++ b/debuginfo/src/object.rs
@@ -115,13 +115,15 @@ pub fn peek(data: &[u8], archive: bool) -> FileFormat {
             // as a macho fat file (CAFEBABE).  This means that we often claim that a java
             // class file is actually a macho binary but it's not.  The next 32 bytes encode
             // the number of embedded architectures in a fat mach.  In case of a JAR file
-            // we have 2 bytes for major version and 2 bytes for minor version of the class
+            // we have 2 bytes for minor version and 2 bytes for major version of the class
             // file format.
             //
             // The internet suggests the first public version of Java had the class version
             // 45.  Thus the logic applied here is that if the number is >= 45 we're more
             // likely to have a java class file than a macho file with 45 architectures
             // which should be very rare.
+            //
+            // https://docs.oracle.com/javase/specs/jvms/se6/html/ClassFile.doc.html
             return if narchs >= 45 {
                 FileFormat::Unknown
             } else {

--- a/debuginfo/src/object.rs
+++ b/debuginfo/src/object.rs
@@ -110,26 +110,9 @@ pub fn peek(data: &[u8], archive: bool) -> FileFormat {
     match goblin::peek_bytes(&magic) {
         Ok(Hint::Elf(_)) => return FileFormat::Elf,
         Ok(Hint::Mach(_)) => return FileFormat::MachO,
-        Ok(Hint::MachFat(narchs)) if archive => {
-            // so this is kind of stupid but java class files share the same cutsey magic
-            // as a macho fat file (CAFEBABE).  This means that we often claim that a java
-            // class file is actually a macho binary but it's not.  The next 32 bytes encode
-            // the number of embedded architectures in a fat mach.  In case of a JAR file
-            // we have 2 bytes for minor version and 2 bytes for major version of the class
-            // file format.
-            //
-            // The internet suggests the first public version of Java had the class version
-            // 45.  Thus the logic applied here is that if the number is >= 45 we're more
-            // likely to have a java class file than a macho file with 45 architectures
-            // which should be very rare.
-            //
-            // https://docs.oracle.com/javase/specs/jvms/se6/html/ClassFile.doc.html
-            return if narchs >= 45 {
-                FileFormat::Unknown
-            } else {
-                FileFormat::MachO
-            };
-        }
+        // mach fat needs to be tested through `MachArchive::test` because of special
+        // handling that is required due to disambiguation with Java class files.
+        Ok(Hint::MachFat(_)) if archive && MachArchive::test(data) => return FileFormat::MachO,
         Ok(Hint::PE) => return FileFormat::Pe,
         _ => (),
     }


### PR DESCRIPTION
This fixes a mis detection of class files as macho fat files by using a
heuristic to tell the files apart based on on number of macho embedded
architectures vs class file versions.

Additionally it changes the slicing code to manual slicing which prevents
us panicking if we accidentally read bad ranges from a macho file.  This
happend commonly when we mis-characterized class files as macho fat files.