### PR TITLE
fix(debuginfo): Improve `.o` handling on MachO (#173)

### DIFF
--- a/debuginfo/src/dwarf.rs
+++ b/debuginfo/src/dwarf.rs
@@ -399,13 +399,6 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             None => return Err(gimli::read::Error::MissingUnitDie.into()),
         };
 
-        // Clang's LLD might eliminate an entire compilation unit and simply set the low_pc to zero
-        // and remove all range entries to indicate that it is missing. Skip such a unit, as it does
-        // not contain any code that can be executed.
-        if unit.low_pc == 0 && entry.attr(constants::DW_AT_ranges)?.is_none() {
-            return Ok(None);
-        }
-
         let language = match entry.attr_value(constants::DW_AT_language)? {
             Some(AttributeValue::Language(lang)) => language_from_dwarf(lang),
             _ => Language::Unknown,
@@ -483,11 +476,8 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             return Ok(tuple);
         }
 
-        // to go by the logic in dwarf2read a low_pc of 0 can indicate an
-        // eliminated duplicate when the GNU linker is used.
-        // TODO: *technically* there could be a relocatable section placed at VA 0
         let low_pc = match low_pc {
-            Some(low_pc) if low_pc != 0 => low_pc,
+            Some(low_pc) => low_pc,
             _ => return Ok(tuple),
         };
 


### PR DESCRIPTION
I am using `symbolic_debuginfo` in a [symbolicator](https://github.com/mozilla/fix-stacks) used for stack traces produced by Firefox.

On Mac, we don't build dSYMs by default because doing so is slow. So I want to emulate `atos`, which is able to read debuginfo from a binary by consulting the binary's symbol table and then reading debug info from the object files and archive files mentioned.
         
I have this working, but it requires a couple of small changes to `symbolic_debuginfo`, due to slight differences between `.o` files and executables/libraries.
