### PR TITLE
fix(context): Fix typo in ContextRuntimeProperties.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ __pycache__/
 
 # C++
 .vscode/ipch
+
+# IDE files
+.idea/

--- a/unreal/src/context.rs
+++ b/unreal/src/context.rs
@@ -120,7 +120,7 @@ pub struct Unreal4ContextRuntimeProperties {
     pub misc_cpu_brand: Option<String>,
     /// Misc.PrimaryGPUBrand
     #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub misc_primary_cpu_brand: Option<String>,
+    pub misc_primary_gpu_brand: Option<String>,
     /// Misc.OSVersionMajor
     #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
     pub misc_os_version_major: Option<String>,
@@ -219,7 +219,7 @@ impl Unreal4ContextRuntimeProperties {
                 }
                 "Misc.CPUVendor" => rv.misc_cpu_vendor = get_text_or_none(&child),
                 "Misc.CPUBrand" => rv.misc_cpu_brand = get_text_or_none(&child),
-                "Misc.PrimaryGPUBrand" => rv.misc_primary_cpu_brand = get_text_or_none(&child),
+                "Misc.PrimaryGPUBrand" => rv.misc_primary_gpu_brand = get_text_or_none(&child),
                 "Misc.OSVersionMajor" => rv.misc_os_version_major = get_text_or_none(&child),
                 "Misc.OSVersionMinor" => rv.misc_os_version_minor = get_text_or_none(&child),
                 "GameStateName" => rv.game_state_name = get_text_or_none(&child),
@@ -480,7 +480,7 @@ test_unreal_runtime_properties!(
     "Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz"
 );
 test_unreal_runtime_properties!(
-    misc_primary_cpu_brand,
+    misc_primary_gpu_brand,
     "Misc.PrimaryGPUBrand",
     "Parallels Display Adapter (WDDM)"
 );

--- a/unreal/src/context.rs
+++ b/unreal/src/context.rs
@@ -308,7 +308,7 @@ pub struct Unreal4Context {
 }
 
 impl Unreal4Context {
-    pub(crate) fn parse(data: &[u8]) -> Result<Self, Unreal4Error> {
+    pub fn parse(data: &[u8]) -> Result<Self, Unreal4Error> {
         let root = Element::from_reader(data).map_err(Unreal4Error::InvalidXml)?;
 
         Ok(Unreal4Context {

--- a/unreal/src/logs.rs
+++ b/unreal/src/logs.rs
@@ -30,7 +30,7 @@ pub struct Unreal4LogEntry {
     pub message: String,
 }
 
-pub(crate) fn parse_logs(
+pub fn parse_logs(
     log_slice: &[u8],
     limit: usize,
 ) -> Result<Vec<Unreal4LogEntry>, Unreal4Error> {


### PR DESCRIPTION
Changed `Unreal4ContextRuntimeProperties::misc_primary_cpu_brand` to `misc_primary_gpu_brand`.