### PR TITLE
fix(cabi): Unconditionally free in decode_str

### DIFF
--- a/py/symbolic/demangle.py
+++ b/py/symbolic/demangle.py
@@ -9,4 +9,4 @@ def demangle_name(symbol, lang=None, no_args=False):
     """Demangles a symbol."""
     func = lib.symbolic_demangle_no_args if no_args else lib.symbolic_demangle
     lang_str = encode_str(lang) if lang else ffi.NULL
-    return decode_str(rustcall(func, encode_str(symbol), lang_str), free=True)
+    return decode_str(rustcall(func, encode_str(symbol), lang_str))

--- a/py/symbolic/utils.py
+++ b/py/symbolic/utils.py
@@ -100,7 +100,8 @@ def decode_str(s):
             return u''
         return ffi.unpack(s.data, s.len).decode('utf-8', 'replace')
     finally:
-        lib.symbolic_str_free(ffi.addressof(s))
+        if s.owned:
+            lib.symbolic_str_free(ffi.addressof(s))
 
 
 def encode_str(s):

--- a/py/symbolic/utils.py
+++ b/py/symbolic/utils.py
@@ -93,15 +93,14 @@ def rustcall(func, *args):
     raise exc
 
 
-def decode_str(s, free=False):
+def decode_str(s):
     """Decodes a SymbolicStr"""
     try:
         if s.len == 0:
             return u''
         return ffi.unpack(s.data, s.len).decode('utf-8', 'replace')
     finally:
-        if free:
-            lib.symbolic_str_free(ffi.addressof(s))
+        lib.symbolic_str_free(ffi.addressof(s))
 
 
 def encode_str(s):


### PR DESCRIPTION
Fixes a memory leak, since we never called `free=True`. `SymbolicStr` checks ownership internally.