### PR TITLE
fix(cabi): Consistently free strings obtained from the C-ABI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ matrix:
         - make lint-python
       env: TEST=style-python
     - os: linux
-      script: make test-python
-      env: TEST=linux-python CXX=clang SYMBOLIC_PYTHON=python2
+      script: make test-python SYMBOLIC_PYTHON=python2
+      env: TEST=linux-python CXX=clang
     - os: osx
       script: make test-python
       env: TEST=mac-python

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ matrix:
   include:
     # Rust test suite
     - os: linux
-      script: make style
+      script: make style-rust
       env: TEST=style-rust
     - os: linux
-      script: make lint
+      script: make lint-rust
       env: TEST=lint-rust CXX=clang
     - os: linux
       script: make test-rust
@@ -31,6 +31,13 @@ matrix:
       env: TEST=mac-rust
 
     # Python test suite
+    - os: linux
+      language: python
+      python: "3.7"
+      script:
+        - make style-python
+        - make lint-python
+      env: TEST=style-python
     - os: linux
       script: make test-python
       env: TEST=linux-python CXX=clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
         - make lint-python
       env: TEST=style-python
     - os: linux
-      script: make test-python SYMBOLIC_PYTHON=python2
+      script: make test-python
       env: TEST=linux-python CXX=clang
     - os: osx
       script: make test-python
@@ -47,7 +47,7 @@ matrix:
 
     # Build wheels
     - os: osx
-      script: make wheel
+      script: make wheel SYMBOLIC_PYTHON=python2
       before_install: HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade node
       env: DEPLOY=mac-wheel
       osx_image: xcode7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
       env: TEST=style-python
     - os: linux
       script: make test-python
-      env: TEST=linux-python CXX=clang
+      env: TEST=linux-python CXX=clang SYMBOLIC_PYTHON=python2
     - os: osx
       script: make test-python
       env: TEST=mac-python

--- a/Makefile
+++ b/Makefile
@@ -94,4 +94,4 @@ format-python: .venv/bin/python
 .venv/bin/python: Makefile
 	@rm -rf .venv
 	@which virtualenv || sudo easy_install virtualenv
-	virtualenv -p python3 .venv
+	virtualenv -p python .venv

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ style-rust:
 
 style-python: .venv/bin/python
 	.venv/bin/pip install -U black
-	.venv/bin/black --check py
+	.venv/bin/black --check py --exclude 'symbolic/_lowlevel*|dist|build|\.eggs'
 
 # Linting
 
@@ -86,7 +86,7 @@ format-rust:
 
 format-python: .venv/bin/python
 	.venv/bin/pip install -U black
-	.venv/bin/black py
+	.venv/bin/black py --exclude 'symbolic/_lowlevel*|dist|build|\.eggs'
 .PHONY: format-python
 
 # Dependencies
@@ -94,4 +94,4 @@ format-python: .venv/bin/python
 .venv/bin/python: Makefile
 	@rm -rf .venv
 	@which virtualenv || sudo easy_install virtualenv
-	virtualenv -p python .venv
+	virtualenv -p python3 .venv

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SYMBOLIC_PYTHON := python3
+
 all: check test
 .PHONY: all
 
@@ -94,4 +96,4 @@ format-python: .venv/bin/python
 .venv/bin/python: Makefile
 	@rm -rf .venv
 	@which virtualenv || sudo easy_install virtualenv
-	virtualenv -p python3 .venv
+	virtualenv -p $(SYMBOLIC_PYTHON) .venv

--- a/cabi/include/symbolic.h
+++ b/cabi/include/symbolic.h
@@ -142,11 +142,26 @@ typedef struct SymbolicUnreal4Crash SymbolicUnreal4Crash;
 typedef struct SymbolicUnreal4File SymbolicUnreal4File;
 
 /**
- * CABI wrapper around a Rust string.
+ * A length-prefixed UTF-8 string.
+ *
+ * As opposed to C strings, this string is not null-terminated. If the string is owned, indicated
+ * by the `owned` flag, the owner must call the `free` function on this string. The convention is:
+ *
+ *  - When obtained as instance through return values, always free the string.
+ *  - When obtained as pointer through field access, never free the string.
  */
 typedef struct {
+  /**
+   * Pointer to the UTF-8 encoded string data.
+   */
   char *data;
+  /**
+   * The length of the string pointed to by `data`.
+   */
   uintptr_t len;
+  /**
+   * Indicates that the string is owned and must be freed.
+   */
   bool owned;
 } SymbolicStr;
 
@@ -283,6 +298,9 @@ typedef struct {
  * CABI wrapper around a UUID.
  */
 typedef struct {
+  /**
+   * UUID bytes in network byte order (big endian).
+   */
   uint8_t data[16];
 } SymbolicUuid;
 
@@ -644,10 +662,6 @@ void symbolic_str_free(SymbolicStr *string);
 
 /**
  * Creates a symbolic string from a raw C string.
- *
- * This sets the string to owned.  In case it's not owned you either have
- * to make sure you are not freeing the memory or you need to set the
- * owned flag to false.
  */
 SymbolicStr symbolic_str_from_cstr(const char *string);
 

--- a/py/symbolic/common.py
+++ b/py/symbolic/common.py
@@ -32,15 +32,14 @@ def normalize_arch(arch):
         raise ValueError("Invalid architecture: expected string")
 
     normalized = rustcall(lib.symbolic_normalize_arch, encode_str(arch))
-    return decode_str(normalized)
+    return decode_str(normalized, free=True)
 
 
 def arch_get_ip_reg_name(arch):
     """Returns the ip register if known for this arch."""
     try:
-        return str(
-            decode_str(rustcall(lib.symbolic_arch_ip_reg_name, encode_str(arch)))
-        )
+        rv = rustcall(lib.symbolic_arch_ip_reg_name, encode_str(arch))
+        return str(decode_str(rv, free=True))
     except ignore_arch_exc:
         pass
 

--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -73,12 +73,14 @@ class Object(RustObject):
     def arch(self):
         """The architecture of the object."""
         # make it an ascii bytestring on 2.x
-        return str(decode_str(self._methodcall(lib.symbolic_object_get_arch)))
+        arch = self._methodcall(lib.symbolic_object_get_arch)
+        return str(decode_str(arch, free=True))
 
     @property
     def code_id(self):
         """The code identifier of the object. Returns None if there is no code id."""
-        code_id = decode_str(self._methodcall(lib.symbolic_object_get_code_id))
+        code_id = self._methodcall(lib.symbolic_object_get_code_id)
+        code_id = decode_str(code_id, free=True)
         if code_id:
             return code_id
         return None
@@ -86,17 +88,20 @@ class Object(RustObject):
     @property
     def debug_id(self):
         """The debug identifier of the object."""
-        return decode_str(self._methodcall(lib.symbolic_object_get_debug_id))
+        debug_id = self._methodcall(lib.symbolic_object_get_debug_id)
+        return decode_str(debug_id, free=True)
 
     @property
     def kind(self):
         """The kind of the object (e.g. executable, debug file, library, ...)."""
-        return str(decode_str(self._methodcall(lib.symbolic_object_get_kind)))
+        kind = self._methodcall(lib.symbolic_object_get_kind)
+        return str(decode_str(kind, free=True))
 
     @property
     def file_format(self):
         """The file format of the object file (e.g. MachO, ELF, ...)."""
-        return str(decode_str(self._methodcall(lib.symbolic_object_get_file_format)))
+        format = self._methodcall(lib.symbolic_object_get_file_format)
+        return str(decode_str(format, free=True))
 
     @property
     def features(self):
@@ -204,7 +209,7 @@ def id_from_breakpad(breakpad_id):
 
     s = encode_str(breakpad_id)
     id = rustcall(lib.symbolic_id_from_breakpad, s)
-    return decode_str(id)
+    return decode_str(id, free=True)
 
 
 def normalize_code_id(code_id):
@@ -214,7 +219,7 @@ def normalize_code_id(code_id):
 
     s = encode_str(code_id)
     id = rustcall(lib.symbolic_normalize_code_id, s)
-    return decode_str(id)
+    return decode_str(id, free=True)
 
 
 def normalize_debug_id(debug_id):
@@ -224,4 +229,4 @@ def normalize_debug_id(debug_id):
 
     s = encode_str(debug_id)
     id = rustcall(lib.symbolic_normalize_debug_id, s)
-    return decode_str(id)
+    return decode_str(id, free=True)

--- a/py/symbolic/demangle.py
+++ b/py/symbolic/demangle.py
@@ -9,4 +9,6 @@ def demangle_name(symbol, lang=None, no_args=False):
     """Demangles a symbol."""
     func = lib.symbolic_demangle_no_args if no_args else lib.symbolic_demangle
     lang_str = encode_str(lang) if lang else ffi.NULL
-    return decode_str(rustcall(func, encode_str(symbol), lang_str), free=True)
+
+    demangled = rustcall(func, encode_str(symbol), lang_str)
+    return decode_str(demangled, free=True)

--- a/py/symbolic/minidump.py
+++ b/py/symbolic/minidump.py
@@ -54,22 +54,22 @@ class CodeModule(RustObject):
     @property
     def code_id(self):
         """Platform native identifier of the loaded module containing the instruction"""
-        return decode_str(self._objptr.code_id) or None
+        return decode_str(self._objptr.code_id, free=False) or None
 
     @property
     def code_file(self):
         """Path to the loaded module"""
-        return decode_str(self._objptr.code_file) or None
+        return decode_str(self._objptr.code_file, free=False) or None
 
     @property
     def debug_id(self):
         """Debug identifier of the loaded module containing the instruction"""
-        return decode_str(self._objptr.debug_id) or None
+        return decode_str(self._objptr.debug_id, free=False) or None
 
     @property
     def debug_file(self):
         """Name of the debug file associated to this module"""
-        return decode_str(self._objptr.debug_file) or None
+        return decode_str(self._objptr.debug_file, free=False) or None
 
     @property
     def addr(self):
@@ -135,8 +135,8 @@ class StackFrame(RustObject):
         self._registers = {}
         for idx in range_type(self._objptr.register_count):
             register = self._objptr.registers[idx]
-            name = decode_str(register.name)
-            value = decode_str(register.value)
+            name = decode_str(register.name, free=False)
+            value = decode_str(register.value, free=False)
             self._registers[name] = value
 
         return self._registers
@@ -184,7 +184,7 @@ class SystemInfo(RustObject):
         its value is unknown, this field will contain a numeric value.  If
         the information is not present in the dump, this field will be empty.
         """
-        return decode_str(self._objptr.os_name)
+        return decode_str(self._objptr.os_name, free=False)
 
     @property
     def os_version(self):
@@ -192,14 +192,14 @@ class SystemInfo(RustObject):
         "5.1.2600" or "10.4.8".  The version will be formatted as three-
         component semantic version.  If the dump does not contain this
         information, this field will contain "0.0.0"."""
-        return decode_str(self._objptr.os_version)
+        return decode_str(self._objptr.os_version, free=False)
 
     @property
     def os_build(self):
         """A string identifying the build of the operating system, such as
         "Service Pack 2" or "8L2127".  If the dump does not contain this
         information, this field will be empty."""
-        return decode_str(self._objptr.os_build)
+        return decode_str(self._objptr.os_build, free=False)
 
     @property
     def cpu_family(self):
@@ -208,7 +208,7 @@ class SystemInfo(RustObject):
         this field will contain a numeric value.  If the information is not
         present in the dump, this field will be empty.  The values stored in
         this field should match those used by MinidumpSystemInfo::GetCPU."""
-        return decode_str(self._objptr.cpu_family)
+        return decode_str(self._objptr.cpu_family, free=False)
 
     @property
     def cpu_info(self):
@@ -216,7 +216,7 @@ class SystemInfo(RustObject):
         "GenuineIntel level 6 model 13 stepping 8".  If the information is not
         present in the dump, or additional identifying information is not
         defined for the CPU family, this field will be empty."""
-        return decode_str(self._objptr.cpu_info)
+        return decode_str(self._objptr.cpu_info, free=False)
 
     @property
     def cpu_count(self):
@@ -295,14 +295,14 @@ class ProcessState(RustObject):
         specific.  For example, "EXCEPTION_ACCESS_VIOLATION" (Windows),
         "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS" (Mac OS X), "SIGSEGV"
         (other Unix)."""
-        return decode_str(self._objptr.crash_reason)
+        return decode_str(self._objptr.crash_reason, free=False)
 
     @property
     def assertion(self):
         """If there was an assertion that was hit, a textual representation
         of that assertion, possibly including the file and line at which
         it occurred."""
-        return decode_str(self._objptr.assertion)
+        return decode_str(self._objptr.assertion, free=False)
 
     @property
     def system_info(self):

--- a/py/symbolic/proguard.py
+++ b/py/symbolic/proguard.py
@@ -57,4 +57,3 @@ class ProguardMappingView(RustObject):
         )
 
         return decode_str(result, free=True)
-

--- a/py/symbolic/proguard.py
+++ b/py/symbolic/proguard.py
@@ -50,10 +50,11 @@ class ProguardMappingView(RustObject):
         """Given a dotted path and an optional line number this resolves
         to the original dotted path.
         """
-        return decode_str(
-            self._methodcall(
-                lib.symbolic_proguardmappingview_convert_dotted_path,
-                encode_str(dotted_path),
-                lineno or 0,
-            )
+        result = self._methodcall(
+            lib.symbolic_proguardmappingview_convert_dotted_path,
+            encode_str(dotted_path),
+            lineno or 0,
         )
+
+        return decode_str(result, free=True)
+

--- a/py/symbolic/sourcemap.py
+++ b/py/symbolic/sourcemap.py
@@ -37,9 +37,9 @@ class SourceMapTokenMatch(object):
         rv.dst_line = tm.dst_line
         rv.dst_col = tm.dst_col
         rv.src_id = tm.src_id
-        rv.name = decode_str(tm.name) or None
-        rv.src = decode_str(tm.src) or None
-        rv.function_name = decode_str(tm.function_name) or None
+        rv.name = decode_str(tm.name, free=False) or None
+        rv.src = decode_str(tm.src, free=False) or None
+        rv.function_name = decode_str(tm.function_name, free=False) or None
         return rv
 
     def __eq__(self, other):
@@ -71,7 +71,8 @@ class SourceView(RustObject):
         return rv
 
     def get_source(self):
-        return decode_str(self._methodcall(lib.symbolic_sourceview_as_str))
+        source = self._methodcall(lib.symbolic_sourceview_as_str)
+        return decode_str(source, free=True)
 
     def __len__(self):
         return self._methodcall(lib.symbolic_sourceview_get_line_count)
@@ -80,7 +81,8 @@ class SourceView(RustObject):
         if not isinstance(idx, slice):
             if idx >= len(self):
                 raise IndexError("No such line")
-            return decode_str(self._methodcall(lib.symbolic_sourceview_get_line, idx))
+            line = self._methodcall(lib.symbolic_sourceview_get_line, idx)
+            return decode_str(line, free=True)
 
         rv = []
         for idx in range_type(*idx.indices(len(self))):
@@ -143,12 +145,8 @@ class SourceMapView(RustObject):
 
     def get_source_name(self, idx):
         """Returns the name of the source at the given index."""
-        return (
-            decode_str(
-                self._methodcall(lib.symbolic_sourcemapview_get_source_name, idx)
-            )
-            or None
-        )
+        name = self._methodcall(lib.symbolic_sourcemapview_get_source_name, idx)
+        return decode_str(name, free=True) or None
 
     def iter_sources(self):
         """Iterates over the sources in the file."""

--- a/py/symbolic/symcache.py
+++ b/py/symbolic/symcache.py
@@ -108,13 +108,15 @@ class SymCache(RustObject):
     @property
     def arch(self):
         """The architecture of the symcache."""
+        arch = self._methodcall(lib.symbolic_symcache_get_arch)
         # make it an ascii bytestring on 2.x
-        return str(decode_str(self._methodcall(lib.symbolic_symcache_get_arch)))
+        return str(decode_str(arch, free=True))
 
     @property
     def debug_id(self):
         """The debug identifier of the object."""
-        return decode_str(self._methodcall(lib.symbolic_symcache_get_debug_id))
+        id = self._methodcall(lib.symbolic_symcache_get_debug_id)
+        return decode_str(id, free=True)
 
     @property
     def has_line_info(self):
@@ -160,11 +162,11 @@ class SymCache(RustObject):
                         line_addr=sym.line_addr,
                         instr_addr=sym.instr_addr,
                         line=sym.line,
-                        lang=decode_str(sym.lang),
-                        symbol=decode_str(sym.symbol),
-                        filename=decode_str(sym.filename),
-                        base_dir=decode_str(sym.base_dir),
-                        comp_dir=decode_str(sym.comp_dir),
+                        lang=decode_str(sym.lang, free=False),
+                        symbol=decode_str(sym.symbol, free=False),
+                        filename=decode_str(sym.filename, free=False),
+                        base_dir=decode_str(sym.base_dir, free=False),
+                        comp_dir=decode_str(sym.comp_dir, free=False),
                     )
                 )
         finally:

--- a/py/symbolic/unreal.py
+++ b/py/symbolic/unreal.py
@@ -29,12 +29,12 @@ class Unreal4Crash(RustObject):
         return rv
 
     def get_context(self):
-        rv = json.loads(decode_str(self._methodcall(lib.symbolic_unreal4_get_context)))
-        return rv
+        context_json = self._methodcall(lib.symbolic_unreal4_get_context)
+        return json.loads(decode_str(context_json, free=True))
 
     def get_logs(self):
-        rv = json.loads(decode_str(self._methodcall(lib.symbolic_unreal4_get_logs)))
-        return rv
+        logs_json = self._methodcall(lib.symbolic_unreal4_get_logs)
+        return json.loads(decode_str(logs_json, free=True))
 
     @property
     def _file_count(self):
@@ -61,12 +61,14 @@ class Unreal4CrashFile(RustObject):
     @property
     def name(self):
         """The file name."""
-        return str(decode_str(self._methodcall(lib.symbolic_unreal4_file_name)))
+        name = self._methodcall(lib.symbolic_unreal4_file_name)
+        return str(decode_str(name, free=True))
 
     @property
     def type(self):
         """The type of the file"""
-        return str(decode_str(self._methodcall(lib.symbolic_unreal4_file_type)))
+        ty = self._methodcall(lib.symbolic_unreal4_file_type)
+        return str(decode_str(ty, free=True))
 
     def open_stream(self):
         """Returns a stream to read files from the internal buffer."""

--- a/py/symbolic/utils.py
+++ b/py/symbolic/utils.py
@@ -85,8 +85,8 @@ def rustcall(func, *args):
         return rv
     msg = lib.symbolic_err_get_last_message()
     cls = exceptions_by_code.get(err, SymbolicError)
-    exc = cls(decode_str(msg))
-    backtrace = decode_str(lib.symbolic_err_get_backtrace())
+    exc = cls(decode_str(msg, free=True))
+    backtrace = decode_str(lib.symbolic_err_get_backtrace(), free=True)
     if backtrace:
         exc.rust_info = backtrace
     raise exc
@@ -99,7 +99,7 @@ def decode_str(s, free=False):
             return u""
         return ffi.unpack(s.data, s.len).decode("utf-8", "replace")
     finally:
-        if free:
+        if free and s.owned:
             lib.symbolic_str_free(ffi.addressof(s))
 
 


### PR DESCRIPTION
We did not consistently call `free=True` on strings returned from the C-ABI. This PR updates docs and adds the flags where appropriate.