### PR TITLE
test(python): test against python3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,9 @@ jobs:
         - make style-python
         - make lint-python
       env: TEST=style-python
-    - script: make test-python
+    - language: python
+      python: "3.6"
+      script: make test-python
       env: TEST=linux-python CXX=clang
     - os: osx
       script: make test-python

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,8 @@ jobs:
         - make lint-python
       env: TEST=style-python
     - before_install:
-        - pyenv versions
+        - pyenv install 3.6.7
+        - pyenv global 3.6.7
         - which python
         - python --version
       script: make test-python

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,10 @@ jobs:
         - make style-python
         - make lint-python
       env: TEST=style-python
-    - language: python
-      python: "3.6"
+    - before_install:
+        - pyenv versions
+        - which python
+        - python --version
       script: make test-python
       env: TEST=linux-python CXX=clang
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,20 +30,24 @@ jobs:
       env: TEST=mac-rust
 
     # Python test suite
-    - language: python
+    - name: "Python 3.7 Style/Linting"
+      language: python
       python: "3.7"
       script:
         - make style-python
         - make lint-python
       env: TEST=style-python
-    - before_install:
+    - name: "Python 3.6 Tests (linux)"
+      before_install:
+        # multi-language jobs not currently possible, pyenv is used here.
+        # if we want later 3.6.x's it isn't possible AFAIK to update travis pyenv,
+        # so would need to install rustup + friends.
         - pyenv install 3.6.3
         - pyenv global 3.6.3
-        - which python
-        - python --version
       script: make test-python
       env: TEST=linux-python CXX=clang
-    - os: osx
+    - name: "Python 3.7 Tests (osx)"
+      os: osx
       script: make test-python
       env: TEST=mac-python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ jobs:
         - make lint-python
       env: TEST=style-python
     - before_install:
-        - pyenv install --list
-#        - pyenv global 3.6.7
+        - pyenv install 3.6.3
+        - pyenv global 3.6.3
         - which python
         - python --version
       script: make test-python

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ jobs:
         - make lint-python
       env: TEST=style-python
     - before_install:
-        - pyenv install 3.6.7
-        - pyenv global 3.6.7
+        - pyenv install --list
+#        - pyenv global 3.6.7
         - which python
         - python --version
       script: make test-python


### PR DESCRIPTION
I'm targetting Python 3.6 support for sentry, so this makes linux-python test against python3.6 instead of the default 3.5. If 3.5 support is desired I can just add another matrix job.

Note that mac-python appears to be 3.7.5, so it should just work.