### PR TITLE
feat(common): Add Path utilities for dSYM structures

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -24,6 +24,9 @@ stable_deref_trait = "1.1.1"
 serde_ = { package = "serde", version = "1.0.88", optional = true, features = ["derive"] }
 uuid = "0.8.1"
 
+[dev-dependencies]
+symbolic-testutils = { path = "../testutils" }
+
 [features]
 default = []
 serde = ["serde_", "debugid/serde"]

--- a/common/src/path.rs
+++ b/common/src/path.rs
@@ -342,7 +342,7 @@ impl DSymPathExt for Path {
         let framework = self.file_name()?;
 
         let mut parent = self.parent()?;
-        if !parent.ends_with("/Contents/Resources/DWARF") {
+        if !parent.ends_with("Contents/Resources/DWARF") {
             return None;
         }
 
@@ -358,143 +358,177 @@ impl DSymPathExt for Path {
     }
 }
 
-#[test]
-fn test_join_path() {
-    assert_eq!(join_path("foo", "C:"), "C:");
-    assert_eq!(join_path("foo", "C:bar"), "foo/C:bar");
-    assert_eq!(join_path("C:\\a", "b"), "C:\\a\\b");
-    assert_eq!(join_path("C:/a", "b"), "C:/a\\b");
-    assert_eq!(join_path("C:\\a", "b\\c"), "C:\\a\\b\\c");
-    assert_eq!(join_path("C:/a", "C:\\b"), "C:\\b");
-    assert_eq!(join_path("a\\b\\c", "d\\e"), "a\\b\\c\\d\\e");
-    assert_eq!(join_path("\\\\UNC\\", "a"), "\\\\UNC\\a");
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use symbolic_testutils::fixture;
 
-    assert_eq!(join_path("C:\\foo/bar", "\\baz"), "C:\\baz");
-    assert_eq!(join_path("\\foo/bar", "\\baz"), "\\baz");
-    assert_eq!(join_path("/a/b", "\\c"), "\\c");
+    #[test]
+    fn test_join_path() {
+        assert_eq!(join_path("foo", "C:"), "C:");
+        assert_eq!(join_path("foo", "C:bar"), "foo/C:bar");
+        assert_eq!(join_path("C:\\a", "b"), "C:\\a\\b");
+        assert_eq!(join_path("C:/a", "b"), "C:/a\\b");
+        assert_eq!(join_path("C:\\a", "b\\c"), "C:\\a\\b\\c");
+        assert_eq!(join_path("C:/a", "C:\\b"), "C:\\b");
+        assert_eq!(join_path("a\\b\\c", "d\\e"), "a\\b\\c\\d\\e");
+        assert_eq!(join_path("\\\\UNC\\", "a"), "\\\\UNC\\a");
 
-    assert_eq!(join_path("/a/b", "c"), "/a/b/c");
-    assert_eq!(join_path("/a/b", "c/d"), "/a/b/c/d");
-    assert_eq!(join_path("/a/b", "/c/d/e"), "/c/d/e");
-    assert_eq!(join_path("a/b/", "c"), "a/b/c");
+        assert_eq!(join_path("C:\\foo/bar", "\\baz"), "C:\\baz");
+        assert_eq!(join_path("\\foo/bar", "\\baz"), "\\baz");
+        assert_eq!(join_path("/a/b", "\\c"), "\\c");
 
-    assert_eq!(join_path("a/b/", "<stdin>"), "<stdin>");
-    assert_eq!(
-        join_path("C:\\test", "<::core::macros::assert_eq macros>"),
-        "<::core::macros::assert_eq macros>"
-    );
-}
+        assert_eq!(join_path("/a/b", "c"), "/a/b/c");
+        assert_eq!(join_path("/a/b", "c/d"), "/a/b/c/d");
+        assert_eq!(join_path("/a/b", "/c/d/e"), "/c/d/e");
+        assert_eq!(join_path("a/b/", "c"), "a/b/c");
 
-#[test]
-fn test_clean_path() {
-    assert_eq!(clean_path("/foo/bar/baz/./blah"), "/foo/bar/baz/blah");
-    assert_eq!(clean_path("/foo/bar/baz/./blah/"), "/foo/bar/baz/blah");
-    assert_eq!(clean_path("foo/bar/baz/./blah/"), "foo/bar/baz/blah");
-    assert_eq!(clean_path("foo/bar/baz/../blah/"), "foo/bar/blah");
-    assert_eq!(clean_path("../../blah/"), "../../blah");
-    assert_eq!(clean_path("..\\../blah/"), "..\\..\\blah");
-    assert_eq!(clean_path("foo\\bar\\baz/../blah/"), "foo\\bar\\blah");
-    assert_eq!(clean_path("foo\\bar\\baz/../../../../blah/"), "..\\blah");
-    assert_eq!(clean_path("foo/bar/baz/../../../../blah/"), "../blah");
-    assert_eq!(clean_path("..\\foo"), "..\\foo");
-    assert_eq!(clean_path("foo"), "foo");
-    assert_eq!(clean_path("foo\\bar\\baz/../../../blah/"), "blah");
-    assert_eq!(clean_path("foo/bar/baz/../../../blah/"), "blah");
+        assert_eq!(join_path("a/b/", "<stdin>"), "<stdin>");
+        assert_eq!(
+            join_path("C:\\test", "<::core::macros::assert_eq macros>"),
+            "<::core::macros::assert_eq macros>"
+        );
+    }
 
-    // XXX currently known broken tests:
-    //assert_eq!(clean_path("/../../blah/"), "/blah");
-    //assert_eq!(clean_path("c:\\..\\foo"), "c:\\foo");
-}
+    #[test]
+    fn test_clean_path() {
+        assert_eq!(clean_path("/foo/bar/baz/./blah"), "/foo/bar/baz/blah");
+        assert_eq!(clean_path("/foo/bar/baz/./blah/"), "/foo/bar/baz/blah");
+        assert_eq!(clean_path("foo/bar/baz/./blah/"), "foo/bar/baz/blah");
+        assert_eq!(clean_path("foo/bar/baz/../blah/"), "foo/bar/blah");
+        assert_eq!(clean_path("../../blah/"), "../../blah");
+        assert_eq!(clean_path("..\\../blah/"), "..\\..\\blah");
+        assert_eq!(clean_path("foo\\bar\\baz/../blah/"), "foo\\bar\\blah");
+        assert_eq!(clean_path("foo\\bar\\baz/../../../../blah/"), "..\\blah");
+        assert_eq!(clean_path("foo/bar/baz/../../../../blah/"), "../blah");
+        assert_eq!(clean_path("..\\foo"), "..\\foo");
+        assert_eq!(clean_path("foo"), "foo");
+        assert_eq!(clean_path("foo\\bar\\baz/../../../blah/"), "blah");
+        assert_eq!(clean_path("foo/bar/baz/../../../blah/"), "blah");
 
-#[test]
-fn test_shorten_path() {
-    assert_eq!(shorten_path("/foo/bar/baz/blah/blafasel", 6), "/fo...");
-    assert_eq!(shorten_path("/foo/bar/baz/blah/blafasel", 2), "/f");
-    assert_eq!(
-        shorten_path("/foo/bar/baz/blah/blafasel", 21),
-        "/foo/.../blafasel"
-    );
-    assert_eq!(
-        shorten_path("/foo/bar/baz/blah/blafasel", 22),
-        "/foo/.../blah/blafasel"
-    );
-    assert_eq!(
-        shorten_path("C:\\bar\\baz\\blah\\blafasel", 20),
-        "C:\\bar\\...\\blafasel"
-    );
-    assert_eq!(
-        shorten_path("/foo/blar/baz/blah/blafasel", 27),
-        "/foo/blar/baz/blah/blafasel"
-    );
-    assert_eq!(
-        shorten_path("/foo/blar/baz/blah/blafasel", 26),
-        "/foo/.../baz/blah/blafasel"
-    );
-    assert_eq!(
-        shorten_path("/foo/b/baz/blah/blafasel", 23),
-        "/foo/.../blah/blafasel"
-    );
-    assert_eq!(shorten_path("/foobarbaz/blahblah", 16), ".../blahblah");
-    assert_eq!(shorten_path("/foobarbazblahblah", 12), "...lahblah");
-    assert_eq!(shorten_path("", 0), "");
-}
+        // XXX currently known broken tests:
+        //assert_eq!(clean_path("/../../blah/"), "/blah");
+        //assert_eq!(clean_path("c:\\..\\foo"), "c:\\foo");
+    }
 
-#[test]
-fn test_split_path() {
-    assert_eq!(split_path("C:\\a\\b"), (Some("C:\\a"), "b"));
-    assert_eq!(split_path("C:/a\\b"), (Some("C:/a"), "b"));
-    assert_eq!(split_path("C:\\a\\b\\c"), (Some("C:\\a\\b"), "c"));
-    assert_eq!(split_path("a\\b\\c\\d\\e"), (Some("a\\b\\c\\d"), "e"));
-    assert_eq!(split_path("\\\\UNC\\a"), (Some("\\\\UNC"), "a"));
+    #[test]
+    fn test_shorten_path() {
+        assert_eq!(shorten_path("/foo/bar/baz/blah/blafasel", 6), "/fo...");
+        assert_eq!(shorten_path("/foo/bar/baz/blah/blafasel", 2), "/f");
+        assert_eq!(
+            shorten_path("/foo/bar/baz/blah/blafasel", 21),
+            "/foo/.../blafasel"
+        );
+        assert_eq!(
+            shorten_path("/foo/bar/baz/blah/blafasel", 22),
+            "/foo/.../blah/blafasel"
+        );
+        assert_eq!(
+            shorten_path("C:\\bar\\baz\\blah\\blafasel", 20),
+            "C:\\bar\\...\\blafasel"
+        );
+        assert_eq!(
+            shorten_path("/foo/blar/baz/blah/blafasel", 27),
+            "/foo/blar/baz/blah/blafasel"
+        );
+        assert_eq!(
+            shorten_path("/foo/blar/baz/blah/blafasel", 26),
+            "/foo/.../baz/blah/blafasel"
+        );
+        assert_eq!(
+            shorten_path("/foo/b/baz/blah/blafasel", 23),
+            "/foo/.../blah/blafasel"
+        );
+        assert_eq!(shorten_path("/foobarbaz/blahblah", 16), ".../blahblah");
+        assert_eq!(shorten_path("/foobarbazblahblah", 12), "...lahblah");
+        assert_eq!(shorten_path("", 0), "");
+    }
 
-    assert_eq!(split_path("/a/b/c"), (Some("/a/b"), "c"));
-    assert_eq!(split_path("/a/b/c/d"), (Some("/a/b/c"), "d"));
-    assert_eq!(split_path("a/b/c"), (Some("a/b"), "c"));
+    #[test]
+    fn test_split_path() {
+        assert_eq!(split_path("C:\\a\\b"), (Some("C:\\a"), "b"));
+        assert_eq!(split_path("C:/a\\b"), (Some("C:/a"), "b"));
+        assert_eq!(split_path("C:\\a\\b\\c"), (Some("C:\\a\\b"), "c"));
+        assert_eq!(split_path("a\\b\\c\\d\\e"), (Some("a\\b\\c\\d"), "e"));
+        assert_eq!(split_path("\\\\UNC\\a"), (Some("\\\\UNC"), "a"));
 
-    assert_eq!(split_path("a"), (None, "a"));
-    assert_eq!(split_path("a/"), (None, "a"));
-    assert_eq!(split_path("/a"), (Some("/"), "a"));
-    assert_eq!(split_path(""), (None, ""));
-}
+        assert_eq!(split_path("/a/b/c"), (Some("/a/b"), "c"));
+        assert_eq!(split_path("/a/b/c/d"), (Some("/a/b/c"), "d"));
+        assert_eq!(split_path("a/b/c"), (Some("a/b"), "c"));
 
-#[test]
-fn test_split_path_bytes() {
-    assert_eq!(
-        split_path_bytes(&b"C:\\a\\b"[..]),
-        (Some(&b"C:\\a"[..]), &b"b"[..])
-    );
-    assert_eq!(
-        split_path_bytes(&b"C:/a\\b"[..]),
-        (Some(&b"C:/a"[..]), &b"b"[..])
-    );
-    assert_eq!(
-        split_path_bytes(&b"C:\\a\\b\\c"[..]),
-        (Some(&b"C:\\a\\b"[..]), &b"c"[..])
-    );
-    assert_eq!(
-        split_path_bytes(&b"a\\b\\c\\d\\e"[..]),
-        (Some(&b"a\\b\\c\\d"[..]), &b"e"[..])
-    );
-    assert_eq!(
-        split_path_bytes(&b"\\\\UNC\\a"[..]),
-        (Some(&b"\\\\UNC"[..]), &b"a"[..])
-    );
+        assert_eq!(split_path("a"), (None, "a"));
+        assert_eq!(split_path("a/"), (None, "a"));
+        assert_eq!(split_path("/a"), (Some("/"), "a"));
+        assert_eq!(split_path(""), (None, ""));
+    }
 
-    assert_eq!(
-        split_path_bytes(&b"/a/b/c"[..]),
-        (Some(&b"/a/b"[..]), &b"c"[..])
-    );
-    assert_eq!(
-        split_path_bytes(&b"/a/b/c/d"[..]),
-        (Some(&b"/a/b/c"[..]), &b"d"[..])
-    );
-    assert_eq!(
-        split_path_bytes(&b"a/b/c"[..]),
-        (Some(&b"a/b"[..]), &b"c"[..])
-    );
+    #[test]
+    fn test_split_path_bytes() {
+        assert_eq!(
+            split_path_bytes(&b"C:\\a\\b"[..]),
+            (Some(&b"C:\\a"[..]), &b"b"[..])
+        );
+        assert_eq!(
+            split_path_bytes(&b"C:/a\\b"[..]),
+            (Some(&b"C:/a"[..]), &b"b"[..])
+        );
+        assert_eq!(
+            split_path_bytes(&b"C:\\a\\b\\c"[..]),
+            (Some(&b"C:\\a\\b"[..]), &b"c"[..])
+        );
+        assert_eq!(
+            split_path_bytes(&b"a\\b\\c\\d\\e"[..]),
+            (Some(&b"a\\b\\c\\d"[..]), &b"e"[..])
+        );
+        assert_eq!(
+            split_path_bytes(&b"\\\\UNC\\a"[..]),
+            (Some(&b"\\\\UNC"[..]), &b"a"[..])
+        );
 
-    assert_eq!(split_path_bytes(&b"a"[..]), (None, &b"a"[..]));
-    assert_eq!(split_path_bytes(&b"a/"[..]), (None, &b"a"[..]));
-    assert_eq!(split_path_bytes(&b"/a"[..]), (Some(&b"/"[..]), &b"a"[..]));
-    assert_eq!(split_path_bytes(&b""[..]), (None, &b""[..]));
+        assert_eq!(
+            split_path_bytes(&b"/a/b/c"[..]),
+            (Some(&b"/a/b"[..]), &b"c"[..])
+        );
+        assert_eq!(
+            split_path_bytes(&b"/a/b/c/d"[..]),
+            (Some(&b"/a/b/c"[..]), &b"d"[..])
+        );
+        assert_eq!(
+            split_path_bytes(&b"a/b/c"[..]),
+            (Some(&b"a/b"[..]), &b"c"[..])
+        );
+
+        assert_eq!(split_path_bytes(&b"a"[..]), (None, &b"a"[..]));
+        assert_eq!(split_path_bytes(&b"a/"[..]), (None, &b"a"[..]));
+        assert_eq!(split_path_bytes(&b"/a"[..]), (Some(&b"/"[..]), &b"a"[..]));
+        assert_eq!(split_path_bytes(&b""[..]), (None, &b""[..]));
+    }
+
+    #[test]
+    fn test_is_dsym_dir() {
+        assert!(fixture("macos/crash.dSYM").is_dsym_dir());
+        assert!(!fixture("macos/crash").is_dsym_dir());
+    }
+
+    #[test]
+    fn test_resolve_dsym() {
+        let crash_path = fixture("macos/crash.dSYM");
+        let resolved = crash_path.resolve_dsym().unwrap();
+        assert!(resolved.exists());
+        assert!(resolved.ends_with("macos/crash.dSYM/Contents/Resources/DWARF/crash"));
+
+        let other_path = fixture("macos/other.dSYM");
+        assert_eq!(other_path.resolve_dsym(), None);
+    }
+
+    #[test]
+    fn test_dsym_parent() {
+        let crash_path = fixture("macos/crash.dSYM/Contents/Resources/DWARF/crash");
+        let dsym_path = crash_path.dsym_parent().unwrap();
+        assert!(dsym_path.exists());
+        assert!(dsym_path.ends_with("macos/crash.dSYM"));
+
+        let other_path = fixture("macos/crash.dSYM/Contents/Resources/DWARF/invalid");
+        assert_eq!(other_path.dsym_parent(), None);
+    }
 }

--- a/debuginfo/Cargo.toml
+++ b/debuginfo/Cargo.toml
@@ -41,3 +41,4 @@ zip = "0.5.2"
 
 [dev-dependencies]
 insta = "0.15.0"
+symbolic-testutils = { path = "../testutils" }

--- a/debuginfo/tests/test_objects.rs
+++ b/debuginfo/tests/test_objects.rs
@@ -5,6 +5,7 @@ use insta;
 
 use symbolic_common::ByteView;
 use symbolic_debuginfo::{FileEntry, Function, Object, SymbolMap};
+use symbolic_testutils::fixture;
 
 /// Helper to create neat snapshots for symbol tables.
 struct SymbolsDebug<'a>(&'a SymbolMap<'a>);
@@ -76,7 +77,7 @@ impl fmt::Debug for FunctionsDebug<'_> {
 #[test]
 fn test_breakpad() -> Result<(), Error> {
     // Using the windows version here since it contains all record kinds
-    let view = ByteView::open("../testutils/fixtures/windows/crash.sym")?;
+    let view = ByteView::open(fixture("windows/crash.sym"))?;
     let object = Object::parse(&view)?;
 
     insta::assert_debug_snapshot!(object, @r###"
@@ -103,7 +104,7 @@ fn test_breakpad() -> Result<(), Error> {
 
 #[test]
 fn test_breakpad_symbols() -> Result<(), Error> {
-    let view = ByteView::open("../testutils/fixtures/windows/crash.sym")?;
+    let view = ByteView::open(fixture("windows/crash.sym"))?;
     let object = Object::parse(&view)?;
 
     let symbols = object.symbol_map();
@@ -114,7 +115,7 @@ fn test_breakpad_symbols() -> Result<(), Error> {
 
 #[test]
 fn test_breakpad_files() -> Result<(), Error> {
-    let view = ByteView::open("../testutils/fixtures/windows/crash.sym")?;
+    let view = ByteView::open(fixture("windows/crash.sym"))?;
     let object = Object::parse(&view)?;
 
     let session = object.debug_session()?;
@@ -127,7 +128,7 @@ fn test_breakpad_files() -> Result<(), Error> {
 
 #[test]
 fn test_breakpad_functions() -> Result<(), Error> {
-    let view = ByteView::open("../testutils/fixtures/windows/crash.sym")?;
+    let view = ByteView::open(fixture("windows/crash.sym"))?;
     let object = Object::parse(&view)?;
 
     let session = object.debug_session()?;
@@ -139,7 +140,7 @@ fn test_breakpad_functions() -> Result<(), Error> {
 
 #[test]
 fn test_elf_executable() -> Result<(), Error> {
-    let view = ByteView::open("../testutils/fixtures/linux/crash")?;
+    let view = ByteView::open(fixture("linux/crash"))?;
     let object = Object::parse(&view)?;
 
     insta::assert_debug_snapshot!(object, @r###"
@@ -167,7 +168,7 @@ fn test_elf_executable() -> Result<(), Error> {
 
 #[test]
 fn test_elf_debug() -> Result<(), Error> {
-    let view = ByteView::open("../testutils/fixtures/linux/crash.debug")?;
+    let view = ByteView::open(fixture("linux/crash.debug"))?;
     let object = Object::parse(&view)?;
 
     insta::assert_debug_snapshot!(object, @r###"
@@ -196,7 +197,7 @@ fn test_elf_debug() -> Result<(), Error> {
 #[test]
 fn test_elf_symbols() -> Result<(), Error> {
     // TODO(ja): Why does crash.debug not retain the symbol table but report has_symbols
-    let view = ByteView::open("../testutils/fixtures/linux/crash")?;
+    let view = ByteView::open(fixture("linux/crash"))?;
     let object = Object::parse(&view)?;
 
     let symbols = object.symbol_map();
@@ -207,7 +208,7 @@ fn test_elf_symbols() -> Result<(), Error> {
 
 #[test]
 fn test_elf_files() -> Result<(), Error> {
-    let view = ByteView::open("../testutils/fixtures/linux/crash.debug")?;
+    let view = ByteView::open(fixture("linux/crash.debug"))?;
     let object = Object::parse(&view)?;
 
     let session = object.debug_session()?;
@@ -220,7 +221,7 @@ fn test_elf_files() -> Result<(), Error> {
 
 #[test]
 fn test_elf_functions() -> Result<(), Error> {
-    let view = ByteView::open("../testutils/fixtures/linux/crash.debug")?;
+    let view = ByteView::open(fixture("linux/crash.debug"))?;
     let object = Object::parse(&view)?;
 
     let session = object.debug_session()?;
@@ -232,7 +233,7 @@ fn test_elf_functions() -> Result<(), Error> {
 
 #[test]
 fn test_mach_executable() -> Result<(), Error> {
-    let view = ByteView::open("../testutils/fixtures/macos/crash")?;
+    let view = ByteView::open(fixture("macos/crash"))?;
     let object = Object::parse(&view)?;
 
     insta::assert_debug_snapshot!(object, @r###"
@@ -260,8 +261,7 @@ fn test_mach_executable() -> Result<(), Error> {
 
 #[test]
 fn test_mach_dsym() -> Result<(), Error> {
-    let view =
-        ByteView::open("../testutils/fixtures/macos/crash.dSYM/Contents/Resources/DWARF/crash")?;
+    let view = ByteView::open(fixture("macos/crash.dSYM/Contents/Resources/DWARF/crash"))?;
     let object = Object::parse(&view)?;
 
     insta::assert_debug_snapshot!(object, @r###"
@@ -289,7 +289,7 @@ fn test_mach_dsym() -> Result<(), Error> {
 
 #[test]
 fn test_mach_symbols() -> Result<(), Error> {
-    let view = ByteView::open("../testutils/fixtures/macos/crash")?;
+    let view = ByteView::open(fixture("macos/crash"))?;
     let object = Object::parse(&view)?;
 
     let symbols = object.symbol_map();
@@ -300,8 +300,7 @@ fn test_mach_symbols() -> Result<(), Error> {
 
 #[test]
 fn test_mach_files() -> Result<(), Error> {
-    let view =
-        ByteView::open("../testutils/fixtures/macos/crash.dSYM/Contents/Resources/DWARF/crash")?;
+    let view = ByteView::open(fixture("macos/crash.dSYM/Contents/Resources/DWARF/crash"))?;
     let object = Object::parse(&view)?;
 
     let session = object.debug_session()?;
@@ -314,8 +313,7 @@ fn test_mach_files() -> Result<(), Error> {
 
 #[test]
 fn test_mach_functions() -> Result<(), Error> {
-    let view =
-        ByteView::open("../testutils/fixtures/macos/crash.dSYM/Contents/Resources/DWARF/crash")?;
+    let view = ByteView::open(fixture("macos/crash.dSYM/Contents/Resources/DWARF/crash"))?;
     let object = Object::parse(&view)?;
 
     let session = object.debug_session()?;
@@ -327,7 +325,7 @@ fn test_mach_functions() -> Result<(), Error> {
 
 #[test]
 fn test_pe_32() -> Result<(), Error> {
-    let view = ByteView::open("../testutils/fixtures/windows/crash.exe")?;
+    let view = ByteView::open(fixture("windows/crash.exe"))?;
     let object = Object::parse(&view)?;
 
     insta::assert_debug_snapshot!(object, @r###"
@@ -358,7 +356,7 @@ fn test_pe_32() -> Result<(), Error> {
 
 #[test]
 fn test_pe_64() -> Result<(), Error> {
-    let view = ByteView::open("../testutils/fixtures/windows/CrashWithException.exe")?;
+    let view = ByteView::open(fixture("windows/CrashWithException.exe"))?;
     let object = Object::parse(&view)?;
 
     insta::assert_debug_snapshot!(object, @r###"
@@ -392,7 +390,7 @@ fn test_pe_64() -> Result<(), Error> {
 
 #[test]
 fn test_pdb() -> Result<(), Error> {
-    let view = ByteView::open("../testutils/fixtures/windows/crash.pdb")?;
+    let view = ByteView::open(fixture("windows/crash.pdb"))?;
     let object = Object::parse(&view)?;
 
     insta::assert_debug_snapshot!(object, @r###"
@@ -416,7 +414,7 @@ fn test_pdb() -> Result<(), Error> {
 
 #[test]
 fn test_pdb_symbols() -> Result<(), Error> {
-    let view = ByteView::open("../testutils/fixtures/windows/crash.pdb")?;
+    let view = ByteView::open(fixture("windows/crash.pdb"))?;
     let object = Object::parse(&view)?;
 
     let symbols = object.symbol_map();
@@ -427,7 +425,7 @@ fn test_pdb_symbols() -> Result<(), Error> {
 
 #[test]
 fn test_pdb_files() -> Result<(), Error> {
-    let view = ByteView::open("../testutils/fixtures/windows/crash.pdb")?;
+    let view = ByteView::open(fixture("windows/crash.pdb"))?;
     let object = Object::parse(&view)?;
 
     let session = object.debug_session()?;
@@ -440,7 +438,7 @@ fn test_pdb_files() -> Result<(), Error> {
 
 #[test]
 fn test_pdb_functions() -> Result<(), Error> {
-    let view = ByteView::open("../testutils/fixtures/windows/crash.pdb")?;
+    let view = ByteView::open(fixture("windows/crash.pdb"))?;
     let object = Object::parse(&view)?;
 
     let session = object.debug_session()?;

--- a/examples/dump_cfi.rs
+++ b/examples/dump_cfi.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use clap::{App, Arg, ArgMatches};
 use failure::Error;
 
-use symbolic::common::ByteView;
+use symbolic::common::{ByteView, DSymPathExt};
 use symbolic::debuginfo::Object;
 use symbolic::minidump::cfi::AsciiCfiWriter;
 
@@ -18,7 +18,8 @@ fn print_error(error: &Error) {
 fn dump_cfi<P: AsRef<Path>>(path: P) -> Result<(), Error> {
     let path = path.as_ref();
 
-    let buffer = ByteView::open(path)?;
+    let dsym_path = path.resolve_dsym();
+    let buffer = ByteView::open(dsym_path.as_deref().unwrap_or(path))?;
     let object = Object::parse(&buffer)?;
 
     println!(

--- a/examples/dump_sources.rs
+++ b/examples/dump_sources.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use clap::{App, Arg, ArgMatches};
 use failure::Error;
 
-use symbolic::common::ByteView;
+use symbolic::common::{ByteView, DSymPathExt};
 use symbolic::debuginfo::sourcebundle::SourceBundleWriter;
 use symbolic::debuginfo::Archive;
 
@@ -18,7 +18,8 @@ fn print_error(error: &Error) {
 fn write_object_sources(path: &Path, output_path: &Path) -> Result<(), Error> {
     println!("Inspecting {}", path.display());
 
-    let buffer = ByteView::open(path)?;
+    let dsym_path = path.resolve_dsym();
+    let buffer = ByteView::open(dsym_path.as_deref().unwrap_or(path))?;
     let archive = Archive::parse(&buffer)?;
 
     println!("File format: {}", archive.file_format());

--- a/examples/object_debug.rs
+++ b/examples/object_debug.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use clap::{App, Arg, ArgMatches};
 use failure::Error;
 
-use symbolic::common::ByteView;
+use symbolic::common::{ByteView, DSymPathExt};
 use symbolic::debuginfo::Archive;
 
 fn print_error(error: &Error) {
@@ -18,7 +18,8 @@ fn inspect_object<P: AsRef<Path>>(path: P) -> Result<(), Error> {
     let path = path.as_ref();
     println!("Inspecting {}", path.display());
 
-    let buffer = ByteView::open(path)?;
+    let dsym_path = path.resolve_dsym();
+    let buffer = ByteView::open(dsym_path.as_deref().unwrap_or(path))?;
     let archive = Archive::parse(&buffer)?;
 
     println!("File format: {}", archive.file_format());

--- a/minidump/Cargo.toml
+++ b/minidump/Cargo.toml
@@ -39,3 +39,4 @@ cc = { version = "1.0.50", features = ["parallel"] }
 
 [dev-dependencies]
 insta = "0.15.0"
+symbolic-testutils = { path = "../testutils" }

--- a/minidump/tests/test_cfi.rs
+++ b/minidump/tests/test_cfi.rs
@@ -6,6 +6,7 @@ use insta;
 use symbolic_common::ByteView;
 use symbolic_debuginfo::Object;
 use symbolic_minidump::cfi::{AsciiCfiWriter, CfiCache};
+use symbolic_testutils::fixture;
 
 #[test]
 fn load_empty_cfi_cache() -> Result<(), Error> {
@@ -17,7 +18,7 @@ fn load_empty_cfi_cache() -> Result<(), Error> {
 
 #[test]
 fn cfi_from_elf() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/linux/crash")?;
+    let buffer = ByteView::open(fixture("linux/crash"))?;
     let object = Object::parse(&buffer)?;
 
     let buf: Vec<u8> = AsciiCfiWriter::transform(&object)?;
@@ -32,7 +33,7 @@ fn cfi_from_elf() -> Result<(), Error> {
 
 #[test]
 fn cfi_from_macho() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/macos/crash")?;
+    let buffer = ByteView::open(fixture("macos/crash"))?;
     let object = Object::parse(&buffer)?;
 
     let buf: Vec<u8> = AsciiCfiWriter::transform(&object)?;
@@ -47,7 +48,7 @@ fn cfi_from_macho() -> Result<(), Error> {
 
 #[test]
 fn cfi_from_sym_linux() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/linux/crash.sym")?;
+    let buffer = ByteView::open(fixture("linux/crash.sym"))?;
     let object = Object::parse(&buffer)?;
 
     let buf: Vec<u8> = AsciiCfiWriter::transform(&object)?;
@@ -59,7 +60,7 @@ fn cfi_from_sym_linux() -> Result<(), Error> {
 
 #[test]
 fn cfi_from_sym_macos() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/macos/crash.sym")?;
+    let buffer = ByteView::open(fixture("macos/crash.sym"))?;
     let object = Object::parse(&buffer)?;
 
     let buf: Vec<u8> = AsciiCfiWriter::transform(&object)?;
@@ -71,7 +72,7 @@ fn cfi_from_sym_macos() -> Result<(), Error> {
 
 #[test]
 fn cfi_from_sym_windows() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/windows/crash.sym")?;
+    let buffer = ByteView::open(fixture("windows/crash.sym"))?;
     let object = Object::parse(&buffer)?;
 
     let buf: Vec<u8> = AsciiCfiWriter::transform(&object)?;
@@ -83,7 +84,7 @@ fn cfi_from_sym_windows() -> Result<(), Error> {
 
 #[test]
 fn cfi_from_pdb_windows() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/windows/crash.pdb")?;
+    let buffer = ByteView::open(fixture("windows/crash.pdb"))?;
     let object = Object::parse(&buffer)?;
 
     let buf: Vec<u8> = AsciiCfiWriter::transform(&object)?;
@@ -95,7 +96,7 @@ fn cfi_from_pdb_windows() -> Result<(), Error> {
 
 #[test]
 fn cfi_from_pe_windows() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/windows/CrashWithException.exe")?;
+    let buffer = ByteView::open(fixture("windows/CrashWithException.exe"))?;
     let object = Object::parse(&buffer)?;
 
     let buf: Vec<u8> = AsciiCfiWriter::transform(&object)?;

--- a/minidump/tests/test_processor.rs
+++ b/minidump/tests/test_processor.rs
@@ -3,10 +3,11 @@ use insta;
 
 use symbolic_common::ByteView;
 use symbolic_minidump::processor::ProcessState;
+use symbolic_testutils::fixture;
 
 #[test]
 fn process_minidump_linux() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/linux/mini.dmp")?;
+    let buffer = ByteView::open(fixture("linux/mini.dmp"))?;
     let state = ProcessState::from_minidump(&buffer, None)?;
     insta::assert_debug_snapshot!("process_state_linux", &state);
     Ok(())
@@ -14,7 +15,7 @@ fn process_minidump_linux() -> Result<(), Error> {
 
 #[test]
 fn process_minidump_macos() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/macos/mini.dmp")?;
+    let buffer = ByteView::open(fixture("macos/mini.dmp"))?;
     let state = ProcessState::from_minidump(&buffer, None)?;
     insta::assert_debug_snapshot!("process_state_macos", &state);
     Ok(())
@@ -22,7 +23,7 @@ fn process_minidump_macos() -> Result<(), Error> {
 
 #[test]
 fn process_minidump_windows() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/windows/mini.dmp")?;
+    let buffer = ByteView::open(fixture("windows/mini.dmp"))?;
     let state = ProcessState::from_minidump(&buffer, None)?;
     insta::assert_debug_snapshot!("process_state_windows", &state);
     Ok(())
@@ -30,7 +31,7 @@ fn process_minidump_windows() -> Result<(), Error> {
 
 #[test]
 fn get_referenced_modules_linux() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/linux/mini.dmp")?;
+    let buffer = ByteView::open(fixture("linux/mini.dmp"))?;
     let state = ProcessState::from_minidump(&buffer, None)?;
     insta::assert_debug_snapshot!("referenced_modules_linux", &state.referenced_modules());
     Ok(())
@@ -38,7 +39,7 @@ fn get_referenced_modules_linux() -> Result<(), Error> {
 
 #[test]
 fn get_referenced_modules_macos() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/macos/mini.dmp")?;
+    let buffer = ByteView::open(fixture("macos/mini.dmp"))?;
     let state = ProcessState::from_minidump(&buffer, None)?;
     insta::assert_debug_snapshot!("referenced_modules_macos", &state.referenced_modules());
     Ok(())
@@ -46,7 +47,7 @@ fn get_referenced_modules_macos() -> Result<(), Error> {
 
 #[test]
 fn get_referenced_modules_windows() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/windows/mini.dmp")?;
+    let buffer = ByteView::open(fixture("windows/mini.dmp"))?;
     let state = ProcessState::from_minidump(&buffer, None)?;
     insta::assert_debug_snapshot!("referenced_modules_windows", &state.referenced_modules());
     Ok(())

--- a/symcache/Cargo.toml
+++ b/symcache/Cargo.toml
@@ -29,6 +29,7 @@ symbolic-debuginfo = { version = "7.2.0", path = "../debuginfo" }
 [dev-dependencies]
 insta = "0.15.0"
 criterion = "0.3.1"
+symbolic-testutils = { path = "../testutils" }
 
 [features]
 bench = []

--- a/symcache/benches/bench_writer.rs
+++ b/symcache/benches/bench_writer.rs
@@ -5,10 +5,11 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use symbolic_common::ByteView;
 use symbolic_debuginfo::Object;
 use symbolic_symcache::SymCacheWriter;
+use symbolic_testutils::fixture;
 
 fn bench_write_linux(c: &mut Criterion) {
     c.bench_function("write_linux", |b| {
-        let buffer = ByteView::open("../testutils/fixtures/linux/crash.debug").expect("open");
+        let buffer = ByteView::open(fixture("linux/crash.debug")).expect("open");
         b.iter(|| {
             let object = Object::parse(&buffer).expect("parse");
             SymCacheWriter::write_object(&object, Cursor::new(Vec::new()))
@@ -20,9 +21,8 @@ fn bench_write_linux(c: &mut Criterion) {
 
 fn bench_write_macos(c: &mut Criterion) {
     c.bench_function("write_macos", |b| {
-        let buffer =
-            ByteView::open("../testutils/fixtures/macos/crash.dSYM/Contents/Resources/DWARF/crash")
-                .expect("open");
+        let buffer = ByteView::open(fixture("macos/crash.dSYM/Contents/Resources/DWARF/crash"))
+            .expect("open");
 
         b.iter(|| {
             let object = Object::parse(&buffer).expect("parse");
@@ -35,7 +35,7 @@ fn bench_write_macos(c: &mut Criterion) {
 
 fn bench_write_breakpad(c: &mut Criterion) {
     c.bench_function("write_breakpad", |b| {
-        let buffer = ByteView::open("../testutils/fixtures/windows/crash.sym").expect("open");
+        let buffer = ByteView::open(fixture("windows/crash.sym")).expect("open");
         b.iter(|| {
             let object = Object::parse(&buffer).expect("parse");
             SymCacheWriter::write_object(&object, Cursor::new(Vec::new()))

--- a/symcache/tests/test_cache.rs
+++ b/symcache/tests/test_cache.rs
@@ -5,6 +5,7 @@ use insta;
 
 use symbolic_common::ByteView;
 use symbolic_symcache::SymCache;
+use symbolic_testutils::fixture;
 
 /// Helper to create neat snapshots for symbol tables.
 struct FunctionsDebug<'a>(&'a SymCache<'a>);
@@ -24,7 +25,7 @@ impl fmt::Debug for FunctionsDebug<'_> {
 
 #[test]
 fn test_load_header_linux() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/symcache/current/linux.symc")?;
+    let buffer = ByteView::open(fixture("symcache/current/linux.symc"))?;
     let symcache = SymCache::parse(&buffer)?;
     insta::assert_debug_snapshot!(symcache, @r###"
    ⋮SymCache {
@@ -43,7 +44,7 @@ fn test_load_header_linux() -> Result<(), Error> {
 
 #[test]
 fn test_load_functions_linux() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/symcache/current/linux.symc")?;
+    let buffer = ByteView::open(fixture("symcache/current/linux.symc"))?;
     let symcache = SymCache::parse(&buffer)?;
     insta::assert_debug_snapshot!("functions_linux", FunctionsDebug(&symcache));
     Ok(())
@@ -51,7 +52,7 @@ fn test_load_functions_linux() -> Result<(), Error> {
 
 #[test]
 fn test_load_header_macos() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/symcache/current/macos.symc")?;
+    let buffer = ByteView::open(fixture("symcache/current/macos.symc"))?;
     let symcache = SymCache::parse(&buffer)?;
     insta::assert_debug_snapshot!(symcache, @r###"
    ⋮SymCache {
@@ -70,7 +71,7 @@ fn test_load_header_macos() -> Result<(), Error> {
 
 #[test]
 fn test_load_functions_macos() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/symcache/current/macos.symc")?;
+    let buffer = ByteView::open(fixture("symcache/current/macos.symc"))?;
     let symcache = SymCache::parse(&buffer)?;
     insta::assert_debug_snapshot!("functions_macos", FunctionsDebug(&symcache));
     Ok(())
@@ -78,7 +79,7 @@ fn test_load_functions_macos() -> Result<(), Error> {
 
 #[test]
 fn test_lookup() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/symcache/current/macos.symc")?;
+    let buffer = ByteView::open(fixture("symcache/current/macos.symc"))?;
     let symcache = SymCache::parse(&buffer)?;
     let line_infos = symcache.lookup(4_458_187_797 - 4_458_131_456)?;
     insta::assert_debug_snapshot!("lookup", &line_infos);

--- a/symcache/tests/test_compat.rs
+++ b/symcache/tests/test_compat.rs
@@ -2,10 +2,11 @@ use failure::Error;
 
 use symbolic_common::ByteView;
 use symbolic_symcache::SymCache;
+use symbolic_testutils::fixture;
 
 #[test]
 fn test_v1() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/symcache/compat/v1.symc")?;
+    let buffer = ByteView::open(fixture("symcache/compat/v1.symc"))?;
     let symcache = SymCache::parse(&buffer)?;
 
     // The symcache ID has changed from UUID to DebugId

--- a/symcache/tests/test_writer.rs
+++ b/symcache/tests/test_writer.rs
@@ -7,6 +7,7 @@ use insta;
 use symbolic_common::ByteView;
 use symbolic_debuginfo::Object;
 use symbolic_symcache::{SymCache, SymCacheWriter};
+use symbolic_testutils::fixture;
 
 /// Helper to create neat snapshots for symbol tables.
 struct FunctionsDebug<'a>(&'a SymCache<'a>);
@@ -26,7 +27,7 @@ impl fmt::Debug for FunctionsDebug<'_> {
 
 #[test]
 fn test_write_header_linux() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/linux/crash.debug")?;
+    let buffer = ByteView::open(fixture("linux/crash.debug"))?;
     let object = Object::parse(&buffer)?;
 
     let mut buffer = Vec::new();
@@ -50,7 +51,7 @@ fn test_write_header_linux() -> Result<(), Error> {
 
 #[test]
 fn test_write_functions_linux() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/linux/crash.debug")?;
+    let buffer = ByteView::open(fixture("linux/crash.debug"))?;
     let object = Object::parse(&buffer)?;
 
     let mut buffer = Vec::new();
@@ -63,8 +64,7 @@ fn test_write_functions_linux() -> Result<(), Error> {
 
 #[test]
 fn test_write_header_macos() -> Result<(), Error> {
-    let buffer =
-        ByteView::open("../testutils/fixtures/macos/crash.dSYM/Contents/Resources/DWARF/crash")?;
+    let buffer = ByteView::open(fixture("macos/crash.dSYM/Contents/Resources/DWARF/crash"))?;
     let object = Object::parse(&buffer)?;
 
     let mut buffer = Vec::new();
@@ -88,8 +88,7 @@ fn test_write_header_macos() -> Result<(), Error> {
 
 #[test]
 fn test_write_functions_macos() -> Result<(), Error> {
-    let buffer =
-        ByteView::open("../testutils/fixtures/macos/crash.dSYM/Contents/Resources/DWARF/crash")?;
+    let buffer = ByteView::open(fixture("macos/crash.dSYM/Contents/Resources/DWARF/crash"))?;
     let object = Object::parse(&buffer)?;
 
     let mut buffer = Vec::new();
@@ -102,7 +101,7 @@ fn test_write_functions_macos() -> Result<(), Error> {
 
 #[test]
 fn test_write_large_symbol_names() -> Result<(), Error> {
-    let buffer = ByteView::open("../testutils/fixtures/regression/large_symbol.sym")?;
+    let buffer = ByteView::open(fixture("regression/large_symbol.sym"))?;
     let object = Object::parse(&buffer)?;
 
     let mut buffer = Vec::new();

--- a/testutils/Cargo.toml
+++ b/testutils/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "symbolic-testutils"
+version = "7.2.0"
+license = "MIT"
+edition = "2018"
+publish = false
+
+[dependencies]

--- a/testutils/fixtures/macos/crash.dSYM/Contents/Resources/DWARF/invalid
+++ b/testutils/fixtures/macos/crash.dSYM/Contents/Resources/DWARF/invalid
@@ -1,0 +1,1 @@
+This file is used to test symbolic::common::DSymPathExt.

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -1,0 +1,33 @@
+//! Test helpers for `symbolic`.
+#![warn(missing_docs)]
+
+use std::path::{Path, PathBuf};
+
+/// Returns the full path to the specified fixture.
+///
+/// Fixtures are stored in the `testutils/fixtures` directory and paths should be given relative to
+/// that location.
+///
+/// # Example
+///
+/// ```
+/// use symbolic_testutils::fixture;
+///
+/// let path = fixture("macos/crash");
+/// assert!(path.ends_with("macos/crash"));
+/// ```
+pub fn fixture<P: AsRef<Path>>(path: P) -> PathBuf {
+    let mut full_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    full_path.push("fixtures");
+
+    let path = path.as_ref();
+    full_path.push(path);
+
+    assert!(
+        full_path.exists(),
+        "Fixture does not exist: {}",
+        path.display()
+    );
+
+    full_path
+}

--- a/unreal/Cargo.toml
+++ b/unreal/Cargo.toml
@@ -36,3 +36,4 @@ serde = { version = "1.0.94", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 insta = "0.15.0"
+symbolic-testutils = { path = "../testutils" }

--- a/unreal/tests/test_unreal_crash_parse.rs
+++ b/unreal/tests/test_unreal_crash_parse.rs
@@ -1,19 +1,18 @@
 use std::fs::File;
 use std::io::Read;
 
+use symbolic_testutils::fixture;
 use symbolic_unreal::{Unreal4Crash, Unreal4Error, Unreal4FileType};
 
 fn get_unreal_crash() -> Result<Unreal4Crash, Unreal4Error> {
-    let mut file =
-        File::open("../testutils/fixtures/unreal/unreal_crash").expect("example file opens");
+    let mut file = File::open(fixture("unreal/unreal_crash")).expect("example file opens");
     let mut file_content = Vec::new();
     file.read_to_end(&mut file_content).expect("fixture file");
     Unreal4Crash::parse(&file_content)
 }
 
 fn get_unreal_apple_crash() -> Result<Unreal4Crash, Unreal4Error> {
-    let mut file =
-        File::open("../testutils/fixtures/unreal/unreal_crash_apple").expect("example file opens");
+    let mut file = File::open(fixture("unreal/unreal_crash_apple")).expect("example file opens");
     let mut file_content = Vec::new();
     file.read_to_end(&mut file_content).expect("fixture file");
     Unreal4Crash::parse(&file_content)


### PR DESCRIPTION
Implements utilities for dealing with `dSYM` folder structures. They can check for a dSYM folder structure, resolve the dSYM parent from a deep path, and resolve the deep path from the parent folder.

`sentry-cli` partially implements this logic already, so we can reduce some duplicate code here. Also, the examples used to require that one declares the full path to a dSYM file, but this is just unnecessary.  

![_Users_jauer_Coding_symbolic_target_doc_symbolic_common_trait DSymPathExt html](https://user-images.githubusercontent.com/1433023/78650169-d4f27400-78be-11ea-9f83-db730b7238f3.png)
