### PR TITLE
fix(debuginfo): Skip eliminated functions in linked objects

### DIFF
--- a/debuginfo/src/dwarf.rs
+++ b/debuginfo/src/dwarf.rs
@@ -406,7 +406,8 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
 
         // Clang's LLD might eliminate an entire compilation unit and simply set the low_pc to zero
         // and remove all range entries to indicate that it is missing. Skip such a unit, as it does
-        // not contain any code that can be executed.
+        // not contain any code that can be executed. Special case relocatable objects, as here the
+        // range information has not been written yet and all units look like this.
         if info.kind != ObjectKind::Relocatable
             && unit.low_pc == 0
             && entry.attr(constants::DW_AT_ranges)?.is_none()

--- a/debuginfo/src/dwarf.rs
+++ b/debuginfo/src/dwarf.rs
@@ -493,7 +493,8 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
 
         // To go by the logic in dwarf2read, a `low_pc` of 0 can indicate an
         // eliminated duplicate when the GNU linker is used. In relocatable
-        // objects, we want to retain those functions.
+        // objects, all functions are at `0` since they have not been placed
+        // yet, so we want to retain them.
         let kind = self.inner.info.kind;
         let low_pc = match low_pc {
             Some(low_pc) if low_pc != 0 || kind == ObjectKind::Relocatable => low_pc,

--- a/debuginfo/src/dwarf.rs
+++ b/debuginfo/src/dwarf.rs
@@ -115,7 +115,7 @@ impl fmt::Debug for DwarfSection<'_> {
 /// data. If so, override the provided `section_data` method. Also, if there is a faster way to
 /// check for the existence of a section without loading its data, override `has_section`.
 pub trait Dwarf<'data> {
-    /// Returns whether the file was written on a big-endian or little-endian machine.
+    /// Returns whether the file was compiled for a big-endian or little-endian machine.
     ///
     /// This can usually be determined by inspecting the file's headers. Sometimes, this is also
     /// given by the architecture.
@@ -404,6 +404,13 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             None => return Err(gimli::read::Error::MissingUnitDie.into()),
         };
 
+        // Clang's LLD might eliminate an entire compilation unit and simply set the low_pc to zero
+        // and remove all range entries to indicate that it is missing. Skip such a unit, as it does
+        // not contain any code that can be executed.
+        if !info.relocatable && unit.low_pc == 0 && entry.attr(constants::DW_AT_ranges)?.is_none() {
+            return Ok(None);
+        }
+
         let language = match entry.attr_value(constants::DW_AT_language)? {
             Some(AttributeValue::Language(lang)) => language_from_dwarf(lang),
             _ => Language::Unknown,
@@ -481,8 +488,11 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             return Ok(tuple);
         }
 
+        // To go by the logic in dwarf2read, a `low_pc` of 0 can indicate an
+        // eliminated duplicate when the GNU linker is used. In relocatable
+        // objects, we want to retain those functions.
         let low_pc = match low_pc {
-            Some(low_pc) => low_pc,
+            Some(low_pc) if low_pc != 0 || self.inner.info.relocatable => low_pc,
             _ => return Ok(tuple),
         };
 
@@ -579,9 +589,6 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
     }
 
     /// Collects all functions within this compilation unit.
-    ///
-    /// Since there are some DWARF files where functions appear out of order -- instead of sorted by
-    /// their start address -- they have to be collected anyway.
     fn functions(&self, range_buf: &mut Vec<Range>) -> Result<Vec<Function<'d>>, DwarfError> {
         let mut depth = 0;
         let mut skipped_depth = None;
@@ -830,6 +837,7 @@ struct DwarfInfo<'data> {
     units: Vec<LazyCell<Option<Unit<'data>>>>,
     symbol_map: SymbolMap<'data>,
     load_address: u64,
+    relocatable: bool,
 }
 
 impl<'d> Deref for DwarfInfo<'d> {
@@ -846,6 +854,7 @@ impl<'d> DwarfInfo<'d> {
         sections: &'d DwarfSections<'d>,
         symbol_map: SymbolMap<'d>,
         load_address: u64,
+        relocatable: bool,
     ) -> Result<Self, DwarfError> {
         let inner = gimli::read::Dwarf {
             debug_abbrev: sections.debug_abbrev.to_gimli(),
@@ -874,6 +883,7 @@ impl<'d> DwarfInfo<'d> {
             units,
             symbol_map,
             load_address,
+            relocatable,
         })
     }
 
@@ -997,13 +1007,14 @@ impl<'d> DwarfDebugSession<'d> {
         dwarf: &D,
         symbol_map: SymbolMap<'d>,
         load_address: u64,
+        relocatable: bool,
     ) -> Result<Self, DwarfError>
     where
         D: Dwarf<'d>,
     {
         let sections = DwarfSections::from_dwarf(dwarf)?;
         let cell = SelfCell::try_new(Box::new(sections), |sections| {
-            DwarfInfo::parse(unsafe { &*sections }, symbol_map, load_address)
+            DwarfInfo::parse(unsafe { &*sections }, symbol_map, load_address, relocatable)
         })?;
 
         Ok(DwarfDebugSession { cell })

--- a/debuginfo/src/elf.rs
+++ b/debuginfo/src/elf.rs
@@ -234,8 +234,7 @@ impl<'d> ElfObject<'d> {
     /// [`has_debug_info`](struct.ElfObject.html#method.has_debug_info).
     pub fn debug_session(&self) -> Result<DwarfDebugSession<'d>, DwarfError> {
         let symbols = self.symbol_map();
-        let relocatable = self.kind() == ObjectKind::Relocatable;
-        DwarfDebugSession::parse(self, symbols, self.load_address(), relocatable)
+        DwarfDebugSession::parse(self, symbols, self.load_address(), self.kind())
     }
 
     /// Determines whether this object contains stack unwinding information.

--- a/debuginfo/src/elf.rs
+++ b/debuginfo/src/elf.rs
@@ -234,7 +234,8 @@ impl<'d> ElfObject<'d> {
     /// [`has_debug_info`](struct.ElfObject.html#method.has_debug_info).
     pub fn debug_session(&self) -> Result<DwarfDebugSession<'d>, DwarfError> {
         let symbols = self.symbol_map();
-        DwarfDebugSession::parse(self, symbols, self.load_address())
+        let relocatable = self.kind() == ObjectKind::Relocatable;
+        DwarfDebugSession::parse(self, symbols, self.load_address(), relocatable)
     }
 
     /// Determines whether this object contains stack unwinding information.

--- a/debuginfo/src/macho.rs
+++ b/debuginfo/src/macho.rs
@@ -213,7 +213,8 @@ impl<'d> MachObject<'d> {
     /// [`has_debug_info`](struct.MachObject.html#method.has_debug_info).
     pub fn debug_session(&self) -> Result<DwarfDebugSession<'d>, DwarfError> {
         let symbols = self.symbol_map();
-        DwarfDebugSession::parse(self, symbols, self.load_address())
+        let relocatable = self.kind() == ObjectKind::Relocatable;
+        DwarfDebugSession::parse(self, symbols, self.load_address(), relocatable)
     }
 
     /// Determines whether this object contains stack unwinding information.

--- a/debuginfo/src/macho.rs
+++ b/debuginfo/src/macho.rs
@@ -213,8 +213,7 @@ impl<'d> MachObject<'d> {
     /// [`has_debug_info`](struct.MachObject.html#method.has_debug_info).
     pub fn debug_session(&self) -> Result<DwarfDebugSession<'d>, DwarfError> {
         let symbols = self.symbol_map();
-        let relocatable = self.kind() == ObjectKind::Relocatable;
-        DwarfDebugSession::parse(self, symbols, self.load_address(), relocatable)
+        DwarfDebugSession::parse(self, symbols, self.load_address(), self.kind())
     }
 
     /// Determines whether this object contains stack unwinding information.


### PR DESCRIPTION
Fixes an issue that indirectly lead to _"inline parent offset too large for symcache file format"_ errors by reintroducing checks for functions with a `DW_AT_low_pc` of `0`.

In regular shared objects or executables, such functions have been eliminated by the linker. As the primary use case of this library is to symbolicate stack traces, yielding such functions from the function iterator is not desirable. Also, the virtual address of the functions is no longer valid and implicitly overlaps with other eliminated functions. At least in the default behavior, they should not be included.

Removing the checks introduced a 10% performance regression on large ELF symbols. I did not notice this on my initial tests, since I missed the fact that this case is only triggered by the GNU linker. If it weren't for the symcache bug, the performance hit alone would be bearable.

Now, for relocatable objects it may make sense to include the functions. This means, there are two options:
1. Adding a method on `DwarfFunctionIterator` that allows to override the check. This has the disadvantage that it would not be exposed on the trait or on `ObjectFunctionIterator`. A possible interface could be:
```rust
for function in debug_session.functions().include_eliminated(true) { ... }
```
2. The DWARF implementation could detect that this is a `Relocatable`, and include the function by default and hide them otherwise. This would mean that the iterator magically does the right thing. Also, this comes closest to the original intention of the previously removed code comment. 

Since I am gravitating to option 2, this is what is implemented in this patch.

Partially reverts https://github.com/getsentry/symbolic/pull/173
cc @nnethercote 