### PR TITLE
fix(common): Avoid panics for UTF-8 characters in paths

### DIFF
--- a/common/src/path.rs
+++ b/common/src/path.rs
@@ -117,7 +117,7 @@ pub fn join_path(base: &str, other: &str) -> String {
         "{}{}{}",
         base.trim_end_matches(is_path_separator),
         if is_windows { '\\' } else { '/' },
-        other.trim_end_matches(is_path_separator)
+        other.trim_start_matches(is_path_separator)
     )
 }
 


### PR DESCRIPTION
Fixes panics when joining or normalizing paths when they contain multi-byte unicode characters. Along with this, some common code is refactored to reduce code duplication.

The behavior of some of these functions is suboptimal, particularly `join_path` and `shorten_path`. The next step could be to refactor those methods internally to fix the known broken tests and odd behavior. Next, we could create a proper library for a unified `Path` type.