### PR TITLE
fix(minidump): Skip TooManyRegisterRules errors in CFI

### DIFF
--- a/minidump/src/cfi.rs
+++ b/minidump/src/cfi.rs
@@ -303,12 +303,10 @@ impl<W: Write> AsciiCfiWriter<W> {
             match table.next_row() {
                 Ok(None) => break,
                 Ok(Some(row)) => rows.push(row.clone()),
-                Err(Error::UnknownCallFrameInstruction(_)) => {
-                    continue;
-                }
-                Err(e) => {
-                    return Err(e.context(CfiErrorKind::BadDebugInfo).into());
-                }
+                Err(Error::UnknownCallFrameInstruction(_)) => continue,
+                // NOTE: Temporary workaround for https://github.com/gimli-rs/gimli/pull/487
+                Err(Error::TooManyRegisterRules) => continue,
+                Err(e) => return Err(e.context(CfiErrorKind::BadDebugInfo).into()),
             }
         }
 


### PR DESCRIPTION
Gimli has a hardcoded limit of 32 register rules per CFI row. There are rare occurrences where this limit is exceeded for single rows. In this case, it does not make sense to abort conversion, and instead just skip the row. 

Ref https://github.com/gimli-rs/gimli/pull/487