### PR TITLE
fix(debuginfo): Calculate line record sizes for DWARF

### DIFF
--- a/debuginfo/src/base.rs
+++ b/debuginfo/src/base.rs
@@ -504,9 +504,15 @@ pub struct LineInfo<'data> {
 
 impl fmt::Debug for LineInfo<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("LineInfo")
-            .field("address", &format_args!("{:#x}", self.address))
-            .field("file", &self.file)
+        let mut s = f.debug_struct("LineInfo");
+        s.field("address", &format_args!("{:#x}", self.address));
+
+        match self.size {
+            Some(size) => s.field("size", &format_args!("{:#x}", size)),
+            None => s.field("size", &self.size),
+        };
+
+        s.field("file", &self.file)
             .field("line", &self.line)
             .finish()
     }


### PR DESCRIPTION
Calculates line record sizes for DWARF by comparing with the previous row emitted from the line number program. Additionally, the sequence end point is used to calculate the length for the last row/record.