### PR TITLE
fix(debuginfo): Detect all scopes when collecting inlinees

### DIFF
--- a/debuginfo/src/dwarf.rs
+++ b/debuginfo/src/dwarf.rs
@@ -613,17 +613,17 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
                 _ => skipped_depth = None,
             }
 
+            // Flush all functions out that exceed the current iteration depth. Since we
+            // encountered an entry at this level, there will be no more inlinees to the
+            // previous function at the same level or any of it's children.
+            stack.flush(depth, &mut functions);
+
             // Skip anything that is not a function.
             let inline = match entry.tag() {
                 constants::DW_TAG_subprogram => false,
                 constants::DW_TAG_inlined_subroutine => true,
                 _ => continue,
             };
-
-            // Flush all functions out that exceed the current iteration depth. Since we
-            // encountered a function at this level, there will be no more inlinees to the
-            // previous function at the same level or any of it's children.
-            stack.flush(depth, &mut functions);
 
             range_buf.clear();
             let (call_line, call_file) = self.parse_ranges(entry, range_buf)?;

--- a/debuginfo/src/pdb.rs
+++ b/debuginfo/src/pdb.rs
@@ -1033,6 +1033,13 @@ impl<'s> Unit<'s> {
                 _ => skipped_depth = None,
             }
 
+            // Flush all functions out that exceed the current iteration depth. Since we
+            // encountered a symbol at this level, there will be no more inlinees to the
+            // previous function at the same level or any of it's children.
+            if symbol.ends_scope() {
+                stack.flush(depth, &mut functions);
+            }
+
             let function = match symbol.parse() {
                 Ok(SymbolData::Procedure(proc)) => {
                     proc_offsets.push((depth, proc.offset));
@@ -1057,11 +1064,6 @@ impl<'s> Unit<'s> {
                 // symbol types. Instead of erroring too often, it's better to swallow these.
                 _ => continue,
             };
-
-            // Flush all functions out that exceed the current iteration depth. Since we
-            // encountered a function at this level, there will be no more inlinees to the
-            // previous function at the same level or any of it's children.
-            stack.flush(depth, &mut functions);
 
             match function {
                 Some(function) => stack.push(depth, function),

--- a/debuginfo/src/private.rs
+++ b/debuginfo/src/private.rs
@@ -227,6 +227,11 @@ impl<'a> FunctionStack<'a> {
     pub fn flush(&mut self, depth: isize, destination: &mut Vec<Function<'a>>) {
         let len = self.0.len();
 
+        // Fast path if the last item is already a parent of the current depth.
+        if self.0.last().map_or(false, |&(d, _)| d < depth) {
+            return;
+        }
+
         // Search for the first function that lies at or beyond the specified depth.
         let cutoff = self.0.iter().position(|&(d, _)| d >= depth).unwrap_or(len);
 

--- a/debuginfo/tests/snapshots/test_objects__elf_functions.snap
+++ b/debuginfo/tests/snapshots/test_objects__elf_functions.snap
@@ -9,15 +9,14 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x1ec5: main.cpp:9 (../linux)
   0x1ec7: main.cpp:15 (../linux)
   0x1eda: main.cpp:19 (../linux)
-  0x1ee0: stdio2.h:104 (/usr/include/x86_64-linux-gnu/bits)
+  0x1ee0: main.cpp:10 (../linux)
   0x1ef7: main.cpp:19 (../linux)
 
   > 0x1ec7: printf (0x13)
     0x1ec7: stdio2.h:104 (/usr/include/x86_64-linux-gnu/bits)
-    0x1ee0: main.cpp:10 (../linux)
 
-    > 0x1ee0: printf (0x17)
-      0x1ee0: stdio2.h:104 (/usr/include/x86_64-linux-gnu/bits)
+  > 0x1ee0: printf (0x17)
+    0x1ee0: stdio2.h:104 (/usr/include/x86_64-linux-gnu/bits)
 
 > 0x1f00: _ZN15google_breakpad18MinidumpDescriptorD1Ev (0x32)
   0x1f00: minidump_descriptor.h:48 (../deps/breakpad/src/client/linux/handler)
@@ -558,7 +557,7 @@ expression: "FunctionsDebug(&functions[..10], 0)"
     0x23aa: exception_handler.cc:170 (../deps/breakpad/src/client/linux/handler)
     0x23b2: exception_handler.cc:171 (../deps/breakpad/src/client/linux/handler)
     0x23b9: exception_handler.cc:170 (../deps/breakpad/src/client/linux/handler)
-    0x23bb: linux_syscall_support.h:3533 (../deps/third_party/lss)
+    0x23bb: exception_handler.cc:176 (../deps/breakpad/src/client/linux/handler)
     0x2408: exception_handler.cc:176 (../deps/breakpad/src/client/linux/handler)
     0x241d: exception_handler.cc:175 (../deps/breakpad/src/client/linux/handler)
     0x2425: linux_syscall_support.h:3533 (../deps/third_party/lss)
@@ -568,10 +567,9 @@ expression: "FunctionsDebug(&functions[..10], 0)"
 
     > 0x23b2: sys_sigaltstack (0x7)
       0x23b2: linux_syscall_support.h:3533 (../deps/third_party/lss)
-      0x23bb: exception_handler.cc:176 (../deps/breakpad/src/client/linux/handler)
 
-      > 0x23bb: sys_sigaltstack (0x71)
-        0x23bb: linux_syscall_support.h:3533 (../deps/third_party/lss)
+    > 0x23bb: sys_sigaltstack (0x71)
+      0x23bb: linux_syscall_support.h:3533 (../deps/third_party/lss)
 
   > 0x220f: _ZNSt7__cxx114listIN15google_breakpad9AppMemoryESaIS2_EED4Ev (0x31)
     0x220f: stl_list.h:507 (/usr/include/c++/5/bits)
@@ -772,7 +770,7 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x282f: exception_handler.cc:550 (../deps/breakpad/src/client/linux/handler)
   0x2832: exception_handler.cc:550 (../deps/breakpad/src/client/linux/handler)
   0x2861: exception_handler.cc:551 (../deps/breakpad/src/client/linux/handler)
-  0x286e: linux_syscall_support.h:3718 (../deps/third_party/lss)
+  0x286e: exception_handler.cc:553 (../deps/breakpad/src/client/linux/handler)
   0x288c: exception_handler.cc:553 (../deps/breakpad/src/client/linux/handler)
   0x2891: linux_syscall_support.h:3718 (../deps/third_party/lss)
   0x28b2: exception_handler.cc:553 (../deps/breakpad/src/client/linux/handler)
@@ -865,13 +863,12 @@ expression: "FunctionsDebug(&functions[..10], 0)"
 
   > 0x2832: sys_prctl (0x2f)
     0x2832: linux_syscall_support.h:3479 (../deps/third_party/lss)
-    0x286e: exception_handler.cc:553 (../deps/breakpad/src/client/linux/handler)
 
-    > 0x286e: sys_waitpid (0x49)
-      0x286e: linux_syscall_support.h:4496 (../deps/third_party/lss)
+  > 0x286e: sys_waitpid (0x49)
+    0x286e: linux_syscall_support.h:4496 (../deps/third_party/lss)
 
-      > 0x286e: sys_wait4 (0x49)
-        0x286e: linux_syscall_support.h:3718 (../deps/third_party/lss)
+    > 0x286e: sys_wait4 (0x49)
+      0x286e: linux_syscall_support.h:3718 (../deps/third_party/lss)
 
   > 0x28cd: sys_close (0x2a)
     0x28cd: linux_syscall_support.h:3357 (../deps/third_party/lss)

--- a/symcache/tests/snapshots/test_writer__functions_macos.snap
+++ b/symcache/tests/snapshots/test_writer__functions_macos.snap
@@ -1,6 +1,4 @@
 ---
-created: "2019-07-02T08:47:28.591628Z"
-creator: insta@0.8.1
 source: symcache/tests/test_writer.rs
 expression: FunctionsDebug(&symcache)
 ---
@@ -565,7 +563,6 @@ expression: FunctionsDebug(&symcache)
             3480 _ZNSt3__16__sortIRNS_6__lessIN15google_breakpad15DynamicImageRefES3_EEPS3_EEvT0_S7_T_
             3505 _ZNKSt3__16__lessIN15google_breakpad15DynamicImageRefES2_EclERKS2_S5_
             3505 _ZNK15google_breakpad15DynamicImageRefltERKS0_
-            3517 _ZNKSt3__16__lessIN15google_breakpad15DynamicImageRefES2_EclERKS2_S5_
             3517 _ZNSt3__17__sort3IRNS_6__lessIN15google_breakpad15DynamicImageRefES3_EEPS3_EEjT0_S7_S7_T_
             3517 _ZNKSt3__16__lessIN15google_breakpad15DynamicImageRefES2_EclERKS2_S5_
             3517 _ZNK15google_breakpad15DynamicImageRefltERKS0_
@@ -601,6 +598,7 @@ expression: FunctionsDebug(&symcache)
             362a _ZNK15google_breakpad12DynamicImage14GetLoadAddressEv
             362e _ZNKSt3__16__lessIN15google_breakpad15DynamicImageRefES2_EclERKS2_S5_
             362e _ZNK15google_breakpad15DynamicImageRefltERKS0_
+            36dc _ZNKSt3__16__lessIN15google_breakpad15DynamicImageRefES2_EclERKS2_S5_
             36dc _ZNK15google_breakpad15DynamicImageRefltERKS0_
             36e6 _ZN15google_breakpad12DynamicImageltERKS0_
             36e6 _ZNK15google_breakpad12DynamicImage14GetLoadAddressEv
@@ -977,9 +975,9 @@ expression: FunctionsDebug(&symcache)
             4c8e _ZN15google_breakpad17MinidumpGenerator23SetExceptionInformationEiiij
             4d80 _ZN15google_breakpad16ExceptionHandler14WaitForMessageEPv
             4db7 _ZN15google_breakpad16ExceptionHandler14SuspendThreadsEv
-            4e42 _ZN15google_breakpad16ExceptionHandler13ResumeThreadsEv
             4e42 _ZN15google_breakpad16ExceptionHandler14SuspendThreadsEv
             4ee5 _ZN15google_breakpad19breakpad_exc_serverEP17mach_msg_header_tS1_
+            4fad _ZN15google_breakpad16ExceptionHandler13ResumeThreadsEv
             5060 _ZN15google_breakpad16ExceptionHandler14SuspendThreadsEv
             50d0 _ZN15google_breakpad16ExceptionHandler13ResumeThreadsEv
             5140 _ZN15google_breakpad16ExceptionHandler16UninstallHandlerEb
@@ -1276,10 +1274,10 @@ expression: FunctionsDebug(&symcache)
             7351 _ZNSt3__116allocator_traitsINS_9allocatorIhEEE10deallocateERS2_Phm
             7351 _ZNSt3__19allocatorIhE10deallocateEPhm
             7351 _ZNSt3__112__deallocateEPv
-            7379 _ZNSt3__16vectorIhNS_9allocatorIhEEED1Ev
             7379 _ZN15google_breakpad12UntypedMDRVA4CopyEPKvm
             73a0 _ZN15google_breakpad12UntypedMDRVA4CopyEPKvm
             73ba _ZNK15google_breakpad12UntypedMDRVA8locationEv
+            73e3 _ZNSt3__16vectorIhNS_9allocatorIhEEED1Ev
             73e3 _ZNSt3__16vectorIhNS_9allocatorIhEEED2Ev
             73e3 _ZNSt3__113__vector_baseIhNS_9allocatorIhEEED2Ev
             73ed _ZNSt3__113__vector_baseIhNS_9allocatorIhEEE5clearEv
@@ -1496,7 +1494,6 @@ expression: FunctionsDebug(&symcache)
             a620 _ZNSt3__116allocator_traitsINS_9allocatorItEEE8allocateERS2_m
             a620 _ZNSt3__19allocatorItE8allocateEmPKv
             a624 _ZNSt3__110__allocateEm
-            a63d _ZNSt3__16vectorItNS_9allocatorItEEE26__swap_out_circular_bufferERNS_14__split_bufferItRS2_EEPt
             a63d _ZNSt3__16vectorItNS_9allocatorItEEE12__move_rangeEPtS4_S4_
             a652 _ZNSt3__16vectorItNS_9allocatorItEEE18__construct_at_endEmRKt
             a68b _ZNSt3__116allocator_traitsINS_9allocatorItEEE9constructItJRKtEEEvRS2_PT_DpOT0_
@@ -1513,6 +1510,7 @@ expression: FunctionsDebug(&symcache)
             a98c _ZNSt3__116allocator_traitsINS_9allocatorItEEE9constructItJRKtEEEvRS2_PT_DpOT0_
             a98c _ZNSt3__116allocator_traitsINS_9allocatorItEEE11__constructItJRKtEEEvNS_17integral_constantIbLb1EEERS2_PT_DpOT0_
             a98c _ZNSt3__19allocatorItE9constructItJRKtEEEvPT_DpOT0_
+            aa41 _ZNSt3__16vectorItNS_9allocatorItEEE26__swap_out_circular_bufferERNS_14__split_bufferItRS2_EEPt
             aa41 _ZNSt3__116allocator_traitsINS_9allocatorItEEE20__construct_backwardItEENS_9enable_ifIXaaoosr7is_sameIS2_NS1_IT_EEEE5valuentsr15__has_constructIS2_PS6_S6_EE5valuesr31is_trivially_move_constructibleIS6_EE5valueEvE4typeERS2_S8_S8_RS8_
             aa7e _ZNSt3__116allocator_traitsINS_9allocatorItEEE19__construct_forwardItEENS_9enable_ifIXaaoosr7is_sameIS2_NS1_IT_EEEE5valuentsr15__has_constructIS2_PS6_S6_EE5valuesr31is_trivially_move_constructibleIS6_EE5valueEvE4typeERS2_S8_S8_RS8_
             aa99 _ZNSt3__14swapIPtEENS_9enable_ifIXaasr21is_move_constructibleIT_EE5valuesr18is_move_assignableIS3_EE5valueEvE4typeERS3_S6_


### PR DESCRIPTION
Fixes an issue where in some cases the inline tree might have been composed wrong. This was particularly the case in DWARF information from Rust programs, as those often contain nested scopes within functions.

Previously, we only considered functions entries when flushing inlinees into the function stream. This was violated in a tree like this:

```
> parent
  > inlinee 1
  > scope
    > inlinee 2
```

Invalid nesting:
```
> parent
  > inlinee 1
    > inlinee 2
```

Correct nesting:
```
> parent
  > inlinee 1
  > inlinee 2
```
