### PR TITLE
feat(examples): Add a naive addr2line example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,10 @@ failure = "0.1.7"
 walkdir = "2.3.1"
 
 [[example]]
+name = "addr2line"
+required-features = ["demangle"]
+
+[[example]]
 name = "dump_cfi"
 required-features = ["minidump"]
 

--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -3,9 +3,9 @@ use std::borrow::Borrow;
 use clap::{clap_app, ArgMatches};
 use failure::{Error, ResultExt};
 
-use symbolic_common::{ByteView, Name};
-use symbolic_debuginfo::{Function, Object};
-use symbolic_demangle::Demangle;
+use symbolic::common::{ByteView, Name};
+use symbolic::debuginfo::{Function, Object};
+use symbolic::demangle::Demangle;
 
 fn print_error(error: &Error) {
     eprintln!("Error: {}", error);

--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -1,0 +1,99 @@
+use clap::{clap_app, ArgMatches};
+use failure::{Error, ResultExt};
+
+use symbolic_common::ByteView;
+use symbolic_debuginfo::{Function, Object};
+use symbolic_demangle::Demangle;
+
+fn print_error(error: &Error) {
+    eprintln!("Error: {}", error);
+
+    for cause in error.iter_causes() {
+        eprintln!("   caused by {}", cause);
+    }
+}
+
+fn resolve(function: &Function<'_>, addr: u64, matches: &ArgMatches<'_>) -> Result<(), Error> {
+    if matches.is_present("inlines") {
+        for il in &function.inlinees {
+            resolve(il, addr, matches)?;
+        }
+    }
+
+    for line in &function.lines {
+        if line.address > addr || line.address + line.size.unwrap_or(1) <= addr {
+            continue;
+        }
+
+        if matches.is_present("functions") {
+            if matches.is_present("demangle") {
+                print!("{}", function.name.try_demangle(Default::default()));
+            } else {
+                print!("{}", function.name);
+            }
+
+            if matches.is_present("ranges") {
+                print!(
+                    " ({:#x} - {:#x})",
+                    function.address,
+                    function.address + function.size
+                );
+            }
+
+            print!("\n  at ");
+        }
+
+        let file = if matches.is_present("basenames") {
+            line.file.name_str()
+        } else {
+            line.file.path_str().into()
+        };
+
+        println!("{}:{}", file, line.line);
+        break;
+    }
+
+    Ok(())
+}
+
+fn execute(matches: &ArgMatches<'_>) -> Result<(), Error> {
+    let path = matches.value_of("path").unwrap_or("a.out");
+    let view = ByteView::open(path).context("failed to open file")?;
+    let object = Object::parse(&view).context("failed to parse file")?;
+    let session = object.debug_session().context("failed to process file")?;
+
+    for addr in matches.values_of("addrs").unwrap_or_default() {
+        let addr = if addr.starts_with("0x") {
+            u64::from_str_radix(&addr[2..], 16)
+        } else {
+            addr.parse()
+        }
+        .context("unable to parse address")?;
+
+        for function in session.functions() {
+            let function = function.context("failed to read function")?;
+            resolve(&function, addr, matches)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn main() {
+    let matches = clap_app!(addr2line =>
+        (about: "addr2line translates addresses into file names and line numbers. Given an address in an executable or an offset in a section of a relocatable object, it uses the debugging information to figure out which file name and line number are associated with it.{n}{n}addr2line has two modes of operation.{n}{n}In the first, hexadecimal addresses are specified on the command line, and addr2line displays the file name and line number for each address.{n}{n}In the second, addr2line reads hexadecimal addresses from standard input, and prints the file name and line number for each address on standard output. In this mode, addr2line may be used in a pipe to convert dynamically chosen addresses.")
+        (@arg demangle: -C --demangle "Decode (demangle) low-level symbol names into user-level names. Besides removing any initial underscore prepended by the system, this makes C ++ function names readable.")
+        (@arg path: -e --exe +takes_value "Specify the name of the executable for which addresses should be translated. The default file is a.out.")
+        (@arg functions: -f --functions "Display function names as well as file and line number information.")
+        (@arg ranges: -r --ranges "Display function address ranges in addition to function names.")
+        (@arg basenames: -s --basenames "Display only the base of each file name.")
+        (@arg inlines: -i --inlinees "If the address belongs to a function that was inlined, the source information for all enclosing scopes back to the first non-inlined function will also be printed. For example, if \"main\" inlines \"callee1\" which inlines \"callee2\", and address is from \"callee2\", the source information for \"callee1\" and \"main\" will also be printed.")
+        (@arg addrs: +required ... "Addresses to be translated.")
+    )
+    .get_matches();
+
+    match execute(&matches) {
+        Ok(()) => (),
+        Err(e) => print_error(&e),
+    };
+}

--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -49,7 +49,17 @@ fn resolve(function: &Function<'_>, addr: u64, matches: &ArgMatches<'_>) -> Resu
             line.file.path_str().into()
         };
 
-        println!("{}:{}", file, line.line);
+        print!("{}:{}", file, line.line);
+
+        if matches.is_present("ranges") {
+            print!(" ({:#x} - ", line.address);
+            match line.size {
+                Some(size) => print!("{:#x})", line.address + size),
+                None => print!("??)"),
+            }
+        }
+
+        println!();
         break;
     }
 

--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -37,6 +37,10 @@ fn print_range(start: u64, len: Option<u64>, matches: &ArgMatches<'_>) {
 }
 
 fn resolve(function: &Function<'_>, addr: u64, matches: &ArgMatches<'_>) -> Result<bool, Error> {
+    if function.address > addr || function.address + function.size <= addr {
+        return Ok(false);
+    }
+
     if matches.is_present("inlines") {
         for il in &function.inlinees {
             resolve(il, addr, matches)?;

--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -48,8 +48,10 @@ fn resolve(function: &Function<'_>, addr: u64, matches: &ArgMatches<'_>) -> Resu
     }
 
     for line in &function.lines {
-        if line.address > addr || line.address + line.size.unwrap_or(1) <= addr {
+        if line.address + line.size.unwrap_or(1) <= addr {
             continue;
+        } else if line.address > addr {
+            break;
         }
 
         if matches.is_present("functions") {


### PR DESCRIPTION
This adds a very naive implementation of `addr2line`, using the high-level functions provided by `Object` and `DebugSession`. It is able to use debug information as well as the symbol map to perform symbol lookups. The CLI is based on https://linux.die.net/man/1/addr2line.

This implementation has a few shortcomings, especially performance: 
- It iterates the full function list multiple times, and collects inline functions just to print out a few records. Optimizing this will require new lookup methods on the `DebugSession` trait.
- When running without `--inlines`, the outer function location is printed, instead of the inner one.
- There is a small chance for invalid lookups when multiple inlinees share code blocks (which can happen in release optimizations).

## Example

```
$ addr2line -Cifse symbolicator.debug 0x7b6bfb
symbolic_minidump::cfi::AsciiCfiWriter<W>::process_dwarf
  at cfi.rs:239
symbolic_minidump::cfi::AsciiCfiWriter<W>::process
  at cfi.rs:205
symbolic_minidump::cfi::AsciiCfiWriter<W>::transform
  at cfi.rs:671
symbolic_minidump::cfi::CfiCache::from_object
  at cfi.rs:728

$ addr2line -se symbolicator.debug 0x7b6bfb
cfi.rs:728
```

## TODO

- [x] Use debug information
- [x] Use symbol tables
- [x] Handle missing symbols
- [x] Handle split ranges