### PR TITLE
fix(symcache): Use same instruction address for full lookup

### DIFF
--- a/symcache/src/cache.rs
+++ b/symcache/src/cache.rs
@@ -369,7 +369,7 @@ impl<'a, 'c> Iterator for Lookup<'a, 'c> {
 
         self.current = fun
             .parent(id)
-            .map(|parent_id| (fun.addr_start(), parent_id, &self.funcs[parent_id]));
+            .map(|parent_id| (addr, parent_id, &self.funcs[parent_id]));
 
         if let Ok(ref line_info) = line_result {
             self.inner = Some((


### PR DESCRIPTION
Ensures that for a lookup with inline frames the same instruction address is yielded for every frame instead of the caller function address. This allows Sentry to display proper inline markers.

When this was implemented originally, this changed address was supposed to show the instruction of the call in the parent. However, this can also be observed using `symbol_addr` on the inlinee. Having the same instruction address is technically more correct.

### Example

Notice the difference in instruction addresses. Inline frames are marked with a blue dashed underline.

**Before**
![Screen Shot 2020-04-22 at 20 43 30](https://user-images.githubusercontent.com/1433023/80020989-2cf1c300-84da-11ea-8e57-6a539761f40e.png)

**After**
![Screen Shot 2020-04-22 at 20 41 18](https://user-images.githubusercontent.com/1433023/80020982-2a8f6900-84da-11ea-9803-623b79668e0e.png)
