### PR TITLE
fix(cfi): Skip invalid PE runtime function entries

### DIFF
--- a/minidump/src/cfi.rs
+++ b/minidump/src/cfi.rs
@@ -604,6 +604,10 @@ impl<W: Write> AsciiCfiWriter<W> {
             // Special handling for machine frames
             let mut machine_frame_offset = 0;
 
+            if function.end_address < function.begin_address {
+                continue;
+            }
+
             let mut next_function = Some(function);
             while let Some(next) = next_function {
                 let unwind_info = exception_data


### PR DESCRIPTION
We've seen files where the start/end addresses in `RuntimeFunction` entries are not matching up. Instead of causing an underflow error, we can skip such errors gracefully.

For reference, Breakpad's `dump_syms` fails with a failed assertion in this case.
