### PR TITLE
build(py): Pin flake8 and restore python linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ lint-rust:
 .PHONY: lint-rust
 
 lint-python: .venv/bin/python
-	.venv/bin/pip install -U flake8
-	.venv/bin/flake8 tests
+	.venv/bin/pip install -U flake8==3.7.9
+	.venv/bin/flake8 py
 .PHONY: lint-python
 
 # Formatting

--- a/py/.flake8
+++ b/py/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E203, E501, W503, E731
+exclude=symbolic/_lowlevel*,.eggs,build,dist

--- a/py/setup.py
+++ b/py/setup.py
@@ -96,8 +96,8 @@ setup(
     include_package_data=True,
     zip_safe=False,
     platforms="any",
-    install_requires=["milksnake>=0.1.2",],
-    setup_requires=["milksnake>=0.1.2",],
-    milksnake_tasks=[build_native,],
-    cmdclass={"sdist": CustomSDist,},
+    install_requires=["milksnake>=0.1.2"],
+    setup_requires=["milksnake>=0.1.2"],
+    milksnake_tasks=[build_native],
+    cmdclass={"sdist": CustomSDist},
 )

--- a/py/symbolic/_compat.py
+++ b/py/symbolic/_compat.py
@@ -4,10 +4,10 @@ import sys
 PY2 = sys.version_info[0] == 2
 
 if PY2:
-    text_type = unicode
-    int_types = (int, long)
-    string_types = (str, unicode)
-    range_type = xrange
+    text_type = unicode  # noqa
+    int_types = (int, long)  # noqa
+    string_types = (str, unicode)  # noqa
+    range_type = xrange  # noqa
     itervalues = lambda x: x.itervalues()
     NUL = "\x00"
 

--- a/py/symbolic/common.py
+++ b/py/symbolic/common.py
@@ -1,7 +1,7 @@
 import os
 
 from symbolic._lowlevel import lib, ffi
-from symbolic._compat import string_types, int_types, string_types
+from symbolic._compat import string_types, int_types
 from symbolic.utils import rustcall, encode_str, decode_str
 from symbolic import exceptions
 

--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -3,7 +3,7 @@ from weakref import WeakValueDictionary
 
 from symbolic._compat import itervalues, range_type, text_type
 from symbolic._lowlevel import lib, ffi
-from symbolic.utils import RustObject, rustcall, decode_str, encode_str, attached_refs
+from symbolic.utils import RustObject, rustcall, decode_str, encode_str
 from symbolic.common import parse_addr, arch_is_known
 from symbolic.symcache import SymCache
 from symbolic.minidump import CfiCache

--- a/py/symbolic/proguard.py
+++ b/py/symbolic/proguard.py
@@ -1,4 +1,4 @@
-from symbolic._lowlevel import lib, ffi
+from symbolic._lowlevel import lib
 from symbolic.utils import (
     RustObject,
     rustcall,

--- a/py/symbolic/unreal.py
+++ b/py/symbolic/unreal.py
@@ -3,7 +3,6 @@ import json
 from symbolic._lowlevel import lib, ffi
 from symbolic._compat import range_type
 
-from symbolic.minidump import ProcessState
 from symbolic.utils import (
     RustObject,
     rustcall,

--- a/py/tests/test_crashprobe.py
+++ b/py/tests/test_crashprobe.py
@@ -24,7 +24,6 @@ def basename(x):
 def _load_dsyms_and_symbolize_stacktrace(
     filename, version, build, arch, res_path, make_report_sym
 ):
-    filename_version = version.replace(" ", "")
     path = os.path.join(res_path, "ext", version, build, arch, filename)
     if not os.path.isfile(path):
         pytest.skip("not test file found")

--- a/py/tests/test_debug.py
+++ b/py/tests/test_debug.py
@@ -49,7 +49,7 @@ def test_id_from_breakpad():
         id_from_breakpad("DFB8E43AF2423D73A453AEB6A777EF75feedface")
         == "dfb8e43a-f242-3d73-a453-aeb6a777ef75-feedface"
     )
-    assert id_from_breakpad(None) == None
+    assert id_from_breakpad(None) is None
 
 
 def test_normalize_code_id():
@@ -65,7 +65,7 @@ def test_normalize_code_id():
     )
     # PE
     assert normalize_code_id("5AB380779000") == "5ab380779000"
-    assert normalize_code_id(None) == None
+    assert normalize_code_id(None) is None
 
 
 def test_normalize_debug_id():
@@ -89,7 +89,7 @@ def test_normalize_debug_id():
         normalize_debug_id("DFB8E43AF2423D73A453AEB6A777EF75a")
         == "dfb8e43a-f242-3d73-a453-aeb6a777ef75-a"
     )
-    assert normalize_debug_id(None) == None
+    assert normalize_debug_id(None) is None
 
 
 def test_object_ref_legacy_apple():

--- a/py/tests/test_minidump.py
+++ b/py/tests/test_minidump.py
@@ -10,7 +10,7 @@ def test_macos_without_cfi(res_path):
     assert state.thread_count == 1
     assert state.requesting_thread == 0
     assert state.timestamp == 1505305307
-    assert state.crashed == True
+    assert state.crashed is True
     assert state.crash_time == datetime(2017, 9, 13, 12, 21, 47)
     assert state.crash_address == 69  # memory address: *(0x45) = 0;
     assert state.crash_reason == "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
@@ -55,7 +55,7 @@ def test_linux_without_cfi(res_path):
     assert state.thread_count == 1
     assert state.requesting_thread == 0
     assert state.timestamp == 1505305040
-    assert state.crashed == True
+    assert state.crashed is True
     assert state.crash_time == datetime(2017, 9, 13, 12, 17, 20)
     assert state.crash_address == 0  # memory address: *(0x0) = 0;
     assert state.crash_reason == "SIGSEGV /0x00000000"
@@ -104,7 +104,7 @@ def test_macos_with_cfi(res_path):
     assert state.thread_count == 1
     assert state.requesting_thread == 0
     assert state.timestamp == 1505305307
-    assert state.crashed == True
+    assert state.crashed is True
     assert state.crash_time == datetime(2017, 9, 13, 12, 21, 47)
     assert state.crash_address == 69  # memory address: *(0x45) = 0;
     assert state.crash_reason == "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
@@ -159,7 +159,7 @@ def test_linux_with_cfi(res_path):
     assert state.thread_count == 1
     assert state.requesting_thread == 0
     assert state.timestamp == 1505305040
-    assert state.crashed == True
+    assert state.crashed is True
     assert state.crash_time == datetime(2017, 9, 13, 12, 17, 20)
     assert state.crash_address == 0  # memory address: *(0x0) = 0;
     assert state.crash_reason == "SIGSEGV /0x00000000"

--- a/py/tests/test_sourcemaps.py
+++ b/py/tests/test_sourcemaps.py
@@ -1,6 +1,4 @@
-import os
 import posixpath
-from symbolic import SourceView, SourceMapView
 
 
 def verify_index(index, sources):
@@ -78,7 +76,7 @@ def test_load_index(get_sourceview, get_sourcemapview):
     view = get_sourcemapview("indexed.sourcemap.js")
     f1 = get_sourceview("file1.js")
     f2 = get_sourceview("file2.js")
-    verify_index(view, {"file1.js": f1, "file2.js": f2,})
+    verify_index(view, {"file1.js": f1, "file2.js": f2})
     verify_token_search(view)
 
 


### PR DESCRIPTION
Python linting was misconfigured and tested a missing folder. Instead, we should lint the `py` subfolder. Since flake8 no longer seems to pick up the config file, we need to pin the version. Also, there are a few lints that needed fixing.