### PR TITLE
fix(debuginfo): Three-way split line records for inlinee-ranges

### DIFF
--- a/debuginfo/src/dwarf.rs
+++ b/debuginfo/src/dwarf.rs
@@ -801,13 +801,12 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
                                     record.size = Some(max_size);
                                 }
 
-                                // Insert a new record pointing to the correct call location. Note that
-                                // "base_dir" can be inherited safely here.
-                                let size = match lines.get(index) {
-                                    Some(next) => range_end.min(next.address) - range_begin,
-                                    None => range_end - range_begin,
-                                };
+                                // For example: [0; 100) split around 20 will give [0; 20) and [20;
+                                // 100) so the size of the second is 100 - 20
+                                let size = record_end.min(range_end) - range_begin;
 
+                                // Insert a new record pointing to the correct call location. Note
+                                // that "base_dir" can be inherited safely here.
                                 let line_info = LineInfo {
                                     address: range_begin,
                                     size: Some(size),


### PR DESCRIPTION
When an inline range is strictly included in a parent line record, it must be split into three parts and the end of the original line record must be retained for the last part. This fixes two distinct issues in the previous implementation:

1. The last record was always aligned with the end of the inlinee-range, which either made it too long or left a gap.
2. The third split was also patched with call site information, instead of retaining the original line info.

**Before patching**:
```
          +-------------------+
 Parent:  |         P         |
          +---+-----------+---+
Inlinee:      |     I     |
              +-----------+
```

**After patching**:
```
          +---+-----------+---+
 Parent:  | P |     C     | P |
          +-------------------+
Inlinee:      |     I     |
              +-----------+
```

(`P` parent line record, `C` Call site record, `I` inlinee line record)

Follow-up on https://github.com/getsentry/symbolic/pull/237