### PR TITLE
Update cpp_demangle::DemangleOptions so simbolic_demangle can compile.

### DIFF
--- a/demangle/Cargo.toml
+++ b/demangle/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [dependencies]
-cpp_demangle = "0.2.16"
+cpp_demangle = "0.2.17"
 msvc-demangler = "0.8.0"
 rustc-demangle = "0.1.16"
 symbolic-common = { version = "7.3.5", path = "../common" }

--- a/demangle/src/lib.rs
+++ b/demangle/src/lib.rs
@@ -129,6 +129,8 @@ fn try_demangle_cpp(ident: &str, opts: DemangleOptions) -> Option<String> {
 
     let opts = CppOptions {
         no_params: !opts.with_arguments,
+        // TODO: Maybe we would like to add return type to `DemangleOptions`?
+        no_return_type: !opts.with_arguments,
     };
 
     match symbol.demangle(&opts) {


### PR DESCRIPTION
cpp_demangle::DemangleOptions now has a no_return_type field which causes an issue in symbolic-demangle lib.rs
the breaking change occured in a patch version which means running `cargo
update` breaks people's builds.