### PR TITLE
doc(common): Add examples and improve common docs

### DIFF
--- a/cabi/src/common.rs
+++ b/cabi/src/common.rs
@@ -21,6 +21,6 @@ ffi_fn! {
     /// Returns the name of the instruction pointer if known.
     unsafe fn symbolic_arch_ip_reg_name(arch: *const SymbolicStr) -> Result<SymbolicStr> {
         let arch = (*arch).as_str().parse::<Arch>()?;
-        Ok(arch.ip_register_name().ok_or(UnknownArchError)?.into())
+        Ok(arch.cpu_family().ip_register_name().ok_or(UnknownArchError)?.into())
     }
 }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -26,7 +26,11 @@ uuid = "0.8.1"
 
 [dev-dependencies]
 symbolic-testutils = { path = "../testutils" }
+tempfile = "3.1.0"
 
 [features]
 default = []
 serde = ["serde_", "debugid/serde"]
+
+[badges]
+travis-ci = { repository = "getsentry/symbolic", branch = "master" }

--- a/common/README.md
+++ b/common/README.md
@@ -12,6 +12,11 @@ This crate exposes a set of key types:
  - [`InstructionInfo`]: A utility type for instruction pointer heuristics.
  - Functions and utilities to deal with paths from different platforms.
 
+## Features
+
+- `serde` (optional): Implements `serde::Deserialize` and `serde::Serialize` for all data types.
+  In the `symbolic` crate, this feature is exposed via `common-serde`.
+
 This module is part of the `symbolic` crate.
 
 [`Name`]: https://docs.rs/symbolic/7/symbolic/common/struct.Name.html

--- a/common/README.md
+++ b/common/README.md
@@ -1,0 +1,22 @@
+[![Build Status](https://travis-ci.org/getsentry/symbolic.svg?branch=master)](https://travis-ci.org/getsentry/symbolic)
+
+# symbolic-common
+
+Common functionality for `symbolic`.
+
+This crate exposes a set of key types:
+
+ - [`ByteView`]: Gives access to binary data in-memory or on the file system.
+ - [`SelfCell`]: Allows to create self-referential types.
+ - [`Name`]: A symbol name that can be demangled with the `demangle` feature.
+ - [`InstructionInfo`]: A utility type for instruction pointer heuristics.
+ - Functions and utilities to deal with paths from different platforms.
+
+This module is part of the `symbolic` crate.
+
+[`Name`]: https://docs.rs/symbolic/7/symbolic/common/struct.Name.html
+[`ByteView`]: https://docs.rs/symbolic/7/symbolic/common/struct.ByteView.html
+[`InstructionInfo`]: https://docs.rs/symbolic/7/symbolic/common/struct.InstructionInfo.html
+[`SelfCell`]: https://docs.rs/symbolic/7/symbolic/common/struct.SelfCell.html
+
+License: MIT

--- a/common/src/byteview.rs
+++ b/common/src/byteview.rs
@@ -50,16 +50,17 @@ impl Deref for ByteViewBacking<'_> {
 /// underlying file handle until the `ByteView` is dropped:
 ///
 /// ```
-/// # fn main() -> Result<(), std::io::Error> {
-/// # use std::io::Write;
+/// use std::io::Write;
 /// use symbolic_common::ByteView;
 ///
-/// # let mut file = tempfile::tempfile()?;
-/// # file.write_all(b"1234");
+/// fn main() -> Result<(), std::io::Error> {
+///     let mut file = tempfile::tempfile()?;
+///     file.write_all(b"1234");
 ///
-/// let view = ByteView::map_file(file)?;
-/// assert_eq!(view.as_slice(), b"1234");
-/// # Ok(()) }
+///     let view = ByteView::map_file(file)?;
+///     assert_eq!(view.as_slice(), b"1234");
+/// Ok(())
+/// }
 /// ```
 #[derive(Clone, Debug)]
 pub struct ByteView<'a> {
@@ -120,13 +121,14 @@ impl<'a> ByteView<'a> {
     /// # Example
     ///
     /// ```
-    /// # fn main() -> Result<(), std::io::Error> {
-    /// # use std::io::Write;
+    /// use std::io::Write;
     /// use symbolic_common::ByteView;
     ///
-    /// # let mut file = tempfile::tempfile()?;
-    /// let view = ByteView::map_file(file)?;
-    /// # Ok(()) }
+    /// fn main() -> Result<(), std::io::Error> {
+    ///     let mut file = tempfile::tempfile()?;
+    ///     let view = ByteView::map_file(file)?;
+    ///     Ok(())
+    /// }
     /// ```
     pub fn map_file(file: File) -> Result<Self, io::Error> {
         let backing = match unsafe { Mmap::map(&file) } {
@@ -157,13 +159,14 @@ impl<'a> ByteView<'a> {
     /// # Example
     ///
     /// ```
-    /// # fn main() -> Result<(), std::io::Error> {
     /// use std::io::Cursor;
     /// use symbolic_common::ByteView;
     ///
-    /// let reader = Cursor::new(b"1234");
-    /// let view = ByteView::read(reader)?;
-    /// # Ok(()) }
+    /// fn main() -> Result<(), std::io::Error> {
+    ///     let reader = Cursor::new(b"1234");
+    ///     let view = ByteView::read(reader)?;
+    ///     Ok(())
+    /// }
     /// ```
     ///
     /// [`open`]: struct.ByteView.html#method.open
@@ -180,11 +183,12 @@ impl<'a> ByteView<'a> {
     /// # Example
     ///
     /// ```no_run
-    /// # fn main() -> Result<(), std::io::Error> {
     /// use symbolic_common::ByteView;
     ///
-    /// let view = ByteView::open("test.txt")?;
-    /// # Ok(()) }
+    /// fn main() -> Result<(), std::io::Error> {
+    ///     let view = ByteView::open("test.txt")?;
+    ///     Ok(())
+    /// }
     /// ```
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, io::Error> {
         let file = File::open(path)?;

--- a/common/src/byteview.rs
+++ b/common/src/byteview.rs
@@ -38,18 +38,28 @@ impl Deref for ByteViewBacking<'_> {
 /// A smart pointer for byte data.
 ///
 /// This type can be used to uniformly access bytes that were created either from mmapping in a
-/// path, a vector or a borrowed slice.  A byteview derefs into a `&[u8]` and is used in symbolic in
-/// most situations where binary files are worked with.
+/// path, a vector or a borrowed slice. A `ByteView` dereferences into a `&[u8]` and guarantees
+/// random access to the underlying buffer or file.
 ///
-/// A `ByteView` can be constructed from borrowed slices, vectors or mmaped from the file system
-/// directly.
+/// A `ByteView` can be constructed from borrowed slices, vectors or memory mapped from the file
+/// system directly.
 ///
 /// # Example
 ///
+/// The most common way to use `ByteView` is to construct it from a file handle. This will own the
+/// underlying file handle until the `ByteView` is dropped:
+///
 /// ```
-/// # use symbolic_common::ByteView;
-/// let bv = ByteView::from_slice(b"1234");
-/// assert_eq!(&*bv, b"1234");
+/// # fn main() -> Result<(), std::io::Error> {
+/// # use std::io::Write;
+/// use symbolic_common::ByteView;
+///
+/// # let mut file = tempfile::tempfile()?;
+/// # file.write_all(b"1234");
+///
+/// let view = ByteView::map_file(file)?;
+/// assert_eq!(view.as_slice(), b"1234");
+/// # Ok(()) }
 /// ```
 #[derive(Clone, Debug)]
 pub struct ByteView<'a> {
@@ -64,28 +74,67 @@ impl<'a> ByteView<'a> {
     }
 
     /// Constructs a `ByteView` from a `Cow`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::borrow::Cow;
+    /// use symbolic_common::ByteView;
+    ///
+    /// let cow = Cow::Borrowed(&b"1234"[..]);
+    /// let view = ByteView::from_cow(cow);
+    /// ```
     pub fn from_cow(cow: Cow<'a, [u8]>) -> Self {
         ByteView::with_backing(ByteViewBacking::Buf(cow))
     }
 
     /// Constructs a `ByteView` from a byte slice.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use symbolic_common::ByteView;
+    ///
+    /// let view = ByteView::from_slice(b"1234");
+    /// ```
     pub fn from_slice(buffer: &'a [u8]) -> Self {
         ByteView::from_cow(Cow::Borrowed(buffer))
     }
 
     /// Constructs a `ByteView` from a vector of bytes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use symbolic_common::ByteView;
+    ///
+    /// let vec = b"1234".to_vec();
+    /// let view = ByteView::from_vec(vec);
+    /// ```
     pub fn from_vec(buffer: Vec<u8>) -> Self {
         ByteView::from_cow(Cow::Owned(buffer))
     }
 
     /// Constructs a `ByteView` from an open file handle by memory mapping the file.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # fn main() -> Result<(), std::io::Error> {
+    /// # use std::io::Write;
+    /// use symbolic_common::ByteView;
+    ///
+    /// # let mut file = tempfile::tempfile()?;
+    /// let view = ByteView::map_file(file)?;
+    /// # Ok(()) }
+    /// ```
     pub fn map_file(file: File) -> Result<Self, io::Error> {
         let backing = match unsafe { Mmap::map(&file) } {
             Ok(mmap) => ByteViewBacking::Mmap(mmap),
             Err(err) => {
-                // this is raised on empty mmaps which we want to ignore.  The
-                // 1006 windows error looks like "The volume for a file has been externally
-                // altered so that the opened file is no longer valid."
+                // this is raised on empty mmaps which we want to ignore. The 1006 Windows error
+                // looks like "The volume for a file has been externally altered so that the opened
+                // file is no longer valid."
                 if err.kind() == io::ErrorKind::InvalidInput
                     || (cfg!(windows) && err.raw_os_error() == Some(1006))
                 {
@@ -101,9 +150,25 @@ impl<'a> ByteView<'a> {
 
     /// Constructs a `ByteView` from any `std::io::Reader`.
     ///
-    /// This currently consumes the entire reader and stores its data in an internal buffer. Prefer
-    /// `ByteView::open` when reading from the file system or `ByteView::from_slice` /
-    /// `ByteView::from_vec` for in-memory operations. This behavior might change in the future.
+    /// **Note**: This currently consumes the entire reader and stores its data in an internal
+    /// buffer. Prefer [`open`] when reading from the file system or [`from_slice`] / [`from_vec`]
+    /// for in-memory operations. This behavior might change in the future.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # fn main() -> Result<(), std::io::Error> {
+    /// use std::io::Cursor;
+    /// use symbolic_common::ByteView;
+    ///
+    /// let reader = Cursor::new(b"1234");
+    /// let view = ByteView::read(reader)?;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [`open`]: struct.ByteView.html#method.open
+    /// [`from_slice`]: struct.ByteView.html#method.from_slice
+    /// [`from_vec`]: struct.ByteView.html#method.from_vec
     pub fn read<R: io::Read>(mut reader: R) -> Result<Self, io::Error> {
         let mut buffer = vec![];
         reader.read_to_end(&mut buffer)?;
@@ -111,12 +176,32 @@ impl<'a> ByteView<'a> {
     }
 
     /// Constructs a `ByteView` from a file path by memory mapping the file.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # fn main() -> Result<(), std::io::Error> {
+    /// use symbolic_common::ByteView;
+    ///
+    /// let view = ByteView::open("test.txt")?;
+    /// # Ok(()) }
+    /// ```
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, io::Error> {
         let file = File::open(path)?;
         Self::map_file(file)
     }
 
     /// Returns a slice of the underlying data.
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use symbolic_common::ByteView;
+    ///
+    /// let view = ByteView::from_slice(b"1234");
+    /// let data = view.as_slice();
+    /// ```
     #[inline(always)]
     pub fn as_slice(&self) -> &[u8] {
         self.backing.deref()
@@ -142,33 +227,33 @@ impl Deref for ByteView<'_> {
 unsafe impl StableDeref for ByteView<'_> {}
 
 #[cfg(test)]
-use {failure::Error, std::fs, std::io::Write};
+mod tests {
+    use super::*;
 
-#[test]
-fn test_open_empty_file() -> Result<(), Error> {
-    let mut path = std::env::temp_dir();
-    path.push(".c0b41a59-801b-4d18-aaa1-88432736116d.empty");
+    use std::io::Write;
 
-    File::create(&path)?;
-    let bv = ByteView::open(&path)?;
-    assert_eq!(&*bv, b"");
+    use failure::Error;
+    use tempfile::NamedTempFile;
 
-    fs::remove_file(&path)?;
-    Ok(())
-}
+    #[test]
+    fn test_open_empty_file() -> Result<(), Error> {
+        let tmp = NamedTempFile::new()?;
 
-#[test]
-fn test_open_file() -> Result<(), Error> {
-    let mut path = std::env::temp_dir();
-    path.push(".c0b41a59-801b-4d18-aaa1-88432736116d");
+        let view = ByteView::open(&tmp.path())?;
+        assert_eq!(&*view, b"");
 
-    let mut file = File::create(&path)?;
-    file.write_all(b"1234")?;
-    drop(file);
+        Ok(())
+    }
 
-    let bv = ByteView::open(&path)?;
-    assert_eq!(&*bv, b"1234");
+    #[test]
+    fn test_open_file() -> Result<(), Error> {
+        let mut tmp = NamedTempFile::new()?;
 
-    fs::remove_file(&path)?;
-    Ok(())
+        tmp.write_all(b"1234")?;
+
+        let view = ByteView::open(&tmp.path())?;
+        assert_eq!(&*view, b"1234");
+
+        Ok(())
+    }
 }

--- a/common/src/cell.rs
+++ b/common/src/cell.rs
@@ -205,7 +205,8 @@ where
 /// assert_eq!(cell.get().0, "hello world");
 /// ```
 ///
-/// [`StableDeref`]: trait.StableDeref.html [`AsSelf`]: trait.AsSelf.html
+/// [`StableDeref`]: trait.StableDeref.html
+/// [`AsSelf`]: trait.AsSelf.html
 #[derive(Clone, Debug)]
 pub struct SelfCell<O, D>
 where
@@ -256,12 +257,13 @@ where
     /// # Example
     ///
     /// ```
-    /// # fn main() -> Result<(), std::str::Utf8Error> {
     /// use symbolic_common::SelfCell;
     ///
-    /// let owner = Vec::from("hello world");
-    /// let cell = SelfCell::try_new(owner, |s| unsafe { std::str::from_utf8(&*s) })?;
-    /// # Ok(()) }
+    /// fn main() -> Result<(), std::str::Utf8Error> {
+    ///     let owner = Vec::from("hello world");
+    ///     let cell = SelfCell::try_new(owner, |s| unsafe { std::str::from_utf8(&*s) })?;
+    ///     Ok(())
+    /// }
     /// ```
     #[inline]
     pub fn try_new<E, F>(owner: O, derive: F) -> Result<Self, E>

--- a/common/src/cell.rs
+++ b/common/src/cell.rs
@@ -25,14 +25,15 @@ pub use stable_deref_trait::StableDeref;
 /// This is particularly useful when the type's lifetime is somehow tied to it's own existence, such
 /// as in self-referential structs. See [`SelfCell`] for an implementation that makes use of this.
 ///
-/// ## Implementation
+/// # Implementation
 ///
 /// While this trait may be implemented for any type, it is only useful for types that specify a
 /// lifetime bound, such as `Cow` or [`ByteView`]. To implement, define `Ref` as the type with all
 /// dependent lifetimes set to `'slf`. Then, simply return `self` in `as_self`.
 ///
 /// ```rust
-/// # use symbolic_common::AsSelf;
+/// use symbolic_common::AsSelf;
+///
 /// struct Foo<'a>(&'a str);
 ///
 /// impl<'slf> AsSelf<'slf> for Foo<'_> {
@@ -44,7 +45,7 @@ pub use stable_deref_trait::StableDeref;
 /// }
 /// ```
 ///
-/// ## Interior Mutability
+/// # Interior Mutability
 ///
 /// **Note** that if your type uses interior mutability (essentially any type from `std::sync`, but
 /// specifically everything built on top of `UnsafeCell`), this implicit coercion will not work. The
@@ -55,8 +56,9 @@ pub use stable_deref_trait::StableDeref;
 /// implement the coercion with an unsafe transmute:
 ///
 /// ```rust
-/// # use symbolic_common::AsSelf;
-/// # use std::cell::UnsafeCell;
+/// use std::cell::UnsafeCell;
+/// use symbolic_common::AsSelf;
+///
 /// struct Foo<'a>(UnsafeCell<&'a str>);
 ///
 /// impl<'slf> AsSelf<'slf> for Foo<'_> {
@@ -108,7 +110,7 @@ where
 
 impl<'slf, T> AsSelf<'slf> for &'slf T
 where
-    T: AsSelf<'slf>,
+    T: AsSelf<'slf> + ?Sized,
 {
     type Ref = T::Ref;
 
@@ -119,7 +121,7 @@ where
 
 impl<'slf, T> AsSelf<'slf> for &'slf mut T
 where
-    T: AsSelf<'slf>,
+    T: AsSelf<'slf> + ?Sized,
 {
     type Ref = T::Ref;
 
@@ -172,7 +174,7 @@ where
 /// reference pointed to by the dependent object never moves over the lifetime of this object. This
 /// is already implemented for most heap-allocating types, like `Box`, `Rc`, `Arc` or `ByteView`.
 ///
-/// Additionally, the dependent object must implement `AsSelf`. This guarantees that the borrow's
+/// Additionally, the dependent object must implement [`AsSelf`]. This guarantees that the borrow's
 /// lifetime and its lifetime bounds never exceed the lifetime of the owner. As such, an object
 /// `Foo<'a>` that borrows data from the owner, will be coerced down to `Foo<'self>` when borrowing.
 /// There are two constructor functions, `new` and `try_new`, each of which are passed a pointer to
@@ -186,7 +188,8 @@ where
 /// ## Example
 ///
 /// ```rust
-/// # use symbolic_common::{AsSelf, SelfCell};
+/// use symbolic_common::{AsSelf, SelfCell};
+///
 /// struct Foo<'a>(&'a str);
 ///
 /// impl<'slf> AsSelf<'slf> for Foo<'_> {
@@ -197,12 +200,12 @@ where
 ///     }
 /// }
 ///
-/// let cell = SelfCell::new(String::from("hello world"), |s| Foo(unsafe { &*s }));
+/// let owner = String::from("hello world");
+/// let cell = SelfCell::new(owner, |s| Foo(unsafe { &*s }));
 /// assert_eq!(cell.get().0, "hello world");
 /// ```
 ///
-/// [`StableDeref`]: trait.StableDeref.html
-/// [`AsSelf`]: trait.AsSelf.html
+/// [`StableDeref`]: trait.StableDeref.html [`AsSelf`]: trait.AsSelf.html
 #[derive(Clone, Debug)]
 pub struct SelfCell<O, D>
 where
@@ -219,8 +222,20 @@ where
 {
     /// Creates a new `SelfCell`.
     ///
-    /// The callback receives a pointer to the owned data. Note that a borrow to that data can only
-    /// safely be used to derive the object and **must not** leave the callback.
+    /// # Safety
+    ///
+    /// The callback receives a pointer to the owned data. Dereferencing the pointer is unsafe. Note
+    /// that a borrow to that data can only safely be used to derive the object and **must not**
+    /// leave the callback.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use symbolic_common::SelfCell;
+    ///
+    /// let owner = String::from("hello world");
+    /// let cell = SelfCell::new(owner, |s| unsafe { &*s });
+    /// ```
     #[inline]
     pub fn new<F>(owner: O, derive: F) -> Self
     where
@@ -232,8 +247,22 @@ where
 
     /// Creates a new `SelfCell` which may fail to construct.
     ///
-    /// The callback receives a pointer to the owned data. Note that a borrow to that data can only
-    /// safely be used to derive the object and **must not** leave the callback.
+    /// # Safety
+    ///
+    /// The callback receives a pointer to the owned data. Dereferencing the pointer is unsafe. Note
+    /// that a borrow to that data can only safely be used to derive the object and **must not**
+    /// leave the callback.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # fn main() -> Result<(), std::str::Utf8Error> {
+    /// use symbolic_common::SelfCell;
+    ///
+    /// let owner = Vec::from("hello world");
+    /// let cell = SelfCell::try_new(owner, |s| unsafe { std::str::from_utf8(&*s) })?;
+    /// # Ok(()) }
+    /// ```
     #[inline]
     pub fn try_new<E, F>(owner: O, derive: F) -> Result<Self, E>
     where
@@ -254,8 +283,9 @@ where
     /// # Example
     ///
     /// ```rust
-    /// # use std::sync::Arc;
-    /// # use symbolic_common::{AsSelf, SelfCell};
+    /// use std::sync::Arc;
+    /// use symbolic_common::{AsSelf, SelfCell};
+    ///
     /// struct Foo<'a>(&'a str);
     ///
     /// impl<'slf> AsSelf<'slf> for Foo<'_> {
@@ -283,12 +313,32 @@ where
     }
 
     /// Returns a reference to the owner of this cell.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use symbolic_common::SelfCell;
+    ///
+    /// let owner = String::from("  hello  ");
+    /// let cell = SelfCell::new(owner, |s| unsafe { (*s).trim() });
+    /// assert_eq!(cell.owner(), "  hello  ");
+    /// ```
     #[inline(always)]
     pub fn owner(&self) -> &O {
         &self.owner
     }
 
     /// Returns a safe reference to the derived object in this cell.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use symbolic_common::SelfCell;
+    ///
+    /// let owner = String::from("  hello  ");
+    /// let cell = SelfCell::new(owner, |s| unsafe { (*s).trim() });
+    /// assert_eq!(cell.get(), "hello");
+    /// ```
     #[inline(always)]
     pub fn get(&'slf self) -> &'slf <T as AsSelf<'slf>>::Ref {
         self.derived.as_self()

--- a/common/src/fail.rs
+++ b/common/src/fail.rs
@@ -13,11 +13,12 @@
 ///  - `From<ErrorKind>`
 ///  - `From<Context<ErrorKind>>`
 ///
-/// ## Example
+/// # Examples
 ///
-/// ```rust
+/// ```
 /// use failure::Fail;
-/// # use symbolic_common::derive_failure;
+/// use symbolic_common::derive_failure;
+///
 /// #[derive(Debug, Fail)]
 /// enum MyErrorKind {
 ///     #[fail(display = "some")] Something,

--- a/common/src/heuristics.rs
+++ b/common/src/heuristics.rs
@@ -8,11 +8,103 @@ const SIGSEGV: u32 = 11;
 
 /// Helper to work with instruction addresses.
 ///
-/// The most useful function is `InstructionInfo::caller_address` which applies
-/// some heuristics to determine the call site of a function call based on the
-/// return address. See `InstructionInfo::caller_address` for more information.
+/// Directly symbolicated stack traces may show the wrong calling symbols, as the stack frame's
+/// return addresses point a few bytes past the original call site, which may place the address
+/// within a different symbol entirely.
 ///
-/// See <https://goo.gl/g17EAn> for detailed information on this topic.
+/// The most useful function is [`caller_address`], which applies some heuristics to determine the
+/// call site of a function call based on the return address.
+///
+/// # Examples
+///
+/// ```
+/// use symbolic_common::{Arch, InstructionInfo};
+///
+/// const SIGSEGV: u32 = 11;
+///
+/// let info = InstructionInfo {
+///     addr: 0x1337,           // The restored instruction pointer of the frame
+///     arch: Arch::Arm64,      // Can be obtained from the object file
+///     crashing_frame: false,  // Set to true for the first frame
+///     signal: Some(SIGSEGV),  // Usually part of the crash report
+///     ip_reg: Some(0x1337),   // The original IP address
+/// };
+///
+/// println!("{:#x}", info.caller_address());
+/// # assert_eq!(info.caller_address(), 0x1330);
+/// ```
+///
+/// # Background
+///
+/// When *calling* a function, it is necessary for the *called* function to know where it should
+/// return to upon completion. To support this, a *return address* is supplied as part of the
+/// standard function call semantics. This return address specifies the instruction that the called
+/// function should jump to upon completion of its execution.
+///
+/// When a crash reporter generates a backtrace, it first collects the thread state of all active
+/// threads, including the **actual** current execution address. The reporter then iterates over
+/// those threads, walking backwards to find calling frames – what it's actually finding during this
+/// process are the **return addresses**. The actual address of the call instruction is not recorded
+/// anywhere. The only address available is the address at which execution should resume after
+/// function return.
+///
+/// To make things more complicated, there is no guarantee that a return address be set to exactly
+/// one instruction after the call. It's entirely proper for a function to remove itself from the
+/// call stack by setting a different return address entirely. This is why you never see
+/// `objc_msgSend` in your backtrace unless you actually crash inside of `objc_msgSend`. When
+/// `objc_msgSend` jumps to a method's implementation, it leaves its caller's return address in
+/// place, and `objc_msgSend` itself disappears from the stack trace. In the case of `objc_msgSend`,
+/// the loss of that information is of no great importance, but it's hardly the only function that
+/// elides its own code from the return address.
+///
+/// # Heuristics
+///
+/// To resolve this particular issue, it is necessary for the symbolication implementor to apply a
+/// per-architecture heuristics to the return addresses, and thus derive the **likely** address of
+/// the actual calling instruction. There is a high probability of correctness, but absolutely no
+/// guarantee.
+///
+/// This derived address **should** be used as the symbolication address, but **should not** replace
+/// the return address in the crash report. This derived address is a best guess, and if you replace
+/// the return address in the report, the end-user will have lost access to the original canonical
+/// data from which they could have made their own assessment.
+///
+/// These heuristics must not be applied to frame #0 on any thread. The first frame of all threads
+/// contains the actual register state of that thread at the time that it crashed (if it's the
+/// crashing thread), or at the time it was suspended (if it is a non-crashing thread). These
+/// heuristics should only be applied to frames *after* frame #0 – that is, starting with frame #1.
+///
+/// Additionally, these heuristics assume that your symbolication implementation correctly handles
+/// addresses that occur within an instruction, rather than directly at the start of a valid
+/// instruction. This should be the case for any reasonable implementation, but is something to be
+/// aware of when deploying these changes.
+///
+/// ## x86 and x86-64
+///
+/// x86 uses variable-width instruction encodings; subtract one byte from the return address to
+/// derive an address that should be within the calling instruction. This will provide an address
+/// within a calling instruction found directly prior to the return address.
+///
+/// ## ARMv6 and ARMv7
+///
+/// - **Step 1:** Strip the low order thumb bit from the return address. ARM uses the low bit to
+///   inform the processor that it should enter thumb mode when jumping to the return address. Since
+///   all instructions are at least 2 byte aligned, an actual instruction address will never have
+///   the low bit set.
+///
+/// - **Step 2:** Subtract 2 Bytes. 32-bit ARM instructions are either 2 or 4 bytes long, depending
+///   on the use of thumb. This will place the symbolication address within the likely calling
+///   instruction. All ARM64 instructions are 4 bytes long; subtract 4 bytes from the return address
+///   to derive the likely address of the calling instruction.
+///
+/// # More Information
+///
+/// The above information was taken and slightly updated from the now-gone *PLCrashReporter Wiki*.
+/// An old copy can still be found in the [internet archive].
+///
+/// [internet archive]:
+/// https://web.archive.org/web/20161012225323/https://opensource.plausible.coop/wiki/display/PLCR/Automated+Crash+Report+Analysis
+
 pub struct InstructionInfo {
     /// The address of the instruction we want to use as a base.
     pub addr: u64,
@@ -29,32 +121,84 @@ pub struct InstructionInfo {
 impl InstructionInfo {
     /// Tries to resolve the start address of the current instruction.
     ///
-    /// For architectures without fixed alignment (such as Intel with variable
-    /// instruction lengths), this will return the same address. Otherwise, the
-    /// address is aligned to the architecture's instruction alignment.
+    /// For architectures without fixed alignment (such as Intel with variable instruction lengths),
+    /// this will return the same address. Otherwise, the address is aligned to the architecture's
+    /// instruction alignment.
+    ///
+    /// # Examples
+    ///
+    /// On 64-bit ARM, addresses are aligned at 4 byte boundaries. This applies to all 64-bit ARM
+    /// variants, even unknown ones:
+    ///
+    /// ```
+    /// use symbolic_common::{Arch, InstructionInfo};
+    ///
+    /// let info = InstructionInfo {
+    ///     addr: 0x1337,
+    ///     arch: Arch::Arm64Unknown,
+    ///     crashing_frame: false,
+    ///     signal: None,
+    ///     ip_reg: None,
+    /// };
+    ///
+    /// assert_eq!(info.aligned_address(), 0x1334);
+    /// ```
     pub fn aligned_address(&self) -> u64 {
-        if let Some(alignment) = self.arch.instruction_alignment() {
+        if let Some(alignment) = self.arch.cpu_family().instruction_alignment() {
             self.addr - (self.addr % alignment)
         } else {
             self.addr
         }
     }
 
-    /// Return the previous instruction to the current one if we can
-    /// determine this for the current architecture.
     /// Returns the instruction preceding the current one.
     ///
-    /// For known architectures, this will return the start address of the
-    /// instruction immediately before the current one in the machine code.
-    /// This is likely the instruction that was just executed or that called
-    /// a function returning at the current address.
+    /// For known architectures, this will return the start address of the instruction immediately
+    /// before the current one in the machine code. This is likely the instruction that was just
+    /// executed or that called a function returning at the current address.
     ///
-    /// For unknown architectures or those using variable instruction size, the
-    /// exact start address cannot be determined. Instead, an address *within*
-    /// the preceding instruction will be returned. For this reason, the return
-    /// value of this function should be considered an upper bound.
+    /// For unknown architectures or those using variable instruction size, the exact start address
+    /// cannot be determined. Instead, an address *within* the preceding instruction will be
+    /// returned. For this reason, the return value of this function should be considered an upper
+    /// bound.
+    ///
+    /// # Examples
+    ///
+    /// On 64-bit ARM, instructions have 4 bytes in size. The previous address is therefore 4 bytes
+    /// before the start of the current instruction (returned by [`aligned_address`]):
+    ///
+    /// ```
+    /// use symbolic_common::{Arch, InstructionInfo};
+    ///
+    /// let info = InstructionInfo {
+    ///     addr: 0x1337,
+    ///     arch: Arch::Arm64,
+    ///     crashing_frame: false,
+    ///     signal: None,
+    ///     ip_reg: None,
+    /// };
+    ///
+    /// assert_eq!(info.previous_address(), 0x1330);
+    /// ```
+    ///
+    /// On the contrary, Intel uses variable-length instruction encoding. In such a case, the best
+    /// effort is to subtract 1 byte and hope that it points into the previous instruction:
+    ///
+    /// ```
+    /// use symbolic_common::{Arch, InstructionInfo};
+    ///
+    /// let info = InstructionInfo {
+    ///     addr: 0x1337,
+    ///     arch: Arch::X86,
+    ///     crashing_frame: false,
+    ///     signal: None,
+    ///     ip_reg: None,
+    /// };
+    ///
+    /// assert_eq!(info.previous_address(), 0x1336);
+    /// ```
     pub fn previous_address(&self) -> u64 {
-        let instruction_size = self.arch.instruction_alignment().unwrap_or(1);
+        let instruction_size = self.arch.cpu_family().instruction_alignment().unwrap_or(1);
 
         // In MIPS, the return address apparently often points two instructions after the the
         // previous program counter. On other architectures, just subtract one instruction.
@@ -66,9 +210,28 @@ impl InstructionInfo {
         self.aligned_address() - pc_offset
     }
 
-    /// Returns whether the application attempted to jump to an invalid,
-    /// privileged or misaligned address. This indicates, that certain
-    /// adjustments should be made on the caller instruction address.
+    /// Returns whether the application attempted to jump to an invalid, privileged or misaligned
+    /// address.
+    ///
+    /// This indicates that certain adjustments should be made on the caller instruction address.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use symbolic_common::{Arch, InstructionInfo};
+    ///
+    /// const SIGSEGV: u32 = 11;
+    ///
+    /// let info = InstructionInfo {
+    ///     addr: 0x1337,
+    ///     arch: Arch::X86,
+    ///     crashing_frame: false,
+    ///     signal: Some(SIGSEGV),
+    ///     ip_reg: None,
+    /// };
+    ///
+    /// assert!(info.is_crash_signal());
+    /// ```
     pub fn is_crash_signal(&self) -> bool {
         match self.signal {
             Some(SIGILL) | Some(SIGBUS) | Some(SIGSEGV) => true,
@@ -76,13 +239,32 @@ impl InstructionInfo {
         }
     }
 
-    /// Determines whether the given address should be adjusted to resolve the
-    /// call site of a stack frame.
+    /// Determines whether the given address should be adjusted to resolve the call site of a stack
+    /// frame.
     ///
-    /// This generally applies to all frames except the crashing / suspended
-    /// frame. However, if the process crashed with an illegal instruction,
-    /// even the top-most frame needs to be adjusted to account for the signal
-    /// handler.
+    /// This generally applies to all frames except the crashing / suspended frame. However, if the
+    /// process crashed with an illegal instruction, even the top-most frame needs to be adjusted to
+    /// account for the signal handler.
+    ///
+    /// # Examples
+    ///
+    /// By default, all frames need to be adjusted. There are only few exceptions to this rule: The
+    /// crashing frame is the first frame yielded in the stack trace and specifies the actual
+    /// instruction pointer address. Therefore, it does not need to be adjusted:
+    ///
+    /// ```
+    /// use symbolic_common::{Arch, InstructionInfo};
+    ///
+    /// let info = InstructionInfo {
+    ///     addr: 0x1337,
+    ///     arch: Arch::X86,
+    ///     crashing_frame: true,
+    ///     signal: None,
+    ///     ip_reg: None,
+    /// };
+    ///
+    /// assert!(!info.should_adjust_caller());
+    /// ```
     pub fn should_adjust_caller(&self) -> bool {
         // All frames other than the crashing frame (or suspended frame for
         // other threads) report the return address. This address (generally)
@@ -110,14 +292,48 @@ impl InstructionInfo {
 
     /// Determines the address of the call site based on a return address.
     ///
-    /// In the top most frame (often referred to as context frame), this is the
-    /// value of the instruction pointer register. In all other frames, the
-    /// return address is generally one instruction after the jump / call.
+    /// In the top most frame (often referred to as context frame), this is the value of the
+    /// instruction pointer register. In all other frames, the return address is generally one
+    /// instruction after the jump / call.
     ///
-    /// This function actually resolves an address _within_ the call instruction
-    /// rather than its beginning. Also, in some cases the top most frame has
-    /// been modified by certain signal handlers or return optimizations. A set
-    /// of heuristics tries to recover this for well-known cases.
+    /// This function actually resolves an address _within_ the call instruction rather than its
+    /// beginning. Also, in some cases the top most frame has been modified by certain signal
+    /// handlers or return optimizations. A set of heuristics tries to recover this for well-known
+    /// cases.
+    ///
+    /// # Examples
+    ///
+    /// Returns the aligned address for crashing frames:
+    ///
+    /// ```
+    /// use symbolic_common::{Arch, InstructionInfo};
+    ///
+    /// let info = InstructionInfo {
+    ///     addr: 0x1337,
+    ///     arch: Arch::Arm64,
+    ///     crashing_frame: true,
+    ///     signal: None,
+    ///     ip_reg: None,
+    /// };
+    ///
+    /// assert_eq!(info.caller_address(), 0x1334);
+    /// ```
+    ///
+    /// For all other frames, it returns the previous address:
+    ///
+    /// ```
+    /// use symbolic_common::{Arch, InstructionInfo};
+    ///
+    /// let info = InstructionInfo {
+    ///     addr: 0x1337,
+    ///     arch: Arch::Arm64,
+    ///     crashing_frame: false,
+    ///     signal: None,
+    ///     ip_reg: None,
+    /// };
+    ///
+    /// assert_eq!(info.caller_address(), 0x1330);
+    /// ```
     pub fn caller_address(&self) -> u64 {
         if self.should_adjust_caller() {
             self.previous_address()

--- a/common/src/heuristics.rs
+++ b/common/src/heuristics.rs
@@ -32,8 +32,7 @@ const SIGSEGV: u32 = 11;
 ///     .ip_register_value(0x4242)
 ///     .caller_address();
 ///
-/// println!("{:#x}", caller_address);
-/// # assert_eq!(caller_address, 0x1330);
+/// assert_eq!(caller_address, 0x1330);
 /// ```
 ///
 /// # Background
@@ -104,9 +103,7 @@ const SIGSEGV: u32 = 11;
 /// The above information was taken and slightly updated from the now-gone *PLCrashReporter Wiki*.
 /// An old copy can still be found in the [internet archive].
 ///
-/// [internet archive]:
-/// https://web.archive.org/web/20161012225323/https://opensource.plausible.coop/wiki/display/PLCR/Automated+Crash+Report+Analysis
-///
+/// [internet archive]: https://web.archive.org/web/20161012225323/https://opensource.plausible.coop/wiki/display/PLCR/Automated+Crash+Report+Analysis
 /// [`caller_address`]: struct.InstructionInfo.html#method.caller_address
 #[derive(Clone, Debug)]
 pub struct InstructionInfo {
@@ -273,7 +270,8 @@ impl InstructionInfo {
     /// let is_crash = InstructionInfo::new(Arch::X86, 0x1337)
     ///     .signal(SIGSEGV)
     ///     .is_crash_signal();
-    /// # assert!(is_crash);
+    ///
+    /// assert!(is_crash);
     /// ```
     pub fn is_crash_signal(&self) -> bool {
         match self.signal {
@@ -301,7 +299,8 @@ impl InstructionInfo {
     /// let should_adjust = InstructionInfo::new(Arch::X86, 0x1337)
     ///     .is_crashing_frame(true)
     ///     .should_adjust_caller();
-    /// # assert!(!should_adjust);
+    ///
+    /// assert!(!should_adjust);
     /// ```
     pub fn should_adjust_caller(&self) -> bool {
         // All frames other than the crashing frame (or suspended frame for

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -8,6 +8,11 @@
 //!  - [`InstructionInfo`]: A utility type for instruction pointer heuristics.
 //!  - Functions and utilities to deal with paths from different platforms.
 //!
+//! # Features
+//!
+//! - `serde` (optional): Implements `serde::Deserialize` and `serde::Serialize` for all data types.
+//!   In the `symbolic` crate, this feature is exposed via `common-serde`.
+//!
 //! This module is part of the `symbolic` crate.
 //!
 //! [`Name`]: struct.Name.html

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -5,10 +5,14 @@
 //!  - [`ByteView`]: Gives access to binary data in-memory or on the file system.
 //!  - [`SelfCell`]: Allows to create self-referential types.
 //!  - [`Name`]: A symbol name that can be demangled with the `demangle` feature.
-//!  - ... and some useful functions to deal with paths in different platforms.
+//!  - [`InstructionInfo`]: A utility type for instruction pointer heuristics.
+//!  - Functions and utilities to deal with paths from different platforms.
+//!
+//! This module is part of the `symbolic` crate.
 //!
 //! [`Name`]: struct.Name.html
 //! [`ByteView`]: struct.ByteView.html
+//! [`InstructionInfo`]: struct.InstructionInfo.html
 //! [`SelfCell`]: struct.SelfCell.html
 
 #![warn(missing_docs)]

--- a/common/src/path.rs
+++ b/common/src/path.rs
@@ -241,7 +241,7 @@ pub fn clean_path(path: &str) -> Cow<'_, str> {
 ///
 /// ```
 /// assert_eq!(
-///     symbolic_common::split_path_bytes("/a/b/c".as_bytes()),
+///     symbolic_common::split_path_bytes(b"/a/b/c"),
 ///     (Some("/a/b".as_bytes()), "c".as_bytes())
 /// );
 /// ```
@@ -250,7 +250,7 @@ pub fn clean_path(path: &str) -> Cow<'_, str> {
 ///
 /// ```
 /// assert_eq!(
-///     symbolic_common::split_path_bytes("C:\\a\\b".as_bytes()),
+///     symbolic_common::split_path_bytes(b"C:\\a\\b"),
 ///     (Some("C:\\a".as_bytes()), "b".as_bytes())
 /// );
 /// ```

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -659,8 +659,7 @@ impl str::FromStr for Language {
 /// use symbolic_common::Name;
 ///
 /// let name = Name::new("_ZN3foo3barEv");
-/// println!("{}", name); // prints "_ZN3foo3barEv"
-/// # assert_eq!(name.to_string(), "_ZN3foo3barEv");
+/// assert_eq!(name.to_string(), "_ZN3foo3barEv");
 /// ```
 ///
 /// Create a name with a language. Alternate formatting prints the language:
@@ -669,8 +668,7 @@ impl str::FromStr for Language {
 /// use symbolic_common::{Language, Name};
 ///
 /// let name = Name::with_language("_ZN3foo3barEv", Language::Cpp);
-/// println!("{:#}", name); // prints "_ZN3foo3barEv [C++]"
-/// # assert_eq!(format!("{:#}", name), "_ZN3foo3barEv [C++]");
+/// assert_eq!(format!("{:#}", name), "_ZN3foo3barEv [C++]");
 /// ```
 ///
 /// [`language`]: struct.Name.html#method.language
@@ -696,8 +694,7 @@ impl<'a> Name<'a> {
     /// use symbolic_common::Name;
     ///
     /// let name = Name::new("_ZN3foo3barEv");
-    /// println!("{}", name); // prints "_ZN3foo3barEv"
-    /// # assert_eq!(name.to_string(), "_ZN3foo3barEv");
+    /// assert_eq!(name.to_string(), "_ZN3foo3barEv");
     /// ```
     #[inline]
     pub fn new<S>(string: S) -> Self
@@ -718,8 +715,7 @@ impl<'a> Name<'a> {
     /// use symbolic_common::{Language, Name};
     ///
     /// let name = Name::with_language("_ZN3foo3barEv", Language::Cpp);
-    /// println!("{:#}", name); // prints "_ZN3foo3barEv [C++]"
-    /// # assert_eq!(format!("{:#}", name), "_ZN3foo3barEv [C++]");
+    /// assert_eq!(format!("{:#}", name), "_ZN3foo3barEv [C++]");
     /// ```
     ///
     /// [`Language`]: enum.Language.html

--- a/examples/minidump_stackwalk.rs
+++ b/examples/minidump_stackwalk.rs
@@ -136,17 +136,14 @@ fn symbolize<'a>(
     };
 
     // TODO: Extract and supply signal and IP register
-    let instruction = InstructionInfo {
-        addr: frame.return_address(arch),
-        arch,
-        crashing_frame: crashing,
-        signal: None,
-        ip_reg: None,
-    };
+    let return_address = frame.return_address(arch);
+    let caller_address = InstructionInfo::new(arch, return_address)
+        .is_crashing_frame(crashing)
+        .caller_address();
 
     let lines = symcache
         .get()
-        .lookup(instruction.caller_address() - module.base_address())?
+        .lookup(caller_address - module.base_address())?
         .collect::<Vec<_>>()?;
 
     if lines.is_empty() {

--- a/minidump/src/cfi.rs
+++ b/minidump/src/cfi.rs
@@ -381,7 +381,7 @@ impl<W: Write> AsciiCfiWriter<W> {
     ) -> Result<bool, CfiError> {
         let formatted = match rule {
             CfaRule::RegisterAndOffset { register, offset } => {
-                match arch.cpu_family().register_name(register.0) {
+                match arch.cpu_family().cfi_register_name(register.0) {
                     Some(register) => format!("{} {} +", register, *offset),
                     None => return Ok(false),
                 }
@@ -402,16 +402,18 @@ impl<W: Write> AsciiCfiWriter<W> {
     ) -> Result<bool, CfiError> {
         let formatted = match rule {
             RegisterRule::Undefined => return Ok(false),
-            RegisterRule::SameValue => match arch.cpu_family().register_name(register.0) {
+            RegisterRule::SameValue => match arch.cpu_family().cfi_register_name(register.0) {
                 Some(reg) => reg.into(),
                 None => return Ok(false),
             },
             RegisterRule::Offset(offset) => format!(".cfa {} + ^", offset),
             RegisterRule::ValOffset(offset) => format!(".cfa {} +", offset),
-            RegisterRule::Register(register) => match arch.cpu_family().register_name(register.0) {
-                Some(reg) => reg.into(),
-                None => return Ok(false),
-            },
+            RegisterRule::Register(register) => {
+                match arch.cpu_family().cfi_register_name(register.0) {
+                    Some(reg) => reg.into(),
+                    None => return Ok(false),
+                }
+            }
             RegisterRule::Expression(_) => return Ok(false),
             RegisterRule::ValExpression(_) => return Ok(false),
             RegisterRule::Architectural => return Ok(false),
@@ -422,7 +424,7 @@ impl<W: Write> AsciiCfiWriter<W> {
         let register_name = if register == ra {
             ".ra"
         } else {
-            match arch.cpu_family().register_name(register.0) {
+            match arch.cpu_family().cfi_register_name(register.0) {
                 Some(reg) => reg,
                 None => return Ok(false),
             }

--- a/minidump/src/cfi.rs
+++ b/minidump/src/cfi.rs
@@ -135,7 +135,7 @@ impl<U> UnwindInfo<U> {
 
         // Based on the architecture, pointers inside eh_frame and debug_frame have different sizes.
         // Configure the section to read them appropriately.
-        if let Some(pointer_size) = arch.pointer_size() {
+        if let Some(pointer_size) = arch.cpu_family().pointer_size() {
             section.set_address_size(pointer_size as u8);
         }
 
@@ -381,7 +381,7 @@ impl<W: Write> AsciiCfiWriter<W> {
     ) -> Result<bool, CfiError> {
         let formatted = match rule {
             CfaRule::RegisterAndOffset { register, offset } => {
-                match arch.register_name(register.0) {
+                match arch.cpu_family().register_name(register.0) {
                     Some(register) => format!("{} {} +", register, *offset),
                     None => return Ok(false),
                 }
@@ -402,13 +402,13 @@ impl<W: Write> AsciiCfiWriter<W> {
     ) -> Result<bool, CfiError> {
         let formatted = match rule {
             RegisterRule::Undefined => return Ok(false),
-            RegisterRule::SameValue => match arch.register_name(register.0) {
+            RegisterRule::SameValue => match arch.cpu_family().register_name(register.0) {
                 Some(reg) => reg.into(),
                 None => return Ok(false),
             },
             RegisterRule::Offset(offset) => format!(".cfa {} + ^", offset),
             RegisterRule::ValOffset(offset) => format!(".cfa {} +", offset),
-            RegisterRule::Register(register) => match arch.register_name(register.0) {
+            RegisterRule::Register(register) => match arch.cpu_family().register_name(register.0) {
                 Some(reg) => reg.into(),
                 None => return Ok(false),
             },
@@ -422,7 +422,7 @@ impl<W: Write> AsciiCfiWriter<W> {
         let register_name = if register == ra {
             ".ra"
         } else {
-            match arch.register_name(register.0) {
+            match arch.cpu_family().register_name(register.0) {
                 Some(reg) => reg,
                 None => return Ok(false),
             }


### PR DESCRIPTION
Updates doc comments all over `symbolic-common` with doc comments and improved descriptions, and also deprecates some APIs that are not future-proof:

- `pointer_size`, `instruction_alignment` and `ip_register_name` have moved from `Arch` to `CpuFamily`.
- `Arch::register_name` as been moved to `CpuFamily::cfi_register_name`.
- `CpuFamily::cfi_register_name` returns `None` instead of `Some("")` for some unknown registers.
- Field access on `InstructionInfo` has been deprecated and replaced with a builder.