### PR TITLE
fix(demangle): Upgrade to cpp_demangle 0.3.0

### DIFF
--- a/demangle/Cargo.toml
+++ b/demangle/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [dependencies]
-cpp_demangle = "0.2.17"
+cpp_demangle = "0.3.0"
 msvc-demangler = "0.8.0"
 rustc-demangle = "0.1.16"
 symbolic-common = { version = "7.3.6", path = "../common" }

--- a/demangle/src/lib.rs
+++ b/demangle/src/lib.rs
@@ -127,13 +127,12 @@ fn try_demangle_cpp(ident: &str, opts: DemangleOptions) -> Option<String> {
         Err(_) => return None,
     };
 
-    let opts = CppOptions {
-        no_params: !opts.with_arguments,
-        // TODO: Maybe we would like to add return type to `DemangleOptions`?
-        no_return_type: !opts.with_arguments,
-    };
+    let mut cpp_options = CppOptions::new();
+    if !opts.with_arguments {
+        cpp_options = cpp_options.no_params().no_return_type();
+    }
 
-    match symbol.demangle(&opts) {
+    match symbol.demangle(&cpp_options) {
         Ok(demangled) => Some(demangled),
         Err(_) => None,
     }


### PR DESCRIPTION
`cpp_demangle 0.2.17` was yanked from the registry.

