### PR TITLE
fix(common): Update doc comments and fix broken links

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
 documentation = "https://docs.rs/symbolic-common"
 homepage = "https://github.com/getsentry/symbolic"
 repository = "https://github.com/getsentry/symbolic"
+readme = "README.md"
 description = """
 Common types and utilities for symbolic, a library to symbolicate and process
 stack traces from native applications, minidumps, minified JavaScripts or

--- a/common/src/byteview.rs
+++ b/common/src/byteview.rs
@@ -59,7 +59,7 @@ impl Deref for ByteViewBacking<'_> {
 ///
 ///     let view = ByteView::map_file(file)?;
 ///     assert_eq!(view.as_slice(), b"1234");
-/// Ok(())
+///     Ok(())
 /// }
 /// ```
 #[derive(Clone, Debug)]

--- a/common/src/cell.rs
+++ b/common/src/cell.rs
@@ -279,8 +279,8 @@ where
     /// # Safety
     ///
     /// This is an inherently unsafe process. The caller must guarantee that the derived object only
-    /// borrows from the owner that is moved into this container. This is useful, when cloning the
-    /// owner by deriving a sub-object.
+    /// borrows from the owner that is moved into this container and the borrowed reference has a
+    /// stable address. This is useful, when cloning the owner by deriving a sub-object.
     ///
     /// # Example
     ///

--- a/common/src/heuristics.rs
+++ b/common/src/heuristics.rs
@@ -242,6 +242,8 @@ impl InstructionInfo {
     /// let info = InstructionInfo::new(Arch::X86, 0x1337);
     /// assert_eq!(info.previous_address(), 0x1336);
     /// ```
+    ///
+    /// [`aligned_address`]: struct.InstructionInfo.html#method.aligned_address
     pub fn previous_address(&self) -> u64 {
         let instruction_size = self.arch.cpu_family().instruction_alignment().unwrap_or(1);
 

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -198,6 +198,8 @@ impl CpuFamily {
     /// // 16 is the instruction pointer register:
     /// assert_eq!(CpuFamily::Amd64.cfi_register_name(16), Some("$rip"));
     /// ```
+    ///
+    /// [`ip_register_name`]: enum.CpuFamily.html#method.ip_register_name
     pub fn cfi_register_name(self, register: u16) -> Option<&'static str> {
         let index = register as usize;
 
@@ -434,6 +436,7 @@ impl Arch {
     /// use symbolic_common::Arch;
     ///
     /// assert!(Arch::X86.well_known());
+    /// assert!(!Arch::X86Unknown.well_known());
     /// ```
     pub fn well_known(self) -> bool {
         match self {
@@ -763,6 +766,15 @@ impl<'a> Name<'a> {
     /// If the language is not declared in the source, this returns `Language::Unknown`. The
     /// language may still be inferred using `detect_language`, which is declared on the `Demangle`
     /// extension trait.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use symbolic_common::{Language, Name};
+    ///
+    /// let name = Name::new("_ZN3foo3barEv");
+    /// assert_eq!(name.language(), Language::Unknown);
+    /// ```
     pub fn language(&self) -> Language {
         self.lang
     }
@@ -781,7 +793,7 @@ impl<'a> Name<'a> {
         self.string
     }
 
-    /// Converts this name into a string, dropping the language.
+    /// Converts this name into a `String`, dropping the language.
     ///
     /// # Example
     ///


### PR DESCRIPTION
Fixes a few cases that were missed in #246 and the `7.4.0` release. Also references the README from `Cargo.toml` so that it shows up on crates.io.