### PR TITLE
C-ABI: Add method to create archive from bytes buffer

### DIFF
--- a/cabi/include/symbolic.h
+++ b/cabi/include/symbolic.h
@@ -373,6 +373,12 @@ uintptr_t symbolic_archive_object_count(const SymbolicArchive *archive);
 SymbolicArchive *symbolic_archive_open(const char *path);
 
 /**
+ * Creates an archive from a byte buffer without taking ownership of the pointer.
+ */
+SymbolicArchive *symbolic_archive_from_bytes(const uint8_t *bytes,
+                                             uintptr_t len);
+
+/**
  * Releases memory held by an unmanaged `SymbolicCfiCache` instance.
  */
 void symbolic_cficache_free(SymbolicCfiCache *cache);

--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -29,6 +29,11 @@ class Archive(RustObject):
             path = path.encode("utf-8")
         return Archive._from_objptr(rustcall(lib.symbolic_archive_open, path))
 
+    @classmethod
+    def from_bytes(self, data):
+        """Loads an archive from a binary buffer."""
+        return Archive._from_objptr(rustcall(lib.symbolic_archive_from_bytes, data, len(data)))
+
     @property
     def object_count(self):
         """The number of objects in this archive."""

--- a/py/tests/test_debug.py
+++ b/py/tests/test_debug.py
@@ -11,7 +11,15 @@ from symbolic import (
 
 def test_object_features_mac(res_path):
     binary_path = os.path.join(res_path, "minidump", "crash_macos")
+
     archive = Archive.open(binary_path)
+    obj = archive.get_object(arch="x86_64")
+    assert obj.features == set(["symtab", "unwind"])
+
+   with open(binary_path, "rb") as f:
+        buf = f.read()
+
+    archive = Archive.from_bytes(buf)
     obj = archive.get_object(arch="x86_64")
     assert obj.features == set(["symtab", "unwind"])
 


### PR DESCRIPTION
It would be nice to have the method to create an archive from bytes buffer. 
I'm building a tool on top of the symbolic C-ABI and in my case, I have a dSYMs bundle (zip archive) which I have to unzip before initializing symbolic archive instances. 
Instead of it, I could just read the slice of bytes from the zip archive and create the symbolic archive instance from it without the necessity to save the buffer to a temporary file to open it further using current exposed methods