### PR TITLE
C-ABI: Add method to create symbolic archive from bytes buffer

### DIFF
--- a/cabi/include/symbolic.h
+++ b/cabi/include/symbolic.h
@@ -28,7 +28,7 @@ enum SymbolicErrorCode {
   SYMBOLIC_ERROR_CODE_OBJECT_ERROR_UNSUPPORTED_OBJECT = 2101,
   SYMBOLIC_ERROR_CODE_OBJECT_ERROR_BAD_BREAKPAD_OBJECT = 2102,
   SYMBOLIC_ERROR_CODE_OBJECT_ERROR_BAD_ELF_OBJECT = 2103,
-  SYMBOLIC_ERROR_CODE_OBJECT_ERROR_BAD_MACH_OOBJECT = 2104,
+  SYMBOLIC_ERROR_CODE_OBJECT_ERROR_BAD_MACH_O_OBJECT = 2104,
   SYMBOLIC_ERROR_CODE_OBJECT_ERROR_BAD_PDB_OBJECT = 2105,
   SYMBOLIC_ERROR_CODE_OBJECT_ERROR_BAD_PE_OBJECT = 2106,
   SYMBOLIC_ERROR_CODE_OBJECT_ERROR_BAD_SOURCE_BUNDLE = 2107,
@@ -357,6 +357,12 @@ bool symbolic_arch_is_known(const SymbolicStr *arch);
 void symbolic_archive_free(SymbolicArchive *archive);
 
 /**
+ * Creates an archive from a byte buffer without taking ownership of the pointer.
+ */
+SymbolicArchive *symbolic_archive_from_bytes(const uint8_t *bytes,
+                                             uintptr_t len);
+
+/**
  * Returns the n-th object, or a null pointer if the object does not exist.
  */
 SymbolicObject *symbolic_archive_get_object(const SymbolicArchive *archive,
@@ -371,12 +377,6 @@ uintptr_t symbolic_archive_object_count(const SymbolicArchive *archive);
  * Loads an archive from a given path.
  */
 SymbolicArchive *symbolic_archive_open(const char *path);
-
-/**
- * Creates an archive from a byte buffer without taking ownership of the pointer.
- */
-SymbolicArchive *symbolic_archive_from_bytes(const uint8_t *bytes,
-                                             uintptr_t len);
 
 /**
  * Releases memory held by an unmanaged `SymbolicCfiCache` instance.

--- a/cabi/include/symbolic.h
+++ b/cabi/include/symbolic.h
@@ -373,6 +373,12 @@ uintptr_t symbolic_archive_object_count(const SymbolicArchive *archive);
 SymbolicArchive *symbolic_archive_open(const char *path);
 
 /**
+ * Creates an archive from a byte buffer without taking ownership of the pointer.
+ */
+SymbolicArchive *symbolic_archive_from_bytes(const uint8_t *bytes,
+                                             uintptr_t len);
+
+/**
  * Releases memory held by an unmanaged `SymbolicCfiCache` instance.
  */
 void symbolic_cficache_free(SymbolicCfiCache *cache);

--- a/cabi/src/debuginfo.rs
+++ b/cabi/src/debuginfo.rs
@@ -1,6 +1,7 @@
 use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::ptr;
+use std::slice;
 use std::str::FromStr;
 
 use symbolic::common::{ByteView, CodeId, DebugId, SelfCell};
@@ -36,6 +37,18 @@ ffi_fn! {
     /// Loads an archive from a given path.
     unsafe fn symbolic_archive_open(path: *const c_char) -> Result<*mut SymbolicArchive> {
         let byteview = ByteView::open(CStr::from_ptr(path).to_str()?)?;
+        let cell = SelfCell::try_new(byteview, |p| Archive::parse(&*p))?;
+        Ok(SymbolicArchive::from_rust(cell))
+    }
+}
+
+ffi_fn! {
+    /// Creates an archive from a byte buffer without taking ownership of the pointer.
+    unsafe fn symbolic_archive_from_bytes(
+        bytes: *const u8,
+        len: usize,
+    ) -> Result<*mut SymbolicArchive> {
+        let byteview = ByteView::from_slice(slice::from_raw_parts(bytes, len));
         let cell = SelfCell::try_new(byteview, |p| Archive::parse(&*p))?;
         Ok(SymbolicArchive::from_rust(cell))
     }

--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -29,6 +29,13 @@ class Archive(RustObject):
             path = path.encode("utf-8")
         return Archive._from_objptr(rustcall(lib.symbolic_archive_open, path))
 
+    @classmethod
+    def from_bytes(self, data):
+        """Loads an archive from a binary buffer."""
+        return Archive._from_objptr(
+            rustcall(lib.symbolic_archive_from_bytes, data, len(data))
+        )
+
     @property
     def object_count(self):
         """The number of objects in this archive."""

--- a/py/tests/test_debug.py
+++ b/py/tests/test_debug.py
@@ -11,7 +11,15 @@ from symbolic import (
 
 def test_object_features_mac(res_path):
     binary_path = os.path.join(res_path, "minidump", "crash_macos")
+
     archive = Archive.open(binary_path)
+    obj = archive.get_object(arch="x86_64")
+    assert obj.features == set(["symtab", "unwind"])
+
+    with open(binary_path, "rb") as f:
+        buf = f.read()
+
+    archive = Archive.from_bytes(buf)
     obj = archive.get_object(arch="x86_64")
     assert obj.features == set(["symtab", "unwind"])
 

--- a/py/tests/test_debug.py
+++ b/py/tests/test_debug.py
@@ -8,6 +8,14 @@ from symbolic import (
     normalize_debug_id,
 )
 
+def test_create_archive_from_bytes(res_path):
+    binary_path = os.path.join(res_path, "minidump", "crash_macos")
+    with open(binary_path, "rb") as f:
+        buf = f.read()
+
+    archive = Archive.from_bytes(buf)
+    obj = archive.get_object(arch="x86_64")
+    assert obj.features == set(["symtab", "unwind"])
 
 def test_object_features_mac(res_path):
     binary_path = os.path.join(res_path, "minidump", "crash_macos")
@@ -16,12 +24,7 @@ def test_object_features_mac(res_path):
     obj = archive.get_object(arch="x86_64")
     assert obj.features == set(["symtab", "unwind"])
 
-    with open(binary_path, "rb") as f:
-        buf = f.read()
 
-    archive = Archive.from_bytes(buf)
-    obj = archive.get_object(arch="x86_64")
-    assert obj.features == set(["symtab", "unwind"])
 
     binary_path = os.path.join(
         res_path,

--- a/py/tests/test_debug.py
+++ b/py/tests/test_debug.py
@@ -8,6 +8,7 @@ from symbolic import (
     normalize_debug_id,
 )
 
+
 def test_create_archive_from_bytes(res_path):
     binary_path = os.path.join(res_path, "minidump", "crash_macos")
     with open(binary_path, "rb") as f:
@@ -17,14 +18,13 @@ def test_create_archive_from_bytes(res_path):
     obj = archive.get_object(arch="x86_64")
     assert obj.features == set(["symtab", "unwind"])
 
+
 def test_object_features_mac(res_path):
     binary_path = os.path.join(res_path, "minidump", "crash_macos")
 
     archive = Archive.open(binary_path)
     obj = archive.get_object(arch="x86_64")
     assert obj.features == set(["symtab", "unwind"])
-
-
 
     binary_path = os.path.join(
         res_path,


### PR DESCRIPTION
It would be nice to have the method to create an archive from bytes buffer.

For instance, I have a zip archive with dSYM files and I have to unpack the zip archive to a temp directory, then call the method symbolic_archive_open for each file in order to get symbolic archive instance.

Instead of it, I want to just read the slice of bytes from the zip archive and create the symbolic archive instance from it without the necessity to save the buffer to a temporary file to open it further using current exposed methods

p.s. I've tried to generate heard file calling make file command but it failed due to rust compilation error, so I just added the new method to the file manually (I'm not good in rust to fix such errors)