### PR TITLE
fix(debuginfo): Detect mangled anonymous namespaces in PDB inlinees

### DIFF
--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -138,7 +138,10 @@ class Object(RustObject):
         )
 
     def __repr__(self):
-        return "<Object %s %r>" % (self.debug_id, self.arch,)
+        return "<Object %s %r>" % (
+            self.debug_id,
+            self.arch,
+        )
 
 
 class ObjectRef(object):
@@ -165,7 +168,10 @@ class ObjectRef(object):
         self.name = self.code_file
 
     def __repr__(self):
-        return "<ObjectRef %s %r>" % (self.debug_id, self.arch,)
+        return "<ObjectRef %s %r>" % (
+            self.debug_id,
+            self.arch,
+        )
 
 
 class ObjectLookup(object):

--- a/py/symbolic/sourcemap.py
+++ b/py/symbolic/sourcemap.py
@@ -51,7 +51,10 @@ class SourceMapTokenMatch(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return "<SourceMapTokenMatch %s:%d>" % (self.src, self.src_line,)
+        return "<SourceMapTokenMatch %s:%d>" % (
+            self.src,
+            self.src_line,
+        )
 
 
 class SourceView(RustObject):

--- a/py/symbolic/symcache.py
+++ b/py/symbolic/symcache.py
@@ -73,7 +73,11 @@ class LineInfo(object):
         return strip_common_path_prefix(self.abs_path, self.comp_dir)
 
     def __str__(self):
-        return "%s:%s (%s)" % (self.function_name, self.line, self.rel_path,)
+        return "%s:%s (%s)" % (
+            self.function_name,
+            self.line,
+            self.rel_path,
+        )
 
     def __repr__(self):
         return "LineInfo(%s)" % (


### PR DESCRIPTION
ID records specify the mangled format for anonymous namespaces: `?A0x<id>`, where `id` is a hex
identifier of the namespace. Demanglers usually resolve this as "anonymous namespace".

This also fixes an issue with demangling: If the anonymous namespace is in the
beginning of the composed name, it leads the demangler to believe that this is a
mangled MSVC name. However, since this is a composed demangled name, this leads
to a demangle error.

