### PR TITLE
build(unreal): Rename with-serde to serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ proguard = ["symbolic-proguard"]
 sourcemap = ["symbolic-sourcemap"]
 symcache = ["symbolic-symcache", "debuginfo"]
 unreal = ["symbolic-unreal"]
-unreal-serde = ["unreal", "common-serde", "symbolic-unreal/with-serde"]
+unreal-serde = ["unreal", "common-serde", "symbolic-unreal/serde"]
 
 [dependencies]
 symbolic-common = { version = "7.5.0", path = "common" }

--- a/unreal/Cargo.toml
+++ b/unreal/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [features]
-with-serde = ["serde", "chrono/serde"]
+serde = ["serde_", "chrono/serde"]
 
 [dependencies]
 anylog = "0.5.0"
@@ -32,7 +32,7 @@ lazy_static = "1.4.0"
 flate2 = { version = "1.0.13", features = ["rust_backend"], default-features = false }
 regex = "1.3.5"
 scroll = { version = "0.10.1", features = ["derive"] }
-serde = { version = "1.0.94", optional = true, features = ["derive"] }
+serde_ = { package = "serde", version = "1.0.94", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 insta = "0.15.0"

--- a/unreal/src/context.rs
+++ b/unreal/src/context.rs
@@ -5,160 +5,158 @@ use elementtree::{Element, QName};
 
 use std::collections::BTreeMap;
 
-#[cfg(feature = "with-serde")]
-use serde::Serialize;
-
 use crate::error::Unreal4Error;
 
 /// RuntimeProperties context element.
 ///
 /// [Source](https://github.com/EpicGames/UnrealEngine/blob/b70f31f6645d764bcb55829228918a6e3b571e0b/Engine/Source/Runtime/Core/Private/GenericPlatform/GenericPlatformCrashContext.cpp#L274)
 #[derive(Clone, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "with-serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde_::Serialize))]
+#[cfg_attr(feature = "serde", serde(crate = "serde_"))]
 pub struct Unreal4ContextRuntimeProperties {
     /// CrashGUID
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub crash_guid: Option<String>,
     /// ProcessId
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub process_id: Option<u32>,
     /// IsInternalBuild
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub is_internal_build: Option<bool>,
     /// IsSourceDistribution
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub is_source_distribution: Option<bool>,
     /// IsAssert
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub is_assert: Option<bool>,
     /// IsEnsure
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub is_ensure: Option<bool>,
     /// CrashType
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub crash_type: Option<String>,
     /// SecondsSinceStart
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub seconds_since_start: Option<u32>,
     /// GameName
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub game_name: Option<String>,
     /// ExecutableName
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub executable_name: Option<String>,
     /// BuildConfiguration
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub build_configuration: Option<String>,
     /// PlatformName
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub platform_name: Option<String>,
     /// EngineMode
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub engine_mode: Option<String>,
     /// EngineVersion
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub engine_version: Option<String>,
     /// LanguageLCID
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub language_lcid: Option<i32>,
     /// AppDefaultLocale
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub app_default_locate: Option<String>,
     /// BuildVersion
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub build_version: Option<String>,
     /// IsUE4Release
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub is_ue4_release: Option<bool>,
     /// UserName
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub username: Option<String>,
     /// BaseDir
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub base_dir: Option<String>,
     /// RootDir
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub root_dir: Option<String>,
     /// MachineId
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub machine_id: Option<String>,
     /// LoginId
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub login_id: Option<String>,
     /// EpicAccountId
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub epic_account_id: Option<String>,
     /// CallStack
     /// [Source](https://github.com/EpicGames/UnrealEngine/blob/b70f31f6645d764bcb55829228918a6e3b571e0b/Engine/Source/Runtime/Core/Private/GenericPlatform/GenericPlatformCrashContext.cpp#L326-L327)
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub legacy_call_stack: Option<String>,
     /// PCallStack
     // [Sopurce](https://github.com/EpicGames/UnrealEngine/blob/b70f31f6645d764bcb55829228918a6e3b571e0b/Engine/Source/Runtime/Core/Private/GenericPlatform/GenericPlatformCrashContext.cpp#L329-L330)
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub portable_call_stack: Option<String>,
     /// UserDescription
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub user_description: Option<String>,
     /// ErrorMessage
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub error_message: Option<String>,
     /// CrashReporterMessage
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub crash_reporter_message: Option<String>,
     /// Misc.NumberOfCores
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub misc_number_of_cores: Option<u32>,
     /// Misc.NumberOfCoresIncludingHyperthreads
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub misc_number_of_cores_inc_hyperthread: Option<u32>,
     /// Misc.Is64bitOperatingSystem
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub misc_is_64bit: Option<bool>,
     /// Misc.CPUVendor
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub misc_cpu_vendor: Option<String>,
     /// Misc.CPUBrand
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub misc_cpu_brand: Option<String>,
     #[doc(hidden)]
     #[deprecated(note = "use misc_primary_gpu_brand instead")]
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub misc_primary_cpu_brand: Option<String>,
     /// Misc.PrimaryGPUBrand
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub misc_primary_gpu_brand: Option<String>,
     /// Misc.OSVersionMajor
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub misc_os_version_major: Option<String>,
     /// Misc.OSVersionMinor
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub misc_os_version_minor: Option<String>,
     /// GameStateName
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub game_state_name: Option<String>,
     /// MemoryStats.TotalPhysical
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub memory_stats_total_physical: Option<u64>,
     /// MemoryStats.TotalVirtual
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub memory_stats_total_virtual: Option<u64>,
     /// MemoryStats.PageSize
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub memory_stats_page_size: Option<u64>,
     /// MemoryStats.TotalPhysicalGB
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub memory_stats_total_phsysical_gb: Option<u32>,
     /// TimeOfCrash
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub time_of_crash: Option<u64>,
     /// bAllowToBeContacted
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub allowed_to_be_contacted: Option<bool>,
     /// CrashReportClientVersion
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub crash_reporter_client_version: Option<String>,
     /// Modules
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub modules: Option<String>,
     /// Custom attributes
     pub custom: BTreeMap<String, String>,
@@ -277,7 +275,8 @@ impl Unreal4ContextRuntimeProperties {
 /// [Source[(https://github.com/EpicGames/UnrealEngine/blob/b70f31f6645d764bcb55829228918a6e3b571e0b/Engine/Source/Runtime/Core/Private/GenericPlatform/GenericPlatformCrashContext.cpp#L451-L455)
 /// [Windows](https://github.com/EpicGames/UnrealEngine/blob/b70f31f6645d764bcb55829228918a6e3b571e0b/Engine/Source/Runtime/Core/Private/Windows/WindowsPlatformCrashContext.cpp#L39-L44)
 #[derive(Clone, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "with-serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde_::Serialize))]
+#[cfg_attr(feature = "serde", serde(crate = "serde_"))]
 pub struct Unreal4ContextPlatformProperties {
     /// Whether the crash happened on a Windows device.
     pub is_windows: Option<bool>,
@@ -317,26 +316,27 @@ impl Unreal4ContextPlatformProperties {
 ///
 /// [Source](https://github.com/EpicGames/UnrealEngine/blob/b70f31f6645d764bcb55829228918a6e3b571e0b/Engine/Source/Runtime/Core/Private/GenericPlatform/GenericPlatformCrashContext.cpp)
 #[derive(Clone, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "with-serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde_::Serialize))]
+#[cfg_attr(feature = "serde", serde(crate = "serde_"))]
 pub struct Unreal4Context {
     /// RuntimeProperties context element.
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub runtime_properties: Option<Unreal4ContextRuntimeProperties>,
 
     /// Platform specific properties.
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub platform_properties: Option<Unreal4ContextPlatformProperties>,
 
     /// Engine data.
     #[cfg_attr(
-        feature = "with-serde",
+        feature = "serde",
         serde(default, skip_serializing_if = "BTreeMap::is_empty")
     )]
     pub engine_data: BTreeMap<String, String>,
 
     /// Game data.
     #[cfg_attr(
-        feature = "with-serde",
+        feature = "serde",
         serde(default, skip_serializing_if = "BTreeMap::is_empty")
     )]
     pub game_data: BTreeMap<String, String>,

--- a/unreal/src/logs.rs
+++ b/unreal/src/logs.rs
@@ -3,9 +3,6 @@ use chrono::{DateTime, TimeZone, Utc};
 use lazy_static::lazy_static;
 use regex::Regex;
 
-#[cfg(feature = "with-serde")]
-use serde::Serialize;
-
 use crate::error::Unreal4Error;
 
 lazy_static! {
@@ -16,14 +13,15 @@ lazy_static! {
 }
 
 /// A log entry from an Unreal Engine 4 crash.
-#[cfg_attr(feature = "with-serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(serde_::Serialize))]
+#[cfg_attr(feature = "serde", serde(crate = "serde_"))]
 pub struct Unreal4LogEntry {
     /// The timestamp of the message, when available.
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub timestamp: Option<DateTime<Utc>>,
 
     /// The component that issued the log, when available.
-    #[cfg_attr(feature = "with-serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub component: Option<String>,
 
     /// The log message.

--- a/unreal/tests/test_unreal_crash_parse.rs
+++ b/unreal/tests/test_unreal_crash_parse.rs
@@ -64,6 +64,7 @@ fn test_get_apple_crash_report() {
 }
 
 #[test]
+#[cfg(feature = "serde")]
 fn test_contexts_runtime_properties() {
     let ue4_crash = get_unreal_crash().expect("test crash file loads");
 


### PR DESCRIPTION
Streamlines the feature name for serde in `symbolic-unreal` with other crates.

