### PR TITLE
ref: Remove all deprecated items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - Usage of `failure` was removed, and all Error types were changed to only implement `std::error::Error` and related traits.
 - `symbolic-proguard` was removed in favor of the `proguard` crate. Proguard is still supported via `symbolic-cabi` and the python API however.
+- Deprecated APIs have been removed:
+  - `InstructionInfo`'s fields are no longer public.
+  - `pointer_size`, `instruction_alignment` and `ip_register_name` have moved from `Arch` to `CpuFamily`.
+  - `Arch::register_name` as been moved to `CpuFamily::cfi_register_name`.
+  - `Dwarf::raw_data` and `Dwarf::section_data` have been replaced with the `raw_section` and `section` APIs.
+  - `Unreal4ContextRuntimeProperties::misc_primary_cpu_brand` is has been removed.
+- Deprecated Python APIs have been removed:
+  - `CodeModule.id` and `CodeModule.name` Use `debug_id` and `code_file`, respectively.
 
 ## 7.5.0
 

--- a/py/symbolic/minidump.py
+++ b/py/symbolic/minidump.py
@@ -81,21 +81,6 @@ class CodeModule(RustObject):
         """Size of the loaded module in virtual memory"""
         return self._objptr.size
 
-    @property
-    def id(self):
-        warnings.warn(
-            "module.id is deprecated, use module.debug_id instead", DeprecationWarning
-        )
-        return self.debug_id
-
-    @property
-    def name(self):
-        warnings.warn(
-            "module.name is deprecated, use module.code_file instead",
-            DeprecationWarning,
-        )
-        return self.code_file
-
 
 class StackFrame(RustObject):
     """A single frame in the call stack of a crashed process"""

--- a/py/symbolic/minidump.py
+++ b/py/symbolic/minidump.py
@@ -2,7 +2,6 @@
 
 import shutil
 from datetime import datetime
-import warnings
 
 from symbolic._compat import range_type
 from symbolic._lowlevel import lib, ffi

--- a/symbolic-common/src/heuristics.rs
+++ b/symbolic-common/src/heuristics.rs
@@ -1,9 +1,5 @@
 //! Heuristics for correcting instruction pointers based on the CPU architecture.
 
-// The fields on `InstructionInfo` are deprecated and will be removed from the public interface in
-// the next major release. They may still be used in this module.
-#![allow(deprecated)]
-
 use crate::types::{Arch, CpuFamily};
 
 const SIGILL: u32 = 4;
@@ -107,21 +103,11 @@ const SIGSEGV: u32 = 11;
 /// [`caller_address`]: struct.InstructionInfo.html#method.caller_address
 #[derive(Clone, Debug)]
 pub struct InstructionInfo {
-    #[doc(hidden)]
-    #[deprecated = "Use InstructionInfo::new() instead"]
-    pub addr: u64,
-    #[doc(hidden)]
-    #[deprecated = "Use InstructionInfo::new() instead"]
-    pub arch: Arch,
-    #[doc(hidden)]
-    #[deprecated = "Use is_crashing_frame() instead"]
-    pub crashing_frame: bool,
-    #[doc(hidden)]
-    #[deprecated = "Use signal() instead"]
-    pub signal: Option<u32>,
-    #[doc(hidden)]
-    #[deprecated = "Use ip_register_value() instead"]
-    pub ip_reg: Option<u64>,
+    addr: u64,
+    arch: Arch,
+    crashing_frame: bool,
+    signal: Option<u32>,
+    ip_reg: Option<u64>,
 }
 
 impl InstructionInfo {

--- a/symbolic-common/src/types.rs
+++ b/symbolic-common/src/types.rs
@@ -414,24 +414,6 @@ impl Arch {
         }
     }
 
-    #[doc(hidden)]
-    #[deprecated = "use CpuFamily::pointer_size instead"]
-    pub fn pointer_size(self) -> Option<usize> {
-        self.cpu_family().pointer_size()
-    }
-
-    #[doc(hidden)]
-    #[deprecated = "use CpuFamily::instruction_alignment instead"]
-    pub fn instruction_alignment(self) -> Option<u64> {
-        self.cpu_family().instruction_alignment()
-    }
-
-    #[doc(hidden)]
-    #[deprecated = "use CpuFamily::ip_register_name instead"]
-    pub fn ip_register_name(self) -> Option<&'static str> {
-        self.cpu_family().ip_register_name()
-    }
-
     /// Returns whether this architecture is well-known.
     ///
     /// This is trivially `true` for all architectures other than the `*Unknown` variants.
@@ -454,12 +436,6 @@ impl Arch {
             | Arch::Arm64_32Unknown => false,
             _ => true,
         }
-    }
-
-    #[doc(hidden)]
-    #[deprecated = "use CpuFamily::cfi_register_name instead"]
-    pub fn register_name(self, register: u16) -> Option<&'static str> {
-        self.cpu_family().cfi_register_name(register)
     }
 }
 

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -111,23 +111,6 @@ pub trait Dwarf<'data> {
     /// given by the architecture.
     fn endianity(&self) -> Endian;
 
-    #[doc(hidden)]
-    #[deprecated(note = "use raw_section instead")]
-    fn raw_data(&self, name: &str) -> Option<(u64, &'data [u8])> {
-        let section = self.raw_section(name)?;
-        match section.data {
-            Cow::Borrowed(data) => Some((section.offset, data)),
-            Cow::Owned(_) => None,
-        }
-    }
-
-    #[doc(hidden)]
-    #[deprecated(note = "use section instead")]
-    fn section_data(&self, name: &str) -> Option<(u64, Cow<'data, [u8]>)> {
-        let section = self.section(name)?;
-        Some((section.offset, section.data))
-    }
-
     /// Returns information and raw data of a section.
     ///
     /// The section name is given without leading punctuation, such dots or underscores. For

--- a/symbolic-unreal/src/context.rs
+++ b/symbolic-unreal/src/context.rs
@@ -118,10 +118,6 @@ pub struct Unreal4ContextRuntimeProperties {
     /// Misc.CPUBrand
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub misc_cpu_brand: Option<String>,
-    #[doc(hidden)]
-    #[deprecated(note = "use misc_primary_gpu_brand instead")]
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub misc_primary_cpu_brand: Option<String>,
     /// Misc.PrimaryGPUBrand
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub misc_primary_gpu_brand: Option<String>,
@@ -225,15 +221,7 @@ impl Unreal4ContextRuntimeProperties {
                 }
                 "Misc.CPUVendor" => rv.misc_cpu_vendor = get_text_or_none(&child),
                 "Misc.CPUBrand" => rv.misc_cpu_brand = get_text_or_none(&child),
-                "Misc.PrimaryGPUBrand" => {
-                    rv.misc_primary_gpu_brand = get_text_or_none(&child);
-
-                    #[allow(deprecated)]
-                    {
-                        // Shim a typo. To be removed with the next major release.
-                        rv.misc_primary_cpu_brand = rv.misc_primary_gpu_brand.clone();
-                    }
-                }
+                "Misc.PrimaryGPUBrand" => rv.misc_primary_gpu_brand = get_text_or_none(&child),
                 "Misc.OSVersionMajor" => rv.misc_os_version_major = get_text_or_none(&child),
                 "Misc.OSVersionMinor" => rv.misc_os_version_minor = get_text_or_none(&child),
                 "GameStateName" => rv.game_state_name = get_text_or_none(&child),

--- a/symbolic-unreal/tests/snapshots/test_unreal_crash_parse__contexts_runtime_properties.snap
+++ b/symbolic-unreal/tests/snapshots/test_unreal_crash_parse__contexts_runtime_properties.snap
@@ -33,7 +33,6 @@ misc_number_of_cores: 6
 misc_number_of_cores_inc_hyperthread: 6
 misc_cpu_vendor: GenuineIntel
 misc_cpu_brand: Intel(R) Core(TM) i5-8600K CPU @ 3.60GHz
-misc_primary_cpu_brand: NVIDIA GeForce GTX 1080
 misc_primary_gpu_brand: NVIDIA GeForce GTX 1080
 misc_os_version_major: Windows 10
 memory_stats_total_physical: 17112477696


### PR DESCRIPTION
Removes all deprecated items from the public API both in Rust and in python.

