### PR TITLE
fix: Add a SymbolIterator and Lifetimes to ObjectLike trait

### DIFF
--- a/symbolic-debuginfo/src/base.rs
+++ b/symbolic-debuginfo/src/base.rs
@@ -625,15 +625,15 @@ pub trait DebugSession {
 }
 
 /// An object containing debug information.
-pub trait ObjectLike<'data: 'slf, 'slf> {
+pub trait ObjectLike<'data, 'slf> {
     /// Errors thrown when reading information from this object.
-    type Error: 'static;
+    type Error;
 
     /// A session that allows optimized access to debugging information.
     type Session: DebugSession<Error = Self::Error>;
 
     /// The iterator over the symbols in the public symbol table.
-    type SymbolIterator: Iterator<Item = Symbol<'data>> + 'slf;
+    type SymbolIterator: Iterator<Item = Symbol<'data>>;
 
     /// The container format of this file.
     fn file_format(&self) -> FileFormat;
@@ -677,7 +677,7 @@ pub trait ObjectLike<'data: 'slf, 'slf> {
     /// Constructing this session will also work if the object does not contain debugging
     /// information, in which case the session will be a no-op. This can be checked via
     /// [`has_debug_info`](trait.ObjectLike.html#tymethod.has_debug_info).
-    fn debug_session(&self) -> Result<Self::Session, Self::Error>;
+    fn debug_session(&'slf self) -> Result<Self::Session, Self::Error>;
 
     /// Determines whether this object contains stack unwinding information.
     fn has_unwind_info(&self) -> bool;

--- a/symbolic-debuginfo/src/base.rs
+++ b/symbolic-debuginfo/src/base.rs
@@ -625,7 +625,7 @@ pub trait DebugSession {
 }
 
 /// An object containing debug information.
-pub trait ObjectLike<'data, 'slf> {
+pub trait ObjectLike<'data, 'object> {
     /// Errors thrown when reading information from this object.
     type Error;
 
@@ -660,7 +660,7 @@ pub trait ObjectLike<'data, 'slf> {
     fn has_symbols(&self) -> bool;
 
     /// Returns an iterator over symbols in the public symbol table.
-    fn symbols(&'slf self) -> Self::SymbolIterator;
+    fn symbols(&'object self) -> Self::SymbolIterator;
 
     /// Returns an ordered map of symbols in the symbol table.
     fn symbol_map(&self) -> SymbolMap<'data>;
@@ -677,7 +677,7 @@ pub trait ObjectLike<'data, 'slf> {
     /// Constructing this session will also work if the object does not contain debugging
     /// information, in which case the session will be a no-op. This can be checked via
     /// [`has_debug_info`](trait.ObjectLike.html#tymethod.has_debug_info).
-    fn debug_session(&'slf self) -> Result<Self::Session, Self::Error>;
+    fn debug_session(&'object self) -> Result<Self::Session, Self::Error>;
 
     /// Determines whether this object contains stack unwinding information.
     fn has_unwind_info(&self) -> bool;

--- a/symbolic-debuginfo/src/base.rs
+++ b/symbolic-debuginfo/src/base.rs
@@ -627,7 +627,7 @@ pub trait DebugSession {
 /// An object containing debug information.
 pub trait ObjectLike<'d> {
     /// Errors thrown when reading information from this object.
-    type Error;
+    type Error: 'static;
 
     /// A session that allows optimized access to debugging information.
     type Session: DebugSession<Error = Self::Error>;

--- a/symbolic-debuginfo/src/base.rs
+++ b/symbolic-debuginfo/src/base.rs
@@ -625,7 +625,7 @@ pub trait DebugSession {
 }
 
 /// An object containing debug information.
-pub trait ObjectLike {
+pub trait ObjectLike<'d> {
     /// Errors thrown when reading information from this object.
     type Error;
 
@@ -657,10 +657,10 @@ pub trait ObjectLike {
     fn has_symbols(&self) -> bool;
 
     /// Returns an iterator over symbols in the public symbol table.
-    fn symbols(&self) -> DynIterator<'_, Symbol<'_>>;
+    fn symbols(&self) -> DynIterator<'_, Symbol<'d>>;
 
     /// Returns an ordered map of symbols in the symbol table.
-    fn symbol_map(&self) -> SymbolMap<'_>;
+    fn symbol_map(&self) -> SymbolMap<'d>;
 
     /// Determines whether this object contains debug information.
     fn has_debug_info(&self) -> bool;

--- a/symbolic-debuginfo/src/base.rs
+++ b/symbolic-debuginfo/src/base.rs
@@ -625,12 +625,15 @@ pub trait DebugSession {
 }
 
 /// An object containing debug information.
-pub trait ObjectLike<'d> {
+pub trait ObjectLike<'data: 'slf, 'slf> {
     /// Errors thrown when reading information from this object.
     type Error: 'static;
 
     /// A session that allows optimized access to debugging information.
     type Session: DebugSession<Error = Self::Error>;
+
+    /// The iterator over the symbols in the public symbol table.
+    type SymbolIterator: Iterator<Item = Symbol<'data>> + 'slf;
 
     /// The container format of this file.
     fn file_format(&self) -> FileFormat;
@@ -657,10 +660,10 @@ pub trait ObjectLike<'d> {
     fn has_symbols(&self) -> bool;
 
     /// Returns an iterator over symbols in the public symbol table.
-    fn symbols(&self) -> DynIterator<'_, Symbol<'d>>;
+    fn symbols(&'slf self) -> Self::SymbolIterator;
 
     /// Returns an ordered map of symbols in the symbol table.
-    fn symbol_map(&self) -> SymbolMap<'d>;
+    fn symbol_map(&self) -> SymbolMap<'data>;
 
     /// Determines whether this object contains debug information.
     fn has_debug_info(&self) -> bool;

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -966,7 +966,7 @@ impl<'d> Parse<'d> for BreakpadObject<'d> {
     }
 }
 
-impl<'d> ObjectLike for BreakpadObject<'d> {
+impl<'d> ObjectLike<'d> for BreakpadObject<'d> {
     type Error = BreakpadError;
     type Session = BreakpadDebugSession<'d>;
 
@@ -998,11 +998,11 @@ impl<'d> ObjectLike for BreakpadObject<'d> {
         self.has_symbols()
     }
 
-    fn symbols(&self) -> DynIterator<'_, Symbol<'_>> {
+    fn symbols(&self) -> DynIterator<'_, Symbol<'d>> {
         Box::new(self.symbols())
     }
 
-    fn symbol_map(&self) -> SymbolMap<'_> {
+    fn symbol_map(&self) -> SymbolMap<'d> {
         self.symbol_map()
     }
 

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -966,9 +966,10 @@ impl<'d> Parse<'d> for BreakpadObject<'d> {
     }
 }
 
-impl<'d> ObjectLike<'d> for BreakpadObject<'d> {
+impl<'d: 'slf, 'slf> ObjectLike<'d, 'slf> for BreakpadObject<'d> {
     type Error = BreakpadError;
     type Session = BreakpadDebugSession<'d>;
+    type SymbolIterator = BreakpadSymbolIterator<'d>;
 
     fn file_format(&self) -> FileFormat {
         self.file_format()
@@ -998,8 +999,8 @@ impl<'d> ObjectLike<'d> for BreakpadObject<'d> {
         self.has_symbols()
     }
 
-    fn symbols(&self) -> DynIterator<'_, Symbol<'d>> {
-        Box::new(self.symbols())
+    fn symbols(&self) -> Self::SymbolIterator {
+        self.symbols()
     }
 
     fn symbol_map(&self) -> SymbolMap<'d> {

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -1161,7 +1161,7 @@ impl<'d> DwarfDebugSession<'d> {
     }
 }
 
-impl<'d> DebugSession for DwarfDebugSession<'d> {
+impl<'data> DebugSession for DwarfDebugSession<'data> {
     type Error = DwarfError;
 
     fn functions(&self) -> DynIterator<'_, Result<Function<'_>, Self::Error>> {

--- a/symbolic-debuginfo/src/elf.rs
+++ b/symbolic-debuginfo/src/elf.rs
@@ -443,7 +443,7 @@ impl<'d> Parse<'d> for ElfObject<'d> {
     }
 }
 
-impl<'d> ObjectLike for ElfObject<'d> {
+impl<'d> ObjectLike<'d> for ElfObject<'d> {
     type Error = DwarfError;
     type Session = DwarfDebugSession<'d>;
 
@@ -475,11 +475,11 @@ impl<'d> ObjectLike for ElfObject<'d> {
         self.has_symbols()
     }
 
-    fn symbols(&self) -> DynIterator<'_, Symbol<'_>> {
+    fn symbols(&self) -> DynIterator<'_, Symbol<'d>> {
         Box::new(self.symbols())
     }
 
-    fn symbol_map(&self) -> SymbolMap<'_> {
+    fn symbol_map(&self) -> SymbolMap<'d> {
         self.symbol_map()
     }
 

--- a/symbolic-debuginfo/src/elf.rs
+++ b/symbolic-debuginfo/src/elf.rs
@@ -48,12 +48,12 @@ pub enum ElfError {
 }
 
 /// Executable and Linkable Format, used for executables and libraries on Linux.
-pub struct ElfObject<'d> {
-    elf: elf::Elf<'d>,
-    data: &'d [u8],
+pub struct ElfObject<'data> {
+    elf: elf::Elf<'data>,
+    data: &'data [u8],
 }
 
-impl<'d> ElfObject<'d> {
+impl<'data> ElfObject<'data> {
     /// Tests whether the buffer could contain an ELF object.
     pub fn test(data: &[u8]) -> bool {
         match goblin::peek(&mut Cursor::new(data)) {
@@ -63,7 +63,7 @@ impl<'d> ElfObject<'d> {
     }
 
     /// Tries to parse an ELF object from the given slice.
-    pub fn parse(data: &'d [u8]) -> Result<Self, ElfError> {
+    pub fn parse(data: &'data [u8]) -> Result<Self, ElfError> {
         Ok(elf::Elf::parse(data).map(|elf| ElfObject { elf, data })?)
     }
 
@@ -84,7 +84,7 @@ impl<'d> ElfObject<'d> {
     }
 
     /// The binary's soname, if any.
-    pub fn name(&self) -> Option<&'d str> {
+    pub fn name(&self) -> Option<&'data str> {
         self.elf.soname
     }
 
@@ -208,7 +208,7 @@ impl<'d> ElfObject<'d> {
     }
 
     /// Returns an iterator over symbols in the public symbol table.
-    pub fn symbols(&self) -> ElfSymbolIterator<'d, '_> {
+    pub fn symbols(&self) -> ElfSymbolIterator<'data, '_> {
         ElfSymbolIterator {
             symbols: self.elf.syms.iter(),
             strtab: &self.elf.strtab,
@@ -218,7 +218,7 @@ impl<'d> ElfObject<'d> {
     }
 
     /// Returns an ordered map of symbols in the symbol table.
-    pub fn symbol_map(&self) -> SymbolMap<'d> {
+    pub fn symbol_map(&self) -> SymbolMap<'data> {
         self.symbols().collect()
     }
 
@@ -239,7 +239,7 @@ impl<'d> ElfObject<'d> {
     /// Constructing this session will also work if the object does not contain debugging
     /// information, in which case the session will be a no-op. This can be checked via
     /// [`has_debug_info`](struct.ElfObject.html#method.has_debug_info).
-    pub fn debug_session(&self) -> Result<DwarfDebugSession<'d>, DwarfError> {
+    pub fn debug_session(&self) -> Result<DwarfDebugSession<'data>, DwarfError> {
         let symbols = self.symbol_map();
         DwarfDebugSession::parse(self, symbols, self.load_address(), self.kind())
     }
@@ -255,7 +255,7 @@ impl<'d> ElfObject<'d> {
     }
 
     /// Returns the raw data of the ELF file.
-    pub fn data(&self) -> &'d [u8] {
+    pub fn data(&self) -> &'data [u8] {
         self.data
     }
 
@@ -295,7 +295,7 @@ impl<'d> ElfObject<'d> {
     }
 
     /// Locates and reads a section in an ELF binary.
-    fn find_section(&self, name: &str) -> Option<(bool, DwarfSection<'d>)> {
+    fn find_section(&self, name: &str) -> Option<(bool, DwarfSection<'data>)> {
         for header in &self.elf.section_headers {
             // NB: Symbolic does not support MIPS, but if it did we would also need to check
             // SHT_MIPS_DWARF sections.
@@ -350,7 +350,7 @@ impl<'d> ElfObject<'d> {
     /// Depending on the compiler and linker, the build ID can be declared in a
     /// PT_NOTE program header entry, the ".note.gnu.build-id" section, or even
     /// both.
-    fn find_build_id(&self) -> Option<&'d [u8]> {
+    fn find_build_id(&self) -> Option<&'data [u8]> {
         // First, search the note program headers (PT_NOTE) for a NT_GNU_BUILD_ID.
         // We swallow all errors during this process and simply fall back to the
         // next method below.
@@ -423,7 +423,7 @@ impl fmt::Debug for ElfObject<'_> {
     }
 }
 
-impl<'slf, 'd: 'slf> AsSelf<'slf> for ElfObject<'d> {
+impl<'slf, 'data: 'slf> AsSelf<'slf> for ElfObject<'data> {
     type Ref = ElfObject<'slf>;
 
     fn as_self(&'slf self) -> &Self::Ref {
@@ -431,22 +431,22 @@ impl<'slf, 'd: 'slf> AsSelf<'slf> for ElfObject<'d> {
     }
 }
 
-impl<'d> Parse<'d> for ElfObject<'d> {
+impl<'data> Parse<'data> for ElfObject<'data> {
     type Error = ElfError;
 
     fn test(data: &[u8]) -> bool {
         Self::test(data)
     }
 
-    fn parse(data: &'d [u8]) -> Result<Self, ElfError> {
+    fn parse(data: &'data [u8]) -> Result<Self, ElfError> {
         Self::parse(data)
     }
 }
 
-impl<'d: 'slf, 'slf> ObjectLike<'d, 'slf> for ElfObject<'d> {
+impl<'data: 'object, 'object> ObjectLike<'data, 'object> for ElfObject<'data> {
     type Error = DwarfError;
-    type Session = DwarfDebugSession<'d>;
-    type SymbolIterator = ElfSymbolIterator<'d, 'slf>;
+    type Session = DwarfDebugSession<'data>;
+    type SymbolIterator = ElfSymbolIterator<'data, 'object>;
 
     fn file_format(&self) -> FileFormat {
         self.file_format()
@@ -476,11 +476,11 @@ impl<'d: 'slf, 'slf> ObjectLike<'d, 'slf> for ElfObject<'d> {
         self.has_symbols()
     }
 
-    fn symbols(&'slf self) -> Self::SymbolIterator {
+    fn symbols(&'object self) -> Self::SymbolIterator {
         self.symbols()
     }
 
-    fn symbol_map(&self) -> SymbolMap<'d> {
+    fn symbol_map(&self) -> SymbolMap<'data> {
         self.symbol_map()
     }
 
@@ -501,7 +501,7 @@ impl<'d: 'slf, 'slf> ObjectLike<'d, 'slf> for ElfObject<'d> {
     }
 }
 
-impl<'d> Dwarf<'d> for ElfObject<'d> {
+impl<'data> Dwarf<'data> for ElfObject<'data> {
     fn endianity(&self) -> Endian {
         if self.elf.little_endian {
             Endian::Little
@@ -510,12 +510,12 @@ impl<'d> Dwarf<'d> for ElfObject<'d> {
         }
     }
 
-    fn raw_section(&self, name: &str) -> Option<DwarfSection<'d>> {
+    fn raw_section(&self, name: &str) -> Option<DwarfSection<'data>> {
         let (_, section) = self.find_section(name)?;
         Some(section)
     }
 
-    fn section(&self, name: &str) -> Option<DwarfSection<'d>> {
+    fn section(&self, name: &str) -> Option<DwarfSection<'data>> {
         let (compressed, mut section) = self.find_section(name)?;
 
         if compressed {
@@ -530,15 +530,15 @@ impl<'d> Dwarf<'d> for ElfObject<'d> {
 /// An iterator over symbols in the ELF file.
 ///
 /// Returned by [`ElfObject::symbols`](struct.ElfObject.html#method.symbols).
-pub struct ElfSymbolIterator<'d, 'o> {
-    symbols: elf::sym::SymIterator<'d>,
-    strtab: &'o strtab::Strtab<'d>,
-    sections: &'o [elf::SectionHeader],
+pub struct ElfSymbolIterator<'data, 'object> {
+    symbols: elf::sym::SymIterator<'data>,
+    strtab: &'object strtab::Strtab<'data>,
+    sections: &'object [elf::SectionHeader],
     load_addr: u64,
 }
 
-impl<'d, 'o> Iterator for ElfSymbolIterator<'d, 'o> {
-    type Item = Symbol<'d>;
+impl<'data, 'object> Iterator for ElfSymbolIterator<'data, 'object> {
+    type Item = Symbol<'data>;
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(symbol) = self.symbols.next() {

--- a/symbolic-debuginfo/src/elf.rs
+++ b/symbolic-debuginfo/src/elf.rs
@@ -443,9 +443,10 @@ impl<'d> Parse<'d> for ElfObject<'d> {
     }
 }
 
-impl<'d> ObjectLike<'d> for ElfObject<'d> {
+impl<'d: 'slf, 'slf> ObjectLike<'d, 'slf> for ElfObject<'d> {
     type Error = DwarfError;
     type Session = DwarfDebugSession<'d>;
+    type SymbolIterator = ElfSymbolIterator<'d, 'slf>;
 
     fn file_format(&self) -> FileFormat {
         self.file_format()
@@ -475,8 +476,8 @@ impl<'d> ObjectLike<'d> for ElfObject<'d> {
         self.has_symbols()
     }
 
-    fn symbols(&self) -> DynIterator<'_, Symbol<'d>> {
-        Box::new(self.symbols())
+    fn symbols(&'slf self) -> Self::SymbolIterator {
+        self.symbols()
     }
 
     fn symbol_map(&self) -> SymbolMap<'d> {

--- a/symbolic-debuginfo/src/macho.rs
+++ b/symbolic-debuginfo/src/macho.rs
@@ -279,10 +279,10 @@ impl<'d> Parse<'d> for MachObject<'d> {
     }
 }
 
-impl<'d: 'slf, 'slf> ObjectLike<'d, 'slf> for MachObject<'d> {
+impl<'data: 'object, 'object> ObjectLike<'data, 'object> for MachObject<'data> {
     type Error = DwarfError;
-    type Session = DwarfDebugSession<'d>;
-    type SymbolIterator = MachOSymbolIterator<'d>;
+    type Session = DwarfDebugSession<'data>;
+    type SymbolIterator = MachOSymbolIterator<'data>;
 
     fn file_format(&self) -> FileFormat {
         self.file_format()
@@ -316,7 +316,7 @@ impl<'d: 'slf, 'slf> ObjectLike<'d, 'slf> for MachObject<'d> {
         self.symbols()
     }
 
-    fn symbol_map(&self) -> SymbolMap<'d> {
+    fn symbol_map(&self) -> SymbolMap<'data> {
         self.symbol_map()
     }
 
@@ -337,7 +337,7 @@ impl<'d: 'slf, 'slf> ObjectLike<'d, 'slf> for MachObject<'d> {
     }
 }
 
-impl<'d> Dwarf<'d> for MachObject<'d> {
+impl<'data> Dwarf<'data> for MachObject<'data> {
     fn endianity(&self) -> Endian {
         if self.macho.little_endian {
             Endian::Little
@@ -346,7 +346,7 @@ impl<'d> Dwarf<'d> for MachObject<'d> {
         }
     }
 
-    fn raw_section(&self, section_name: &str) -> Option<DwarfSection<'d>> {
+    fn raw_section(&self, section_name: &str) -> Option<DwarfSection<'data>> {
         for segment in &self.macho.segments {
             for section in segment {
                 if let Ok((header, data)) = section {
@@ -379,14 +379,14 @@ impl<'d> Dwarf<'d> for MachObject<'d> {
 /// An iterator over symbols in the MachO file.
 ///
 /// Returned by [`MachObject::symbols`](struct.MachObject.html#method.symbols).
-pub struct MachOSymbolIterator<'d> {
-    symbols: mach::symbols::SymbolIterator<'d>,
+pub struct MachOSymbolIterator<'data> {
+    symbols: mach::symbols::SymbolIterator<'data>,
     sections: SmallVec<[usize; 2]>,
     vmaddr: u64,
 }
 
-impl<'d> Iterator for MachOSymbolIterator<'d> {
-    type Item = Symbol<'d>;
+impl<'data> Iterator for MachOSymbolIterator<'data> {
+    type Item = Symbol<'data>;
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(next) = self.symbols.next() {

--- a/symbolic-debuginfo/src/macho.rs
+++ b/symbolic-debuginfo/src/macho.rs
@@ -279,9 +279,10 @@ impl<'d> Parse<'d> for MachObject<'d> {
     }
 }
 
-impl<'d> ObjectLike<'d> for MachObject<'d> {
+impl<'d: 'slf, 'slf> ObjectLike<'d, 'slf> for MachObject<'d> {
     type Error = DwarfError;
     type Session = DwarfDebugSession<'d>;
+    type SymbolIterator = MachOSymbolIterator<'d>;
 
     fn file_format(&self) -> FileFormat {
         self.file_format()
@@ -311,8 +312,8 @@ impl<'d> ObjectLike<'d> for MachObject<'d> {
         self.has_symbols()
     }
 
-    fn symbols(&self) -> DynIterator<'_, Symbol<'d>> {
-        Box::new(self.symbols())
+    fn symbols(&self) -> Self::SymbolIterator {
+        self.symbols()
     }
 
     fn symbol_map(&self) -> SymbolMap<'d> {

--- a/symbolic-debuginfo/src/macho.rs
+++ b/symbolic-debuginfo/src/macho.rs
@@ -279,7 +279,7 @@ impl<'d> Parse<'d> for MachObject<'d> {
     }
 }
 
-impl<'d> ObjectLike for MachObject<'d> {
+impl<'d> ObjectLike<'d> for MachObject<'d> {
     type Error = DwarfError;
     type Session = DwarfDebugSession<'d>;
 
@@ -311,11 +311,11 @@ impl<'d> ObjectLike for MachObject<'d> {
         self.has_symbols()
     }
 
-    fn symbols(&self) -> DynIterator<'_, Symbol<'_>> {
+    fn symbols(&self) -> DynIterator<'_, Symbol<'d>> {
         Box::new(self.symbols())
     }
 
-    fn symbol_map(&self) -> SymbolMap<'_> {
+    fn symbol_map(&self) -> SymbolMap<'d> {
         self.symbol_map()
     }
 

--- a/symbolic-debuginfo/src/object.rs
+++ b/symbolic-debuginfo/src/object.rs
@@ -308,9 +308,10 @@ impl<'slf, 'd: 'slf> AsSelf<'slf> for Object<'d> {
     }
 }
 
-impl<'d> ObjectLike<'d> for Object<'d> {
+impl<'d: 'slf, 'slf> ObjectLike<'d, 'slf> for Object<'d> {
     type Error = ObjectError;
     type Session = ObjectDebugSession<'d>;
+    type SymbolIterator = SymbolIterator<'d, 'slf>;
 
     fn file_format(&self) -> FileFormat {
         self.file_format()
@@ -344,8 +345,8 @@ impl<'d> ObjectLike<'d> for Object<'d> {
         self.symbol_map()
     }
 
-    fn symbols(&self) -> DynIterator<'_, Symbol<'d>> {
-        Box::new(self.symbols())
+    fn symbols(&'slf self) -> Self::SymbolIterator {
+        self.symbols()
     }
 
     fn has_debug_info(&self) -> bool {

--- a/symbolic-debuginfo/src/object.rs
+++ b/symbolic-debuginfo/src/object.rs
@@ -308,7 +308,7 @@ impl<'slf, 'd: 'slf> AsSelf<'slf> for Object<'d> {
     }
 }
 
-impl<'d> ObjectLike for Object<'d> {
+impl<'d> ObjectLike<'d> for Object<'d> {
     type Error = ObjectError;
     type Session = ObjectDebugSession<'d>;
 
@@ -340,12 +340,12 @@ impl<'d> ObjectLike for Object<'d> {
         self.has_symbols()
     }
 
-    fn symbol_map(&self) -> SymbolMap<'_> {
+    fn symbol_map(&self) -> SymbolMap<'d> {
         self.symbol_map()
     }
 
-    fn symbols(&self) -> DynIterator<'_, Symbol<'_>> {
-        unsafe { std::mem::transmute(Box::new(self.symbols()) as DynIterator<'_, _>) }
+    fn symbols(&self) -> DynIterator<'_, Symbol<'d>> {
+        Box::new(self.symbols())
     }
 
     fn has_debug_info(&self) -> bool {

--- a/symbolic-debuginfo/src/object.rs
+++ b/symbolic-debuginfo/src/object.rs
@@ -131,22 +131,22 @@ pub fn peek(data: &[u8], archive: bool) -> FileFormat {
 /// A generic object file providing uniform access to various file formats.
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
-pub enum Object<'d> {
+pub enum Object<'data> {
     /// Breakpad ASCII symbol.
-    Breakpad(BreakpadObject<'d>),
+    Breakpad(BreakpadObject<'data>),
     /// Executable and Linkable Format, used on Linux.
-    Elf(ElfObject<'d>),
+    Elf(ElfObject<'data>),
     /// Mach Objects, used on macOS and iOS derivatives.
-    MachO(MachObject<'d>),
+    MachO(MachObject<'data>),
     /// Program Database, the debug companion format on Windows.
-    Pdb(PdbObject<'d>),
+    Pdb(PdbObject<'data>),
     /// Portable Executable, an extension of COFF used on Windows.
-    Pe(PeObject<'d>),
+    Pe(PeObject<'data>),
     /// A source bundle
-    SourceBundle(SourceBundle<'d>),
+    SourceBundle(SourceBundle<'data>),
 }
 
-impl<'d> Object<'d> {
+impl<'data> Object<'data> {
     /// Tests whether the buffer could contain an object.
     pub fn test(data: &[u8]) -> bool {
         Self::peek(data) != FileFormat::Unknown
@@ -158,7 +158,7 @@ impl<'d> Object<'d> {
     }
 
     /// Tries to parse a supported object from the given slice.
-    pub fn parse(data: &'d [u8]) -> Result<Self, ObjectError> {
+    pub fn parse(data: &'data [u8]) -> Result<Self, ObjectError> {
         macro_rules! parse_object {
             ($kind:ident, $file:ident, $data:expr) => {
                 Object::$kind($file::parse(data).map_err(ObjectError::$kind)?)
@@ -228,12 +228,12 @@ impl<'d> Object<'d> {
     }
 
     /// Returns an iterator over symbols in the public symbol table.
-    pub fn symbols(&self) -> SymbolIterator<'d, '_> {
+    pub fn symbols(&self) -> SymbolIterator<'data, '_> {
         map_inner!(self, Object(ref o) => SymbolIterator(o.symbols()))
     }
 
     /// Returns an ordered map of symbols in the symbol table.
-    pub fn symbol_map(&self) -> SymbolMap<'d> {
+    pub fn symbol_map(&self) -> SymbolMap<'data> {
         match_inner!(self, Object(ref o) => o.symbol_map())
     }
 
@@ -255,7 +255,7 @@ impl<'d> Object<'d> {
     /// Constructing this session will also work if the object does not contain debugging
     /// information, in which case the session will be a no-op. This can be checked via
     /// [`has_debug_info`](enum.Object.html#method.has_debug_info).
-    pub fn debug_session(&self) -> Result<ObjectDebugSession<'d>, ObjectError> {
+    pub fn debug_session(&self) -> Result<ObjectDebugSession<'data>, ObjectError> {
         match *self {
             Object::Breakpad(ref o) => o
                 .debug_session()
@@ -295,12 +295,12 @@ impl<'d> Object<'d> {
     }
 
     /// Returns the raw data of the underlying buffer.
-    pub fn data(&self) -> &'d [u8] {
+    pub fn data(&self) -> &'data [u8] {
         match_inner!(self, Object(ref o) => o.data())
     }
 }
 
-impl<'slf, 'd: 'slf> AsSelf<'slf> for Object<'d> {
+impl<'slf, 'data: 'slf> AsSelf<'slf> for Object<'data> {
     type Ref = Object<'slf>;
 
     fn as_self(&'slf self) -> &Self::Ref {
@@ -308,10 +308,10 @@ impl<'slf, 'd: 'slf> AsSelf<'slf> for Object<'d> {
     }
 }
 
-impl<'d: 'slf, 'slf> ObjectLike<'d, 'slf> for Object<'d> {
+impl<'data: 'object, 'object> ObjectLike<'data, 'object> for Object<'data> {
     type Error = ObjectError;
-    type Session = ObjectDebugSession<'d>;
-    type SymbolIterator = SymbolIterator<'d, 'slf>;
+    type Session = ObjectDebugSession<'data>;
+    type SymbolIterator = SymbolIterator<'data, 'object>;
 
     fn file_format(&self) -> FileFormat {
         self.file_format()
@@ -341,11 +341,11 @@ impl<'d: 'slf, 'slf> ObjectLike<'d, 'slf> for Object<'d> {
         self.has_symbols()
     }
 
-    fn symbol_map(&self) -> SymbolMap<'d> {
+    fn symbol_map(&self) -> SymbolMap<'data> {
         self.symbol_map()
     }
 
-    fn symbols(&'slf self) -> Self::SymbolIterator {
+    fn symbols(&'object self) -> Self::SymbolIterator {
         self.symbols()
     }
 
@@ -501,17 +501,17 @@ impl<'s> Iterator for ObjectFileIterator<'s> {
 
 /// A generic symbol iterator
 #[allow(missing_docs)]
-pub enum SymbolIterator<'d, 'o> {
-    Breakpad(BreakpadSymbolIterator<'d>),
-    Elf(ElfSymbolIterator<'d, 'o>),
-    MachO(MachOSymbolIterator<'d>),
-    Pdb(PdbSymbolIterator<'d, 'o>),
-    Pe(PeSymbolIterator<'d, 'o>),
-    SourceBundle(SourceBundleSymbolIterator<'d>),
+pub enum SymbolIterator<'data, 'object> {
+    Breakpad(BreakpadSymbolIterator<'data>),
+    Elf(ElfSymbolIterator<'data, 'object>),
+    MachO(MachOSymbolIterator<'data>),
+    Pdb(PdbSymbolIterator<'data, 'object>),
+    Pe(PeSymbolIterator<'data, 'object>),
+    SourceBundle(SourceBundleSymbolIterator<'data>),
 }
 
-impl<'d, 'o> Iterator for SymbolIterator<'d, 'o> {
-    type Item = Symbol<'d>;
+impl<'data, 'object> Iterator for SymbolIterator<'data, 'object> {
+    type Item = Symbol<'data>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match_inner!(self, SymbolIterator(ref mut iter) => iter.next())

--- a/symbolic-debuginfo/src/pdb.rs
+++ b/symbolic-debuginfo/src/pdb.rs
@@ -239,7 +239,7 @@ impl<'d> Parse<'d> for PdbObject<'d> {
     }
 }
 
-impl<'d> ObjectLike for PdbObject<'d> {
+impl<'d> ObjectLike<'d> for PdbObject<'d> {
     type Error = PdbError;
     type Session = PdbDebugSession<'d>;
 
@@ -271,12 +271,11 @@ impl<'d> ObjectLike for PdbObject<'d> {
         self.has_symbols()
     }
 
-    fn symbols(&self) -> DynIterator<'_, Symbol<'_>> {
-        // TODO: Avoid this transmute by introducing explicit lifetimes on the trait.
-        unsafe { std::mem::transmute(Box::new(self.symbols()) as DynIterator<'_, _>) }
+    fn symbols(&self) -> DynIterator<'_, Symbol<'d>> {
+        Box::new(self.symbols())
     }
 
-    fn symbol_map(&self) -> SymbolMap<'_> {
+    fn symbol_map(&self) -> SymbolMap<'d> {
         self.symbol_map()
     }
 

--- a/symbolic-debuginfo/src/pdb.rs
+++ b/symbolic-debuginfo/src/pdb.rs
@@ -22,7 +22,7 @@ use symbolic_common::{Arch, AsSelf, CodeId, CpuFamily, DebugId, Name, SelfCell, 
 use crate::base::*;
 use crate::private::{FunctionStack, Parse};
 
-type Pdb<'d> = pdb::PDB<'d, Cursor<&'d [u8]>>;
+type Pdb<'data> = pdb::PDB<'data, Cursor<&'data [u8]>>;
 
 const MAGIC_BIG: &[u8] = b"Microsoft C/C++ MSF 7.00\r\n\x1a\x44\x53\x00\x00\x00";
 
@@ -50,12 +50,12 @@ pub enum PdbError {
 /// Program Database, the debug companion format on Windows.
 ///
 /// This object is a sole debug companion to [`PeObject`](../pdb/struct.PdbObject.html).
-pub struct PdbObject<'d> {
-    pdb: Arc<RwLock<Pdb<'d>>>,
-    debug_info: Arc<pdb::DebugInformation<'d>>,
-    pdb_info: pdb::PDBInformation<'d>,
-    public_syms: pdb::SymbolTable<'d>,
-    data: &'d [u8],
+pub struct PdbObject<'data> {
+    pdb: Arc<RwLock<Pdb<'data>>>,
+    debug_info: Arc<pdb::DebugInformation<'data>>,
+    pdb_info: pdb::PDBInformation<'data>,
+    public_syms: pdb::SymbolTable<'data>,
+    data: &'data [u8],
 }
 
 // NB: The pdb crate simulates mmap behavior on any Read + Seek type. This implementation requires
@@ -65,7 +65,7 @@ pub struct PdbObject<'d> {
 unsafe impl Send for PdbObject<'_> {}
 unsafe impl Sync for PdbObject<'_> {}
 
-impl<'d> PdbObject<'d> {
+impl<'data> PdbObject<'data> {
     /// Tests whether the buffer could contain an PDB object.
     pub fn test(data: &[u8]) -> bool {
         // NB: "Microsoft C/C++ program database 2.00" is not supported by the pdb crate, so there
@@ -74,7 +74,7 @@ impl<'d> PdbObject<'d> {
     }
 
     /// Tries to parse a PDB object from the given slice.
-    pub fn parse(data: &'d [u8]) -> Result<Self, PdbError> {
+    pub fn parse(data: &'data [u8]) -> Result<Self, PdbError> {
         let mut pdb = Pdb::open(Cursor::new(data))?;
         let dbi = pdb.debug_information()?;
         let pdbi = pdb.pdb_information()?;
@@ -155,7 +155,7 @@ impl<'d> PdbObject<'d> {
     }
 
     /// Returns an iterator over symbols in the public symbol table.
-    pub fn symbols(&self) -> PdbSymbolIterator<'d, '_> {
+    pub fn symbols(&self) -> PdbSymbolIterator<'data, '_> {
         PdbSymbolIterator {
             symbols: self.public_syms.iter(),
             address_map: self.pdb.write().address_map().ok(),
@@ -163,7 +163,7 @@ impl<'d> PdbObject<'d> {
     }
 
     /// Returns an ordered map of symbols in the symbol table.
-    pub fn symbol_map(&self) -> SymbolMap<'d> {
+    pub fn symbol_map(&self) -> SymbolMap<'data> {
         self.symbols().collect()
     }
 
@@ -182,7 +182,7 @@ impl<'d> PdbObject<'d> {
     }
 
     /// Constructs a debugging session.
-    pub fn debug_session(&self) -> Result<PdbDebugSession<'d>, PdbError> {
+    pub fn debug_session(&self) -> Result<PdbDebugSession<'data>, PdbError> {
         PdbDebugSession::build(self)
     }
 
@@ -196,12 +196,12 @@ impl<'d> PdbObject<'d> {
     }
 
     /// Returns the raw data of the ELF file.
-    pub fn data(&self) -> &'d [u8] {
+    pub fn data(&self) -> &'data [u8] {
         self.data
     }
 
     #[doc(hidden)]
-    pub fn inner(&self) -> &RwLock<Pdb<'d>> {
+    pub fn inner(&self) -> &RwLock<Pdb<'data>> {
         &self.pdb
     }
 }
@@ -219,7 +219,7 @@ impl fmt::Debug for PdbObject<'_> {
     }
 }
 
-impl<'slf, 'd: 'slf> AsSelf<'slf> for PdbObject<'d> {
+impl<'slf, 'data: 'slf> AsSelf<'slf> for PdbObject<'data> {
     type Ref = PdbObject<'slf>;
 
     fn as_self(&'slf self) -> &Self::Ref {
@@ -227,22 +227,22 @@ impl<'slf, 'd: 'slf> AsSelf<'slf> for PdbObject<'d> {
     }
 }
 
-impl<'d> Parse<'d> for PdbObject<'d> {
+impl<'data> Parse<'data> for PdbObject<'data> {
     type Error = PdbError;
 
     fn test(data: &[u8]) -> bool {
         Self::test(data)
     }
 
-    fn parse(data: &'d [u8]) -> Result<Self, PdbError> {
+    fn parse(data: &'data [u8]) -> Result<Self, PdbError> {
         Self::parse(data)
     }
 }
 
-impl<'d: 'slf, 'slf> ObjectLike<'d, 'slf> for PdbObject<'d> {
+impl<'data: 'object, 'object> ObjectLike<'data, 'object> for PdbObject<'data> {
     type Error = PdbError;
-    type Session = PdbDebugSession<'d>;
-    type SymbolIterator = PdbSymbolIterator<'d, 'slf>;
+    type Session = PdbDebugSession<'data>;
+    type SymbolIterator = PdbSymbolIterator<'data, 'object>;
 
     fn file_format(&self) -> FileFormat {
         self.file_format()
@@ -272,11 +272,11 @@ impl<'d: 'slf, 'slf> ObjectLike<'d, 'slf> for PdbObject<'d> {
         self.has_symbols()
     }
 
-    fn symbols(&'slf self) -> Self::SymbolIterator {
+    fn symbols(&'object self) -> Self::SymbolIterator {
         self.symbols()
     }
 
-    fn symbol_map(&self) -> SymbolMap<'d> {
+    fn symbol_map(&self) -> SymbolMap<'data> {
         self.symbol_map()
     }
 
@@ -311,13 +311,13 @@ pub(crate) fn arch_from_machine(machine: MachineType) -> Arch {
 /// An iterator over symbols in the PDB file.
 ///
 /// Returned by [`PdbObject::symbols`](struct.PdbObject.html#method.symbols).
-pub struct PdbSymbolIterator<'d, 'o> {
-    symbols: pdb::SymbolIter<'o>,
-    address_map: Option<AddressMap<'d>>,
+pub struct PdbSymbolIterator<'data, 'object> {
+    symbols: pdb::SymbolIter<'object>,
+    address_map: Option<AddressMap<'data>>,
 }
 
-impl<'d, 'o> Iterator for PdbSymbolIterator<'d, 'o> {
-    type Item = Symbol<'d>;
+impl<'data, 'object> Iterator for PdbSymbolIterator<'data, 'object> {
+    type Item = Symbol<'data>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let address_map = self.address_map.as_ref()?;
@@ -336,7 +336,7 @@ impl<'d, 'o> Iterator for PdbSymbolIterator<'d, 'o> {
                 let cow = public.name.to_string();
                 // pdb::SymbolIter offers data bound to its own lifetime since it holds the
                 // buffer containing public symbols. The contract requires that we return
-                // `Symbol<'d>`, so we cannot return zero-copy symbols here.
+                // `Symbol<'data>`, so we cannot return zero-copy symbols here.
                 let name = Cow::from(String::from(if cow.starts_with('_') {
                     &cow[1..]
                 } else {

--- a/symbolic-debuginfo/src/pdb.rs
+++ b/symbolic-debuginfo/src/pdb.rs
@@ -239,9 +239,10 @@ impl<'d> Parse<'d> for PdbObject<'d> {
     }
 }
 
-impl<'d> ObjectLike<'d> for PdbObject<'d> {
+impl<'d: 'slf, 'slf> ObjectLike<'d, 'slf> for PdbObject<'d> {
     type Error = PdbError;
     type Session = PdbDebugSession<'d>;
+    type SymbolIterator = PdbSymbolIterator<'d, 'slf>;
 
     fn file_format(&self) -> FileFormat {
         self.file_format()
@@ -271,8 +272,8 @@ impl<'d> ObjectLike<'d> for PdbObject<'d> {
         self.has_symbols()
     }
 
-    fn symbols(&self) -> DynIterator<'_, Symbol<'d>> {
-        Box::new(self.symbols())
+    fn symbols(&'slf self) -> Self::SymbolIterator {
+        self.symbols()
     }
 
     fn symbol_map(&self) -> SymbolMap<'d> {

--- a/symbolic-debuginfo/src/pe.rs
+++ b/symbolic-debuginfo/src/pe.rs
@@ -257,7 +257,7 @@ impl<'d> Parse<'d> for PeObject<'d> {
     }
 }
 
-impl<'d> ObjectLike for PeObject<'d> {
+impl<'d> ObjectLike<'d> for PeObject<'d> {
     type Error = PeError;
     type Session = PeDebugSession<'d>;
 
@@ -289,11 +289,11 @@ impl<'d> ObjectLike for PeObject<'d> {
         self.has_symbols()
     }
 
-    fn symbols(&self) -> DynIterator<'_, Symbol<'_>> {
+    fn symbols(&self) -> DynIterator<'_, Symbol<'d>> {
         Box::new(self.symbols())
     }
 
-    fn symbol_map(&self) -> SymbolMap<'_> {
+    fn symbol_map(&self) -> SymbolMap<'d> {
         self.symbol_map()
     }
 

--- a/symbolic-debuginfo/src/pe.rs
+++ b/symbolic-debuginfo/src/pe.rs
@@ -257,9 +257,10 @@ impl<'d> Parse<'d> for PeObject<'d> {
     }
 }
 
-impl<'d> ObjectLike<'d> for PeObject<'d> {
+impl<'d: 'slf, 'slf> ObjectLike<'d, 'slf> for PeObject<'d> {
     type Error = PeError;
     type Session = PeDebugSession<'d>;
+    type SymbolIterator = PeSymbolIterator<'d, 'slf>;
 
     fn file_format(&self) -> FileFormat {
         self.file_format()
@@ -289,8 +290,8 @@ impl<'d> ObjectLike<'d> for PeObject<'d> {
         self.has_symbols()
     }
 
-    fn symbols(&self) -> DynIterator<'_, Symbol<'d>> {
-        Box::new(self.symbols())
+    fn symbols(&'slf self) -> Self::SymbolIterator {
+        self.symbols()
     }
 
     fn symbol_map(&self) -> SymbolMap<'d> {

--- a/symbolic-debuginfo/src/sourcebundle.rs
+++ b/symbolic-debuginfo/src/sourcebundle.rs
@@ -492,7 +492,7 @@ impl<'d> Parse<'d> for SourceBundle<'d> {
     }
 }
 
-impl<'d> ObjectLike for SourceBundle<'d> {
+impl<'d> ObjectLike<'d> for SourceBundle<'d> {
     type Error = SourceBundleError;
     type Session = SourceBundleDebugSession<'d>;
 
@@ -524,11 +524,11 @@ impl<'d> ObjectLike for SourceBundle<'d> {
         self.has_symbols()
     }
 
-    fn symbol_map(&self) -> SymbolMap<'_> {
+    fn symbol_map(&self) -> SymbolMap<'d> {
         self.symbol_map()
     }
 
-    fn symbols(&self) -> DynIterator<'_, Symbol<'_>> {
+    fn symbols(&self) -> DynIterator<'_, Symbol<'d>> {
         Box::new(self.symbols())
     }
 
@@ -862,9 +862,13 @@ where
     /// sources could be resolved. Otherwise, an error is returned if writing the bundle fails.
     ///
     /// This finishes the source bundle and flushes the underlying writer.
-    pub fn write_object<O>(self, object: &O, object_name: &str) -> Result<bool, SourceBundleError>
+    pub fn write_object<'d, O>(
+        self,
+        object: &O,
+        object_name: &str,
+    ) -> Result<bool, SourceBundleError>
     where
-        O: ObjectLike,
+        O: ObjectLike<'d>,
         O::Error: std::error::Error + Send + Sync + 'static,
     {
         self.write_object_with_filter(object, object_name, |_| true)
@@ -878,14 +882,14 @@ where
     /// This finishes the source bundle and flushes the underlying writer.
     ///
     /// Before a file is written a callback is invoked which can return `false` to skip a file.
-    pub fn write_object_with_filter<O, F>(
+    pub fn write_object_with_filter<'d, O, F>(
         mut self,
         object: &O,
         object_name: &str,
         mut filter: F,
     ) -> Result<bool, SourceBundleError>
     where
-        O: ObjectLike,
+        O: ObjectLike<'d>,
         O::Error: std::error::Error + Send + Sync + 'static,
         F: FnMut(&FileEntry) -> bool,
     {

--- a/symbolic-debuginfo/src/sourcebundle.rs
+++ b/symbolic-debuginfo/src/sourcebundle.rs
@@ -863,14 +863,14 @@ where
     /// sources could be resolved. Otherwise, an error is returned if writing the bundle fails.
     ///
     /// This finishes the source bundle and flushes the underlying writer.
-    pub fn write_object<'d: 'o, 'o, O>(
+    pub fn write_object<'d, 'o, O, E>(
         self,
-        object: &O,
+        object: &'o O,
         object_name: &str,
     ) -> Result<bool, SourceBundleError>
     where
-        O: ObjectLike<'d, 'o>,
-        O::Error: std::error::Error + Send + Sync + 'static,
+        O: ObjectLike<'d, 'o, Error = E>,
+        E: std::error::Error + Send + Sync + 'static,
     {
         self.write_object_with_filter(object, object_name, |_| true)
     }
@@ -883,9 +883,9 @@ where
     /// This finishes the source bundle and flushes the underlying writer.
     ///
     /// Before a file is written a callback is invoked which can return `false` to skip a file.
-    pub fn write_object_with_filter<'d: 'o, 'o, O, F>(
+    pub fn write_object_with_filter<'d, 'o, O, F>(
         mut self,
-        object: &O,
+        object: &'o O,
         object_name: &str,
         mut filter: F,
     ) -> Result<bool, SourceBundleError>

--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -131,9 +131,9 @@ struct UnwindInfo<U> {
 }
 
 impl<U> UnwindInfo<U> {
-    pub fn new<'d, O, R>(object: &O, addr: u64, mut section: U) -> Self
+    pub fn new<'d: 'o, 'o, O, R>(object: &O, addr: u64, mut section: U) -> Self
     where
-        O: ObjectLike<'d>,
+        O: ObjectLike<'d, 'o>,
         R: Reader,
         U: UnwindSectionExt<R>,
     {
@@ -236,9 +236,9 @@ impl<W: Write> AsciiCfiWriter<W> {
         Ok(())
     }
 
-    fn process_dwarf<'o, O>(&mut self, object: &O) -> Result<(), CfiError>
+    fn process_dwarf<'d: 'o, 'o, O>(&mut self, object: &O) -> Result<(), CfiError>
     where
-        O: ObjectLike<'o> + Dwarf<'o>,
+        O: ObjectLike<'d, 'o> + Dwarf<'o>,
     {
         let endian = object.endianity();
 

--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -131,9 +131,9 @@ struct UnwindInfo<U> {
 }
 
 impl<U> UnwindInfo<U> {
-    pub fn new<O, R>(object: &O, addr: u64, mut section: U) -> Self
+    pub fn new<'d, O, R>(object: &O, addr: u64, mut section: U) -> Self
     where
-        O: ObjectLike,
+        O: ObjectLike<'d>,
         R: Reader,
         U: UnwindSectionExt<R>,
     {
@@ -238,7 +238,7 @@ impl<W: Write> AsciiCfiWriter<W> {
 
     fn process_dwarf<'o, O>(&mut self, object: &O) -> Result<(), CfiError>
     where
-        O: ObjectLike + Dwarf<'o>,
+        O: ObjectLike<'o> + Dwarf<'o>,
     {
         let endian = object.endianity();
 

--- a/symbolic-symcache/src/writer.rs
+++ b/symbolic-symcache/src/writer.rs
@@ -194,9 +194,9 @@ where
     W: Write + Seek,
 {
     /// Converts an entire object into a SymCache.
-    pub fn write_object<O>(object: &O, target: W) -> Result<W, SymCacheError>
+    pub fn write_object<'d, O>(object: &O, target: W) -> Result<W, SymCacheError>
     where
-        O: ObjectLike,
+        O: ObjectLike<'d>,
         O::Error: std::error::Error + Send + Sync + 'static,
     {
         let mut writer = SymCacheWriter::new(target)?;

--- a/symbolic-symcache/src/writer.rs
+++ b/symbolic-symcache/src/writer.rs
@@ -194,7 +194,7 @@ where
     W: Write + Seek,
 {
     /// Converts an entire object into a SymCache.
-    pub fn write_object<'d: 'o, 'o, O>(object: &O, target: W) -> Result<W, SymCacheError>
+    pub fn write_object<'d, 'o, O>(object: &'o O, target: W) -> Result<W, SymCacheError>
     where
         O: ObjectLike<'d, 'o>,
         O::Error: std::error::Error + Send + Sync + 'static,

--- a/symbolic-symcache/src/writer.rs
+++ b/symbolic-symcache/src/writer.rs
@@ -194,9 +194,9 @@ where
     W: Write + Seek,
 {
     /// Converts an entire object into a SymCache.
-    pub fn write_object<'d, O>(object: &O, target: W) -> Result<W, SymCacheError>
+    pub fn write_object<'d: 'o, 'o, O>(object: &O, target: W) -> Result<W, SymCacheError>
     where
-        O: ObjectLike<'d>,
+        O: ObjectLike<'d, 'o>,
         O::Error: std::error::Error + Send + Sync + 'static,
     {
         let mut writer = SymCacheWriter::new(target)?;


### PR DESCRIPTION
This avoids both boxing, and unsafely transmuting the symbol iterators.