### PR TITLE
fix(debuginfo): Update dmsort to 1.0.1 to avoid panic due to UB

### DIFF
--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 all-features = true
 
 [dependencies]
-dmsort = "1.0.0"
+dmsort = "1.0.1"
 fallible-iterator = "0.2.0"
 flate2 = { version = "1.0.13", features = ["rust_backend"], default-features = false }
 gimli = { version = "0.22.0", features = ["read", "std"], default-features = false }

--- a/symbolic-symcache/Cargo.toml
+++ b/symbolic-symcache/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 all-features = true
 
 [dependencies]
-dmsort = "1.0.0"
+dmsort = "1.0.1"
 fnv = "1.0.6"
 num = "0.3.0"
 symbolic-common = { version = "7.5.0", path = "../symbolic-common" }


### PR DESCRIPTION
dmsort 1.0 misuses `mem::uninitialized` which is now leading to a panic
which causes problems for certain symbols.

Refs https://github.com/emilk/drop-merge-sort/issues/2