### PR TITLE
ci: Run rust nighlty on a schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - "release/**"
   pull_request:
 
+env:
+  RUSTFLAGS: -Dwarnings
+
 jobs:
   lints:
     name: Style/Linting

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         rust: [nightly, beta]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
         with:
           submodules: recursive
 
@@ -23,7 +23,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           profile: minimal
           override: true
-          components: rustfmt, clippy
+          components: clippy
 
       - name: Run clipppy
         uses: actions-rs/clippy-check@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,37 @@
+name: Nightly CI
+
+on:
+  schedule:
+    - cron: '11 7 * * 1,4'
+
+env:
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [nightly, beta]
+    steps:
+      - uses: actions/checkout@master
+        with:
+          submodules: recursive
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run clipppy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features --workspace --tests --examples -- -D clippy::all
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --all-features


### PR DESCRIPTION
This ensures we're aware of issues with newer rust compilers sooner.
We run clippy and tests in the same step since caching matters more
than speed of completion as this does not block PRs.

No explicit caching since the compiler changes every time anyway.

#skip-changelog