### PR TITLE
fix(dwarf): Skip line program sequences at 0

### DIFF
--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -185,6 +185,13 @@ impl<'d, 'a> DwarfLineProgram<'d> {
         while let Ok(Some((_, &program_row))) = state_machine.next_row() {
             let address = program_row.address();
 
+            // we have seen rustc emit for WASM targets a bad sequence that spans from 0 to
+            // the end of the program.  https://github.com/rust-lang/rust/issues/79410
+            // Since DWARF does not permit code to sit at address 0 we can safely skip here.
+            if address == 0 {
+                continue;
+            }
+
             if let Some(last_row) = sequence_rows.last_mut() {
                 if address >= last_row.address {
                     last_row.size = Some(address - last_row.address);


### PR DESCRIPTION
It would appear that rustc is emitting bad sequences for WASM we need
to skip.  See comment for rationale of why we can work around this.

Refs https://github.com/rust-lang/rust/issues/79410