### PR TITLE
feat: Rename architecture to wasm32

### DIFF
--- a/symbolic-common/src/types.rs
+++ b/symbolic-common/src/types.rs
@@ -90,8 +90,8 @@ pub enum CpuFamily {
     Mips64 = 8,
     /// ILP32 ABI on 64-bit ARM.
     Arm64_32 = 9,
-    /// Virtual WASM architecture.
-    Wasm = 10,
+    /// Virtual WASM 32-bit architecture.
+    Wasm32 = 10,
 }
 
 impl CpuFamily {
@@ -113,7 +113,7 @@ impl CpuFamily {
     pub fn pointer_size(self) -> Option<usize> {
         match self {
             CpuFamily::Unknown => None,
-            CpuFamily::Wasm => Some(4),
+            CpuFamily::Wasm32 => Some(4),
             CpuFamily::Amd64
             | CpuFamily::Arm64
             | CpuFamily::Ppc64
@@ -142,7 +142,7 @@ impl CpuFamily {
     /// ```
     pub fn instruction_alignment(self) -> Option<u64> {
         match self {
-            CpuFamily::Wasm => Some(4),
+            CpuFamily::Wasm32 => Some(4),
             CpuFamily::Arm32 => Some(2),
             CpuFamily::Arm64 | CpuFamily::Arm64_32 => Some(4),
             CpuFamily::Ppc32 | CpuFamily::Mips32 | CpuFamily::Mips64 => Some(4),
@@ -178,7 +178,7 @@ impl CpuFamily {
             CpuFamily::Arm32 | CpuFamily::Arm64 | CpuFamily::Arm64_32 => Some("pc"),
             CpuFamily::Ppc32 | CpuFamily::Ppc64 => Some("srr0"),
             CpuFamily::Mips32 | CpuFamily::Mips64 => Some("pc"),
-            CpuFamily::Wasm => None,
+            CpuFamily::Wasm32 => None,
             CpuFamily::Unknown => None,
         }
     }
@@ -285,7 +285,7 @@ pub enum Arch {
     Arm64_32 = 901,
     Arm64_32V8 = 902,
     Arm64_32Unknown = 999,
-    Wasm = 1001,
+    Wasm32 = 1001,
 }
 
 impl Arch {
@@ -331,7 +331,7 @@ impl Arch {
             901 => Arch::Arm64_32,
             902 => Arch::Arm64_32V8,
             999 => Arch::Arm64_32Unknown,
-            1001 => Arch::Wasm,
+            1001 => Arch::Wasm32,
             _ => Arch::Unknown,
         }
     }
@@ -368,7 +368,7 @@ impl Arch {
             Arch::Mips => CpuFamily::Mips32,
             Arch::Mips64 => CpuFamily::Mips64,
             Arch::Arm64_32 | Arch::Arm64_32V8 | Arch::Arm64_32Unknown => CpuFamily::Arm64_32,
-            Arch::Wasm => CpuFamily::Wasm,
+            Arch::Wasm32 => CpuFamily::Wasm32,
         }
     }
 
@@ -392,7 +392,7 @@ impl Arch {
     pub fn name(self) -> &'static str {
         match self {
             Arch::Unknown => "unknown",
-            Arch::Wasm => "wasm",
+            Arch::Wasm32 => "wasm32",
             Arch::X86 => "x86",
             Arch::X86Unknown => "x86_unknown",
             Arch::Amd64 => "x86_64",
@@ -501,7 +501,7 @@ impl str::FromStr for Arch {
             "arm-64" => Arch::Arm64,
 
             // wasm extensions
-            "wasm" => Arch::Wasm,
+            "wasm32" => Arch::Wasm32,
 
             _ => return Err(UnknownArchError),
         })

--- a/symbolic-debuginfo/src/wasm.rs
+++ b/symbolic-debuginfo/src/wasm.rs
@@ -59,7 +59,7 @@ impl<'data> WasmObject<'data> {
         })
     }
 
-    /// The container file format, which is always `FileFormat::Wasm`.
+    /// The container file format, which currently is always `FileFormat::Wasm`.
     pub fn file_format(&self) -> FileFormat {
         FileFormat::Wasm
     }
@@ -99,7 +99,8 @@ impl<'data> WasmObject<'data> {
 
     /// The CPU architecture of this object.
     pub fn arch(&self) -> Arch {
-        Arch::Wasm
+        // TODO: we do not yet support wasm64 and thus always return wasm32 here.
+        Arch::Wasm32
     }
 
     /// The kind of this object.


### PR DESCRIPTION
Since there are two wasm architectures (32 and 64) we should be explicit about the architectures in code.

See https://github.com/WebAssembly/design/blob/master/CAndC%2B%2B.md