### PR TITLE
ref(symcache): Switch to error with kind

### DIFF
--- a/symbolic-cabi/src/core.rs
+++ b/symbolic-cabi/src/core.rs
@@ -335,33 +335,33 @@ impl SymbolicErrorCode {
                 return SymbolicErrorCode::ParseSourceMapError;
             }
 
-            use symbolic::symcache::SymCacheError;
+            use symbolic::symcache::{SymCacheError, SymCacheErrorKind};
             if let Some(error) = error.downcast_ref::<SymCacheError>() {
-                return match error {
-                    SymCacheError::BadFileMagic => SymbolicErrorCode::SymCacheErrorBadFileMagic,
-                    SymCacheError::BadFileHeader(_) => {
+                return match error.kind() {
+                    SymCacheErrorKind::BadFileMagic => SymbolicErrorCode::SymCacheErrorBadFileMagic,
+                    SymCacheErrorKind::BadFileHeader => {
                         SymbolicErrorCode::SymCacheErrorBadFileHeader
                     }
-                    SymCacheError::BadSegment => SymbolicErrorCode::SymCacheErrorBadSegment,
-                    SymCacheError::BadCacheFile => SymbolicErrorCode::SymCacheErrorBadCacheFile,
-                    SymCacheError::UnsupportedVersion => {
+                    SymCacheErrorKind::BadSegment => SymbolicErrorCode::SymCacheErrorBadSegment,
+                    SymCacheErrorKind::BadCacheFile => SymbolicErrorCode::SymCacheErrorBadCacheFile,
+                    SymCacheErrorKind::UnsupportedVersion => {
                         SymbolicErrorCode::SymCacheErrorUnsupportedVersion
                     }
-                    SymCacheError::BadDebugFile(_) => SymbolicErrorCode::SymCacheErrorBadDebugFile,
-                    SymCacheError::MissingDebugSection => {
+                    SymCacheErrorKind::BadDebugFile => SymbolicErrorCode::SymCacheErrorBadDebugFile,
+                    SymCacheErrorKind::MissingDebugSection => {
                         SymbolicErrorCode::SymCacheErrorMissingDebugSection
                     }
-                    SymCacheError::MissingDebugInfo => {
+                    SymCacheErrorKind::MissingDebugInfo => {
                         SymbolicErrorCode::SymCacheErrorMissingDebugInfo
                     }
-                    SymCacheError::UnsupportedDebugKind => {
+                    SymCacheErrorKind::UnsupportedDebugKind => {
                         SymbolicErrorCode::SymCacheErrorUnsupportedDebugKind
                     }
-                    SymCacheError::ValueTooLarge(_) => {
+                    SymCacheErrorKind::ValueTooLarge(_) => {
                         SymbolicErrorCode::SymCacheErrorValueTooLarge
                     }
-                    SymCacheError::WriteFailed(_) => SymbolicErrorCode::SymCacheErrorWriteFailed,
-                    SymCacheError::TooManyValues(_) => {
+                    SymCacheErrorKind::WriteFailed => SymbolicErrorCode::SymCacheErrorWriteFailed,
+                    SymCacheErrorKind::TooManyValues(_) => {
                         SymbolicErrorCode::SymCacheErrorTooManyValues
                     }
                     _ => SymbolicErrorCode::SymCacheErrorUnknown,

--- a/symbolic-symcache/src/cache.rs
+++ b/symbolic-symcache/src/cache.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use symbolic_common::{Arch, AsSelf, DebugId, Language, Name, NameMangling};
 
 use crate::error::SymCacheError;
-use crate::format;
+use crate::{format, SymCacheErrorKind};
 
 /// A platform independent symbolication cache.
 ///
@@ -267,7 +267,7 @@ impl<'a> SymCache<'a> {
             if let Some((line_addr, file_id, line)) = self.run_to_line(fun, addr)? {
                 // A missing file record indicates a bad symcache.
                 let file_record = read_file_record(self.data, self.header.files, file_id)?
-                    .ok_or(SymCacheError::BadCacheFile)?;
+                    .ok_or(SymCacheErrorKind::BadCacheFile)?;
 
                 // The address was found in the function's line records, so use
                 // it directly. This should is the default case for all valid

--- a/symbolic-symcache/src/cache.rs
+++ b/symbolic-symcache/src/cache.rs
@@ -2,8 +2,8 @@ use std::fmt;
 
 use symbolic_common::{Arch, AsSelf, DebugId, Language, Name, NameMangling};
 
-use crate::error::SymCacheError;
-use crate::{format, SymCacheErrorKind};
+use crate::error::{SymCacheError, SymCacheErrorKind};
+use crate::format;
 
 /// A platform independent symbolication cache.
 ///

--- a/symbolic-symcache/src/error.rs
+++ b/symbolic-symcache/src/error.rs
@@ -101,7 +101,7 @@ impl SymCacheError {
     /// arbitrary error payload.
     ///
     /// This function is used to generically create symcache errors which do not
-    /// originate from `symbolic` itself. The `sourcce` argument is an arbitrary
+    /// originate from `symbolic` itself. The `source` argument is an arbitrary
     /// payload which will be contained in this [`SymCacheError`].
     pub fn new<E>(kind: SymCacheErrorKind, source: E) -> Self
     where

--- a/symbolic-symcache/src/error.rs
+++ b/symbolic-symcache/src/error.rs
@@ -99,11 +99,7 @@ pub struct SymCacheError {
 impl SymCacheError {
     /// Creates a new SymCache error from a known kind of error as well as an
     /// arbitrary error payload.
-    ///
-    /// This function is used to generically create symcache errors which do not
-    /// originate from `symbolic` itself. The `source` argument is an arbitrary
-    /// payload which will be contained in this [`SymCacheError`].
-    pub fn new<E>(kind: SymCacheErrorKind, source: E) -> Self
+    pub(crate) fn new<E>(kind: SymCacheErrorKind, source: E) -> Self
     where
         E: Into<Box<dyn Error + Send + Sync>>,
     {

--- a/symbolic-symcache/src/error.rs
+++ b/symbolic-symcache/src/error.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use std::fmt;
 
 use thiserror::Error;
@@ -28,53 +29,96 @@ impl fmt::Display for ValueKind {
 
 /// An error returned when handling [`SymCache`](struct.SymCache.html).
 #[non_exhaustive]
-#[derive(Debug, Error)]
-pub enum SymCacheError {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SymCacheErrorKind {
     /// Invalid magic bytes in the symcache header.
-    #[error("bad symcache magic")]
     BadFileMagic,
 
     /// Invalid flags or fields in the symcache header.
-    #[error("invalid symcache header")]
-    BadFileHeader(#[source] std::io::Error),
+    BadFileHeader,
 
     /// A segment could not be read, likely due to IO errors.
-    #[error("cannot read symcache segment")]
     BadSegment,
 
     /// Contents in the symcache file are malformed.
-    #[error("malformed symcache file")]
     BadCacheFile,
 
     /// The symcache version is not known.
-    #[error("unsupported symcache version")]
     UnsupportedVersion,
 
     /// The `Object` contains invalid data and cannot be converted.
-    #[error("malformed debug info file")]
-    BadDebugFile(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    BadDebugFile,
 
     /// A required debug section is missing in the `Object` file.
-    #[error("missing debug section")]
     MissingDebugSection,
 
     /// The `Object` file was stripped of debug information.
-    #[error("no debug information found in file")]
     MissingDebugInfo,
 
     /// The debug information in the `Object` file is not supported.
-    #[error("unsupported debug information")]
     UnsupportedDebugKind,
 
     /// A value cannot be written to symcache as it overflows the record size.
-    #[error("{0} too large for symcache file format")]
     ValueTooLarge(ValueKind),
 
     /// A value cannot be written to symcache as it overflows the segment counter.
-    #[error("too many {0}s for symcache")]
     TooManyValues(ValueKind),
 
     /// Generic error when writing a symcache, most likely IO.
-    #[error("failed to write symcache")]
-    WriteFailed(#[source] std::io::Error),
+    WriteFailed,
+}
+
+impl fmt::Display for SymCacheErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BadFileMagic => write!(f, "bad symcache magic"),
+            Self::BadFileHeader => write!(f, "invalid symcache header"),
+            Self::BadSegment => write!(f, "cannot read symcache segment"),
+            Self::BadCacheFile => write!(f, "malformed symcache file"),
+            Self::UnsupportedVersion => write!(f, "unsupported symcache version"),
+            Self::BadDebugFile => write!(f, "malformed debug info file"),
+            Self::MissingDebugSection => write!(f, "missing debug section"),
+            Self::MissingDebugInfo => write!(f, "no debug information found in file"),
+            Self::UnsupportedDebugKind => write!(f, "unsupported debug information"),
+            Self::ValueTooLarge(kind) => write!(f, "{} too large for symcache file format", kind),
+            Self::TooManyValues(kind) => write!(f, "too many {}s for symcache", kind),
+            Self::WriteFailed => write!(f, "failed to write symcache"),
+        }
+    }
+}
+
+/// An error returned when handling [`SymCache`](struct.SymCache.html).
+#[derive(Debug, Error)]
+#[error("{kind}")]
+pub struct SymCacheError {
+    kind: SymCacheErrorKind,
+    #[source]
+    source: Option<Box<dyn Error + Send + Sync + 'static>>,
+}
+
+impl SymCacheError {
+    /// Creates a new SymCache error from a known kind of error as well as an
+    /// arbitrary error payload.
+    ///
+    /// This function is used to generically create symcache errors which do not
+    /// originate from `symbolic` itself. The `sourcce` argument is an arbitrary
+    /// payload which will be contained in this [`SymCacheError`].
+    pub fn new<E>(kind: SymCacheErrorKind, source: E) -> Self
+    where
+        E: Into<Box<dyn Error + Send + Sync>>,
+    {
+        let source = Some(source.into());
+        Self { kind, source }
+    }
+
+    /// Returns the corresponding [`SymCacheErrorKind`] for this error.
+    pub fn kind(&self) -> SymCacheErrorKind {
+        self.kind
+    }
+}
+
+impl From<SymCacheErrorKind> for SymCacheError {
+    fn from(kind: SymCacheErrorKind) -> Self {
+        Self { kind, source: None }
+    }
 }

--- a/symbolic-symcache/src/error.rs
+++ b/symbolic-symcache/src/error.rs
@@ -27,7 +27,7 @@ impl fmt::Display for ValueKind {
     }
 }
 
-/// An error returned when handling [`SymCache`](struct.SymCache.html).
+/// The error type for [`SymCacheError`].
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SymCacheErrorKind {

--- a/symbolic-symcache/src/format.rs
+++ b/symbolic-symcache/src/format.rs
@@ -7,8 +7,7 @@ use std::marker::PhantomData;
 
 use symbolic_common::{DebugId, Uuid};
 
-use crate::error::SymCacheError;
-use crate::SymCacheErrorKind;
+use crate::error::{SymCacheError, SymCacheErrorKind};
 
 /// The magic file preamble to identify symcache files.
 pub const SYMCACHE_MAGIC: [u8; 4] = *b"SYMC";

--- a/symbolic-symcache/src/writer.rs
+++ b/symbolic-symcache/src/writer.rs
@@ -8,8 +8,8 @@ use num::FromPrimitive;
 use symbolic_common::{Arch, DebugId, Language};
 use symbolic_debuginfo::{DebugSession, FileInfo, Function, LineInfo, ObjectLike, Symbol};
 
-use crate::error::{SymCacheError, ValueKind};
-use crate::{format, SymCacheErrorKind};
+use crate::error::{SymCacheError, SymCacheErrorKind, ValueKind};
+use crate::format;
 
 // Performs a shallow check whether this function might contain any lines.
 fn is_empty_function(function: &Function<'_>) -> bool {


### PR DESCRIPTION
Follows the conventions set by `std::io::Error`.