### PR TITLE
ref(debuginfo): Switch to error with kind

### DIFF
--- a/symbolic-cabi/src/core.rs
+++ b/symbolic-cabi/src/core.rs
@@ -247,42 +247,14 @@ impl SymbolicErrorCode {
             }
 
             use symbolic::debuginfo::{
-                dwarf::DwarfError, ObjectError, UnknownFileFormatError, UnknownObjectKindError,
+                ObjectError, UnknownFileFormatError, UnknownObjectKindError,
             };
             if error.downcast_ref::<UnknownObjectKindError>().is_some() {
                 return SymbolicErrorCode::UnknownObjectKindError;
             } else if error.downcast_ref::<UnknownFileFormatError>().is_some() {
                 return SymbolicErrorCode::UnknownFileFormatError;
-            } else if let Some(error) = error.downcast_ref::<ObjectError>() {
-                return match error {
-                    ObjectError::UnsupportedObject => {
-                        SymbolicErrorCode::ObjectErrorUnsupportedObject
-                    }
-                    ObjectError::Breakpad(_) => SymbolicErrorCode::ObjectErrorBadBreakpadObject,
-                    ObjectError::Elf(_) => SymbolicErrorCode::ObjectErrorBadElfObject,
-                    ObjectError::MachO(_) => SymbolicErrorCode::ObjectErrorBadMachOObject,
-                    ObjectError::Pdb(_) => SymbolicErrorCode::ObjectErrorBadPdbObject,
-                    ObjectError::Pe(_) => SymbolicErrorCode::ObjectErrorBadPeObject,
-                    ObjectError::Wasm(_) => SymbolicErrorCode::ObjectErrorBadWasmObject,
-                    ObjectError::Dwarf(ref e) => match e {
-                        DwarfError::InvalidUnitRef(_) => {
-                            SymbolicErrorCode::DwarfErrorInvalidUnitRef
-                        }
-                        DwarfError::InvalidFileRef(_) => {
-                            SymbolicErrorCode::DwarfErrorInvalidFileRef
-                        }
-                        DwarfError::UnexpectedInline => {
-                            SymbolicErrorCode::DwarfErrorUnexpectedInline
-                        }
-                        DwarfError::InvertedFunctionRange => {
-                            SymbolicErrorCode::DwarfErrorInvertedFunctionRange
-                        }
-                        DwarfError::CorruptedData(_) => SymbolicErrorCode::DwarfErrorCorruptedData,
-                        _ => SymbolicErrorCode::DwarfErrorUnknown,
-                    },
-                    ObjectError::SourceBundle(_) => SymbolicErrorCode::ObjectErrorBadSourceBundle,
-                    _ => SymbolicErrorCode::ObjectErrorUnknown,
-                };
+            } else if error.downcast_ref::<ObjectError>().is_some() {
+                return SymbolicErrorCode::ObjectErrorUnknown;
             }
 
             use symbolic::minidump::cfi::{CfiError, CfiErrorKind};

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -8,6 +8,7 @@
 //! [`MachObject`]: ../macho/struct.MachObject.html
 
 use std::borrow::Cow;
+use std::error::Error;
 use std::fmt;
 use std::marker::PhantomData;
 use std::ops::{Deref, RangeBounds};
@@ -51,29 +52,76 @@ fn offset(addr: u64, offset: i64) -> u64 {
     (addr as i64).wrapping_sub(offset as i64) as u64
 }
 
-/// An error handling [`DWARF`](trait.Dwarf.html) debugging information.
+/// The error type for [`DwarfError`].
 #[non_exhaustive]
-#[derive(Debug, Error)]
-pub enum DwarfError {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DwarfErrorKind {
     /// A compilation unit referenced by index does not exist.
-    #[error("compilation unit for offset {0} does not exist")]
     InvalidUnitRef(usize),
 
     /// A file record referenced by index does not exist.
-    #[error("referenced file {0} does not exist")]
     InvalidFileRef(u64),
 
     /// An inline record was encountered without an inlining parent.
-    #[error("unexpected inline function without parent")]
     UnexpectedInline,
 
     /// The debug_ranges of a function are invalid.
-    #[error("function with inverted address range")]
     InvertedFunctionRange,
 
     /// The DWARF file is corrupted. See the cause for more information.
-    #[error("corrupted dwarf debug data")]
-    CorruptedData(#[from] GimliError),
+    CorruptedData,
+}
+
+impl fmt::Display for DwarfErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidUnitRef(offset) => {
+                write!(f, "compilation unit for offset {} does not exist", offset)
+            }
+            Self::InvalidFileRef(id) => write!(f, "referenced file {} does not exist", id),
+            Self::UnexpectedInline => write!(f, "unexpected inline function without parent"),
+            Self::InvertedFunctionRange => write!(f, "function with inverted address range"),
+            Self::CorruptedData => write!(f, "corrupted dwarf debug data"),
+        }
+    }
+}
+
+/// An error handling [`DWARF`](trait.Dwarf.html) debugging information.
+#[derive(Debug, Error)]
+#[error("{kind}")]
+pub struct DwarfError {
+    kind: DwarfErrorKind,
+    #[source]
+    source: Option<Box<dyn Error + Send + Sync + 'static>>,
+}
+
+impl DwarfError {
+    /// Creates a new DWARF error from a known kind of error as well as an arbitrary error
+    /// payload.
+    fn new<E>(kind: DwarfErrorKind, source: E) -> Self
+    where
+        E: Into<Box<dyn Error + Send + Sync>>,
+    {
+        let source = Some(source.into());
+        Self { kind, source }
+    }
+
+    /// Returns the corresponding [`DwarfErrorKind`] for this error.
+    pub fn kind(&self) -> DwarfErrorKind {
+        self.kind
+    }
+}
+
+impl From<DwarfErrorKind> for DwarfError {
+    fn from(kind: DwarfErrorKind) -> Self {
+        Self { kind, source: None }
+    }
+}
+
+impl From<GimliError> for DwarfError {
+    fn from(e: GimliError) -> Self {
+        Self::new(DwarfErrorKind::CorruptedData, e)
+    }
 }
 
 /// DWARF section information including its data.
@@ -525,7 +573,7 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
 
         if low_pc > high_pc {
             // TODO: consider swallowing errors here?
-            return Err(DwarfError::InvertedFunctionRange);
+            return Err(DwarfErrorKind::InvertedFunctionRange.into());
         }
 
         range_buf.push(Range {
@@ -737,7 +785,7 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
                 // indicates invalid debug information.
                 let parent = match stack.peek_mut() {
                     Some(parent) => parent,
-                    None => return Err(DwarfError::UnexpectedInline),
+                    None => return Err(DwarfErrorKind::UnexpectedInline.into()),
                 };
 
                 // Make sure there is correct line information for the call site of this inlined
@@ -1076,7 +1124,7 @@ impl<'d> DwarfInfo<'d> {
 
         let index = match search_result {
             Ok(index) => index,
-            Err(0) => return Err(DwarfError::InvalidUnitRef(offset.0)),
+            Err(0) => return Err(DwarfErrorKind::InvalidUnitRef(offset.0).into()),
             Err(next_index) => next_index - 1,
         };
 
@@ -1087,7 +1135,7 @@ impl<'d> DwarfInfo<'d> {
             }
         }
 
-        Err(DwarfError::InvalidUnitRef(offset.0))
+        Err(DwarfErrorKind::InvalidUnitRef(offset.0).into())
     }
 
     /// Returns an iterator over all compilation units.

--- a/symbolic-debuginfo/src/macho.rs
+++ b/symbolic-debuginfo/src/macho.rs
@@ -1,10 +1,11 @@
 //! Support for Mach Objects, used on macOS and iOS.
 
 use std::borrow::Cow;
+use std::error::Error;
 use std::fmt;
 use std::io::Cursor;
 
-use goblin::{error::Error as GoblinError, mach};
+use goblin::mach;
 use smallvec::SmallVec;
 use thiserror::Error;
 
@@ -15,12 +16,22 @@ use crate::dwarf::{Dwarf, DwarfDebugSession, DwarfError, DwarfSection, Endian};
 use crate::private::{MonoArchive, MonoArchiveObjects, Parse};
 
 /// An error when dealing with [`MachObject`](struct.MachObject.html).
-#[non_exhaustive]
 #[derive(Debug, Error)]
-pub enum MachError {
-    /// The data in the MachO file could not be parsed.
-    #[error("invalid MachO file")]
-    BadObject(#[from] GoblinError),
+#[error("invalid MachO file")]
+pub struct MachError {
+    #[source]
+    source: Option<Box<dyn Error + Send + Sync + 'static>>,
+}
+
+impl MachError {
+    /// Creates a new MachO error from an arbitrary error payload.
+    fn new<E>(source: E) -> Self
+    where
+        E: Into<Box<dyn Error + Send + Sync>>,
+    {
+        let source = Some(source.into());
+        Self { source }
+    }
 }
 
 /// Mach Object containers, used for executables and debug companions on macOS and iOS.
@@ -40,7 +51,9 @@ impl<'d> MachObject<'d> {
 
     /// Tries to parse a MachO from the given slice.
     pub fn parse(data: &'d [u8]) -> Result<Self, MachError> {
-        Ok(mach::MachO::parse(data, 0).map(|macho| MachObject { macho, data })?)
+        mach::MachO::parse(data, 0)
+            .map(|macho| MachObject { macho, data })
+            .map_err(MachError::new)
     }
 
     /// The container file format, which is always `FileFormat::MachO`.
@@ -455,7 +468,7 @@ impl<'d, 'a> Iterator for FatMachObjectIterator<'d, 'a> {
                 let end = ((arch.offset + arch.size) as usize).min(self.data.len());
                 Some(MachObject::parse(&self.data[start..end]))
             }
-            Some(Err(error)) => Some(Err(MachError::BadObject(error))),
+            Some(Err(error)) => Some(Err(MachError::new(error))),
             None => None,
         }
     }
@@ -487,7 +500,9 @@ impl<'d> FatMachO<'d> {
 
     /// Tries to parse a fat MachO container from the given slice.
     pub fn parse(data: &'d [u8]) -> Result<Self, MachError> {
-        Ok(mach::MultiArch::new(data).map(|fat| FatMachO { fat, data })?)
+        mach::MultiArch::new(data)
+            .map(|fat| FatMachO { fat, data })
+            .map_err(MachError::new)
     }
 
     /// Returns an iterator over objects in this container.
@@ -510,7 +525,7 @@ impl<'d> FatMachO<'d> {
     /// be parsed.
     pub fn object_by_index(&self, index: usize) -> Result<Option<MachObject<'d>>, MachError> {
         let arch = match self.fat.iter_arches().nth(index) {
-            Some(arch) => arch?,
+            Some(arch) => arch.map_err(MachError::new)?,
             None => return Ok(None),
         };
 

--- a/symbolic-debuginfo/src/object.rs
+++ b/symbolic-debuginfo/src/object.rs
@@ -97,8 +97,8 @@ impl ObjectError {
 impl fmt::Debug for ObjectError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.repr {
-            ObjectErrorRepr::Transparent(ref inner) => inner.fmt(f),
-            _ => self.repr.fmt(f),
+            ObjectErrorRepr::Transparent(ref inner) => fmt::Debug::fmt(inner, f),
+            _ => fmt::Debug::fmt(&self.repr, f),
         }
     }
 }
@@ -107,7 +107,7 @@ impl fmt::Display for ObjectError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.repr {
             ObjectErrorRepr::UnsupportedObject => write!(f, "unsupported object file format"),
-            ObjectErrorRepr::Transparent(ref inner) => inner.fmt(f),
+            ObjectErrorRepr::Transparent(ref inner) => fmt::Display::fmt(inner, f),
         }
     }
 }

--- a/symbolic-debuginfo/src/pdb.rs
+++ b/symbolic-debuginfo/src/pdb.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use std::cell::{RefCell, RefMut};
 use std::cmp::Ordering;
 use std::collections::btree_map::{BTreeMap, Entry};
+use std::error::Error;
 use std::fmt;
 use std::io::Cursor;
 use std::sync::Arc;
@@ -32,21 +33,72 @@ const MAGIC_BIG: &[u8] = b"Microsoft C/C++ MSF 7.00\r\n\x1a\x44\x53\x00\x00\x00"
 #[doc(hidden)]
 pub use pdb;
 
-/// An error when dealing with [`PdbObject`](struct.PdbObject.html).
+/// The error type for [`PdbError`].
 #[non_exhaustive]
-#[derive(Debug, Error)]
-pub enum PdbError {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PdbErrorKind {
     /// The PDB file is corrupted. See the cause for more information.
-    #[error("invalid pdb file")]
-    BadObject(#[from] pdb::Error),
+    BadObject,
 
     /// An inline record was encountered without an inlining parent.
-    #[error("unexpected inline function without parent")]
     UnexpectedInline,
 
-    /// Formatting of a type name failed
-    #[error("failed to format type name")]
-    FormattingFailed(#[from] fmt::Error),
+    /// Formatting of a type name failed.
+    FormattingFailed,
+}
+
+impl fmt::Display for PdbErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BadObject => write!(f, "invalid pdb file"),
+            Self::UnexpectedInline => write!(f, "unexpected inline function without parent"),
+            Self::FormattingFailed => write!(f, "failed to format type name"),
+        }
+    }
+}
+
+/// An error when dealing with [`PdbObject`](struct.PdbObject.html).
+#[derive(Debug, Error)]
+#[error("{kind}")]
+pub struct PdbError {
+    kind: PdbErrorKind,
+    #[source]
+    source: Option<Box<dyn Error + Send + Sync + 'static>>,
+}
+
+impl PdbError {
+    /// Creates a new PDB error from a known kind of error as well as an arbitrary error
+    /// payload.
+    fn new<E>(kind: PdbErrorKind, source: E) -> Self
+    where
+        E: Into<Box<dyn Error + Send + Sync>>,
+    {
+        let source = Some(source.into());
+        Self { kind, source }
+    }
+
+    /// Returns the corresponding [`PdbErrorKind`] for this error.
+    pub fn kind(&self) -> PdbErrorKind {
+        self.kind
+    }
+}
+
+impl From<PdbErrorKind> for PdbError {
+    fn from(kind: PdbErrorKind) -> Self {
+        Self { kind, source: None }
+    }
+}
+
+impl From<pdb::Error> for PdbError {
+    fn from(e: pdb::Error) -> Self {
+        Self::new(PdbErrorKind::BadObject, e)
+    }
+}
+
+impl From<fmt::Error> for PdbError {
+    fn from(e: fmt::Error) -> Self {
+        Self::new(PdbErrorKind::FormattingFailed, e)
+    }
 }
 
 /// Program Database, the debug companion format on Windows.
@@ -1058,7 +1110,7 @@ impl<'s> Unit<'s> {
                     let parent_offset = proc_offsets
                         .last()
                         .map(|&(_, offset)| offset)
-                        .ok_or(PdbError::UnexpectedInline)?;
+                        .ok_or(PdbErrorKind::UnexpectedInline)?;
 
                     // We can assume that inlinees will be listed in the inlinee table. If missing,
                     // skip silently instead of erroring out. Missing a single inline function is


### PR DESCRIPTION
Follows the conventions set by `std::io::Error`.
