### PR TITLE
ci(gha): Build a wheel for macOS 11

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -16,6 +16,7 @@ targets:
   - name: github
 requireNames:
   - /^symbolic-.*-py2.py3-none-macosx_10_15_x86_64.whl$/
+  - /^symbolic-.*-py2.py3-none-macosx_11_0_x86_64.whl$/
   - /^symbolic-.*-py2.py3-none-manylinux2010_i686.whl$/
   - /^symbolic-.*-py2.py3-none-manylinux2010_x86_64.whl$/
   - /^symbolic-.*.zip$/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - "release/**"
 
+  # FIXME: Temporarily build pull requests.
+  pull_request:
+
 jobs:
   python-wheel-mac:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,16 @@ on:
 
 jobs:
   python-wheel-mac:
-    name: Python macOS
-    runs-on: macos-10.15
+    strategy:
+      matrix:
+        include:
+          - os: macos-10.15
+            python-version: 2.7
+          - os: macos-11.0
+            python-version: 3.8
+
+    name: Python macOS ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
@@ -23,9 +31,9 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 2.7
+          python-version: ${{ matrix.python-version }}
 
-      - run: make wheel SYMBOLIC_PYTHON=python2
+      - run: make wheel SYMBOLIC_PYTHON=python
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-10.15
-            python-version: 2.7
-          - os: macos-11.0
-            python-version: 3.8
+          - macos-version: "10.15"
+            python-version: "2.7"
+          - macos-version: "11.0"
+            python-version: "3.8"
 
-    name: Python macOS ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Python macOS ${{ matrix.macos-version }}
+    runs-on: macos-${{ matrix.macos-version }}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
On macOS Big Sur, python2 reports as `10.16` but python3 reports as `11.0`. For this reason, the `10.15` wheel does not install under python 3 and requires a separate wheel build.

Attempts to fix #301.