### PR TITLE
fix(pytest): Pin pytest 5 for debugfail customizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ test-rust:
 .PHONY: test-rust
 
 test-python: .venv/bin/python
-	.venv/bin/pip install -U pytest
+	.venv/bin/pip install -U "pytest>=5.0.0,<6.0.0"
 	.venv/bin/pip install -v --editable py
 	.venv/bin/pytest -v py
 .PHONY: test-python


### PR DESCRIPTION
With pytest 6, the internal representation of tests seems to have changed. Our overrides in `conftest.py` no longer emit compatible output which causes pytest to fail with an `INTERNALERROR`.

Until we get that fixed, this pins pytest to v5.