### PR TITLE
fix(unreal): Avoid panic during log parsing

### DIFF
--- a/symbolic-unreal/Cargo.toml
+++ b/symbolic-unreal/Cargo.toml
@@ -26,7 +26,7 @@ all-features = true
 serde = ["serde_", "chrono/serde"]
 
 [dependencies]
-anylog = "0.5.0"
+anylog = "0.6.0"
 bytes = "0.5.6"
 chrono = "0.4.7"
 elementtree = "0.5.0"

--- a/symbolic-unreal/Cargo.toml
+++ b/symbolic-unreal/Cargo.toml
@@ -26,7 +26,7 @@ all-features = true
 serde = ["serde_", "chrono/serde"]
 
 [dependencies]
-anylog = "0.6.0"
+anylog = "0.6.1"
 bytes = "0.5.6"
 chrono = "0.4.7"
 elementtree = "0.5.0"


### PR DESCRIPTION
Updates anylog and symbolic's own log parsing code to avoid panics when invalid or ambiguous dates are specified in the unreal crash log stream.

Ref mitsuhiko/rust-anylog#4
Ref mitsuhiko/rust-anylog#5