### PR TITLE
fix(build): Ensure submodules are included in sdist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - uses: actions/setup-python@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Bug Fixes**:
+
+- Include third-party submodules to allow the Python `sdist` to build again. ([#310](https://github.com/getsentry/symbolic/pull/310))
+
 ## 8.0.1
 
 **Bug Fixes**:


### PR DESCRIPTION
Starting with 8.0.0, the sdist package was missing the Breakpad and LSS third-party submodules and therefore would not build. After merging this, we will release 8.0.2 with a fixed sdist.

Note that this increases the size of the sdist. This could be reduced by removing Breakpad's binaries and test fixtures before bundling the package. Since the wheel is still reasonable in size, however, we can defer that until there is actual demand for it.

Fixes #309 