### PR TITLE
build(debuginfo): Match wasmparser version from walrus

### DIFF
--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -42,7 +42,7 @@ symbolic-common = { version = "8.0.2", path = "../symbolic-common" }
 thiserror = "1.0.20"
 zip = "0.5.2"
 walrus = "0.18.0"
-wasmparser = "0.68.0"
+wasmparser = "0.59.0"
 
 [dev-dependencies]
 insta = "1.3.0"


### PR DESCRIPTION
Downgrades wasmparser to 0.59.0 to match the version `walrus` uses. This avoids
a duplicate dependency in the dependency tree.

