### PR TITLE
fix(symcache): Compute correct line offsets

### DIFF
--- a/symbolic-symcache/src/format.rs
+++ b/symbolic-symcache/src/format.rs
@@ -13,7 +13,7 @@ use crate::error::{SymCacheError, SymCacheErrorKind};
 pub const SYMCACHE_MAGIC: [u8; 4] = *b"SYMC";
 
 /// The latest version of the file format.
-pub const SYMCACHE_VERSION: u32 = 5;
+pub const SYMCACHE_VERSION: u32 = 6;
 
 // Version history:
 //
@@ -22,6 +22,7 @@ pub const SYMCACHE_VERSION: u32 = 5;
 // 3: PR #148: Consider all PT_LOAD segments in ELF
 // 4: PR #155: Functions with more than 65k line records
 // 5: PR #221: Invalid inlinee nesting leading to wrong stack traces
+// 6: PR #319: Correct line offsets and spacer line records
 
 /// Loads binary data from a segment.
 pub(crate) fn get_slice(data: &[u8], offset: usize, len: usize) -> Result<&[u8], io::Error> {


### PR DESCRIPTION
SymCaches store line records where record specifies the delta to the previous line record. These deltas are stored as `u8` to save space for the common case where only small increments are needed. If two records are more than `0xff` apart, we insert filler line records.

This PR solves two bugs in creating these filler line records:
1. The delta was computed with `(diff & 0xff) as u8` instead of `diff.min(0xff) as u8`. This means that there was an address drift every time we had to insert filler line records.
2. The filler line records are technically still part of the previous range. However, they already carried information of the next line record, leading to wrong line numbers.

**SymCache version is incremented to `6`.** 

The previous implementation originates affe7b9dd119416bfaa6a07d928ea464b00c4bab and 5209ebd7e47d73a273fca3c14978386f63bbad17 and was subsequently amended with split functions in #155.