### PR TITLE
fix(symcache): Support lookup for public syms larger than 65k

### DIFF
--- a/symbolic-symcache/src/format.rs
+++ b/symbolic-symcache/src/format.rs
@@ -178,7 +178,7 @@ pub struct FuncRecord {
     pub addr_low: u32,
     /// High bits of the address.
     pub addr_high: u16,
-    /// The length of the function.
+    /// The length of the function. A value of 0xffff indicates that the size is unknown.
     pub len: u16,
     /// The line record of this function.  If it fully overlaps with an inline the record could be
     /// `~0`.
@@ -210,7 +210,8 @@ impl FuncRecord {
 
     /// The instruction address _after_ the end of the function.
     ///
-    /// TODO(ja): Describe special case.
+    /// If the function's `len` is 0xffff, we assume it extends all the way to
+    /// the end of the file.
     pub fn addr_end(&self) -> u64 {
         match self.len {
             0xffff => u64::MAX,
@@ -238,7 +239,7 @@ impl FuncRecord {
     }
 }
 
-/// A mapping between instruction addresses and file / line information.
+/// A mapping between an instruction address and file / line information.
 #[repr(C, packed)]
 #[derive(Default, Copy, Clone, Debug)]
 pub struct LineRecord {

--- a/symbolic-symcache/src/format.rs
+++ b/symbolic-symcache/src/format.rs
@@ -210,8 +210,8 @@ impl FuncRecord {
 
     /// The instruction address _after_ the end of the function.
     ///
-    /// If the function's `len` is 0xffff, we assume it extends all the way to
-    /// the end of the file.
+    /// If the function's [`len`](FuncRecord::len) is [`u16::MAX`], we assume it extends all the way
+    /// to the end of the file.
     pub fn addr_end(&self) -> u64 {
         match self.len {
             0xffff => u64::MAX,
@@ -221,8 +221,12 @@ impl FuncRecord {
 
     /// Checks whether the given address is covered by the function.
     ///
-    /// TODO(ja): Describe special case.
+    /// If the function's [`len`](FuncRecord::len) is [`u16::MAX`], we assume it extends all the way
+    /// to the end of the file.
     pub fn addr_in_range(&self, addr: u64) -> bool {
+        // Special case: The end address is treated as inclusive. TODO: Check if this is
+        // intentional. We may want to consider empty functions as occupying the start location with
+        // a single byte instruction.
         addr >= self.addr_start() && addr <= self.addr_end()
     }
 

--- a/symbolic-symcache/src/format.rs
+++ b/symbolic-symcache/src/format.rs
@@ -209,11 +209,18 @@ impl FuncRecord {
     }
 
     /// The instruction address _after_ the end of the function.
+    ///
+    /// TODO(ja): Describe special case.
     pub fn addr_end(&self) -> u64 {
-        self.addr_start() + u64::from(self.len)
+        match self.len {
+            0xffff => u64::MAX,
+            len => self.addr_start() + u64::from(len),
+        }
     }
 
     /// Checks whether the given address is covered by the function.
+    ///
+    /// TODO(ja): Describe special case.
     pub fn addr_in_range(&self, addr: u64) -> bool {
         addr >= self.addr_start() && addr <= self.addr_end()
     }


### PR DESCRIPTION
Fixes part of https://github.com/getsentry/symbolic/issues/284#issuecomment-715587454

Public symbol records often have no size. If there's a gap larger than 65k, the symcache lookup would not resolve the last symbol. For example, with this Breakpad symbol a lookup for `0x180000` should resolve `symbol_a`:

```
PUBLIC 100000 0 symbol_a
PUBLIC 200000 0 symbol_b
```

In practice, it is likely that there are symbols missing and the lookup would in fact be wrong. However, there could be the possibility of such large functions and with how symbol tables are structured, this would be the expected result. Note that this now also matches Breakpad's behavior.