### PR TITLE
ref(symcache): FuncRecord::len must be nonzero

### DIFF
--- a/symbolic-symcache/Cargo.toml
+++ b/symbolic-symcache/Cargo.toml
@@ -34,7 +34,6 @@ thiserror = "1.0.20"
 insta = "1.3.0"
 criterion = "0.3.1"
 symbolic-testutils = { path = "../symbolic-testutils" }
-symbolic-demangle = { path = "../symbolic-demangle" }
 
 [features]
 bench = []

--- a/symbolic-symcache/Cargo.toml
+++ b/symbolic-symcache/Cargo.toml
@@ -34,6 +34,7 @@ thiserror = "1.0.20"
 insta = "1.3.0"
 criterion = "0.3.1"
 symbolic-testutils = { path = "../symbolic-testutils" }
+symbolic-demangle = { path = "../symbolic-demangle" }
 
 [features]
 bench = []

--- a/symbolic-symcache/src/format.rs
+++ b/symbolic-symcache/src/format.rs
@@ -4,6 +4,7 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::io;
 use std::marker::PhantomData;
+use std::num::NonZeroU16;
 
 use symbolic_common::{DebugId, Uuid};
 
@@ -172,14 +173,14 @@ pub struct FileRecord {
 
 /// A function or public symbol.
 #[repr(C, packed)]
-#[derive(Default, Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct FuncRecord {
     /// Low bits of the address.
     pub addr_low: u32,
     /// High bits of the address.
     pub addr_high: u16,
     /// The length of the function. A value of 0xffff indicates that the size is unknown.
-    pub len: u16,
+    pub len: NonZeroU16,
     /// The line record of this function.  If it fully overlaps with an inline the record could be
     /// `~0`.
     pub line_records: Seg<LineRecord, u16>,
@@ -213,7 +214,7 @@ impl FuncRecord {
     /// If the function's [`len`](FuncRecord::len) is [`u16::MAX`], we assume it extends all the way
     /// to the end of the file.
     pub fn addr_end(&self) -> u64 {
-        match self.len {
+        match self.len.into() {
             0xffff => u64::MAX,
             len => self.addr_start() + u64::from(len),
         }

--- a/symbolic-symcache/src/writer.rs
+++ b/symbolic-symcache/src/writer.rs
@@ -13,7 +13,7 @@ use crate::format;
 
 // Performs a shallow check whether this function might contain any lines.
 fn is_empty_function(function: &Function<'_>) -> bool {
-    function.lines.is_empty() && function.inlinees.is_empty()
+    function.size == 0
 }
 
 /// Performs a check whether this line has already been written in the scope of this function.

--- a/symbolic-symcache/tests/test_writer.rs
+++ b/symbolic-symcache/tests/test_writer.rs
@@ -3,7 +3,6 @@ use std::io::Cursor;
 
 use symbolic_common::ByteView;
 use symbolic_debuginfo::Object;
-use symbolic_demangle::{Demangle, DemangleOptions};
 use symbolic_symcache::{SymCache, SymCacheWriter};
 use symbolic_testutils::fixture;
 
@@ -127,7 +126,7 @@ fn test_lookup_no_lines() -> Result<(), Error> {
     let name = symbols[0].function_name();
 
     assert_eq!(
-        name.try_demangle(DemangleOptions::name_only()),
+        name,
         "std::_Func_impl_no_alloc<`lambda at \
         /builds/worker/checkouts/gecko/netwerk/\
         protocol/http/HttpChannelChild.cpp:411:7',void>::_Do_call()"
@@ -151,10 +150,7 @@ fn test_lookup_no_size() -> Result<(), Error> {
     assert_eq!(symbols.len(), 1);
     let name = symbols[0].function_name();
 
-    assert_eq!(
-        name.try_demangle(DemangleOptions::name_only()),
-        "nouveau_drm_screen_create"
-    );
+    assert_eq!(name, "nouveau_drm_screen_create");
 
     Ok(())
 }

--- a/symbolic-testutils/fixtures/libgallium_dri.sym
+++ b/symbolic-testutils/fixtures/libgallium_dri.sym
@@ -1,0 +1,20 @@
+MODULE Linux x86_64 5A5F32914295A4FA22B591670A49FBEF0 libgallium_dri.so
+INFO CODE_ID 91325F5A9542FAA422B591670A49FBEF719A143E
+PUBLIC 135380 0 __driDriverGetExtensions_swrast
+PUBLIC 1353a0 0 __driDriverGetExtensions_kms_swrast
+PUBLIC 1353c0 0 __driDriverGetExtensions_iris
+PUBLIC 1353e0 0 __driDriverGetExtensions_nouveau
+PUBLIC 135400 0 __driDriverGetExtensions_r300
+PUBLIC 135420 0 __driDriverGetExtensions_r600
+PUBLIC 135440 0 __driDriverGetExtensions_radeonsi
+PUBLIC 135460 0 __driDriverGetExtensions_vmwgfx
+PUBLIC 135480 0 __driDriverGetExtensions_virtio_gpu
+PUBLIC 1354a0 0 __driDriverGetExtensions_zink
+PUBLIC 6dd790 0 radeon_drm_winsys_create
+PUBLIC 872f20 0 amdgpu_winsys_create
+PUBLIC 87cb40 0 ac_init_shared_llvm_once
+PUBLIC 88e650 0 nouveau_drm_screen_create
+STACK CFI INIT 103020 10 .cfa: $rsp 16 + .ra: .cfa -8 + ^ 
+STACK CFI 103026 .cfa: $rsp 24 +
+STACK CFI INIT 103030 8 .cfa: $rsp 8 + .ra: .cfa -8 + ^ 
+STACK CFI INIT 103040 13 $r12: .cfa -24 + ^ $r13: .cfa -16 + ^ $rbp: .cfa -32 + ^ $rbx: .cfa -40 + ^ .cfa: $rsp 96 + .ra: .cfa -8 + ^ 

--- a/symbolic-testutils/fixtures/libgallium_dri.sym
+++ b/symbolic-testutils/fixtures/libgallium_dri.sym
@@ -1,20 +1,3 @@
 MODULE Linux x86_64 5A5F32914295A4FA22B591670A49FBEF0 libgallium_dri.so
 INFO CODE_ID 91325F5A9542FAA422B591670A49FBEF719A143E
-PUBLIC 135380 0 __driDriverGetExtensions_swrast
-PUBLIC 1353a0 0 __driDriverGetExtensions_kms_swrast
-PUBLIC 1353c0 0 __driDriverGetExtensions_iris
-PUBLIC 1353e0 0 __driDriverGetExtensions_nouveau
-PUBLIC 135400 0 __driDriverGetExtensions_r300
-PUBLIC 135420 0 __driDriverGetExtensions_r600
-PUBLIC 135440 0 __driDriverGetExtensions_radeonsi
-PUBLIC 135460 0 __driDriverGetExtensions_vmwgfx
-PUBLIC 135480 0 __driDriverGetExtensions_virtio_gpu
-PUBLIC 1354a0 0 __driDriverGetExtensions_zink
-PUBLIC 6dd790 0 radeon_drm_winsys_create
-PUBLIC 872f20 0 amdgpu_winsys_create
-PUBLIC 87cb40 0 ac_init_shared_llvm_once
 PUBLIC 88e650 0 nouveau_drm_screen_create
-STACK CFI INIT 103020 10 .cfa: $rsp 16 + .ra: .cfa -8 + ^ 
-STACK CFI 103026 .cfa: $rsp 24 +
-STACK CFI INIT 103030 8 .cfa: $rsp 8 + .ra: .cfa -8 + ^ 
-STACK CFI INIT 103040 13 $r12: .cfa -24 + ^ $r13: .cfa -16 + ^ $rbp: .cfa -32 + ^ $rbx: .cfa -40 + ^ .cfa: $rsp 96 + .ra: .cfa -8 + ^ 

--- a/symbolic-testutils/fixtures/xul.sym
+++ b/symbolic-testutils/fixtures/xul.sym
@@ -1,13 +1,3 @@
 MODULE windows x86_64 09F9D7ECF31F60E34C4C44205044422E1 xul.pdb
 INFO CODE_ID 5E8F310E69D0000 xul.dll
-FILE 0 hg:hg.mozilla.org/mozilla-central:vs2017_15.8.4/VC/include/functional:93bdbca5399c12b3eec5f03bbc323e00f7ef3a51
-FUNC c6db60 f 0 std::_Func_impl_no_alloc<`lambda at /builds/worker/checkouts/gecko/netwerk/protocol/http/HttpChannelChild.cpp:411:7',void>::_Move(void*)
-c6db60 f 1219 0
 FUNC c6db70 23e 0 std::_Func_impl_no_alloc<`lambda at /builds/worker/checkouts/gecko/netwerk/protocol/http/HttpChannelChild.cpp:411:7',void>::_Do_call()
-FUNC c6ddb0 8 0 std::_Func_impl_no_alloc<`lambda at /builds/worker/checkouts/gecko/netwerk/protocol/http/HttpChannelChild.cpp:411:7',void>::_Target_type() const
-c6ddb0 8 1227 0
-FUNC c6ddc0 209 0 std::_Func_impl_no_alloc<`lambda at /builds/worker/checkouts/gecko/netwerk/protocol/http/HttpChannelChild.cpp:411:7',void>::_Delete_this(bool)
-c6ddc0 b 1239 0
-c6ddcb 102 1240 0
-c6decd 8 1241 0
-c6ded5 10 1243 0

--- a/symbolic-testutils/fixtures/xul.sym
+++ b/symbolic-testutils/fixtures/xul.sym
@@ -1,0 +1,13 @@
+MODULE windows x86_64 09F9D7ECF31F60E34C4C44205044422E1 xul.pdb
+INFO CODE_ID 5E8F310E69D0000 xul.dll
+FILE 0 hg:hg.mozilla.org/mozilla-central:vs2017_15.8.4/VC/include/functional:93bdbca5399c12b3eec5f03bbc323e00f7ef3a51
+FUNC c6db60 f 0 std::_Func_impl_no_alloc<`lambda at /builds/worker/checkouts/gecko/netwerk/protocol/http/HttpChannelChild.cpp:411:7',void>::_Move(void*)
+c6db60 f 1219 0
+FUNC c6db70 23e 0 std::_Func_impl_no_alloc<`lambda at /builds/worker/checkouts/gecko/netwerk/protocol/http/HttpChannelChild.cpp:411:7',void>::_Do_call()
+FUNC c6ddb0 8 0 std::_Func_impl_no_alloc<`lambda at /builds/worker/checkouts/gecko/netwerk/protocol/http/HttpChannelChild.cpp:411:7',void>::_Target_type() const
+c6ddb0 8 1227 0
+FUNC c6ddc0 209 0 std::_Func_impl_no_alloc<`lambda at /builds/worker/checkouts/gecko/netwerk/protocol/http/HttpChannelChild.cpp:411:7',void>::_Delete_this(bool)
+c6ddc0 b 1239 0
+c6ddcb 102 1240 0
+c6decd 8 1241 0
+c6ded5 10 1243 0


### PR DESCRIPTION
@jan-auer and I believe that there is no reason to consider functions of length 0 in `symcache` and all such functions occurring in a debug object should be discarded before building the cache. The type of the `len` field of the `FuncRecord` struct is changed from `u16` to `NonZeroU16` to enforce this invariant.