### PR TITLE
build: Replace virtualenv with venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,4 +93,4 @@ format-python: .venv/bin/python
 
 .venv/bin/python: Makefile
 	@rm -rf .venv
-	$SYMBOLIC_PYTHON_VERSION -m venv .venv
+	$$SYMBOLIC_PYTHON_VERSION -m venv .venv

--- a/Makefile
+++ b/Makefile
@@ -93,4 +93,4 @@ format-python: .venv/bin/python
 
 .venv/bin/python: Makefile
 	@rm -rf .venv
-	python3 -m venv .venv
+	$SYMBOLIC_PYTHON_VERSION -m venv .venv

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-SHELL = /bin/bash
 export SYMBOLIC_PYTHON_VERSION := python3
 
 all: check test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-SYMBOLIC_PYTHON := python3
+SHELL = /bin/bash
+export SYMBOLIC_PYTHON_VERSION := python3
 
 all: check test
 .PHONY: all
@@ -92,5 +93,4 @@ format-python: .venv/bin/python
 
 .venv/bin/python: Makefile
 	@rm -rf .venv
-	@which virtualenv || sudo pip install virtualenv
-	virtualenv -p $(SYMBOLIC_PYTHON) .venv
+	python3 -m venv .venv


### PR DESCRIPTION
I also slightly changed the beginning of the `Makefile` to unify it with the one in `symbolicator`.

When I run `make test` locally, quite a lot of tests fail, is that expected?

#skip-changelog