### PR TITLE
ref(unwind): Simplify & improve evaluator

### DIFF
--- a/symbolic-unwind/src/base.rs
+++ b/symbolic-unwind/src/base.rs
@@ -79,8 +79,6 @@ pub trait RegisterValue:
     + Div<Output = Self>
     + Sub<Output = Self>
     + Rem<Output = Self>
-    + PartialOrd
-    + Ord
     + Copy
     + Sized
     + Debug

--- a/symbolic-unwind/src/base.rs
+++ b/symbolic-unwind/src/base.rs
@@ -79,6 +79,8 @@ pub trait RegisterValue:
     + Div<Output = Self>
     + Sub<Output = Self>
     + Rem<Output = Self>
+    + PartialOrd
+    + Ord
     + Copy
     + Sized
     + Debug

--- a/symbolic-unwind/src/evaluator/mod.rs
+++ b/symbolic-unwind/src/evaluator/mod.rs
@@ -87,13 +87,13 @@ impl<'memory, A: Ord, E> Evaluator<'memory, A, E> {
         }
     }
 
-    /// Sets the evaluator's [memory](Self::memory) to the given `MemoryRegion`.
+    /// Sets the evaluator's memory to the given `MemoryRegion`.
     pub fn memory(mut self, memory: MemoryRegion<'memory>) -> Self {
         self.memory = Some(memory);
         self
     }
 
-    /// Sets the evaluator's [register map](Self::registers) to the given map.
+    /// Sets the evaluator's register map to the given map.
     pub fn registers(mut self, registers: BTreeMap<Register, A>) -> Self {
         self.registers = registers;
         self

--- a/symbolic-unwind/src/evaluator/mod.rs
+++ b/symbolic-unwind/src/evaluator/mod.rs
@@ -115,7 +115,7 @@ impl<'memory, A, E> Evaluator<'memory, A, E> {
     /// [`evaluate_register`](Self::evaluate_register)
     /// and [`evaluate_all_registers`](Self::evaluate_all_registers).
     pub fn add_cfi_rule(&mut self, register: Register, expr: Expr<A>) {
-        if register == Register::cfa() {
+        if register.is_cfa() {
             self.cfa_rule = Some(expr);
         } else {
             self.cfi_rules.insert(register, expr);
@@ -191,7 +191,7 @@ impl<'memory, A: RegisterValue, E: Endianness> Evaluator<'memory, A, E> {
             return Ok(*val);
         }
 
-        if *register == Register::cfa() {
+        if register.is_cfa() {
             let cfa_rule = match self.cfa_rule.take() {
                 Some(e) => e,
                 None => {
@@ -434,6 +434,14 @@ impl Register {
         match self {
             Self::Const(_) => true,
             Self::Var(_) => false,
+        }
+    }
+
+    /// Returns true if this is the CFA register.
+    pub fn is_cfa(&self) -> bool {
+        match self {
+            Self::Var(_) => false,
+            Self::Const(name) => name == ".cfa",
         }
     }
 }

--- a/symbolic-unwind/src/evaluator/parsing.rs
+++ b/symbolic-unwind/src/evaluator/parsing.rs
@@ -109,7 +109,12 @@ fn constant(input: &str) -> IResult<&str, Register, ParseExprError> {
         alt((alpha1, tag("_"), tag("."))),
         many0(alt((alphanumeric1, tag("_"), tag(".")))),
     ))(input)?;
-    Ok((rest, Register::Const(con.to_string())))
+    let reg = if con == ".cfa" {
+        Register::Cfa
+    } else {
+        Register::Const(con.to_string())
+    };
+    Ok((rest, reg))
 }
 
 /// Parses a [constant register](super::Register).

--- a/symbolic-unwind/src/evaluator/parsing.rs
+++ b/symbolic-unwind/src/evaluator/parsing.rs
@@ -333,42 +333,6 @@ pub fn rules_complete<T: RegisterValue>(input: &str) -> Result<Vec<Rule<T>>, Par
     all_consuming(rules)(input).finish().map(|(_, a)| a)
 }
 
-/// Parses a sequence of rules or assignments into a map from registers to expressions.
-pub fn rules_or_assignments<T: RegisterValue>(
-    input: &str,
-) -> IResult<&str, BTreeMap<Register, Expr<T>>, ParseExprError> {
-    alt((
-        map(rules, |r| {
-            r.into_iter().map(|Rule(reg, expr)| (reg, expr)).collect()
-        }),
-        map(assignments, |a| {
-            a.into_iter()
-                .map(|Assignment(reg, expr)| (reg, expr))
-                .collect()
-        }),
-    ))(input)
-}
-
-/// Parses a sequence of rules or assignments into a map from registers to expressions.
-///
-/// It will fail if there is any non-whitespace input remaining afterwards.
-pub fn rules_or_assignments_complete<T: RegisterValue>(
-    input: &str,
-) -> Result<BTreeMap<Register, Expr<T>>, ParseExprError> {
-    alt((
-        map(all_consuming(rules), |r| {
-            r.into_iter().map(|Rule(reg, expr)| (reg, expr)).collect()
-        }),
-        map(all_consuming(assignments), |a| {
-            a.into_iter()
-                .map(|Assignment(reg, expr)| (reg, expr))
-                .collect()
-        }),
-    ))(input)
-    .finish()
-    .map(|(_, v)| v)
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/symbolic-unwind/src/evaluator/parsing.rs
+++ b/symbolic-unwind/src/evaluator/parsing.rs
@@ -333,6 +333,42 @@ pub fn rules_complete<T: RegisterValue>(input: &str) -> Result<Vec<Rule<T>>, Par
     all_consuming(rules)(input).finish().map(|(_, a)| a)
 }
 
+/// Parses a sequence of rules or assignments into a map from registers to expressions.
+pub fn rules_or_assignments<T: RegisterValue>(
+    input: &str,
+) -> IResult<&str, BTreeMap<Register, Expr<T>>, ParseExprError> {
+    alt((
+        map(rules, |r| {
+            r.into_iter().map(|Rule(reg, expr)| (reg, expr)).collect()
+        }),
+        map(assignments, |a| {
+            a.into_iter()
+                .map(|Assignment(reg, expr)| (reg, expr))
+                .collect()
+        }),
+    ))(input)
+}
+
+/// Parses a sequence of rules or assignments into a map from registers to expressions.
+///
+/// It will fail if there is any non-whitespace input remaining afterwards.
+pub fn rules_or_assignments_complete<T: RegisterValue>(
+    input: &str,
+) -> Result<BTreeMap<Register, Expr<T>>, ParseExprError> {
+    alt((
+        map(all_consuming(rules), |r| {
+            r.into_iter().map(|Rule(reg, expr)| (reg, expr)).collect()
+        }),
+        map(all_consuming(assignments), |a| {
+            a.into_iter()
+                .map(|Assignment(reg, expr)| (reg, expr))
+                .collect()
+        }),
+    ))(input)
+    .finish()
+    .map(|(_, v)| v)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
This does three things:

- It unifies the types `Variable` and `Constant` into the type `Register`. I think the separation between the two actually causes way more problems than it prevents.
- It adds a cache to the evaluator such that no expression is evaluated more than once.
- The method `Evaluator::process` is replaced by `process_rules`, which takes a string of rules such as would be extracted from a `STACK CFI` record and produces a map containing new (i.e. the caller's) register values. I will deal with assignments/`STACK WIN` records once I understand how Breakpad handles them.