### PR TITLE
feat(demangle): Strip hash suffixes from C++ function names

### DIFF
--- a/symbolic-demangle/Cargo.toml
+++ b/symbolic-demangle/Cargo.toml
@@ -25,16 +25,14 @@ all-features = true
 
 [features]
 default = ["cpp", "msvc", "rust", "swift"]
-cpp = ["cpp_demangle", "lazy_static", "regex"]
+cpp = ["cpp_demangle"]
 msvc = ["msvc-demangler"]
 rust = ["rustc-demangle"]
 swift = ["cc"]
 
 [dependencies]
 cpp_demangle = { version = "0.3.0", optional = true }
-lazy_static = { version = "1.4.0", optional = true }
 msvc-demangler = { version = "0.8.0", optional = true }
-regex = { version = "1.4.3", optional = true }
 rustc-demangle = { version = "0.1.16", optional = true }
 symbolic-common = { version = "8.0.5", path = "../symbolic-common" }
 

--- a/symbolic-demangle/Cargo.toml
+++ b/symbolic-demangle/Cargo.toml
@@ -25,14 +25,16 @@ all-features = true
 
 [features]
 default = ["cpp", "msvc", "rust", "swift"]
-cpp = ["cpp_demangle"]
+cpp = ["cpp_demangle", "lazy_static", "regex"]
 msvc = ["msvc-demangler"]
 rust = ["rustc-demangle"]
 swift = ["cc"]
 
 [dependencies]
 cpp_demangle = { version = "0.3.0", optional = true }
+lazy_static = { version = "1.4.0", optional = true }
 msvc-demangler = { version = "0.8.0", optional = true }
+regex = { version = "1.4.3", optional = true }
 rustc-demangle = { version = "0.1.16", optional = true }
 symbolic-common = { version = "8.0.5", path = "../symbolic-common" }
 

--- a/symbolic-demangle/src/lib.rs
+++ b/symbolic-demangle/src/lib.rs
@@ -176,6 +176,21 @@ fn try_demangle_cpp(ident: &str, opts: DemangleOptions) -> Option<String> {
     {
         use cpp_demangle::{DemangleOptions as CppOptions, Symbol as CppSymbol};
 
+        // If ident has a suffix of $ followed by 32 hex digits, discard it.
+        let ident = {
+            let n = ident.len();
+            if n < 33 {
+                ident
+            } else {
+                let (front, back) = ident.split_at(n - 33);
+                if back.starts_with('$') && back[1..].chars().all(|c| c.is_ascii_hexdigit()) {
+                    front
+                } else {
+                    ident
+                }
+            }
+        };
+
         let symbol = match CppSymbol::new(ident) {
             Ok(symbol) => symbol,
             Err(_) => return None,

--- a/symbolic-demangle/src/lib.rs
+++ b/symbolic-demangle/src/lib.rs
@@ -36,24 +36,12 @@ use std::ffi::{CStr, CString};
 #[cfg(feature = "swift")]
 use std::os::raw::{c_char, c_int};
 
-#[cfg(feature = "cpp")]
-use lazy_static::lazy_static;
-#[cfg(feature = "cpp")]
-use regex::bytes::Regex;
-
 use symbolic_common::{Language, Name, NameMangling};
 
 #[cfg(feature = "swift")]
 const SYMBOLIC_SWIFT_FEATURE_RETURN_TYPE: c_int = 0x1;
 #[cfg(feature = "swift")]
 const SYMBOLIC_SWIFT_FEATURE_PARAMETERS: c_int = 0x2;
-
-#[cfg(feature = "cpp")]
-lazy_static! {
-    // This matches the hash suffixes described in
-    // https://github.com/gimli-rs/cpp_demangle/pull/210
-    static ref HASH_SUFFIX: Regex = Regex::new(r"\$[[:xdigit:]]{32}$").unwrap();
-}
 
 #[cfg(feature = "swift")]
 extern "C" {
@@ -187,12 +175,6 @@ fn try_demangle_cpp(ident: &str, opts: DemangleOptions) -> Option<String> {
     #[cfg(feature = "cpp")]
     {
         use cpp_demangle::{DemangleOptions as CppOptions, Symbol as CppSymbol};
-
-        // Strip away the hash suffixes described in
-        // https://github.com/gimli-rs/cpp_demangle/pull/210.
-        // Why the empty string needs a type annotation I have no earthly idea.
-        let empty: &[u8] = b"";
-        let ident = HASH_SUFFIX.replace(ident.as_bytes(), empty);
 
         let symbol = match CppSymbol::new(ident) {
             Ok(symbol) => symbol,

--- a/symbolic-demangle/src/lib.rs
+++ b/symbolic-demangle/src/lib.rs
@@ -170,11 +170,11 @@ fn try_demangle_msvc(_ident: &str, _opts: DemangleOptions) -> Option<String> {
 /// Removes a suffix consisting of $ followed by 32 hex digits, if there is one,
 /// otherwise returns its input.
 fn strip_hash_suffix(ident: &str) -> &str {
-    let n = ident.len();
-    if n < 33 {
+    let len = ident.len();
+    if len < 33 {
         ident
     } else {
-        let (front, back) = ident.split_at(n - 33);
+        let (front, back) = ident.split_at(len - 33);
         if back.starts_with('$') && back[1..].chars().all(|c| c.is_ascii_hexdigit()) {
             front
         } else {

--- a/symbolic-demangle/tests/test_cpp.rs
+++ b/symbolic-demangle/tests/test_cpp.rs
@@ -38,3 +38,11 @@ fn test_demangle_cpp_no_args() {
         // "_Z3MinIiiEDTqultfp_fp0_cl7forwardIT_Efp_Ecl7forwardIT0_Efp0_EEOS0_OS1_" => "decltype (({parm#1}<{parm#2})?((forward<int>)({parm#1})) : ((forward<int>)({parm#2}))) Min<int, int>",
     });
 }
+
+#[test]
+fn test_demangle_cpp_hash_suffix() {
+    assert_demangle!(Language::Cpp, DemangleOptions::complete(), {
+    "__ZZN3xxx12xxxxxxxxxxxx9xxxxxxxxxILNS0_16xxxxxxxxxxxxxxxxE0EZNKS_6xxxxxx16xxxxxxxxxxxxxxxxEPjbbE4$_76EEvRKT0_PS3_PNS_7xxxxxxxENS0_13xxxxxxxxxxxxxEbbEN18xxxxxxxxxxxxxxxxxx10xxxxxxxxxxEv$57c34bde3fedbd1a4bf6fbbe5453ff24" =>
+    "void xxx::xxxxxxxxxxxx::xxxxxxxxx<(xxx::xxxxxxxxxxxx::xxxxxxxxxxxxxxxx)0, xxx::xxxxxx::xxxxxxxxxxxxxxxx(unsigned int*, bool, bool) const::$_76>(xxx::xxxxxx::xxxxxxxxxxxxxxxx(unsigned int*, bool, bool) const::$_76 const&, xxx::xxxxxx*, xxx::xxxxxxx*, xxx::xxxxxxxxxxxx::xxxxxxxxxxxxx, bool, bool)::xxxxxxxxxxxxxxxxxx::xxxxxxxxxx()"
+    });
+}

--- a/symbolic-demangle/tests/test_cpp.rs
+++ b/symbolic-demangle/tests/test_cpp.rs
@@ -38,11 +38,3 @@ fn test_demangle_cpp_no_args() {
         // "_Z3MinIiiEDTqultfp_fp0_cl7forwardIT_Efp_Ecl7forwardIT0_Efp0_EEOS0_OS1_" => "decltype (({parm#1}<{parm#2})?((forward<int>)({parm#1})) : ((forward<int>)({parm#2}))) Min<int, int>",
     });
 }
-
-#[test]
-fn test_demangle_cpp_hash_suffix() {
-    assert_demangle!(Language::Cpp, DemangleOptions::complete(), {
-    "__ZZN3xxx12xxxxxxxxxxxx9xxxxxxxxxILNS0_16xxxxxxxxxxxxxxxxE0EZNKS_6xxxxxx16xxxxxxxxxxxxxxxxEPjbbE4$_76EEvRKT0_PS3_PNS_7xxxxxxxENS0_13xxxxxxxxxxxxxEbbEN18xxxxxxxxxxxxxxxxxx10xxxxxxxxxxEv$57c34bde3fedbd1a4bf6fbbe5453ff24" =>
-    "void xxx::xxxxxxxxxxxx::xxxxxxxxx<(xxx::xxxxxxxxxxxx::xxxxxxxxxxxxxxxx)0, xxx::xxxxxx::xxxxxxxxxxxxxxxx(unsigned int*, bool, bool) const::$_76>(xxx::xxxxxx::xxxxxxxxxxxxxxxx(unsigned int*, bool, bool) const::$_76 const&, xxx::xxxxxx*, xxx::xxxxxxx*, xxx::xxxxxxxxxxxx::xxxxxxxxxxxxx, bool, bool)::xxxxxxxxxxxxxxxxxx::xxxxxxxxxx()"
-    });
-}


### PR DESCRIPTION
This is a port of https://github.com/gimli-rs/cpp_demangle/pull/210 to `symbolic-demangle`.