### PR TITLE
fix(parser): Correct handling of numbers and identifiers

### DIFF
--- a/symbolic-unwind/src/base.rs
+++ b/symbolic-unwind/src/base.rs
@@ -2,6 +2,7 @@
 use std::convert::TryInto;
 use std::fmt::Debug;
 use std::ops::{Add, Div, Mul, Rem, Sub};
+use std::str::FromStr;
 
 /// Trait that abstracts over the [endianness](https://en.wikipedia.org/wiki/Endianness)
 /// of data representation.
@@ -79,6 +80,7 @@ pub trait RegisterValue:
     + Div<Output = Self>
     + Sub<Output = Self>
     + Rem<Output = Self>
+    + FromStr
     + Copy
     + Sized
     + Debug
@@ -90,20 +92,12 @@ pub trait RegisterValue:
     ///
     /// May fail if an invalid byte is encountered or there are not enough bytes in the slice.
     fn read_bytes<E: Endianness>(bytes: &[u8], endian: E) -> Option<Self>;
-
-    /// Attempt to read a value of this type from a string of hexadecimal
-    /// digits.
-    fn from_str_hex(input: &str) -> Result<Self, std::num::ParseIntError>;
 }
 
 impl RegisterValue for u8 {
     const WIDTH: usize = 1;
     fn read_bytes<E: Endianness>(bytes: &[u8], _endian: E) -> Option<Self> {
         bytes.first().copied()
-    }
-
-    fn from_str_hex(input: &str) -> Result<Self, std::num::ParseIntError> {
-        Self::from_str_radix(input, 16)
     }
 }
 
@@ -117,10 +111,6 @@ impl RegisterValue for u16 {
             Some(Self::from_le_bytes(*bytes))
         }
     }
-
-    fn from_str_hex(input: &str) -> Result<Self, std::num::ParseIntError> {
-        Self::from_str_radix(input, 16)
-    }
 }
 
 impl RegisterValue for u32 {
@@ -133,10 +123,6 @@ impl RegisterValue for u32 {
             Some(Self::from_le_bytes(*bytes))
         }
     }
-
-    fn from_str_hex(input: &str) -> Result<Self, std::num::ParseIntError> {
-        Self::from_str_radix(input, 16)
-    }
 }
 
 impl RegisterValue for u64 {
@@ -148,10 +134,6 @@ impl RegisterValue for u64 {
         } else {
             Some(Self::from_le_bytes(*bytes))
         }
-    }
-
-    fn from_str_hex(input: &str) -> Result<Self, std::num::ParseIntError> {
-        Self::from_str_radix(input, 16)
     }
 }
 

--- a/symbolic-unwind/src/evaluator/mod.rs
+++ b/symbolic-unwind/src/evaluator/mod.rs
@@ -11,7 +11,7 @@
 //! <constant>   ::=  [a-zA-Z_.][a-zA-Z0-9_.]*
 //! <variable>   ::=  $[a-zA-Z][a-zA-Z0-9]*
 //! <binop>      ::=  + | - | * | / | % | @
-//! <literal>    ::=  [0-9a-fA-F]+
+//! <literal>    ::=  -?[0-9]+
 //! ```
 //! Most of this syntax should be familiar. The symbol `^` denotes a dereference operation,
 //! i.e. assuming that some representation `m` of a region of memory is available,

--- a/symbolic-unwind/src/evaluator/mod.rs
+++ b/symbolic-unwind/src/evaluator/mod.rs
@@ -8,8 +8,8 @@
 //! <assignment> ::=  <variable> <expr> =
 //! <expr>       ::=  <identifier> | <literal> | <expr> <expr> <binop> | <expr> ^
 //! <identifier> ::=  <constant> | <variable>
-//! <constant>   ::=  [a-zA-Z_.][a-zA-Z0-9_.]*
-//! <variable>   ::=  $[a-zA-Z][a-zA-Z0-9]*
+//! <constant>   ::=  \.[a-zA-Z0-9]+
+//! <variable>   ::=  \$[a-zA-Z0-9]+
 //! <binop>      ::=  + | - | * | / | % | @
 //! <literal>    ::=  -?[0-9]+
 //! ```

--- a/symbolic-unwind/src/evaluator/parsing.rs
+++ b/symbolic-unwind/src/evaluator/parsing.rs
@@ -7,7 +7,7 @@ use std::fmt;
 
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_while};
-use nom::character::complete::{alpha1, alphanumeric0, alphanumeric1, char, multispace0};
+use nom::character::complete::{alphanumeric1, multispace0};
 use nom::combinator::{all_consuming, map, map_res, not, opt, recognize, value};
 use nom::error::ParseError;
 use nom::multi::many0;
@@ -87,15 +87,15 @@ impl Error for ParseExprError {}
 
 /// Parses a [variable](super::Variable).
 ///
-/// This accepts identifiers of the form `$[a-zA-Z][a-zA-Z0-9]*`.
+/// This accepts identifiers of the form `$[a-zA-Z0-9]+`.
 fn variable(input: &str) -> IResult<&str, Variable, ParseExprError> {
-    let (rest, var) = recognize(tuple((char('$'), alpha1, alphanumeric0)))(input)?;
+    let (rest, var) = recognize(tuple((tag("$"), alphanumeric1)))(input)?;
     Ok((rest, Variable(var.to_string())))
 }
 
 /// Parses a [variable](super::Variable).
 ///
-/// This accepts identifiers of the form `$[a-zA-Z][a-zA-Z0-9]*`.
+/// This accepts identifiers of the form `$[a-zA-Z0-9]+`.
 /// It will fail if there is any non-whitespace input remaining afterwards.
 pub fn variable_complete(input: &str) -> Result<Variable, ParseExprError> {
     all_consuming(variable)(input).finish().map(|(_, v)| v)
@@ -103,18 +103,15 @@ pub fn variable_complete(input: &str) -> Result<Variable, ParseExprError> {
 
 /// Parses a [constant](super::Constant).
 ///
-/// This accepts identifiers of the form `[a-zA-Z_.][a-zA-Z0-9_.]*`.
+/// This accepts identifiers of the form `\.[a-zA-Z0-9]+`.
 fn constant(input: &str) -> IResult<&str, Constant, ParseExprError> {
-    let (rest, con) = recognize(preceded(
-        alt((alpha1, tag("_"), tag("."))),
-        many0(alt((alphanumeric1, tag("_"), tag(".")))),
-    ))(input)?;
+    let (rest, con) = recognize(preceded(tag("."), alphanumeric1))(input)?;
     Ok((rest, Constant(con.to_string())))
 }
 
 /// Parses a [constant](super::Constant).
 ///
-/// This accepts identifiers of the form `[a-zA-Z_.][a-zA-Z0-9_.]*`.
+/// This accepts identifiers of the form `\.[a-zA-Z0-9]+`.
 /// It will fail if there is any non-whitespace input remaining afterwards.
 pub fn constant_complete(input: &str) -> Result<Constant, ParseExprError> {
     all_consuming(constant)(input).finish().map(|(_, c)| c)

--- a/symbolic-unwind/src/evaluator/parsing.rs
+++ b/symbolic-unwind/src/evaluator/parsing.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_while};
 use nom::character::complete::{alpha1, alphanumeric0, alphanumeric1, char, multispace0};
-use nom::combinator::{all_consuming, map, map_res, not, recognize, value};
+use nom::combinator::{all_consuming, map, map_res, not, opt, recognize, value};
 use nom::error::ParseError;
 use nom::multi::many0;
 use nom::sequence::{delimited, preceded, terminated, tuple};
@@ -149,11 +149,14 @@ fn bin_op(input: &str) -> IResult<&str, BinOp, ParseExprError> {
 
 /// Parses an integer.
 ///
-/// This accepts expressions of the form `[0-9a-fA-F]+`.
+/// This accepts expressions of the form `-?[0-9]+`.
 fn number<T: RegisterValue>(input: &str) -> IResult<&str, T, ParseExprError> {
     map_res(
-        recognize(take_while(|c: char| c.is_ascii_alphanumeric())),
-        T::from_str_hex,
+        recognize(preceded(
+            opt(tag("-")),
+            take_while(|c: char| c.is_ascii_digit()),
+        )),
+        T::from_str,
     )(input)
 }
 
@@ -417,12 +420,12 @@ mod test {
     fn test_assignment_2() {
         use nom::multi::many1;
         use Expr::*;
-        let input = "$foo 4 ^ = $bar baz a7 + = 42";
+        let input = "$foo 4 ^ = $bar .baz 17 + = 42";
         let (v1, v2) = (Variable("$foo".to_string()), Variable("$bar".to_string()));
         let e1 = Deref(Box::new(Value(4u8)));
         let e2 = Op(
-            Box::new(Const(Constant("baz".to_string()))),
-            Box::new(Value(0xa7)),
+            Box::new(Const(Constant(".baz".to_string()))),
+            Box::new(Value(17)),
             BinOp::Add,
         );
 
@@ -456,8 +459,8 @@ mod test {
     fn test_rules() {
         use Expr::*;
 
-        let input = "cfa: 7 $rax + $r0: $r1 ^   ";
-        let cfa = Constant("cfa".to_string());
+        let input = ".cfa: 7 $rax + $r0: $r1 ^   ";
+        let cfa = Constant(".cfa".to_string());
         let rax = Variable("$rax".to_string());
         let r0 = Variable("$r0".to_string());
         let r1 = Variable("$r1".to_string());


### PR DESCRIPTION
This makes two changes to the way we parse Breakpad expressions:
- Numbers are signed and decimal
- Constants and variables have their valid names restricted to `\.[a-zA-Z0-9]+` and `\$[a-zA-Z0-9]+`, respectively.