### PR TITLE
fix(unwind): Only allow negative numbers on rhs of addition

### DIFF
--- a/symbolic-unwind/src/base.rs
+++ b/symbolic-unwind/src/base.rs
@@ -137,30 +137,6 @@ impl RegisterValue for u64 {
     }
 }
 
-impl RegisterValue for i32 {
-    const WIDTH: usize = 4;
-    fn read_bytes<E: Endianness>(bytes: &[u8], endian: E) -> Option<Self> {
-        let bytes: &[u8; Self::WIDTH] = bytes.get(..Self::WIDTH)?.try_into().ok()?;
-        if endian.is_big_endian() {
-            Some(Self::from_be_bytes(*bytes))
-        } else {
-            Some(Self::from_le_bytes(*bytes))
-        }
-    }
-}
-
-impl RegisterValue for i64 {
-    const WIDTH: usize = 8;
-    fn read_bytes<E: Endianness>(bytes: &[u8], endian: E) -> Option<Self> {
-        let bytes: &[u8; Self::WIDTH] = bytes.get(..Self::WIDTH)?.try_into().ok()?;
-        if endian.is_big_endian() {
-            Some(Self::from_be_bytes(*bytes))
-        } else {
-            Some(Self::from_le_bytes(*bytes))
-        }
-    }
-}
-
 /// A view into a region of memory, given by a slice and a base address.
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
The `expr` parser now automatically interprets e.g. `$foo -17 +` as `$foo 17 -`. In all other contexts, negative numbers are an error. This is because conceptually these expressions are always supposed to be positive, but sometimes negative offsets occur in CFI rules and program strings.

Semi-independently of that, the `expr` parser is now smarter as well. It parses `$foo 17 -` as one expression with no input left over, but `$foo 17` as `$foo` with ` 17` left over. This accounts for some of the added complexity of the parser (we need to remember when we had last parsed a complete expression), but the majority is caused by having to record the signs of subexpressions and making lots of case distinctions about when negative numbers are valid.

I am not particularly happy with this. @jan-auer has remarked that handling negative numbers this way means that if we parse an expression and then write it back to a string, the result is non-trivially different from the input. However, I currently don't see a better way of doing this.