### PR TITLE
ref(debuginfo): Improve representation of Breakpad cfi records

### DIFF
--- a/symbolic-debuginfo/src/breakpad.pest
+++ b/symbolic-debuginfo/src/breakpad.pest
@@ -58,7 +58,9 @@ stack_win = { "STACK WIN" ~ text }
 // STACK CFI ("Call Frame Information") records describe how to walk the stack when execution is at a given machine instruction.
 // Example: "STACK CFI INIT 804c4b0 40 .cfa: $esp 4 + $eip: .cfa 4 - ^"
 // see <https://github.com/google/breakpad/blob/master/docs/symbol_files.md#stack-cfi-records>
-stack_cfi = { "STACK CFI" ~ text }
+stack_cfi = { stack_cfi_init | stack_cfi_delta }
+stack_cfi_init = { "STACK CFI INIT" ~ addr ~ size ~ text }
+stack_cfi_delta = { "STACK CFI" ~ addr ~ text }
 
 // helpers
 ident = @{ XID_START ~ XID_CONTINUE{,31} }

--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -26,7 +26,9 @@ use std::ops::Range;
 use thiserror::Error;
 
 use symbolic_common::{Arch, ByteView, UnknownArchError};
-use symbolic_debuginfo::breakpad::{BreakpadError, BreakpadObject, BreakpadStackRecord};
+use symbolic_debuginfo::breakpad::{
+    BreakpadError, BreakpadObject, BreakpadStackCfiRecord, BreakpadStackRecord,
+};
 use symbolic_debuginfo::dwarf::gimli::{
     BaseAddresses, CfaRule, CieOrFde, DebugFrame, EhFrame, Error as GimliError,
     FrameDescriptionEntry, Reader, Register, RegisterRule, UninitializedUnwindContext,
@@ -284,7 +286,14 @@ impl<W: Write> AsciiCfiWriter<W> {
     fn process_breakpad(&mut self, object: &BreakpadObject<'_>) -> Result<(), CfiError> {
         for record in object.stack_records() {
             match record? {
-                BreakpadStackRecord::Cfi(r) => writeln!(self.inner, "STACK CFI {}", r.text),
+                BreakpadStackRecord::Cfi(r) => match r {
+                    BreakpadStackCfiRecord::Init { start, size, text } => {
+                        writeln!(self.inner, "STACK CFI INIT {:x} {:x} {}", start, size, text)
+                    }
+                    BreakpadStackCfiRecord::Delta { address, text } => {
+                        writeln!(self.inner, "STACK CFI {:x} {}", address, text)
+                    }
+                },
                 BreakpadStackRecord::Win(r) => writeln!(self.inner, "STACK WIN {}", r.text),
             }?
         }


### PR DESCRIPTION
This turns `BreakpadStackCfiRecord` into an enum with two variants (`Init` and `Delta`) and factors address/size information out of the `text` field.