### PR TITLE
ref(debuginfo): Further refactor Stack CFI records

### DIFF
--- a/symbolic-debuginfo/src/breakpad.pest
+++ b/symbolic-debuginfo/src/breakpad.pest
@@ -58,13 +58,14 @@ stack_win = { "STACK WIN" ~ text }
 // STACK CFI ("Call Frame Information") records describe how to walk the stack when execution is at a given machine instruction.
 // Example: "STACK CFI INIT 804c4b0 40 .cfa: $esp 4 + $eip: .cfa 4 - ^"
 // see <https://github.com/google/breakpad/blob/master/docs/symbol_files.md#stack-cfi-records>
-stack_cfi = { stack_cfi_init | stack_cfi_delta }
-stack_cfi_init = { "STACK CFI INIT" ~ addr ~ size ~ text }
-stack_cfi_delta = { "STACK CFI" ~ addr ~ text }
+stack_cfi = { stack_cfi_init ~ ( NEWLINE ~ stack_cfi_delta)* }
+stack_cfi_init = { "STACK CFI INIT" ~ addr ~ size ~ rules}
+stack_cfi_delta = { "STACK CFI" ~ addr ~ rules }
 
 // helpers
 ident = @{ XID_START ~ XID_CONTINUE{,31} }
 name = @{ text }
+rules = @{ text }
 text = @{ char+ }
 addr = @{ hex }
 size = @{ hex }

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -659,6 +659,16 @@ pub struct BreakpadStackCfiDeltaRecord<'d> {
 }
 
 impl<'d> BreakpadStackCfiDeltaRecord<'d> {
+    /// Parses a single `STACK CFI` record.
+    pub fn parse(data: &'d [u8]) -> Result<Self, BreakpadError> {
+        let string = str::from_utf8(data)?;
+        let parsed = BreakpadParser::parse(Rule::stack_cfi_delta, string)?
+            .next()
+            .unwrap();
+
+        Ok(Self::from_pair(parsed))
+    }
+
     /// Constructs a delta record directly from a Pest parser pair.
     fn from_pair(pair: pest::iterators::Pair<'d, Rule>) -> Self {
         let mut pair = pair.into_inner();

--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -286,14 +286,17 @@ impl<W: Write> AsciiCfiWriter<W> {
     fn process_breakpad(&mut self, object: &BreakpadObject<'_>) -> Result<(), CfiError> {
         for record in object.stack_records() {
             match record? {
-                BreakpadStackRecord::Cfi(r) => match r {
-                    BreakpadStackCfiRecord::Init { start, size, text } => {
-                        writeln!(self.inner, "STACK CFI INIT {:x} {:x} {}", start, size, text)
+                BreakpadStackRecord::Cfi(r) => {
+                    writeln!(
+                        self.inner,
+                        "STACK CFI INIT {:x} {:x} {}",
+                        r.start, r.size, r.init_rules
+                    );
+
+                    for d in r.deltas {
+                        writeln!(self.inner, "STACK CFI {:x} {}", d.address, d.rules);
                     }
-                    BreakpadStackCfiRecord::Delta { address, text } => {
-                        writeln!(self.inner, "STACK CFI {:x} {}", address, text)
-                    }
-                },
+                }
                 BreakpadStackRecord::Win(r) => writeln!(self.inner, "STACK WIN {}", r.text),
             }?
         }

--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -26,9 +26,7 @@ use std::ops::Range;
 use thiserror::Error;
 
 use symbolic_common::{Arch, ByteView, UnknownArchError};
-use symbolic_debuginfo::breakpad::{
-    BreakpadError, BreakpadObject, BreakpadStackCfiRecord, BreakpadStackRecord,
-};
+use symbolic_debuginfo::breakpad::{BreakpadError, BreakpadObject, BreakpadStackRecord};
 use symbolic_debuginfo::dwarf::gimli::{
     BaseAddresses, CfaRule, CieOrFde, DebugFrame, EhFrame, Error as GimliError,
     FrameDescriptionEntry, Reader, Register, RegisterRule, UninitializedUnwindContext,
@@ -291,11 +289,13 @@ impl<W: Write> AsciiCfiWriter<W> {
                         self.inner,
                         "STACK CFI INIT {:x} {:x} {}",
                         r.start, r.size, r.init_rules
-                    );
+                    )?;
 
                     for d in r.deltas {
-                        writeln!(self.inner, "STACK CFI {:x} {}", d.address, d.rules);
+                        writeln!(self.inner, "STACK CFI {:x} {}", d.address, d.rules)?;
                     }
+
+                    Ok(())
                 }
                 BreakpadStackRecord::Win(r) => writeln!(self.inner, "STACK WIN {}", r.text),
             }?
@@ -796,7 +796,6 @@ enum CfiCacheInner<'a> {
 /// # Ok(())
 /// # }
 /// ```
-///
 pub struct CfiCache<'a> {
     inner: CfiCacheInner<'a>,
 }

--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -291,8 +291,10 @@ impl<W: Write> AsciiCfiWriter<W> {
                         r.start, r.size, r.init_rules
                     )?;
 
-                    for d in r.deltas {
-                        writeln!(self.inner, "STACK CFI {:x} {}", d.address, d.rules)?;
+                    for d in r.deltas() {
+                        if let Ok(d) = d {
+                            writeln!(self.inner, "STACK CFI {:x} {}", d.address, d.rules)?;
+                        }
                     }
 
                     Ok(())


### PR DESCRIPTION
As per @jan-auer's suggestions, a `BreakpadStackCfiRecord` now bundles together an init record and its associated "delta "records.