### PR TITLE
ref(compiler): Upgrade to Rust 1.51

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -3,6 +3,7 @@ name: Nightly CI
 on:
   schedule:
     - cron: "11 7 * * 1,4"
+  workflow_dispatch:
 
 env:
   RUSTFLAGS: -Dwarnings
@@ -10,6 +11,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    fail-fast: false
     strategy:
       matrix:
         rust: [nightly, beta]
@@ -25,7 +27,7 @@ jobs:
           override: true
           components: clippy
 
-      - name: Run clippy
+      - name: Run clippy ${{ matrix.rust }}
         uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -1,4 +1,4 @@
-name: Nightly CI
+name: Periodic CI
 
 on:
   schedule:

--- a/symbolic-common/src/types.rs
+++ b/symbolic-common/src/types.rs
@@ -850,9 +850,9 @@ impl AsRef<str> for Name<'_> {
     }
 }
 
-impl Into<String> for Name<'_> {
-    fn into(self) -> String {
-        self.string.into()
+impl From<Name<'_>> for String {
+    fn from(name: Name) -> Self {
+        name.string.into()
     }
 }
 

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -15,6 +15,7 @@ use crate::base::*;
 use crate::private::{Lines, Parse};
 
 mod parser {
+    #![allow(clippy::upper_case_acronyms)]
     use pest_derive::Parser;
 
     #[derive(Debug, Parser)]

--- a/symbolic-debuginfo/src/object.rs
+++ b/symbolic-debuginfo/src/object.rs
@@ -193,7 +193,7 @@ impl<'data> Object<'data> {
             ($kind:ident, $file:ident, $data:expr) => {
                 Object::$kind($file::parse(data).map_err(ObjectError::transparent)?)
             };
-        };
+        }
 
         let object = match Self::peek(data) {
             FileFormat::Breakpad => parse_object!(Breakpad, BreakpadObject, data),

--- a/symbolic-minidump/src/processor.rs
+++ b/symbolic-minidump/src/processor.rs
@@ -323,6 +323,7 @@ impl fmt::Debug for CodeModule {
 /// stack scanning, it can wind up with dubious frames.
 ///
 /// In rough order of "trust metric".
+#[allow(clippy::upper_case_acronyms)]
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum FrameTrust {

--- a/symbolic-minidump/src/processor.rs
+++ b/symbolic-minidump/src/processor.rs
@@ -142,9 +142,9 @@ impl From<DebugId> for CodeModuleId {
     }
 }
 
-impl Into<DebugId> for CodeModuleId {
-    fn into(self) -> DebugId {
-        self.inner
+impl From<CodeModuleId> for DebugId {
+    fn from(source: CodeModuleId) -> Self {
+        source.inner
     }
 }
 

--- a/symbolic/README.md
+++ b/symbolic/README.md
@@ -64,4 +64,8 @@ implementations for `serde::{Deserialize, Serialize}` on suitable types:
 - **`minidump-serde`**
 - **`unreal-serde`**
 
+## Minimal Rust Version
+
+This crate is known to require at least Rust 1.41.
+
 License: MIT

--- a/symbolic/src/lib.rs
+++ b/symbolic/src/lib.rs
@@ -58,6 +58,10 @@
 //! - **`debuginfo-serde`**
 //! - **`minidump-serde`**
 //! - **`unreal-serde`**
+//!
+//! ## Minimal Rust Version
+//!
+//! This crate is known to require at least Rust 1.41.
 
 #![warn(missing_docs)]
 


### PR DESCRIPTION
Fix some clippy warnings and disable some that we can't or want
to fix, because they're from a third party or would break the API.

The Into -> From changes are possible since the orphan rules have
been relaxed in Rust 1.41.  So we no longer work on older rust
versions.

Also bring the periodic CI job to the same level as the symbolicator
one.  Allowing to run it on demand and continue tests when one
fails.

#skip-changelog