### PR TITLE
feat(unwind): Add RangeMap struct

### DIFF
--- a/symbolic-minidump/Cargo.toml
+++ b/symbolic-minidump/Cargo.toml
@@ -43,9 +43,15 @@ cc = { version = "1.0.50", features = ["parallel"] }
 [dev-dependencies]
 criterion = { version = "0.3.4", features = [ "html_reports" ] }
 insta = "1.3.0"
+proptest = "1.0.0"
+rand = "0.8.3"
 symbolic-testutils = { path = "../symbolic-testutils" }
 similar-asserts = "1.0.0"
 walkdir = "2.3.1"
+
+[[bench]]
+name = "nested_range_map"
+harness = false
 
 [[bench]]
 name = "from_minidump"

--- a/symbolic-minidump/Cargo.toml
+++ b/symbolic-minidump/Cargo.toml
@@ -44,7 +44,7 @@ cc = { version = "1.0.50", features = ["parallel"] }
 criterion = { version = "0.3.4", features = [ "html_reports" ] }
 insta = "1.3.0"
 proptest = "1.0.0"
-rand = "0.8.3"
+rand = { version = "0.8.3", features = [ "small_rng" ] }
 symbolic-testutils = { path = "../symbolic-testutils" }
 similar-asserts = "1.0.0"
 walkdir = "2.3.1"

--- a/symbolic-minidump/benches/nested_range_map.rs
+++ b/symbolic-minidump/benches/nested_range_map.rs
@@ -1,0 +1,47 @@
+use std::ops::Range;
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use rand::{seq::SliceRandom, Rng};
+
+use symbolic_minidump::processor::NestedRangeMap;
+
+fn create_ranges(range: Range<u32>) -> Vec<Range<u32>> {
+    let mut rng = rand::thread_rng();
+    let mut ranges = Vec::new();
+    go(range, &mut ranges);
+    ranges.shuffle(&mut rng);
+
+    ranges
+}
+
+fn go(range: Range<u32>, acc: &mut Vec<Range<u32>>) {
+    let mid = (range.end - range.start) / 2;
+    if mid > range.start + 1 {
+        go(range.start..mid, acc);
+    }
+    if range.start > mid + 1 {
+        go(mid..range.end, acc);
+    }
+
+    acc.push(range);
+}
+
+pub fn nested_range_map_benchmark(c: &mut Criterion) {
+    let ranges = create_ranges(0..10_000);
+    c.bench_function("NestedRangeMap insertions", |b| {
+        b.iter_batched(
+            || ranges.clone(),
+            |ranges| {
+                let mut map = NestedRangeMap::default();
+                for range in ranges.into_iter() {
+                    let contents = format!("[{},{})", range.start, range.end);
+                    map.insert(range, contents);
+                }
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(benches, nested_range_map_benchmark);
+criterion_main!(benches);

--- a/symbolic-minidump/benches/nested_range_map.rs
+++ b/symbolic-minidump/benches/nested_range_map.rs
@@ -1,15 +1,14 @@
 use std::ops::Range;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use rand::{seq::SliceRandom, Rng};
+use rand::{seq::SliceRandom, SeedableRng};
 
 use symbolic_minidump::processor::NestedRangeMap;
 
-fn create_ranges(range: Range<u32>) -> Vec<Range<u32>> {
-    let mut rng = rand::thread_rng();
+fn create_ranges(range: Range<u32>, rng: &mut rand::rngs::SmallRng) -> Vec<Range<u32>> {
     let mut ranges = Vec::new();
     go(range, &mut ranges);
-    ranges.shuffle(&mut rng);
+    ranges.shuffle(rng);
 
     ranges
 }
@@ -27,7 +26,8 @@ fn go(range: Range<u32>, acc: &mut Vec<Range<u32>>) {
 }
 
 pub fn nested_range_map_benchmark(c: &mut Criterion) {
-    let ranges = create_ranges(0..10_000);
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
+    let ranges = create_ranges(0..10_000, &mut rng);
     c.bench_function("NestedRangeMap insertions", |b| {
         b.iter_batched(
             || ranges.clone(),

--- a/symbolic-minidump/src/processor.rs
+++ b/symbolic-minidump/src/processor.rs
@@ -187,11 +187,7 @@ pub struct NestedRangeMap<A, E> {
     inner: Vec<NestedRangeMapEntry<A, E>>,
 }
 
-impl<A: Ord + Copy + fmt::Debug, E> NestedRangeMap<A, E> {
-    fn from_vec_unchecked(inner: Vec<NestedRangeMapEntry<A, E>>) -> Self {
-        Self { inner }
-    }
-
+impl<A: Ord + Copy, E> NestedRangeMap<A, E> {
     /// Insert a range into the map.
 
     /// The insertion is valid if the new range does not
@@ -355,7 +351,7 @@ impl<A: Ord + Copy + fmt::Debug, E> NestedRangeMap<A, E> {
             );
             let mut sub_vec = vec![prev_entry];
             sub_vec.extend(self.inner.drain(tail));
-            self.inner[head].2 = Box::new(Self::from_vec_unchecked(sub_vec));
+            self.inner[head].2 = Box::new(Self { inner: sub_vec });
         } else {
             self.inner
                 .insert(indices.start, (range, contents, Box::new(Self::default())));


### PR DESCRIPTION
This adds a `RangeMap` struct containing a set of disjoint ranges. It has significant overlap with `symbolic_debuginfo::SymbolMap`, but is generic.