### PR TITLE
ref(debuginfo): Breakpad stack record refactoring

### DIFF
--- a/symbolic-debuginfo/src/breakpad.pest
+++ b/symbolic-debuginfo/src/breakpad.pest
@@ -52,7 +52,20 @@ public = { "PUBLIC" ~ multiple? ~ addr ~ param_size ~ name? }
 // Given a stack frame, a STACK WIN record indicates how to find the frame that called it.
 // Example: "STACK WIN 4 2170 14 1 0 0 0 0 0 1 $eip 4 + ^ = $esp $ebp 8 + = $ebp $ebp ^ ="
 // see <https://github.com/google/breakpad/blob/master/docs/symbol_files.md#stack-win-records>
-stack_win = { "STACK WIN" ~ text }
+stack_win = { "STACK WIN"
+                ~ frame_type // type
+                ~ hex // rva
+                ~ hex // code_size
+                ~ hex // prologue_size
+                ~ hex // epilogue_size
+                ~ hex // parameter_size
+                ~ hex // saved_register_size
+                ~ hex // local_size
+                ~ hex // max_stack_size
+                ~ hex // has_program_string
+                ~ text // program_string_OR_allocates_base_pointer
+            }
+frame_type = { "0" | "4" }
 
 // STACK CFI record
 // STACK CFI ("Call Frame Information") records describe how to walk the stack when execution is at a given machine instruction.

--- a/symbolic-debuginfo/src/breakpad.pest
+++ b/symbolic-debuginfo/src/breakpad.pest
@@ -1,7 +1,7 @@
 breakpad = { SOI ~ module ~ (NEWLINE ~ record)* ~ NEWLINE* ~ EOI }
 record = { module | info | file | func_lines | public | stack }
 func_lines = { func ~ (NEWLINE ~ !record ~ line)* }
-stack = { stack_cfi | stack_win }
+stack = { stack_cfi_init | stack_win }
 
 // MODULE record
 // A MODULE record provides meta-information about the module the symbol file describes.
@@ -58,7 +58,6 @@ stack_win = { "STACK WIN" ~ text }
 // STACK CFI ("Call Frame Information") records describe how to walk the stack when execution is at a given machine instruction.
 // Example: "STACK CFI INIT 804c4b0 40 .cfa: $esp 4 + $eip: .cfa 4 - ^"
 // see <https://github.com/google/breakpad/blob/master/docs/symbol_files.md#stack-cfi-records>
-stack_cfi = { stack_cfi_init ~ ( NEWLINE ~ stack_cfi_delta)* }
 stack_cfi_init = { "STACK CFI INIT" ~ addr ~ size ~ rules}
 stack_cfi_delta = { "STACK CFI" ~ addr ~ rules }
 

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -833,6 +833,16 @@ pub struct BreakpadStackRecords<'d> {
     finished: bool,
 }
 
+impl<'d> BreakpadStackRecords<'d> {
+    /// Creates an iterator over [`BreakpadStackRecord`]s contained in a slice of data.
+    pub fn new(data: &'d [u8]) -> Self {
+        Self {
+            lines: Lines::new(data),
+            finished: false,
+        }
+    }
+}
+
 impl<'d> Iterator for BreakpadStackRecords<'d> {
     type Item = Result<BreakpadStackRecord<'d>, BreakpadError>;
 

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -786,28 +786,28 @@ pub struct BreakpadStackWinRecord<'d> {
     pub frame_type: BreakpadStackWinRecordType,
 
     /// The starting address covered by this record, relative to the module's load address.
-    pub rva: u64,
+    pub rva: u32,
 
     /// The number of bytes covered by this record.
-    pub code_size: u64,
+    pub code_size: u32,
 
     /// The size of the prologue machine code within the record's range in bytes.
-    pub prologue_size: u64,
+    pub prologue_size: u16,
 
     /// The size of the epilogue machine code within the record's range in bytes.
-    pub epilogue_size: u64,
+    pub epilogue_size: u16,
 
     /// The number of bytes this function expects to be passed as arguments.
-    pub parameter_size: u64,
+    pub parameter_size: u32,
 
     /// The number of bytes used by this function to save callee-saves registers.
-    pub saved_register_size: u64,
+    pub saved_register_size: u16,
 
     /// The number of bytes used to save this function's local variables.
-    pub local_size: u64,
+    pub local_size: u32,
 
     /// The maximum number of bytes pushed on the stack in the frame.
-    pub max_stack_size: u64,
+    pub max_stack_size: u32,
 
     /// Whether this record contains a program string.
     pub has_program_string: bool,
@@ -842,14 +842,14 @@ impl<'d> BreakpadStackWinRecord<'d> {
         } else {
             BreakpadStackWinRecordType::Fpo
         };
-        let rva = u64::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
-        let code_size = u64::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
-        let prologue_size = u64::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
-        let epilogue_size = u64::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
-        let parameter_size = u64::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
-        let saved_register_size = u64::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
-        let local_size = u64::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
-        let max_stack_size = u64::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
+        let rva = u32::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
+        let code_size = u32::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
+        let prologue_size = u16::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
+        let epilogue_size = u16::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
+        let parameter_size = u32::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
+        let saved_register_size = u16::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
+        let local_size = u32::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
+        let max_stack_size = u32::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
         let has_program_string = pairs.next().unwrap().as_str() != "0";
         let (allocates_base_pointer, program_string) = if has_program_string {
             (false, pairs.next().unwrap().as_str())

--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -316,9 +316,9 @@ impl<W: Write> AsciiCfiWriter<W> {
                     r.saved_register_size,
                     r.local_size,
                     r.max_stack_size,
-                    if r.has_program_string { "1" } else { "0" },
-                    if r.has_program_string {
-                        r.program_string
+                    if r.program_string.is_some() { "1" } else { "0" },
+                    if let Some(ps) = r.program_string {
+                        ps
                     } else if r.allocates_base_pointer {
                         "1"
                     } else {

--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -304,22 +304,22 @@ impl<W: Write> AsciiCfiWriter<W> {
                 BreakpadStackRecord::Win(r) => writeln!(
                     self.inner,
                     "STACK WIN {} {:x} {:x} {:x} {:x} {:x} {:x} {:x} {:x} {} {}",
-                    match r.frame_type {
+                    match r.ty {
                         BreakpadStackWinRecordType::Fpo => "0",
                         BreakpadStackWinRecordType::FrameData => "4",
                     },
-                    r.rva,
+                    r.code_start,
                     r.code_size,
-                    r.prologue_size,
-                    r.epilogue_size,
-                    r.parameter_size,
-                    r.saved_register_size,
-                    r.local_size,
+                    r.prolog_size,
+                    r.epilog_size,
+                    r.params_size,
+                    r.saved_regs_size,
+                    r.locals_size,
                     r.max_stack_size,
                     if r.program_string.is_some() { "1" } else { "0" },
                     if let Some(ps) = r.program_string {
                         ps
-                    } else if r.allocates_base_pointer {
+                    } else if r.uses_base_pointer {
                         "1"
                     } else {
                         "0"

--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -26,7 +26,9 @@ use std::ops::Range;
 use thiserror::Error;
 
 use symbolic_common::{Arch, ByteView, UnknownArchError};
-use symbolic_debuginfo::breakpad::{BreakpadError, BreakpadObject, BreakpadStackRecord, BreakpadStackWinRecordType};
+use symbolic_debuginfo::breakpad::{
+    BreakpadError, BreakpadObject, BreakpadStackRecord, BreakpadStackWinRecordType,
+};
 use symbolic_debuginfo::dwarf::gimli::{
     BaseAddresses, CfaRule, CieOrFde, DebugFrame, EhFrame, Error as GimliError,
     FrameDescriptionEntry, Reader, Register, RegisterRule, UninitializedUnwindContext,


### PR DESCRIPTION
This PR mainly serves to structure `BreakpadStackWinRecord` in a similar way as `BreakpadStackCfiRecord`. One thing I am not entirely sure about is how to handle the issue of program string vs `allocates_base_pointer` field. Briefly, the next-to-last field of a `STACK WIN` record indicates whether the last field is a program string or an `allocates_base_pointer` flag. For now I just gave the struct fields for both and set the one that isn't used to a dummy value, but that's not exactly the most rigorously typed solution. Is this good enough or should I use e.g. an enum?

Aside from `BreakpadStackWinRecord`, there is also new constructor for the `BreakpadStackRecords` iterator and the `BreakpadStackCfiRecord::parse` method has had its `deltas` argument removed.