### PR TITLE
feat(debuginfo): Add back PList parsing

### DIFF
--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -24,6 +24,7 @@ all-features = true
 
 [dependencies]
 dmsort = "1.0.1"
+elementtree = "0.5.0"
 fallible-iterator = "0.2.0"
 flate2 = { version = "1.0.13", features = ["rust_backend"], default-features = false }
 gimli = { version = "0.23.0", features = ["read", "std"], default-features = false }

--- a/symbolic-debuginfo/src/macho/bcsymbolmap.rs
+++ b/symbolic-debuginfo/src/macho/bcsymbolmap.rs
@@ -367,7 +367,7 @@ fn uuid_from_plist(data: &[u8]) -> Result<DebugId, PListError> {
     for element in dict.children() {
         if element.tag().name() == "key" && element.text() == "DBGOriginalUUID" {
             found_key = true;
-        } else if found_key == true {
+        } else if found_key {
             raw_original = Some(element.text().to_string());
             break;
         }

--- a/symbolic-debuginfo/src/macho/bcsymbolmap.rs
+++ b/symbolic-debuginfo/src/macho/bcsymbolmap.rs
@@ -191,7 +191,7 @@ impl<'a, 'd> Iterator for BcSymbolMapIterator<'a, 'd> {
 
 impl FusedIterator for BcSymbolMapIterator<'_, '_> {}
 
-/// Error type when parsing an Apple PropertyList into [`UuidMapping`].
+/// Error for handling or creating a [`UuidMapping`].
 #[derive(Debug, Error)]
 #[error("{kind}")]
 pub struct UuidMappingError {
@@ -224,7 +224,7 @@ impl From<ParseDebugIdError> for UuidMappingError {
     }
 }
 
-/// Error kind for [`PListError`].
+/// Error kind for [`UuidMappingError`].
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum UuidMappingErrorKind {
@@ -254,8 +254,10 @@ impl fmt::Display for UuidMappingErrorKind {
 /// This is used e.g. when dealing with bitcode builds, when Apple compiles objects from
 /// bitcode these objects will have new UUIDs as debug identifiers.  This mapping can be
 /// found in the `dSYMs/<object-id>/Contents/Resources/<object-id>.plist` file of downloaded
-/// debugging symbols.  This struct allows you to keep track of such a mapping and provides
-/// support for parsing it from the ProperyList file format.
+/// debugging symbols.
+///
+/// This struct allows you to keep track of such a mapping and provides support for parsing
+/// it from the ProperyList file format.
 #[derive(Clone, Copy, Debug)]
 pub struct UuidMapping {
     dsym_uuid: DebugId,

--- a/symbolic-debuginfo/src/macho/mod.rs
+++ b/symbolic-debuginfo/src/macho/mod.rs
@@ -18,7 +18,7 @@ use crate::private::{MonoArchive, MonoArchiveObjects, Parse};
 
 mod bcsymbolmap;
 
-pub use bcsymbolmap::{BcSymbolMap, BcSymbolMapError, BitcodeUuidMapping};
+pub use bcsymbolmap::*;
 
 /// Prefix for hidden symbols from Apple BCSymbolMap builds.
 const SWIFT_HIDDEN_PREFIX: &str = "__hidden#";

--- a/symbolic-debuginfo/src/macho/mod.rs
+++ b/symbolic-debuginfo/src/macho/mod.rs
@@ -18,7 +18,7 @@ use crate::private::{MonoArchive, MonoArchiveObjects, Parse};
 
 mod bcsymbolmap;
 
-pub use bcsymbolmap::{BcSymbolMap, BcSymbolMapError};
+pub use bcsymbolmap::{BcSymbolMap, BcSymbolMapError, BitcodeUuidMapping};
 
 /// Prefix for hidden symbols from Apple BCSymbolMap builds.
 const SWIFT_HIDDEN_PREFIX: &str = "__hidden#";


### PR DESCRIPTION
But the type this time round is a simple mapping of UUIDs, the plist
is never representable itself so stays out of the API and allows us to
change the implementation.

#skip-changelog