### PR TITLE
fix(unwind): Constants don't have to start with .

### DIFF
--- a/symbolic-unwind/src/evaluator/mod.rs
+++ b/symbolic-unwind/src/evaluator/mod.rs
@@ -8,7 +8,7 @@
 //! <assignment> ::=  <variable> <expr> =
 //! <expr>       ::=  <identifier> | <literal> | <expr> <expr> <binop> | <expr> ^
 //! <identifier> ::=  <constant> | <variable>
-//! <constant>   ::=  \.[a-zA-Z0-9]+
+//! <constant>   ::=  \.?[a-zA-Z0-9]+
 //! <variable>   ::=  \$[a-zA-Z0-9]+
 //! <binop>      ::=  + | - | * | / | % | @
 //! <literal>    ::=  -?[0-9]+


### PR DESCRIPTION
From real-world data it's clear that constants actually don't have to have a leading `.`.