### PR TITLE
test(debuginfo): Benchmark breakpad parsers

### DIFF
--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -46,7 +46,7 @@ wasmparser = "0.59.0"
 zip = "0.5.2"
 
 [dev-dependencies]
-criterion = "0.3.4"
+criterion = { version = "0.3", features = [ "html_reports" ] }
 insta = "1.3.0"
 similar-asserts = "1.0.0"
 symbolic-testutils = { path = "../symbolic-testutils" }

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -46,7 +46,7 @@ wasmparser = "0.59.0"
 zip = "0.5.2"
 
 [dev-dependencies]
-criterion = { version = "0.3", features = [ "html_reports" ] }
+criterion = { version = "0.3.4", features = [ "html_reports" ] }
 insta = "1.3.0"
 similar-asserts = "1.0.0"
 symbolic-testutils = { path = "../symbolic-testutils" }

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -46,6 +46,11 @@ wasmparser = "0.59.0"
 zip = "0.5.2"
 
 [dev-dependencies]
+criterion = "0.3.4"
 insta = "1.3.0"
 similar-asserts = "1.0.0"
 symbolic-testutils = { path = "../symbolic-testutils" }
+
+[[bench]]
+name = "breakpad_parser"
+harness = false

--- a/symbolic-debuginfo/benches/breakpad_parser.rs
+++ b/symbolic-debuginfo/benches/breakpad_parser.rs
@@ -10,77 +10,81 @@ use symbolic_testutils::fixture;
 pub fn breakpad_parser(c: &mut Criterion) {
     let mut group = c.benchmark_group("Breakpad parser benchmarks");
 
-    let mut buf_reader = BufReader::new(File::open(fixture("linux/crash.sym")).unwrap());
-    let mut buffer = String::new();
-    buf_reader.read_to_string(&mut buffer).unwrap();
-    let view = ByteView::from_slice(&buffer.as_bytes());
-    let object: BreakpadObject = BreakpadObject::parse(&view).unwrap();
+    for file in ["linux/crash.sym", "macos/crash.sym", "windows/crash.sym"].iter() {
+        let mut buf_reader = BufReader::new(File::open(fixture(file)).unwrap());
+        let mut buffer = String::new();
+        buf_reader.read_to_string(&mut buffer).unwrap();
+        let view = ByteView::from_slice(&buffer.as_bytes());
+        let object: BreakpadObject = BreakpadObject::parse(&view).unwrap();
 
-    group.bench_with_input(
-        BenchmarkId::new("info records", "linux/crash.sym"),
-        &object,
-        |b, object| {
-            b.iter(|| {
-                for record in object.info_records() {
-                    record.unwrap();
-                }
-            })
-        },
-    );
-
-    group.bench_with_input(
-        BenchmarkId::new("func and line records", "linux/crash.sym"),
-        &object,
-        |b, object| {
-            b.iter(|| {
-                for record in object.func_records() {
-                    for line in record.unwrap().lines() {
-                        line.unwrap();
+        group.bench_with_input(
+            BenchmarkId::new("info records", file),
+            &object,
+            |b, object| {
+                b.iter(|| {
+                    for record in object.info_records() {
+                        record.unwrap();
                     }
-                }
-            })
-        },
-    );
+                })
+            },
+        );
 
-    group.bench_with_input(
-        BenchmarkId::new("public records", "linux/crash.sym"),
-        &object,
-        |b, object| {
-            b.iter(|| {
-                for record in object.public_records() {
-                    record.unwrap();
-                }
-            })
-        },
-    );
-
-    group.bench_with_input(
-        BenchmarkId::new("file records", "linux/crash.sym"),
-        &object,
-        |b, object| {
-            b.iter(|| {
-                for record in object.file_records() {
-                    record.unwrap();
-                }
-            })
-        },
-    );
-
-    group.bench_with_input(
-        BenchmarkId::new("stack records", "linux/crash.sym"),
-        &object,
-        |b, object| {
-            b.iter(|| {
-                for record in object.stack_records() {
-                    if let BreakpadStackRecord::Cfi(cfi_record) = record.unwrap() {
-                        for delta in cfi_record.deltas() {
-                            delta.unwrap();
+        group.bench_with_input(
+            BenchmarkId::new("func and line records", file),
+            &object,
+            |b, object| {
+                b.iter(|| {
+                    for record in object.func_records() {
+                        for line in record.unwrap().lines() {
+                            line.unwrap();
                         }
                     }
-                }
-            })
-        },
-    );
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("public records", file),
+            &object,
+            |b, object| {
+                b.iter(|| {
+                    for record in object.public_records() {
+                        record.unwrap();
+                    }
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("file records", file),
+            &object,
+            |b, object| {
+                b.iter(|| {
+                    for record in object.file_records() {
+                        record.unwrap();
+                    }
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("stack records", file),
+            &object,
+            |b, object| {
+                b.iter(|| {
+                    for record in object.stack_records() {
+                        if let BreakpadStackRecord::Cfi(cfi_record) = record.unwrap() {
+                            for delta in cfi_record.deltas() {
+                                delta.unwrap();
+                            }
+                        }
+                    }
+                })
+            },
+        );
+    }
+
+    group.finish();
 }
 
 criterion_group!(benches, breakpad_parser);

--- a/symbolic-debuginfo/benches/breakpad_parser.rs
+++ b/symbolic-debuginfo/benches/breakpad_parser.rs
@@ -1,0 +1,87 @@
+use std::fs::File;
+use std::io::{BufReader, Read};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use symbolic_common::ByteView;
+use symbolic_debuginfo::breakpad::{BreakpadObject, BreakpadStackRecord};
+use symbolic_testutils::fixture;
+
+pub fn breakpad_parser(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Breakpad parser benchmarks");
+
+    let mut buf_reader = BufReader::new(File::open(fixture("linux/crash.sym")).unwrap());
+    let mut buffer = String::new();
+    buf_reader.read_to_string(&mut buffer).unwrap();
+    let view = ByteView::from_slice(&buffer.as_bytes());
+    let object: BreakpadObject = BreakpadObject::parse(&view).unwrap();
+
+    group.bench_with_input(
+        BenchmarkId::new("info records", "linux/crash.sym"),
+        &object,
+        |b, object| {
+            b.iter(|| {
+                for record in object.info_records() {
+                    record.unwrap();
+                }
+            })
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("func and line records", "linux/crash.sym"),
+        &object,
+        |b, object| {
+            b.iter(|| {
+                for record in object.func_records() {
+                    for line in record.unwrap().lines() {
+                        line.unwrap();
+                    }
+                }
+            })
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("public records", "linux/crash.sym"),
+        &object,
+        |b, object| {
+            b.iter(|| {
+                for record in object.public_records() {
+                    record.unwrap();
+                }
+            })
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("file records", "linux/crash.sym"),
+        &object,
+        |b, object| {
+            b.iter(|| {
+                for record in object.file_records() {
+                    record.unwrap();
+                }
+            })
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("stack records", "linux/crash.sym"),
+        &object,
+        |b, object| {
+            b.iter(|| {
+                for record in object.stack_records() {
+                    if let BreakpadStackRecord::Cfi(cfi_record) = record.unwrap() {
+                        for delta in cfi_record.deltas() {
+                            delta.unwrap();
+                        }
+                    }
+                }
+            })
+        },
+    );
+}
+
+criterion_group!(benches, breakpad_parser);
+criterion_main!(benches);


### PR DESCRIPTION
This adds a group of `criterion` benchmarks that test the various Breakpad record parsers.