### PR TITLE
Implement compact unwinding info

### DIFF
--- a/py/tests/res/minidump/crash_macos.sym
+++ b/py/tests/res/minidump/crash_macos.sym
@@ -1,3 +1,5 @@
+STACK CFI INIT 1170 1a0 .cfa: $rsp 432 + .ra: .cfa -8 + ^
+STACK CFI INIT 1310 70 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 1380 8 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 1381 .cfa: $rsp 16 +
 STACK CFI INIT 1390 18 .cfa: $rsp 8 + .ra: .cfa -8 + ^
@@ -6,187 +8,450 @@ STACK CFI 13b1 .cfa: $rsp 16 +
 STACK CFI INIT 13c0 24 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 13f0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 13f1 .cfa: $rsp 16 +
+STACK CFI INIT 1400 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 1450 90 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 14e0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 14e1 .cfa: $rsp 16 +
+STACK CFI INIT 14f0 f0 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 15e0 100 .cfa: $rsp 80 + .ra: .cfa -8 + ^
+STACK CFI INIT 16e0 c0 .cfa: $rsp 64 + .ra: .cfa -8 + ^
+STACK CFI INIT 17a0 110 .cfa: $rsp 96 + .ra: .cfa -8 + ^
+STACK CFI INIT 18b0 40 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 18f0 2e0 .cfa: $rsp 192 + .ra: .cfa -8 + ^
+STACK CFI INIT 1bd0 40 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 1c10 2e0 .cfa: $rsp 192 + .ra: .cfa -8 + ^
+STACK CFI INIT 1ef0 150 .cfa: $rsp 112 + .ra: .cfa -8 + ^
+STACK CFI INIT 2040 90 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 20d0 f .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 20e0 160 .cfa: $rsp 80 + .ra: .cfa -8 + ^
+STACK CFI INIT 2240 170 .cfa: $rsp 64 + .ra: .cfa -8 + ^
+STACK CFI INIT 23b0 120 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 24d0 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 24e0 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 2510 b0 .cfa: $rsp 64 + .ra: .cfa -8 + ^
 STACK CFI INIT 25c0 12 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 25e0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 25e1 .cfa: $rsp 16 +
+STACK CFI INIT 25f0 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 2640 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 2690 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 29f0 20 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 2a10 d .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 2a20 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 2a21 .cfa: $rsp 16 +
 STACK CFI INIT 2a30 46 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 2a80 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 2a81 .cfa: $rsp 16 +
+STACK CFI INIT 2a90 140 .cfa: $rsp 128 + .ra: .cfa -8 + ^
+STACK CFI INIT 2bd0 1b0 .cfa: $rsp 208 + .ra: .cfa -8 + ^
+STACK CFI INIT 2d80 70 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 2df0 23 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 2df1 .cfa: $rsp 16 +
+STACK CFI INIT 2e20 400 .cfa: $rsp 96 + .ra: .cfa -8 + ^
+STACK CFI INIT 3220 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 3270 33 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 32b0 33 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 32f0 100 .cfa: $rsp 160 + .ra: .cfa -8 + ^
+STACK CFI INIT 33f0 160 .cfa: $rsp 128 + .ra: .cfa -8 + ^
+STACK CFI INIT 3550 90 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 35e0 f0 .cfa: $rsp 80 + .ra: .cfa -8 + ^
 STACK CFI INIT 36d0 8 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 36e0 23 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 36e1 .cfa: $rsp 16 +
+STACK CFI INIT 3710 140 .cfa: $rsp 256 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
+STACK CFI INIT 3850 140 .cfa: $rsp 224 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
+STACK CFI INIT 61a0 f0 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 6290 320 .cfa: $rsp 336 + .ra: .cfa -8 + ^
+STACK CFI INIT 65b0 f0 .cfa: $rsp 144 + .ra: .cfa -8 + ^
+STACK CFI INIT 66a0 40 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 66e0 b8 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 67a0 300 .cfa: $rsp 304 + .ra: .cfa -8 + ^
 STACK CFI INIT 6aa0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 6aa1 .cfa: $rsp 16 +
+STACK CFI INIT 6ab0 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 6ae0 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 6af0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 6b00 f0 .cfa: $rsp 56 + .ra: .cfa -8 + ^
+STACK CFI INIT 6bf0 200 .cfa: $rsp 256 + .ra: .cfa -8 + ^
+STACK CFI INIT 6df0 140 .cfa: $rsp 176 + .ra: .cfa -8 + ^
+STACK CFI INIT 6f30 150 .cfa: $rsp 192 + .ra: .cfa -8 + ^
 STACK CFI INIT 7080 1a .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 70a0 220 .cfa: $rsp 304 + .ra: .cfa -8 + ^
+STACK CFI INIT 72c0 110 .cfa: $rsp 160 + .ra: .cfa -8 + ^
 STACK CFI INIT 73d0 f .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 73e0 120 .cfa: $rsp 176 + .ra: .cfa -8 + ^
+STACK CFI INIT 7500 4d0 .cfa: $rsp 528 + .ra: .cfa -8 + ^
+STACK CFI INIT 79d0 70 .cfa: $rsp 80 + .ra: .cfa -8 + ^
 STACK CFI INIT 7a40 1d .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 7a41 .cfa: $rsp 16 +
+STACK CFI INIT 7a60 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 7a90 4c0 .cfa: $rsp 560 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
+STACK CFI INIT 7f50 40 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 7f90 400 .cfa: $rsp 432 + .ra: .cfa -8 + ^
 STACK CFI INIT 8390 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 8391 .cfa: $rsp 16 +
+STACK CFI INIT 83a0 210 .cfa: $rsp 256 + .ra: .cfa -8 + ^
+STACK CFI INIT 85b0 2f0 .cfa: $rsp 192 + .ra: .cfa -8 + ^
 STACK CFI INIT 88a0 1a .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 88c0 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 88f0 1b .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 8910 230 .cfa: $rsp 304 + .ra: .cfa -8 + ^
+STACK CFI INIT 8b40 1b0 .cfa: $rsp 176 + .ra: .cfa -8 + ^
+STACK CFI INIT 8cf0 120 .cfa: $rsp 112 + .ra: .cfa -8 + ^
+STACK CFI INIT 8e10 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 8e40 190 .cfa: $rsp 208 + .ra: .cfa -8 + ^
+STACK CFI INIT 8fd0 110 .cfa: $rsp 144 + .ra: .cfa -8 + ^
+STACK CFI INIT 90e0 e0 .cfa: $rsp 128 + .ra: .cfa -8 + ^
+STACK CFI INIT 91c0 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 91f0 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 9200 370 .cfa: $rsp 432 + .ra: .cfa -8 + ^
 STACK CFI INIT 9570 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 9580 100 .cfa: $rsp 56 + .ra: .cfa -8 + ^
 STACK CFI INIT 9680 18 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 96a0 d10 .cfa: $rsp 720 + .ra: .cfa -8 + ^
+STACK CFI INIT a3b0 470 .cfa: $rsp 416 + .ra: .cfa -8 + ^
+STACK CFI INIT a820 2c0 .cfa: $rsp 272 + .ra: .cfa -8 + ^
+STACK CFI INIT aae0 3b0 .cfa: $rsp 352 + .ra: .cfa -8 + ^
+STACK CFI INIT ae90 1b0 .cfa: $rsp 160 + .ra: .cfa -8 + ^
+STACK CFI INIT b040 4c0 .cfa: $rsp 304 + .ra: .cfa -8 + ^
+STACK CFI INIT b500 70 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT b570 470 .cfa: $rsp 448 + .ra: .cfa -8 + ^
+STACK CFI INIT b9e0 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT ba30 120 .cfa: $rsp 160 + .ra: .cfa -8 + ^
+STACK CFI INIT bb50 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT bb80 70 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT bbf0 1d0 .cfa: $rsp 320 + .ra: .cfa -8 + ^
+STACK CFI INIT bdc0 540 .cfa: $rsp 448 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
+STACK CFI INIT c300 60 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT c360 160 .cfa: $rsp 192 + .ra: .cfa -8 + ^
+STACK CFI INIT c4c0 60 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT c520 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT c550 1b0 .cfa: $rsp 144 + .ra: .cfa -8 + ^
 STACK CFI INIT c700 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI c701 .cfa: $rsp 16 +
 STACK CFI INIT c710 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI c711 .cfa: $rsp 16 +
+STACK CFI INIT c720 70 .cfa: $rsp 80 + .ra: .cfa -8 + ^
+STACK CFI INIT c790 460 .cfa: $rsp 400 + .ra: .cfa -8 + ^
+STACK CFI INIT cbf0 40 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT cc30 e0 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT cd10 f0 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT ce00 f .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI ce01 .cfa: $rsp 16 +
 STACK CFI INIT ce10 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI ce11 .cfa: $rsp 16 +
+STACK CFI INIT ce20 100 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT cf20 110 .cfa: $rsp 656 + .ra: .cfa -8 + ^
+STACK CFI INIT d030 680 .cfa: $rsp 736 + .ra: .cfa -8 + ^
+STACK CFI INIT d6b0 100 .cfa: $rsp 368 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
+STACK CFI INIT d7b0 670 .cfa: $rsp 832 + .ra: .cfa -8 + ^
+STACK CFI INIT de20 20 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT de40 38 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT de80 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI de81 .cfa: $rsp 16 +
+STACK CFI INIT de90 650 .cfa: $rsp 528 + .ra: .cfa -8 + ^
 STACK CFI INIT e4e0 24 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI e4e1 .cfa: $rsp 16 +
+STACK CFI INIT e510 60 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT e570 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI e571 .cfa: $rsp 16 +
+STACK CFI INIT e580 2b0 .cfa: $rsp 736 + .ra: .cfa -8 + ^
+STACK CFI INIT e830 180 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT e9b0 1c0 .cfa: $rsp 64 + .ra: .cfa -8 + ^
+STACK CFI INIT eb70 80 .cfa: $rsp 80 + .ra: .cfa -8 + ^
+STACK CFI INIT ebf0 3a0 .cfa: $rsp 176 + .ra: .cfa -8 + ^
 STACK CFI INIT ef90 e .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT efa0 30 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT efd0 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT f000 60 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT f060 60 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT f0c0 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT f0f0 e .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT f100 11 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT f120 40 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT f160 1e .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT f180 18 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT f1a0 18 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT f1c0 80 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT f240 19 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT f260 170 .cfa: $rsp 112 + .ra: .cfa -8 + ^
 STACK CFI INIT f3d0 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT f3e0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI f3e1 .cfa: $rsp 16 +
+STACK CFI INIT f3f0 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT f420 4b0 .cfa: $rsp 1344 + .ra: .cfa -8 + ^
 STACK CFI INIT f8d0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI f8d1 .cfa: $rsp 16 +
 STACK CFI INIT f8e0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI f8e1 .cfa: $rsp 16 +
 STACK CFI INIT f8f0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI f8f1 .cfa: $rsp 16 +
+STACK CFI INIT f900 210 .cfa: $rsp 112 + .ra: .cfa -8 + ^
 STACK CFI INIT fb10 e .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT fb20 b0 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT fbd0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI fbd1 .cfa: $rsp 16 +
 STACK CFI INIT fbe0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI fbe1 .cfa: $rsp 16 +
+STACK CFI INIT fbf0 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT fc20 19 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT fc40 640 .cfa: $rsp 608 + .ra: .cfa -8 + ^
+STACK CFI INIT 10280 420 .cfa: $rsp 416 + .ra: .cfa -8 + ^
+STACK CFI INIT 106a0 2f0 .cfa: $rsp 288 + .ra: .cfa -8 + ^
+STACK CFI INIT 10990 b40 .cfa: $rsp 1968 + .ra: .cfa -8 + ^
+STACK CFI INIT 114d0 450 .cfa: $rsp 320 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $rbx: .cfa -24 + ^
+STACK CFI INIT 11920 310 .cfa: $rsp 416 + .ra: .cfa -8 + ^
+STACK CFI INIT 11fa0 1b0 .cfa: $rsp 160 + .ra: .cfa -8 + ^
+STACK CFI INIT 12150 a0 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 121f0 90 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 12280 12 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 122a0 e .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 122b0 d0 .cfa: $rsp 80 + .ra: .cfa -8 + ^
 STACK CFI INIT 12380 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 12381 .cfa: $rsp 16 +
 STACK CFI INIT 12390 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 12391 .cfa: $rsp 16 +
+STACK CFI INIT 123a0 1d0 .cfa: $rsp 176 + .ra: .cfa -8 + ^
+STACK CFI INIT 12570 3c0 .cfa: $rsp 336 + .ra: .cfa -8 + ^
+STACK CFI INIT 12930 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 12960 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 129b0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 129b1 .cfa: $rsp 16 +
 STACK CFI INIT 129c0 21 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 129f0 b0 .cfa: $rsp 64 + .ra: .cfa -8 + ^
+STACK CFI INIT 12aa0 a0 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 12b40 b0 .cfa: $rsp 64 + .ra: .cfa -8 + ^
+STACK CFI INIT 12bf0 290 .cfa: $rsp 880 + .ra: .cfa -8 + ^
+STACK CFI INIT 12e80 330 .cfa: $rsp 1408 + .ra: .cfa -8 + ^
+STACK CFI INIT 131b0 b0 .cfa: $rsp 64 + .ra: .cfa -8 + ^
 STACK CFI INIT 13260 1d .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 13280 21 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 132b0 70 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 13320 12 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 13340 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 13341 .cfa: $rsp 16 +
+STACK CFI INIT 13350 70 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 133c0 12 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 133e0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 133e1 .cfa: $rsp 16 +
+STACK CFI INIT 133f0 230 .cfa: $rsp 208 + .ra: .cfa -8 + ^
+STACK CFI INIT 13620 2e0 .cfa: $rsp 1168 + .ra: .cfa -8 + ^
+STACK CFI INIT 13900 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 13930 b0 .cfa: $rsp 64 + .ra: .cfa -8 + ^
 STACK CFI INIT 139e0 12 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 13a00 c0 .cfa: $rsp 64 + .ra: .cfa -8 + ^
 STACK CFI INIT 13ac0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 13ac1 .cfa: $rsp 16 +
+STACK CFI INIT 13ad0 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 13b00 b0 .cfa: $rsp 64 + .ra: .cfa -8 + ^
 STACK CFI INIT 13bb0 12 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 13bd0 c0 .cfa: $rsp 64 + .ra: .cfa -8 + ^
 STACK CFI INIT 13c90 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 13c91 .cfa: $rsp 16 +
+STACK CFI INIT 13ca0 280 .cfa: $rsp 1248 + .ra: .cfa -8 + ^
+STACK CFI INIT 13f20 70 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 13f90 12 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 13fb0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 13fb1 .cfa: $rsp 16 +
+STACK CFI INIT 13fc0 70 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 14030 12 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 14050 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 14051 .cfa: $rsp 16 +
+STACK CFI INIT 14060 880 .cfa: $rsp 560 + .ra: .cfa -8 + ^
+STACK CFI INIT 148e0 90 .cfa: $rsp 64 + .ra: .cfa -8 + ^
+STACK CFI INIT 14970 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 149a0 f .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 149b0 f .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 149c0 f .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 149d0 d0 .cfa: $rsp 64 + .ra: .cfa -8 + ^
 STACK CFI INIT 14aa0 e .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 14f80 e .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 14f90 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 14fc0 170 .cfa: $rsp 64 + .ra: .cfa -8 + ^
 STACK CFI INIT 15130 12 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 15150 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 15151 .cfa: $rsp 16 +
 STACK CFI INIT 15160 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 15161 .cfa: $rsp 16 +
+STACK CFI INIT 15170 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 151a0 2b .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 151d0 c0 .cfa: $rsp 64 + .ra: .cfa -8 + ^
 STACK CFI INIT 15290 12 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 152b0 c0 .cfa: $rsp 64 + .ra: .cfa -8 + ^
 STACK CFI INIT 15370 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 15371 .cfa: $rsp 16 +
+STACK CFI INIT 15380 70 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 153f0 12 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 15410 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 15411 .cfa: $rsp 16 +
+STACK CFI INIT 15420 70 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 15490 12 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 154b0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 154b1 .cfa: $rsp 16 +
+STACK CFI INIT 154c0 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 15510 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 15511 .cfa: $rsp 16 +
 STACK CFI INIT 15520 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 15521 .cfa: $rsp 16 +
+STACK CFI INIT 15530 1a0 .cfa: $rsp 240 + .ra: .cfa -8 + ^
 STACK CFI INIT 156d0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 156e0 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 15710 70 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 15780 110 .cfa: $rsp 96 + .ra: .cfa -8 + ^
 STACK CFI INIT 15890 e .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 158a0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 158a1 .cfa: $rsp 16 +
 STACK CFI INIT 158b0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 158b1 .cfa: $rsp 16 +
+STACK CFI INIT 158c0 40 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 15900 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 15901 .cfa: $rsp 16 +
+STACK CFI INIT 15910 1d0 .cfa: $rsp 256 + .ra: .cfa -8 + ^
+STACK CFI INIT 15ae0 40 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 15b20 e .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 15b30 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 15b31 .cfa: $rsp 16 +
+STACK CFI INIT 15b40 1d0 .cfa: $rsp 256 + .ra: .cfa -8 + ^
 STACK CFI INIT 15d10 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 15d20 270 .cfa: $rsp 336 + .ra: .cfa -8 + ^
+STACK CFI INIT 15f90 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 15fc0 130 .cfa: $rsp 176 + .ra: .cfa -8 + ^
 STACK CFI INIT 160f0 30 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 16120 40 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 16160 400 .cfa: $rsp 432 + .ra: .cfa -8 + ^
 STACK CFI INIT 16560 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 16561 .cfa: $rsp 16 +
+STACK CFI INIT 16570 1e0 .cfa: $rsp 224 + .ra: .cfa -8 + ^
+STACK CFI INIT 16750 70 .cfa: $rsp 64 + .ra: .cfa -8 + ^
+STACK CFI INIT 167c0 260 .cfa: $rsp 80 + .ra: .cfa -8 + ^
+STACK CFI INIT 16a20 2f0 .cfa: $rsp 192 + .ra: .cfa -8 + ^
 STACK CFI INIT 16d10 1a .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 16d30 210 .cfa: $rsp 272 + .ra: .cfa -8 + ^
+STACK CFI INIT 16f40 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 16f90 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 16fe0 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 17030 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 17040 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 17090 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 170e0 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 17130 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 17140 60 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 171a0 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 171f0 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 17240 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 17250 60 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 172b0 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 17300 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 17350 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 17360 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 17390 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 173a0 3b0 .cfa: $rsp 432 + .ra: .cfa -8 + ^
 STACK CFI INIT 17750 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 17760 100 .cfa: $rsp 56 + .ra: .cfa -8 + ^
+STACK CFI INIT 17860 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 178b0 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 17900 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 17950 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 17960 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 179b0 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 17a00 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 17a50 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 17a60 60 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 17ac0 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 17b10 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 17b60 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 17b70 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 17bc0 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 17c10 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 17c60 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 17c70 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 17cc0 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 17d10 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 17d60 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 17d70 60 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 17dd0 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 17e20 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 17e70 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 17e80 60 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 17ee0 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 17f30 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 17f80 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 17f90 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 17fe0 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 18030 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 18080 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 18090 40 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 180d0 80 .cfa: $rsp 64 + .ra: .cfa -8 + ^
+STACK CFI INIT 18150 40 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 18190 80 .cfa: $rsp 64 + .ra: .cfa -8 + ^
 STACK CFI INIT 18f70 d .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 19c70 208 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 19e80 209 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 1a090 3dd .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 1a480 70 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 1a4f0 248 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 1a7a0 450 .cfa: $rsp 96 + .ra: .cfa -8 + ^
 STACK CFI INIT 1abf0 2f1 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 1af00 360 .cfa: $rsp 96 + .ra: .cfa -8 + ^
 STACK CFI INIT 1b260 4d .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 1b2b0 1b0 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 1b460 1220 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 1c680 130 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 1c7b0 450 .cfa: $rsp 496 + .ra: .cfa -8 + ^
+STACK CFI INIT 1cc00 910 .cfa: $rsp 848 + .ra: .cfa -8 + ^
+STACK CFI INIT 1d510 1c0 .cfa: $rsp 208 + .ra: .cfa -8 + ^
+STACK CFI INIT 1d6d0 f0 .cfa: $rsp 80 + .ra: .cfa -8 + ^
+STACK CFI INIT 1d7c0 460 .cfa: $rsp 496 + .ra: .cfa -8 + ^
+STACK CFI INIT 1dc20 a0 .cfa: $rsp 64 + .ra: .cfa -8 + ^
+STACK CFI INIT 1dcc0 690 .cfa: $rsp 656 + .ra: .cfa -8 + ^
+STACK CFI INIT 1e350 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 1e380 60 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 1e3e0 e .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 1e3f0 27 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 1e420 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 1e421 .cfa: $rsp 16 +
+STACK CFI INIT 1e430 120 .cfa: $rsp 160 + .ra: .cfa -8 + ^
 STACK CFI INIT 1e550 1a .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 1e570 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 1e5a0 2c0 .cfa: $rsp 320 + .ra: .cfa -8 + ^
 STACK CFI INIT 1e860 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 1e870 40 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 1e8b0 110 .cfa: $rsp 64 + .ra: .cfa -8 + ^
+STACK CFI INIT 1e9c0 420 .cfa: $rsp 384 + .ra: .cfa -8 + ^
 STACK CFI INIT 1ede0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 1ede1 .cfa: $rsp 16 +
 STACK CFI INIT 1edf0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 1ee00 100 .cfa: $rsp 56 + .ra: .cfa -8 + ^
+STACK CFI INIT 1ef00 210 .cfa: $rsp 256 + .ra: .cfa -8 + ^
+STACK CFI INIT 1f110 2f0 .cfa: $rsp 192 + .ra: .cfa -8 + ^
+STACK CFI INIT 1f400 230 .cfa: $rsp 304 + .ra: .cfa -8 + ^
+STACK CFI INIT 1f630 330 .cfa: $rsp 336 + .ra: .cfa -8 + ^
+STACK CFI INIT 1f960 f0 .cfa: $rsp 144 + .ra: .cfa -8 + ^
 STACK CFI INIT 1fa50 ba .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 1fb10 310 .cfa: $rsp 304 + .ra: .cfa -8 + ^
 STACK CFI INIT 1fe20 18 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 1fe40 70 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 1feb0 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 1ff00 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 20050 120 .cfa: $rsp 1232 + .ra: .cfa -8 + ^
 STACK CFI INIT 20170 198 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 20310 100 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 20410 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 20440 110 .cfa: $rsp 64 + .ra: .cfa -8 + ^
+STACK CFI INIT 20550 40 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 20590 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 205a0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 205a1 .cfa: $rsp 16 +
 STACK CFI INIT 205b0 51a .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 20ad0 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 20cb0 d0 .cfa: $rsp 80 + .ra: .cfa -8 + ^
+STACK CFI INIT 20d80 180 .cfa: $rsp 240 + .ra: .cfa -8 + ^
+STACK CFI INIT 20f00 b0 .cfa: $rsp 80 + .ra: .cfa -8 + ^
+STACK CFI INIT 20fb0 260 .cfa: $rsp 96 + .ra: .cfa -8 + ^
+STACK CFI INIT 21210 b0 .cfa: $rsp 80 + .ra: .cfa -8 + ^
+STACK CFI INIT 212c0 90 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 21350 410 .cfa: $rsp 496 + .ra: .cfa -8 + ^
+STACK CFI INIT 21760 b0 .cfa: $rsp 64 + .ra: .cfa -8 + ^
 STACK CFI INIT 21810 2b .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 21811 .cfa: $rsp 16 +
 STACK CFI INIT 21840 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
@@ -205,34 +470,68 @@ STACK CFI INIT 21ab0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 21ab1 .cfa: $rsp 16 +
 STACK CFI INIT 21ac0 2b .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 21ac1 .cfa: $rsp 16 +
+STACK CFI INIT 21af0 110 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 21c00 8a .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 21c01 .cfa: $rsp 16 +
 STACK CFI INIT 21c90 9d .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 21c91 .cfa: $rsp 16 +
+STACK CFI INIT 21d30 360 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 22090 d .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 220a0 11 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 220c0 c0 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 22180 61 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 221f0 40 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 22230 50 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 22280 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 22281 .cfa: $rsp 16 +
+STACK CFI INIT 22290 110 .cfa: $rsp 64 + .ra: .cfa -8 + ^
+STACK CFI INIT 223a0 2f0 .cfa: $rsp 144 + .ra: .cfa -8 + ^
+STACK CFI INIT 22690 110 .cfa: $rsp 96 + .ra: .cfa -8 + ^
+STACK CFI INIT 227a0 150 .cfa: $rsp 144 + .ra: .cfa -8 + ^
+STACK CFI INIT 228f0 100 .cfa: $rsp 64 + .ra: .cfa -8 + ^
 STACK CFI INIT 229f0 75 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 22a70 6 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 22a80 120 .cfa: $rsp 96 + .ra: .cfa -8 + ^
+STACK CFI INIT 22ba0 3b0 .cfa: $rsp 352 + .ra: .cfa -8 + ^
+STACK CFI INIT 22f50 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 22f80 e .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 22f90 b0 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 23040 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 23041 .cfa: $rsp 16 +
 STACK CFI INIT 245e0 18 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 24600 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 24630 70 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 246a0 d .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 246b0 c0 .cfa: $rsp 64 + .ra: .cfa -8 + ^
 STACK CFI INIT 24770 23 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 247a0 80 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 24820 19 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 24821 .cfa: $rsp 16 +
 STACK CFI INIT 24840 49 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 24890 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 248c0 c0 .cfa: $rsp 80 + .ra: .cfa -8 + ^
+STACK CFI INIT 24980 20 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 249a0 c0 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 24a60 13 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 24a61 .cfa: $rsp 16 +
 STACK CFI INIT 24a80 e .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 24a90 3c .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 24ad0 f0 .cfa: $rsp 96 + .ra: .cfa -8 + ^
+STACK CFI INIT 24bc0 70 .cfa: $rsp 64 + .ra: .cfa -8 + ^
+STACK CFI INIT 24c30 60 .cfa: $rsp 48 + .ra: .cfa -8 + ^
 STACK CFI INIT 24c90 d .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 24ca0 e0 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 24d80 a0 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 24e20 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 24e21 .cfa: $rsp 16 +
 STACK CFI INIT 24e30 1c .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 24e50 20 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 24e70 60 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 24ed0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 24ed1 .cfa: $rsp 16 +
+STACK CFI INIT 24ee0 100 .cfa: $rsp 64 + .ra: .cfa -8 + ^
+STACK CFI INIT 24fe0 80 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 25060 30 .cfa: $rsp 32 + .ra: .cfa -8 + ^
 STACK CFI INIT 25090 1c .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 250b0 20 .cfa: $rsp 32 + .ra: .cfa -8 + ^
+STACK CFI INIT 250d0 a8 .cfa: $rsp 64 + .ra: .cfa -8 + ^

--- a/py/tests/test_minidump.py
+++ b/py/tests/test_minidump.py
@@ -120,7 +120,7 @@ def test_macos_with_cfi(res_path):
 
     thread = state.get_thread(0)
     assert thread.thread_id == 775
-    assert thread.frame_count == 9
+    assert thread.frame_count == 5
 
     frame = thread.get_frame(1)
     assert frame.trust == "cfi"

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -36,6 +36,7 @@ pdb = "0.7.0"
 pest = "2.1.1"
 pest_derive = "2.1.0"
 regex = "1.3.5"
+scroll = "0.10"
 serde = { version = "1.0.94", features = ["derive"] }
 serde_json = "1.0.40"
 smallvec = "1.2.0"

--- a/symbolic-debuginfo/src/macho/compact.rs
+++ b/symbolic-debuginfo/src/macho/compact.rs
@@ -1361,6 +1361,7 @@ impl CompactUnwindInfoEntry {
 }
 
 /// A Compact Unwinding Operation
+#[derive(Debug)]
 pub enum CompactUnwindOp {
     /// The instructions can be described with simple CFI operations.
     CfiOps(CompactCfiOpIter),

--- a/symbolic-debuginfo/src/macho/compact.rs
+++ b/symbolic-debuginfo/src/macho/compact.rs
@@ -1,0 +1,1517 @@
+//! Support for the "compact unwinding format" used by Apple platforms,
+//! which can be found in __unwind_info sections of binaries.
+//!
+//! The primary type of interest is CompactUnwindInfoIter, which can be
+//! constructed from a CompactUnwindInfo, which can be constructed from
+//! a UnwindInfoFrame.
+//!
+//! The CompactUnwindInfoIter lets you iterate through all of the mappings
+//! from instruction addresses to unwinding instructions, or lookup a specific
+//! mapping by instruction address.
+//!
+//! Example:
+//!
+//! ```rust,ignore
+//! fn process_dwarf<'d: 'o, 'o, O>(&mut self, object: &O) -> error::Result<(), CfiError>
+//!     where
+//!         O: ObjectLike<'d, 'o> + Dwarf<'o>,
+//! {
+//!     let endian = object.endianity();
+//!     if let Some(section) = object.section("unwind_info") {
+//!         let frame = UnwindInfoFrame::new(&section.data, endian);
+//!         let info = CompactUnwindInfo::new(object, section.address, frame);
+//!
+//!         let mut iter = info.iter()?;
+//!         while let Some(entry) = iter.next()? {
+//!             let base_address = entry.instruction_address;
+//!             let len = entry.len;
+//!             if let Some(instructions) = entry.cfi_instructions(&iter) {
+//!                 for instruction in instructions {
+//!                     // Interpret the CFI instructions
+//!                 }
+//!             }
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! # Unimplemented Features (TODO)
+//!
+//! * ARM64 opcode decoding (and writing the section on that format)
+//! * Personality/LSDA lookup (for runtime unwinders)
+//! * Entry lookup by address (for runtime unwinders)
+//! * x86/x64 Stackless-Indirect mode decoding (for stack frames > 2KB)
+//! * x86/x64 DWARF mode decoding (for when compact unwinding defers to the DWARF in eh_frame)
+//!
+//!
+//! # The Compact Unwinding Format
+//!
+//! This format is defined only by its implementation in llvm. Notably these two
+//! files include lots of useful comments and definitions:
+//!
+//! * [Header describing layout of the format](https://github.com/llvm/llvm-project/blob/main/libunwind/include/mach-o/compact_unwind_encoding.h)
+//! * [Implementation that outputs the format](https://github.com/llvm/llvm-project/blob/main/lld/MachO/UnwindInfoSection.cpp)
+//! * [Implementation of lldb interpreting that format (CreateUnwindPlan_x86_64 especially useful)](https://github.com/llvm/llvm-project/blob/main/lldb/source/Symbol/CompactUnwindInfo.cpp)
+//!
+//! This implementation is based on those files at commit `d480f968ad8b56d3ee4a6b6df5532d485b0ad01e`.
+//!
+//! Unfortunately the description of the format in those files elides some important
+//! details, and it uses some naming conventions that are confusing, so this document
+//! will attempt to define this format more completely, and with more clear terms.
+//!
+//! Some notable terminology changes from llvm:
+//!
+//! * "encoding" or "encoding type" => opcode
+//! * "function offset" => instruction address
+//!
+//! Like all unwinding info formats, the goal of the compact unwinding format
+//! is to create a mapping from addresses in the binary to opcodes describing
+//! how to unwind from that location.
+//!
+//! These opcodes describe:
+//!
+//! * How to recover the return pointer for the current frame
+//! * How to recover some of the registers for the current frame
+//! * How to run destructors / catch the unwind at runtime (personality/LSDA)
+//!
+//! A user of the compact unwinding format would:
+//!
+//! 1. Get the current instruction pointer (e.g. `%rip`).
+//! 2. Lookup the corresponding opcode in the compact unwinding structure.
+//! 3. Follow the instructions of that opcode to recover the current frame.
+//! 4. Optionally perform runtime unwinding tasks for the current frame (destructors).
+//! 5. Use that information to recover the instruction pointer of the previous frame.
+//! 6. Repeat until unwinding is complete.
+//!
+//! The compact unwinding format can be understood as two separate pieces:
+//!
+//! * An architecture-agnostic "page-table" structure for finding opcode entries
+//! * Architecture-specific opcode formats (x86, x64, and ARM64)
+//!
+//! Unlike DWARF CFI, compact unwinding doesn't have facilities for incrementally
+//! updating how to recover certain registers as the function progresses.
+//!
+//! Empirical analysis suggests that there tends to only be one opcode for
+//! an entire function (which explains why llvm refers to instruction addresses
+//! as "function offsets"), although nothing in the format seems to *require*
+//! this to be the case.
+//!
+//! One consequence of only having one opcode for a whole function is that
+//! functions will generally have incorrect instructions for the function's
+//! prologue (where callee-saved registers are individually PUSHed onto the
+//! stack before the rest of the stack space is allocated).
+//!
+//! Presumably this isn't a very big deal, since there's very few situations
+//! where unwinding would involve a function still executing its prologue.
+//! This might matter when handling a stack overflow that occurred while
+//! saving the registers, or when processing a non-crashing thread in a minidump
+//! that happened to be in its prologue.
+//!
+//! Similarly, the way ranges of instructions are mapped means that Compact
+//! Unwinding will generally incorrectly map the padding bytes between functions
+//! (attributing them to the previous function), while DWARF CFI tends to more
+//! more carefully exclude those addresses. Presumably also not a big deal.
+//!
+//! Both of these things mean that if DWARF CFI and Compact Unwinding are
+//! available for a function, the DWARF CFI is expected to be more precise.
+//!
+//! It's possible that LSDA entries have addresses decoupled from the primary
+//! opcode so that instructions on how to run destructors can vary more
+//! granularly, but LSDA support is still TODO as it's not needed for
+//! backtraces.
+//!
+//!
+//! ## Page Tables
+//!
+//! This section describes the architecture-agnostic layout of the compact
+//! unwinding format. The layout of the format is a two-level page-table
+//! with one root first-level node pointing to arbitrarily many second-level
+//! nodes, which in turn can hold several hundred opcode entries.
+//!
+//! There are two high-level concepts in this format that enable significant
+//! compression of the tables:
+//!
+//! 1. Eliding duplicate function offsets
+//! 2. Palettizing the opcodes
+//!
+//! Trick 1 is standard for unwinders: the table of mappings is sorted by
+//! address, and any entries that would have the same opcode as the
+//! previous one are elided. So for instance the following:
+//!
+//! ```
+//! address: 1, opcode: 1
+//! address: 2, opcode: 1
+//! address: 3, opcode: 2
+//! ```
+//!
+//! Is just encoded like this:
+//!
+//! ```
+//! address: 1, opcode: 1
+//! address: 3, opcode: 2
+//! ```
+//!
+//! Trick 2 is more novel: At the first level a global palette of up to 127 opcodes
+//! is defined. Each second-level "compressed" (leaf) page can also define up to 128 local
+//! opcodes. Then the entries mapping function offsets to opcodes can use 8-bit
+//! indices into those palettes instead of entire 32-bit opcodes. If an index is
+//! smaller than the number of global opcodes, it's global, otherwise it's local
+//! (subtract the global count to get the local index).
+//!
+//! > Unclear detail: If the global palette is smaller than 127, can the local
+//!   palette be larger than 128?
+//!
+//! To compress these entries into a single 32-bit value, the address is truncated
+//! to 24 bits and packed with the index. The addresses stored in these entries
+//! are also relative to a base address that each second-level page defines.
+//! (This will be made more clear below).
+//!
+//! There are also non-palletized "regular" second-level pages with absolute
+//! 32-bit addresses, but those are fairly rare. llvm seems to only want to emit
+//! them in the final page.
+//!
+//! The root page also stores the first address mapped by each second-level
+//! page, allowing for more efficient binary search for a particular function
+//! offset entry. (This is the base address the compressed pages use.)
+//!
+//! The root page also seems to always have a sentinel entry which has a null
+//! pointer to its second-level page, but does specify a first address, which
+//! makes it easy to lookup the maximum mapped address (the sentinel will store
+//! that value +1).
+//!
+//!
+//!
+//! # Layout of the Page Table
+//!
+//! The page table starts at the very beginning of the __unwind_info section
+//! with the root page:
+//!
+//! ```rust,ignore
+//! struct RootPage {
+//!   /// Only version 1 is currently defined
+//!   version: u32 = 1,
+//!
+//!   /// The array of u32 global opcodes (offset relative to start of root page).
+//!   ///
+//!   /// These may be indexed by "compressed" second-level pages.
+//!   global_opcodes_offset: u32,
+//!   global_opcodes_len: u32,
+//!
+//!   /// The array of u32 global personality codes
+//!   /// (offset relative to start of root page).
+//!   ///
+//!   /// Personalities define the style of unwinding that an unwinder should
+//!   /// use, and how to interpret the LSDA entries for a function (see below).
+//!   personalities_offset: u32,
+//!   personalities_len: u32,
+//!
+//!   /// The array of FirstLevelPageEntry's describing the second-level pages
+//!   /// (offset relative to start of root page).
+//!   pages_offset: u32,
+//!   pages_len: u32,
+//!
+//!   // After this point there are several dynamically-sized arrays whose
+//!   // precise order and positioning don't matter, because they are all
+//!   // accessed using offsets like the ones above. The arrays are:
+//!
+//!   global_opcodes: [u32; global_opcodes_len],
+//!   personalities: [u32; personalities_len],
+//!   pages: [FirstLevelPageEntry; pages_len],
+//!
+//!   /// An array of LSDA pointers (Language Specific Data Areas).
+//!   ///
+//!   /// LSDAs are tables that an unwinder's personality function will use to
+//!   /// find what destructors should be run and whether unwinding should
+//!   /// be caught and normal execution resumed. We can treat them opaquely.
+//!   ///
+//!   /// Second-level pages have addresses into this array so that it can
+//!   /// can be indexed, the root page doesn't need to know about them.
+//!   lsdas: [LsdaEntry; unknown_len],
+//! }
+//!
+//!
+//! struct FirstLevelPageEntry {
+//!   /// The first address mapped by this page.
+//!   ///
+//!   /// This is useful for binary-searching for the page that can map
+//!   /// a specific address in the binary (the primary kind of lookup
+//!   /// performed by an unwinder).
+//!   first_address: u32,
+//!
+//!   /// Offset to the second-level page (offset relative to start of root page).
+//!   ///
+//!   /// This may point to a RegularSecondLevelPage or a CompactSecondLevelPage.
+//!   /// Which it is can be determined by the 32-bit "kind" value that is at
+//!   /// the start of both layouts.
+//!   second_level_page_offset: u32,
+//!
+//!   /// Base offset into the lsdas array that entries in this page will be
+//!   /// relative to (offset relative to start of root page).
+//!   lsda_index_offset: u32,
+//! }
+//!
+//!
+//! struct RegularSecondLevelPage {
+//!   /// Always 2 (use to distinguish from CompressedSecondLevelPage).
+//!   kind: u32 = 2,
+//!
+//!   /// The Array of RegularEntry's (offset relative to **start of this page**).
+//!   entries_offset: u16,
+//!   entries_len: u16,
+//! }
+//!
+//!
+//! struct RegularEntry {
+//!   /// The address in the binary for this entry (absolute).
+//!   instruction_address: u32,
+//!   /// The opcode for this address.
+//!   opcode: u32,
+//! }
+//!
+//! struct CompressedSecondLevelPage {
+//!   /// Always 3 (use to distinguish from RegularSecondLevelPage).
+//!   kind: u32 = 3,
+//!
+//!   /// The array of compressed u32 entries
+//!   /// (offset relative to **start of this page**).
+//!   ///
+//!   /// Entries are a u32 that contains two packed values (from high to low):
+//!   /// * 8 bits: opcode index
+//!   ///   * 0..global_opcodes_len => index into global palette
+//!   ///   * global_opcodes_len..255 => index into local palette
+//!   ///     (subtract global_opcodes_len to get the real local index)
+//!   /// * 24 bits: instruction address
+//!   ///   * address is relative to this page's first_address!
+//!   entries_offset: u16,
+//!   entries_len: u16,
+//!
+//!   /// The array of u32 local opcodes for this page
+//!   /// (offset relative to **start of this page**).
+//!   local_opcodes_offset: u16,
+//!   local_opcodes_len: u16,
+//! }
+//!
+//!
+//! // TODO: why do these have instruction_addresses? Are they not in sync
+//! // with the second-level entries?
+//! struct LsdaEntry {
+//!   instruction_address: u32,
+//!   lsda_address: u32,
+//! }
+//! ```
+//!
+//!
+//!
+//! # Opcode Format
+//!
+//! There are 3 architecture-specific opcode formats: x86, x64, and ARM64.
+//!
+//! All 3 formats share a common header in the top 8 bits (from high to low):
+//!
+//! ```rust,ignore
+//! /// Whether this instruction is the start of a function.
+//! is_start: u1,
+//!
+//! /// Whether there is an lsda entry for this instruction.
+//! has_lsda: u1,
+//!
+//! /// An index into the global personalities array
+//! /// (TODO: ignore if has_lsda == false?)
+//! personality_index: u2,
+//!
+//! /// The architecture-specific kind of opcode this is, specifying how to
+//! /// interpret the remaining 24 bits of the opcode.
+//! opcode_kind: u4,
+//! ```
+//!
+//!
+//! ## x86 and x64 Opcodes
+//!
+//! x86 and x64 use the same opcode layout, differing only in the registers
+//! being restored. Registers are numbered 0-6, with the following mappings:
+//!
+//! x86:
+//! * 0 => no register (like Option::None)
+//! * 1 => ebx
+//! * 2 => ecx
+//! * 3 => edx
+//! * 4 => edi
+//! * 5 => esi
+//! * 6 => ebp
+//!
+//! x64:
+//! * 0 => no register (like Option::None)
+//! * 1 => rbx
+//! * 2 => r12
+//! * 3 => r13
+//! * 4 => r14
+//! * 5 => r15
+//! * 6 => rbp
+//!
+//! Note also that encoded sizes/offsets are generally divided by the pointer size
+//! (since all values we are interested in are pointer-aligned), which of course differs
+//! between x86 and x64.
+//!
+//! There are 4 kinds of x86/x64 opcodes (specified by opcode_kind):
+//!
+//! (One of the llvm headers refers to "0=old", but nothing else seems to
+//! produce it or refer to it, so let's assume that's a typo for now.)
+//!
+//!
+//! ### x86 Opcode Mode 1: BP-Based
+//!
+//! The function has the standard bp-based prelude which:
+//!
+//! * Pushes the caller's bp (frame pointer) to the stack
+//! * Sets bp = sp (new frame pointer is the current top of the stack)
+//!
+//! bp has been preserved, and any callee-saved registers that need to be restored
+//! are saved on the stack at a known offset from bp.
+//!
+//! The return address is stored just before the caller's bp. The caller's stack
+//! pointer should point before where the return address is saved.
+//!
+//! Registers are stored in increasing order (so `reg1` comes before `reg2`).
+//!
+//! If a register has the "no register" value, continue iterating the offset
+//! forward. This lets the registers be stored slightly-non-contiguously on the
+//! stack.
+//!
+//! The remaining 24 bits of the opcode are interpreted as follows (from high to low):
+//!
+//! ```rust,ignore
+//! /// Registers to restore (see register mapping above)
+//! reg1: u3,
+//! reg2: u3,
+//! reg3: u3,
+//! reg4: u3,
+//! reg5: u3,
+//! _unused: u1,
+//!
+//! /// The offset from bp that the registers to restore are saved at,
+//! /// divided by pointer size.
+//! stack_offset: u8,
+//! ```
+//!
+//!
+//!
+//! ### x86 Opcode Mode 2: Frameless (Stack-Immediate)
+//!
+//! The callee's stack frame has a known size, so we can find the start
+//! of the frame by offsetting from sp (the stack pointer). Any callee-saved
+//! registers that need to be restored are saved at the start of the stack
+//! frame.
+//!
+//! The return address is saved immediately before the start of this frame. The
+//! caller's stack pointer should point before where the return address is saved.
+//!
+//! Registers are stored in *reverse* order on the stack from the order the
+//! decoding algorithm outputs (so `reg[1]` comes before `reg[0]`).
+//!
+//! If a register has the "no register" value, *do not* continue iterating the
+//! offset forward -- registers are strictly contiguous (it's possible
+//! "no register" can only be trailing due to the encoding, but I haven't
+//! verified this).
+//!
+//!
+//! The remaining 24 bits of the opcode are interpreted as follows (from high to low):
+//!
+//! ```rust,ignore
+//! /// How big the stack frame is, divided by pointer size.
+//! stack_size: u8,
+//!
+//! _unused: u3,
+//!
+//! /// The number of registers that are saved on the stack.
+//! register_count: u3,
+//!
+//! /// The permutation encoding of the registers that are saved
+//! /// on the stack (see below).
+//! register_permutations: u10,
+//! ```
+//!
+//! The register permutation encoding is a Lehmer code sequence encoded into a
+//! single variable-base number so we can encode the ordering of up to
+//! six registers in a 10-bit space.
+//!
+//! This can't really be described well with anything but code, so
+//! just read this implementation or llvm's implementation for how to
+//! encode/decode this.
+//!
+//!
+//!
+//! ### x86 Opcode Mode 3: Frameless (Stack-Indirect)
+//!
+//! (Currently Unimplemented)
+//!
+//! Stack-Indirect is exactly the same situation as Stack-Immediate, but the
+//! the stack-frame size is too large for Stack-Immediate to encode. However,
+//! the function prereserved the size of the frame in its prologue, so we can
+//! extract the the size of the frame from a `sub` instruction at a known
+//! offset from the start of the function (`subl $nnnnnnnn,ESP` in x86,
+//! `subq $nnnnnnnn,RSP` in x64).
+//!
+//! This requires being able to find the first instruction of the function
+//! (TODO: presumably the first is_start entry <= this one?).
+//!
+//! TODO: describe how to extract the value from the `sub` instruction.
+//!
+//!
+//! ```rust,ignore
+//! /// Offset from the start of the function where the `sub` instruction
+//! /// we need is stored. (NOTE: not divided by anything!)
+//! instruction_offset: u8,
+//!
+//! /// An offset to add to the loaded stack size, divided by pointer size.
+//! /// This allows the stack size to differ slightly from the `sub`, to
+//! /// compensate for any function prologue that pushes a bunch of
+//! /// pointer-sized registers.
+//! stack_adjust: u3,
+//!
+//! /// The number of registers that are saved on the stack.
+//! register_count: u3,
+//!
+//! /// The permutation encoding of the registers that are saved on the stack
+//! /// (see Stack-Immediate for a description of this format).
+//! register_permutations: u10,
+//! ```
+//!
+//! **Note**: apparently binaries generated by the clang in Xcode 6 generated
+//! corrupted versions of this opcode, but this was fixed in Xcode 7
+//! (released in September 2015), so *presumably* this isn't something we're
+//! likely to encounter. But if you encounter messed up opcodes this might be why.
+//!
+//!
+//!
+//! ### x86 Opcode Mode 4: Dwarf
+//!
+//! (Currently only partially implemented)
+//!
+//! There is no compact unwind info here, and you should instead use the
+//! DWARF CFI in .eh_frame for this line. The remaining 24 bits of the opcode
+//! are an offset into the .eh_frame section that should hold the DWARF FDE
+//! for this line.
+//!
+//!
+//!
+//! ## ARM64 Opcodes
+//!
+//! (Currently unimplemented)
+//!
+//! TODO: write this section
+//!
+//! ```text
+//! kind:
+//!   4=frame-based, 3=DWARF, 2=frameless
+//!
+//!  frameless:
+//!        12-bits of stack size
+//!  frame-based:
+//!        4-bits D reg pairs saved
+//!        5-bits X reg pairs saved
+//!  DWARF:
+//!        24-bits offset of DWARF FDE in __eh_frame section
+//!
+//! ```
+
+use crate::macho::MachError;
+use goblin::error::Error;
+use goblin::mach::segment::SectionData;
+use scroll::{Endian, Pread};
+use std::mem;
+
+type Result<T> = std::result::Result<T, MachError>;
+
+#[derive(Debug, Clone)]
+enum Arch {
+    X86,
+    X64,
+    Arm64,
+    Other,
+}
+
+/// An iterator over the CompactUnwindInfoEntry's of a `.unwind_info` section.
+#[derive(Debug, Clone)]
+pub struct CompactUnwindInfoIter<'a> {
+    /// Parent .unwind_info metadata.
+    arch: Arch,
+    endian: Endian,
+    section: SectionData<'a>,
+    /// Parsed root page.
+    root: FirstLevelPage,
+
+    // Iterator state
+    /// Current index in the root node.
+    first_idx: u32,
+    /// Current index in the second-level node.
+    second_idx: u32,
+    /// Parsed version of the current pages.
+    page_of_next_entry: Option<(FirstLevelPageEntry, SecondLevelPage)>,
+    /// Minimally parsed version of the next entry, which we need to have
+    /// already loaded to know how many instructions the previous entry covered.
+    next_entry: Option<RawCompactUnwindInfoEntry>,
+    done_page: bool,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Pread)]
+struct FirstLevelPage {
+    // Only version 1 is currently defined
+    // version: u32 = 1,
+    /// The array of u32 global opcodes (offset relative to start of root page).
+    ///
+    /// These may be indexed by "compressed" second-level pages.
+    global_opcodes_offset: u32,
+    global_opcodes_len: u32,
+
+    /// The array of u32 global personality codes (offset relative to start of root page).
+    ///
+    /// Personalities define the style of unwinding that an unwinder should use,
+    /// and how to interpret the LSDA entries for a function (see below).
+    personalities_offset: u32,
+    personalities_len: u32,
+
+    /// The array of FirstLevelPageEntry's describing the second-level pages
+    /// (offset relative to start of root page).
+    pages_offset: u32,
+    pages_len: u32,
+    // After this point there are several dynamically-sized arrays whose precise
+    // order and positioning don't matter, because they are all accessed using
+    // offsets like the ones above. The arrays are:
+
+    // global_opcodes: [u32; global_opcodes_len],
+    // personalities: [u32; personalities_len],
+    // pages: [FirstLevelPageEntry; pages_len],
+    // lsdas: [LsdaEntry; unknown_len],
+}
+
+/// A Compact Unwind Info entry.
+#[derive(Debug, Clone)]
+pub struct CompactUnwindInfoEntry {
+    /// The first instruction this entry covers.
+    pub instruction_address: u32,
+    /// How many addresses this entry covers.
+    pub len: u32,
+    /// The opcode for this entry.
+    opcode: Opcode,
+}
+
+#[derive(Debug, Clone)]
+struct RawCompactUnwindInfoEntry {
+    /// The address of the first instruction this entry applies to
+    /// (may apply to later instructions as well).
+    instruction_address: u32,
+    /// Either an opcode or the index into an opcode palette
+    opcode_or_index: OpcodeOrIndex,
+}
+
+#[derive(Debug, Clone)]
+enum OpcodeOrIndex {
+    Opcode(u32),
+    Index(u32),
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Pread)]
+struct FirstLevelPageEntry {
+    /// The first address mapped by this page.
+    ///
+    /// This is useful for binary-searching for the page that can map
+    /// a specific address in the binary (the primary kind of lookup
+    /// performed by an unwinder).
+    first_address: u32,
+
+    /// Offset to the second-level page (offset relative to start of root page).
+    ///
+    /// This may point to either a RegularSecondLevelPage or a CompactSecondLevelPage.
+    /// Which it is can be determined by the 32-bit "kind" value that is at
+    /// the start of both layouts.
+    second_level_page_offset: u32,
+
+    /// Base offset into the lsdas array that entries in this page will be relative
+    /// to (offset relative to start of root page).
+    lsda_index_offset: u32,
+}
+
+#[derive(Debug, Clone)]
+enum SecondLevelPage {
+    Compressed(CompressedSecondLevelPage),
+    Regular(RegularSecondLevelPage),
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Pread)]
+struct RegularSecondLevelPage {
+    // Always 2 (use to distinguish from CompressedSecondLevelPage).
+    // kind: u32 = 2,
+    /// The Array of RegularEntry's (offset relative to **start of this page**).
+    entries_offset: u16,
+    entries_len: u16,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Pread)]
+struct CompressedSecondLevelPage {
+    // Always 3 (use to distinguish from RegularSecondLevelPage).
+    // kind: u32 = 3,
+    /// The array of compressed u32 entries (offset relative to **start of this page**).
+    ///
+    /// Entries are a u32 that contains two packed values (from highest to lowest bits):
+    /// * 8 bits: opcode index
+    ///   * 0..global_opcodes_len => index into global palette
+    ///   * global_opcodes_len..255 => index into local palette (subtract global_opcodes_len)
+    /// * 24 bits: function address
+    ///   * address is relative to this page's first_address!
+    entries_offset: u16,
+    entries_len: u16,
+
+    /// The array of u32 local opcodes for this page (offset relative to **start of this page**).
+    local_opcodes_offset: u16,
+    local_opcodes_len: u16,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Pread)]
+struct RegularEntry {
+    /// The address in the binary for this entry (absolute).
+    instruction_address: u32,
+    /// The opcode for this address.
+    opcode: u32,
+}
+
+#[derive(Debug, Clone)]
+#[repr(C)]
+struct LsdaEntry {
+    instruction_address: u32,
+    lsda_address: u32,
+}
+
+#[derive(Debug, Clone)]
+struct Opcode(u32);
+
+#[derive(Debug, Clone)]
+enum X86UnwindingMode {
+    RbpFrame,
+    StackImmediate,
+    StackIndirect,
+    Dwarf,
+}
+
+/// Minimal set of CFI ops needed to express Compact Unwinding semantics:
+#[derive(Debug, Clone)]
+pub enum CompactCfiOp {
+    /// The value of `dest_reg` is *stored at* `src_reg + offset_from_src`.
+    RegisterAt {
+        /// Destination
+        dest_reg: CompactCfiRegister,
+        /// Source
+        src_reg: CompactCfiRegister,
+        /// Offset
+        offset_from_src: i32,
+    },
+    /// The value of `dest_reg` *is* `src_reg + offset_from_src`.
+    RegisterIs {
+        /// Destination
+        dest_reg: CompactCfiRegister,
+        /// Source
+        src_reg: CompactCfiRegister,
+        /// Offset
+        offset_from_src: i32,
+    },
+}
+
+/// A register for a CompactCfiOp, as used by Compact Unwinding.
+///
+/// You should just treat this opaquely and use its methods to make sense of it.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum CompactCfiRegister {
+    /// The CFA register (Canonical Frame Address) -- the frame pointer (e.g. rbp)
+    Cfa,
+    /// Any other register, restricted to those referenced by Compact Unwinding.
+    Other(u8),
+}
+
+impl<'a> CompactUnwindInfoIter<'a> {
+    /// Creates a new CompactUnwindInfoIter for the given section.
+    pub fn new(
+        section: SectionData<'a>,
+        little_endian: bool,
+        arch: symbolic_common::Arch,
+    ) -> Result<Self> {
+        const UNWIND_SECTION_VERSION: u32 = 1;
+
+        use symbolic_common::CpuFamily;
+        let arch = match arch.cpu_family() {
+            CpuFamily::Intel32 => Arch::X86,
+            CpuFamily::Amd64 => Arch::X64,
+            CpuFamily::Arm64 => Arch::Arm64,
+            _ => Arch::Other,
+        };
+
+        let endian = if little_endian {
+            Endian::Little
+        } else {
+            Endian::Big
+        };
+
+        let offset = &mut 0;
+
+        // Grab all the fields from the header
+        let version: u32 = section.gread_with(offset, endian)?;
+        if version != UNWIND_SECTION_VERSION {
+            return Err(MachError::from(Error::Malformed(format!(
+                "Unknown Compact Unwinding Info version {}",
+                version
+            ))));
+        }
+
+        let root = section.gread_with(offset, endian)?;
+
+        let iter = CompactUnwindInfoIter {
+            arch,
+            endian,
+            section,
+            root,
+
+            first_idx: 0,
+            second_idx: 0,
+            page_of_next_entry: None,
+            next_entry: None,
+            done_page: true,
+        };
+
+        Ok(iter)
+    }
+    /// Gets the next entry in the iterator.
+    pub fn next(&mut self) -> Result<Option<CompactUnwindInfoEntry>> {
+        // Iteration is slightly more complex here because we want to be able to
+        // report how many instructions an entry covers, and knowing this requires us
+        // to parse the *next* entry's instruction_address value. Also, there's
+        // a sentinel page at the end of the listing with a null second_level_page_offset
+        // which requires some special handling.
+        //
+        // To handle this, we split iteration into two phases:
+        //
+        // * next_raw minimally parses the next entry so we can extract the opcode,
+        //   while also ensuring page_of_next_entry is set to match it.
+        //
+        // * next uses next_raw to "peek" the instruction_address of the next entry,
+        //   and then saves the result as `next_entry`, to avoid doing a bunch of
+        //   repeated work.
+
+        // If this is our first iteration next_entry will be empty, try to get it.
+        if self.next_entry.is_none() {
+            self.next_entry = self.next_raw()?;
+        }
+
+        if let Some(cur_entry) = self.next_entry.take() {
+            // Copy the first and second page data, as it may get overwritten
+            // by next_raw, then peek the next entry.
+            let (first_page, second_page) = self.page_of_next_entry.clone().unwrap();
+            self.next_entry = self.next_raw()?;
+            if let Some(next_entry) = self.next_entry.as_ref() {
+                let result = self.complete_entry(
+                    &cur_entry,
+                    next_entry.instruction_address,
+                    &first_page,
+                    &second_page,
+                )?;
+                Ok(Some(result))
+            } else {
+                // If there's no next_entry, then cur_entry is the sentinel, which
+                // we shouldn't yield.
+                Ok(None)
+            }
+        } else {
+            // next_raw still yielded nothing, we're done.
+            Ok(None)
+        }
+    }
+
+    // Yields a minimally parsed version of the next entry, and sets
+    // page_of_next_entry to the page matching it (so it can be further
+    // parsed when needed.
+    fn next_raw(&mut self) -> Result<Option<RawCompactUnwindInfoEntry>> {
+        // First, load up the page for this value if needed
+        if self.done_page {
+            // Only advance the indices if we've already loaded up a page
+            // (so it's not the first iteration) and we have pages left.
+            if self.page_of_next_entry.is_some() && self.first_idx != self.root.pages_len {
+                self.first_idx += 1;
+                self.second_idx = 0;
+            }
+            if let Some(entry) = self.first_level_entry(self.first_idx)? {
+                if entry.second_level_page_offset == 0 {
+                    // sentinel page at the end of the list, create a dummy entry
+                    // and advance past this page (don't reset done_page).
+                    return Ok(Some(RawCompactUnwindInfoEntry {
+                        instruction_address: entry.first_address,
+                        opcode_or_index: OpcodeOrIndex::Opcode(0),
+                    }));
+                }
+                let second_level_page = self.second_level_page(entry.second_level_page_offset)?;
+                self.page_of_next_entry = Some((entry, second_level_page));
+                self.done_page = false;
+            } else {
+                // Couldn't load a page, so we're at the end of our iteration.
+                return Ok(None);
+            }
+        }
+
+        // If we get here, we must have loaded a page
+        let (first_level_entry, second_level_page) = self.page_of_next_entry.as_ref().unwrap();
+        let entry =
+            self.second_level_entry(&first_level_entry, &second_level_page, self.second_idx)?;
+
+        // Advance to the next entry
+        self.second_idx += 1;
+
+        // If we reach the end of the page, setup for the next page
+        if self.second_idx == second_level_page.len() {
+            self.done_page = true;
+        }
+
+        Ok(Some(entry))
+    }
+
+    /// Gets the entry associated with a particular address.
+    pub fn entry_for_address(&mut self, _address: u32) -> Option<CompactUnwindInfoEntry> {
+        // TODO: this would be nice for an actual unwinding implementation, but
+        // dumping all of the entries doesn't need this.
+        unimplemented!()
+    }
+
+    fn first_level_entry(&self, idx: u32) -> Result<Option<FirstLevelPageEntry>> {
+        if idx < self.root.pages_len {
+            let idx_offset = mem::size_of::<FirstLevelPageEntry>() * idx as usize;
+            let offset = self.root.pages_offset as usize + idx_offset;
+
+            Ok(Some(self.section.pread_with(offset, self.endian)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn second_level_page(&self, offset: u32) -> Result<SecondLevelPage> {
+        const SECOND_LEVEL_REGULAR: u32 = 2;
+        const SECOND_LEVEL_COMPRESSED: u32 = 3;
+
+        let mut offset = offset as usize;
+
+        let kind: u32 = self.section.gread_with(&mut offset, self.endian)?;
+        if kind == SECOND_LEVEL_REGULAR {
+            Ok(SecondLevelPage::Regular(
+                self.section.gread_with(&mut offset, self.endian)?,
+            ))
+        } else if kind == SECOND_LEVEL_COMPRESSED {
+            Ok(SecondLevelPage::Compressed(
+                self.section.gread_with(&mut offset, self.endian)?,
+            ))
+        } else {
+            Err(MachError::from(Error::Malformed(format!(
+                "Unknown second-level page kind: {}",
+                kind
+            ))))
+        }
+    }
+
+    fn second_level_entry(
+        &self,
+        first_level_entry: &FirstLevelPageEntry,
+        second_level_page: &SecondLevelPage,
+        second_level_idx: u32,
+    ) -> Result<RawCompactUnwindInfoEntry> {
+        match *second_level_page {
+            SecondLevelPage::Compressed(ref page) => {
+                let offset = first_level_entry.second_level_page_offset as usize
+                    + page.entries_offset as usize
+                    + second_level_idx as usize * 4;
+                let compressed_entry: u32 = self.section.pread_with(offset, self.endian)?;
+
+                let instruction_address =
+                    (compressed_entry & 0x00FFFFFF) + first_level_entry.first_address;
+                let opcode_idx = (compressed_entry >> 24) & 0xFF;
+                Ok(RawCompactUnwindInfoEntry {
+                    instruction_address,
+                    opcode_or_index: OpcodeOrIndex::Index(opcode_idx),
+                })
+            }
+            SecondLevelPage::Regular(ref page) => {
+                let offset = first_level_entry.second_level_page_offset as usize
+                    + page.entries_offset as usize
+                    + second_level_idx as usize * 8;
+
+                let entry: RegularEntry = self.section.pread_with(offset, self.endian)?;
+
+                Ok(RawCompactUnwindInfoEntry {
+                    instruction_address: entry.instruction_address,
+                    opcode_or_index: OpcodeOrIndex::Opcode(entry.opcode),
+                })
+            }
+        }
+    }
+
+    fn complete_entry(
+        &self,
+        entry: &RawCompactUnwindInfoEntry,
+        next_entry_instruction_address: u32,
+        first_level_entry: &FirstLevelPageEntry,
+        second_level_page: &SecondLevelPage,
+    ) -> Result<CompactUnwindInfoEntry> {
+        let opcode = match entry.opcode_or_index {
+            OpcodeOrIndex::Opcode(opcode) => opcode,
+            OpcodeOrIndex::Index(opcode_idx) => {
+                if let SecondLevelPage::Compressed(ref page) = second_level_page {
+                    if opcode_idx < self.root.global_opcodes_len {
+                        self.global_opcode(opcode_idx)?
+                    } else {
+                        let opcode_idx = opcode_idx - self.root.global_opcodes_len;
+                        if opcode_idx >= page.local_opcodes_len as u32 {
+                            return Err(MachError::from(Error::Malformed(format!(
+                                "Local opcode index too large ({} >= {})",
+                                opcode_idx, page.local_opcodes_len
+                            ))));
+                        }
+                        let offset = first_level_entry.second_level_page_offset as usize
+                            + page.local_opcodes_offset as usize
+                            + opcode_idx as usize * 4;
+                        let opcode: u32 = self.section.pread_with(offset, self.endian)?;
+                        opcode
+                    }
+                } else {
+                    unreachable!()
+                }
+            }
+        };
+        let opcode = Opcode(opcode);
+
+        Ok(CompactUnwindInfoEntry {
+            instruction_address: entry.instruction_address,
+            len: next_entry_instruction_address - entry.instruction_address,
+            opcode,
+        })
+    }
+
+    fn global_opcode(&self, opcode_idx: u32) -> Result<u32> {
+        if opcode_idx >= self.root.global_opcodes_len {
+            return Err(MachError::from(Error::Malformed(format!(
+                "Global opcode index too large ({} >= {})",
+                opcode_idx, self.root.global_opcodes_len
+            ))));
+        }
+        let offset = self.root.global_opcodes_offset as usize + opcode_idx as usize * 4;
+        let opcode: u32 = self.section.pread_with(offset, self.endian)?;
+        Ok(opcode)
+    }
+
+    fn personality(&self, personality_idx: u32) -> Result<u32> {
+        if personality_idx >= self.root.personalities_len {
+            return Err(MachError::from(Error::Malformed(format!(
+                "Personality index too large ({} >= {})",
+                personality_idx, self.root.personalities_len
+            ))));
+        }
+        let offset = self.root.personalities_offset as usize + personality_idx as usize * 4;
+        let personality: u32 = self.section.pread_with(offset, self.endian)?;
+        Ok(personality)
+    }
+
+    /// Dumps similar output to `llvm-objdump --unwind-info`, for debugging.
+    pub fn dump(&self) -> Result<()> {
+        println!("Contents of __unwind_info section:");
+        println!("  Version:                                   0x1");
+        println!(
+            "  Common encodings array section offset:     0x{:x}",
+            self.root.global_opcodes_offset
+        );
+        println!(
+            "  Number of common encodings in array:       0x{:x}",
+            self.root.global_opcodes_len
+        );
+        println!(
+            "  Personality function array section offset: 0x{:x}",
+            self.root.personalities_offset
+        );
+        println!(
+            "  Number of personality functions in array:  0x{:x}",
+            self.root.personalities_len
+        );
+        println!(
+            "  Index array section offset:                0x{:x}",
+            self.root.pages_offset
+        );
+        println!(
+            "  Number of indices in array:                0x{:x}",
+            self.root.pages_len
+        );
+
+        println!(
+            "  Common encodings: (count = {})",
+            self.root.global_opcodes_len
+        );
+        for i in 0..self.root.global_opcodes_len {
+            let opcode = self.global_opcode(i)?;
+            println!("    encoding[{}]: 0x{:08x}", i, opcode);
+        }
+
+        println!(
+            "  Personality functions: (count = {})",
+            self.root.personalities_len
+        );
+        for i in 0..self.root.personalities_len {
+            let personality = self.personality(i)?;
+            println!("    personality[{}]: 0x{:08x}", i, personality);
+        }
+
+        println!("  Top level indices: (count = {})", self.root.pages_len);
+        for i in 0..self.root.pages_len {
+            let entry = self.first_level_entry(i)?.unwrap();
+            println!("    [{}]: function offset=0x{:08x}, 2nd level page offset=0x{:08x}, LSDA offset=0x{:08x}",
+                    i,
+                    entry.first_address,
+                    entry.second_level_page_offset,
+                    entry.lsda_index_offset);
+        }
+
+        // TODO: print LSDA info
+        println!("  LSDA descriptors:");
+        println!("  Second level indices:");
+
+        let mut iter = (*self).clone();
+        while let Some(raw_entry) = iter.next_raw()? {
+            let (first, second) = iter.page_of_next_entry.clone().unwrap();
+            // Always observing the index after the step, so subtract 1
+            let second_idx = iter.second_idx - 1;
+
+            // If this is the first entry of this page, dump the page
+            if second_idx == 0 {
+                println!("    Second level index[{}]: offset in section=0x{:08x}, base function=0x{:08x}",
+                iter.first_idx,
+                first.second_level_page_offset,
+                first.first_address);
+            }
+
+            // Dump the entry
+
+            // Feed in own instruction_address as a dummy value (we don't need it for this format)
+            let entry =
+                iter.complete_entry(&raw_entry, raw_entry.instruction_address, &first, &second)?;
+            if let OpcodeOrIndex::Index(opcode_idx) = raw_entry.opcode_or_index {
+                println!(
+                    "      [{}]: function offset=0x{:08x}, encoding[{}]=0x{:08x}",
+                    second_idx, entry.instruction_address, opcode_idx, entry.opcode.0
+                );
+            } else {
+                println!(
+                    "      [{}]: function offset=0x{:08x}, encoding=0x{:08x}",
+                    second_idx, entry.instruction_address, entry.opcode.0
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl SecondLevelPage {
+    fn len(&self) -> u32 {
+        match *self {
+            SecondLevelPage::Regular(ref page) => page.entries_len as u32,
+            SecondLevelPage::Compressed(ref page) => page.entries_len as u32,
+        }
+    }
+}
+
+impl CompactUnwindInfoEntry {
+    /// Gets cfi instructions associated with this entry.
+    pub fn cfi_instructions(
+        &self,
+        iter: &CompactUnwindInfoIter,
+    ) -> Option<impl Iterator<Item = CompactCfiOp>> {
+        self.opcode.cfi_instructions(iter)
+    }
+}
+
+// Arch-generic stuff
+impl Opcode {
+    fn cfi_instructions(
+        &self,
+        iter: &CompactUnwindInfoIter,
+    ) -> Option<impl Iterator<Item = CompactCfiOp>> {
+        match iter.arch {
+            Arch::X86 | Arch::X64 => self.x86_cfi_instructions(iter),
+            Arch::Arm64 => self.arm64_cfi_instructions(iter),
+            _ => None,
+        }
+    }
+
+    fn pointer_size(&self, iter: &CompactUnwindInfoIter) -> u32 {
+        match iter.arch {
+            Arch::X86 => 4,
+            Arch::X64 => 8,
+            Arch::Arm64 => 8,
+            _ => unimplemented!(),
+        }
+    }
+
+    /*
+    // potentially needed for future work:
+
+    fn is_start(&self) -> bool {
+        let offset = 32 - 1;
+        (self.0 & (1 << offset)) != 0
+    }
+    fn has_lsda(&self) -> bool{
+        let offset = 32 - 2;
+        (self.0 & (1 << offset)) != 0
+    }
+    fn personality_index(&self) -> u32 {
+        let offset = 32 - 4;
+        (self.0 >> offset) & 0b11
+    }
+    */
+}
+
+// x86/x64 implementation
+impl Opcode {
+    fn x86_cfi_instructions(
+        &self,
+        iter: &CompactUnwindInfoIter,
+    ) -> Option<std::vec::IntoIter<CompactCfiOp>> {
+        let pointer_size = self.pointer_size(iter) as i32;
+        // TODO: don't allocate for this (use ArrayVec..?)
+        match self.x86_mode() {
+            Some(X86UnwindingMode::RbpFrame) => {
+                // This function has the standard function prelude and rbp
+                // has been preserved. Additionally, any callee-saved registers
+                // that haven't been preserved (x86_rbp_registers) are saved on
+                // the stack at x86_rbp_stack_offset.
+                let mut ops = vec![
+                    CompactCfiOp::RegisterIs {
+                        dest_reg: CompactCfiRegister::Cfa,
+                        src_reg: CompactCfiRegister::frame_pointer(),
+                        offset_from_src: 2 * pointer_size,
+                    },
+                    CompactCfiOp::RegisterAt {
+                        dest_reg: CompactCfiRegister::frame_pointer(),
+                        src_reg: CompactCfiRegister::Cfa,
+                        offset_from_src: -2 * pointer_size,
+                    },
+                    CompactCfiOp::RegisterAt {
+                        dest_reg: CompactCfiRegister::instruction_pointer(),
+                        src_reg: CompactCfiRegister::Cfa,
+                        offset_from_src: -1 * pointer_size,
+                    },
+                ];
+
+                // These offsets are relative to the frame pointer, but
+                // cfi prefers things to be relative to the cfa, so apply
+                // the same offset here too.
+                let offset = self.x86_rbp_stack_offset() as i32 + 2;
+                // Offset advances even if there's no register here
+                for (i, reg) in self.x86_rbp_registers().iter().enumerate() {
+                    if let Some(reg) = *reg {
+                        ops.push(CompactCfiOp::RegisterAt {
+                            dest_reg: reg,
+                            src_reg: CompactCfiRegister::Cfa,
+                            offset_from_src: (offset - i as i32) * pointer_size,
+                        });
+                    }
+                }
+                Some(ops.into_iter())
+            }
+            Some(X86UnwindingMode::StackImmediate) => {
+                // This function doesn't have the standard rbp-based prelude,
+                // but we know how large its stack frame is (x86_frameless_stack_size),
+                // and any callee-saved registers that haven't been preserved are
+                // saved *immediately* after the location at rip.
+
+                let mut ops = vec![];
+
+                let stack_size = self.x86_frameless_stack_size();
+                ops.push(CompactCfiOp::RegisterIs {
+                    dest_reg: CompactCfiRegister::Cfa,
+                    src_reg: CompactCfiRegister::stack_pointer(),
+                    offset_from_src: stack_size as i32 * pointer_size,
+                });
+                ops.push(CompactCfiOp::RegisterAt {
+                    dest_reg: CompactCfiRegister::instruction_pointer(),
+                    src_reg: CompactCfiRegister::Cfa,
+                    offset_from_src: -1 * pointer_size,
+                });
+
+                let mut offset = 2;
+                // offset only advances if there's a register here.
+                // also note registers are in reverse order.
+                for reg in self.x86_frameless_registers().iter().rev() {
+                    if let Some(reg) = *reg {
+                        ops.push(CompactCfiOp::RegisterAt {
+                            dest_reg: reg,
+                            src_reg: CompactCfiRegister::Cfa,
+                            offset_from_src: -offset * pointer_size,
+                        });
+                        offset += 1;
+                    }
+                }
+                Some(ops.into_iter())
+            }
+            Some(X86UnwindingMode::StackIndirect) => {
+                // TODO: implement this? Perhaps there is no reasonable implementation
+                // since this involves parsing a value out of a machine instruction
+                // in the binary? Or can we just do that work here and it just
+                // becomes a constant in the CFI output?
+                //
+                // Either way it's not urgent, since this mode is only needed for
+                // stack frames that are bigger than ~2KB.
+                None
+            }
+            Some(X86UnwindingMode::Dwarf) => None,
+            None => None,
+        }
+    }
+
+    fn x86_mode(&self) -> Option<X86UnwindingMode> {
+        const X86_MODE_MASK: u32 = 0x0F00_0000;
+        const X86_MODE_RBP_FRAME: u32 = 0x0100_0000;
+        const X86_MODE_STACK_IMMD: u32 = 0x0200_0000;
+        const X86_MODE_STACK_IND: u32 = 0x0300_0000;
+        const X86_MODE_DWARF: u32 = 0x0400_0000;
+
+        let masked = self.0 & X86_MODE_MASK;
+
+        match masked {
+            X86_MODE_RBP_FRAME => Some(X86UnwindingMode::RbpFrame),
+            X86_MODE_STACK_IMMD => Some(X86UnwindingMode::StackImmediate),
+            X86_MODE_STACK_IND => Some(X86UnwindingMode::StackIndirect),
+            X86_MODE_DWARF => Some(X86UnwindingMode::Dwarf),
+            _ => None,
+        }
+    }
+
+    fn x86_rbp_registers(&self) -> [Option<CompactCfiRegister>; 5] {
+        let mask = 0b111;
+        let offset1 = 32 - 8 - 3;
+        let offset2 = offset1 - 3;
+        let offset3 = offset2 - 3;
+        let offset4 = offset3 - 3;
+        let offset5 = offset4 - 3;
+        [
+            CompactCfiRegister::from_encoded((self.0 >> offset1) & mask),
+            CompactCfiRegister::from_encoded((self.0 >> offset2) & mask),
+            CompactCfiRegister::from_encoded((self.0 >> offset3) & mask),
+            CompactCfiRegister::from_encoded((self.0 >> offset4) & mask),
+            CompactCfiRegister::from_encoded((self.0 >> offset5) & mask),
+        ]
+    }
+
+    fn x86_rbp_stack_offset(&self) -> u32 {
+        self.0 & 0b1111_1111
+    }
+
+    fn x86_frameless_stack_size(&self) -> u32 {
+        let offset = 32 - 8 - 8;
+        (self.0 >> offset) & 0b1111_1111
+    }
+
+    fn x86_frameless_register_count(&self) -> u32 {
+        let offset = 32 - 8 - 8 - 3 - 3;
+        (self.0 >> offset) & 0b111
+    }
+
+    fn x86_frameless_registers(&self) -> [Option<CompactCfiRegister>; 6] {
+        let mut permutation = self.0 & 0b11_1111_1111;
+        let mut permunreg = [0; 6];
+        let register_count = self.x86_frameless_register_count();
+
+        // I honestly haven't looked into what the heck this is doing, I
+        // just copied this implementation from llvm since it honestly doesn't
+        // matter much. Magically unpack 6 values from 10 bits!
+        match register_count {
+            6 => {
+                permunreg[0] = permutation / 120; // 120 == 5!
+                permutation -= permunreg[0] * 120;
+                permunreg[1] = permutation / 24; // 24 == 4!
+                permutation -= permunreg[1] * 24;
+                permunreg[2] = permutation / 6; // 6 == 3!
+                permutation -= permunreg[2] * 6;
+                permunreg[3] = permutation / 2; // 2 == 2!
+                permutation -= permunreg[3] * 2;
+                permunreg[4] = permutation; // 1 == 1!
+                permunreg[5] = 0;
+            }
+            5 => {
+                permunreg[0] = permutation / 120;
+                permutation -= permunreg[0] * 120;
+                permunreg[1] = permutation / 24;
+                permutation -= permunreg[1] * 24;
+                permunreg[2] = permutation / 6;
+                permutation -= permunreg[2] * 6;
+                permunreg[3] = permutation / 2;
+                permutation -= permunreg[3] * 2;
+                permunreg[4] = permutation;
+            }
+            4 => {
+                permunreg[0] = permutation / 60;
+                permutation -= permunreg[0] * 60;
+                permunreg[1] = permutation / 12;
+                permutation -= permunreg[1] * 12;
+                permunreg[2] = permutation / 3;
+                permutation -= permunreg[2] * 3;
+                permunreg[3] = permutation;
+            }
+            3 => {
+                permunreg[0] = permutation / 20;
+                permutation -= permunreg[0] * 20;
+                permunreg[1] = permutation / 4;
+                permutation -= permunreg[1] * 4;
+                permunreg[2] = permutation;
+            }
+            2 => {
+                permunreg[0] = permutation / 5;
+                permutation -= permunreg[0] * 5;
+                permunreg[1] = permutation;
+            }
+            1 => {
+                permunreg[0] = permutation;
+            }
+            _ => {
+                // Do nothing
+            }
+        }
+
+        let mut registers = [0u32; 6];
+        let mut used = [false; 7];
+        for i in 0..register_count {
+            let mut renum = 0;
+            for j in 1u32..7 {
+                if !used[j as usize] {
+                    if renum == permunreg[i as usize] {
+                        registers[i as usize] = j;
+                        used[j as usize] = true;
+                        break;
+                    }
+                    renum += 1;
+                }
+            }
+        }
+        [
+            CompactCfiRegister::from_encoded(registers[0]),
+            CompactCfiRegister::from_encoded(registers[1]),
+            CompactCfiRegister::from_encoded(registers[2]),
+            CompactCfiRegister::from_encoded(registers[3]),
+            CompactCfiRegister::from_encoded(registers[4]),
+            CompactCfiRegister::from_encoded(registers[5]),
+        ]
+    }
+    /*
+    // potentially needed for future work:
+
+    fn x86_frameless_stack_adjust(&self) -> u32 {
+        let offset = 32 - 8 - 8 - 3;
+        (self.0 >> offset) & 0b111
+    }
+    fn x86_dwarf_fde(&self) -> u32 {
+        self.0 & 0x00FF_FFFF
+    }
+    */
+}
+
+// ARM64 implementation
+impl Opcode {
+    fn arm64_cfi_instructions(
+        &self,
+        _iter: &CompactUnwindInfoIter,
+    ) -> Option<std::vec::IntoIter<CompactCfiOp>> {
+        // TODO: implement ARM64 decoding
+        None
+    }
+}
+
+impl CompactCfiRegister {
+    fn from_encoded(val: u32) -> Option<Self> {
+        if 1 <= val && val <= 6 {
+            Some(CompactCfiRegister::Other(val as u8))
+        } else {
+            None
+        }
+    }
+
+    /// Whether this register is the cfa register.
+    pub fn is_cfa(&self) -> bool {
+        matches!(*self, CompactCfiRegister::Cfa)
+    }
+
+    /// The name of this register that cfi wants.
+    pub fn name(&self, iter: &CompactUnwindInfoIter) -> Option<&'static str> {
+        match self {
+            CompactCfiRegister::Cfa => Some("cfa"),
+            CompactCfiRegister::Other(other) => name_of_other_reg(*other, iter),
+        }
+    }
+
+    /// Gets the register for the frame pointer (e.g. rbp).
+    pub fn frame_pointer() -> Self {
+        CompactCfiRegister::Other(6)
+    }
+
+    /// Gets the register for the instruction pointer (e.g. rip).
+    pub fn instruction_pointer() -> Self {
+        CompactCfiRegister::Other(254)
+    }
+
+    /// Gets the register for the stack pointer (e.g. rsp).
+    pub fn stack_pointer() -> Self {
+        CompactCfiRegister::Other(255)
+    }
+}
+
+fn name_of_other_reg(reg: u8, iter: &CompactUnwindInfoIter) -> Option<&'static str> {
+    match iter.arch {
+        Arch::X86 => match reg {
+            0 => None,
+            1 => Some("ebx"),
+            2 => Some("ecx"),
+            3 => Some("edx"),
+            4 => Some("edi"),
+            5 => Some("esi"),
+            6 => Some("ebp"),
+            // Not part of the compact format, but needed to describe opcode behaviours
+            254 => Some("eip"),
+            255 => Some("esp"),
+
+            _ => None,
+        },
+        Arch::X64 => match reg {
+            0 => None,
+            1 => Some("rbx"),
+            2 => Some("r12"),
+            3 => Some("r13"),
+            4 => Some("r14"),
+            5 => Some("r15"),
+            6 => Some("rbp"),
+            // Not part of the compact format, but needed to describe opcode behaviours
+            254 => Some("rip"),
+            255 => Some("rsp"),
+            _ => None,
+        },
+        Arch::Arm64 => {
+            unimplemented!();
+            // Leaving these here to help whoever decides to implement ARM64 support
+            /*
+            match reg {
+                0x00000001 => Some("x19/x20"),
+                0x00000002 => Some("x21/x22"),
+                0x00000004 => Some("x23/x24"),
+                0x00000008 => Some("x25/x26"),
+                0x00000010 => Some("x27/x28"),
+                0x00000100 => Some("d8/d9"),
+                0x00000200 => Some("d10/d11"),
+                0x00000400 => Some("d12/d13"),
+                0x00000800 => Some("d14/d15"),
+                _ => None
+            }
+            */
+        }
+        _ => None,
+    }
+}

--- a/symbolic-debuginfo/src/macho/mod.rs
+++ b/symbolic-debuginfo/src/macho/mod.rs
@@ -17,8 +17,10 @@ use crate::dwarf::{Dwarf, DwarfDebugSession, DwarfError, DwarfSection, Endian};
 use crate::private::{MonoArchive, MonoArchiveObjects, Parse};
 
 mod bcsymbolmap;
+pub mod compact;
 
 pub use bcsymbolmap::*;
+pub use compact::*;
 
 /// Prefix for hidden symbols from Apple BCSymbolMap builds.
 const SWIFT_HIDDEN_PREFIX: &str = "__hidden#";
@@ -39,6 +41,18 @@ impl MachError {
     {
         let source = Some(source.into());
         Self { source }
+    }
+}
+
+impl From<goblin::error::Error> for MachError {
+    fn from(e: goblin::error::Error) -> Self {
+        Self::new(e)
+    }
+}
+
+impl From<scroll::Error> for MachError {
+    fn from(e: scroll::Error) -> Self {
+        Self::new(e)
     }
 }
 
@@ -111,6 +125,22 @@ impl<'d> MachObject<'d> {
     /// ```
     pub fn load_symbolmap(&mut self, symbolmap: BcSymbolMap<'d>) {
         self.bcsymbolmap = Some(Arc::new(symbolmap));
+    }
+
+    /// Gets the Compact Unwind Info of this object, if any exists.
+    pub fn compact_unwind_info(&self) -> Result<Option<CompactUnwindInfoIter<'d>>, MachError> {
+        if let Some(section) = self.section("unwind_info") {
+            if let Cow::Borrowed(section) = section.data {
+                let arch = self.arch();
+                let is_little_endian = self.endianity() == Endian::Little;
+                return Ok(Some(CompactUnwindInfoIter::new(
+                    section,
+                    is_little_endian,
+                    arch,
+                )?));
+            }
+        }
+        Ok(None)
     }
 
     /// The container file format, which is always `FileFormat::MachO`.
@@ -293,7 +323,9 @@ impl<'d> MachObject<'d> {
 
     /// Determines whether this object contains stack unwinding information.
     pub fn has_unwind_info(&self) -> bool {
-        self.has_section("eh_frame") || self.has_section("debug_frame")
+        self.has_section("eh_frame")
+            || self.has_section("debug_frame")
+            || self.has_section("unwind_info")
     }
 
     /// Determines whether this object contains embedded source.

--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -469,8 +469,10 @@ impl<W: Write> AsciiCfiWriter<W> {
                         }
                     }
 
+                    let line = line.strip_suffix(b" ").unwrap_or(&line);
+
                     self.inner
-                        .write_all(&line)
+                        .write_all(line)
                         .and_then(|_| writeln!(self.inner))?;
                 }
             }

--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -432,7 +432,7 @@ impl<W: Write> AsciiCfiWriter<W> {
                             info.section
                                 .fde_from_offset(&info.bases, offset, U::cie_from_offset)
                         {
-                            self.process_fde(info, &mut ctx, &fde)?
+                            self.process_fde(info, &mut ctx, &fde)?;
                         }
                     }
                 }

--- a/symbolic-minidump/tests/snapshots/test_cfi__cfi_macho.snap
+++ b/symbolic-minidump/tests/snapshots/test_cfi__cfi_macho.snap
@@ -5,19 +5,19 @@ expression: cfi
 ---
 STACK CFI INIT d20 1a .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT d40 1a .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT d60 40 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
-STACK CFI INIT da0 40 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
-STACK CFI INIT de0 40 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
-STACK CFI INIT e20 50 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
+STACK CFI INIT d60 40 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
+STACK CFI INIT da0 40 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
+STACK CFI INIT de0 40 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
+STACK CFI INIT e20 50 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
 STACK CFI INIT e70 2d .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI e71 .cfa: $rsp 16 +
-STACK CFI INIT ea0 150 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
-STACK CFI INIT ff0 150 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT ea0 150 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
+STACK CFI INIT ff0 150 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
 STACK CFI INIT 1140 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT 1150 2d0 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $rbx: .cfa -40 + ^ 
+STACK CFI INIT 1150 2d0 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $rbx: .cfa -40 + ^
 STACK CFI INIT 1420 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT 1430 2d0 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $rbx: .cfa -40 + ^ 
-STACK CFI INIT 1700 d0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r12: .cfa -32 + ^ $rbx: .cfa -40 + ^ 
+STACK CFI INIT 1430 2d0 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $rbx: .cfa -40 + ^
+STACK CFI INIT 1700 d0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r12: .cfa -32 + ^ $rbx: .cfa -40 + ^
 STACK CFI INIT 17d0 104 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 17d1 .cfa: $rsp 16 +
 STACK CFI 17d3 .cfa: $rsp 24 +
@@ -26,7 +26,7 @@ STACK CFI 17d7 .cfa: $rsp 40 +
 STACK CFI 17d9 .cfa: $rsp 48 +
 STACK CFI 17da .cfa: $rsp 56 +
 STACK CFI 17db .cfa: $rsp 64 + $rbx: .cfa -56 + ^ $r12: .cfa -48 + ^ $r13: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
-STACK CFI INIT 18e0 c0 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
+STACK CFI INIT 18e0 c0 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^
 STACK CFI INIT 19a0 c8 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 19a2 .cfa: $rsp 16 +
 STACK CFI 19a4 .cfa: $rsp 24 +
@@ -39,7 +39,7 @@ STACK CFI 1a74 .cfa: $rsp 24 +
 STACK CFI 1a76 .cfa: $rsp 32 +
 STACK CFI 1a77 .cfa: $rsp 40 +
 STACK CFI 1a78 .cfa: $rsp 48 + $rbx: .cfa -40 + ^ $r12: .cfa -32 + ^ $r14: .cfa -24 + ^ $r15: .cfa -16 + ^
-STACK CFI INIT 1d30 c0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
+STACK CFI INIT 1d30 c0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^
 STACK CFI INIT 1df0 1ba .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 1df1 .cfa: $rsp 16 +
 STACK CFI 1df3 .cfa: $rsp 24 +
@@ -49,13 +49,13 @@ STACK CFI 1df9 .cfa: $rsp 48 +
 STACK CFI 1dfa .cfa: $rsp 56 +
 STACK CFI 1dfb .cfa: $rsp 64 + $rbx: .cfa -56 + ^ $r12: .cfa -48 + ^ $r13: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
 STACK CFI INIT 1fb0 7 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT 1fc0 c0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
-STACK CFI INIT 2080 e0 .cfa: $rsp 112 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
-STACK CFI INIT 2160 60 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
+STACK CFI INIT 1fc0 c0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^
+STACK CFI INIT 2080 e0 .cfa: $rsp 112 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
+STACK CFI INIT 2160 60 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
 STACK CFI INIT 21c0 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT 21d0 40 .cfa: $rsp 48 + .ra: .cfa -8 + ^ 
-STACK CFI INIT 2210 5d0 .cfa: $rsp 288 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
-STACK CFI INIT 27e0 5d0 .cfa: $rsp 288 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT 21d0 40 .cfa: $rsp 48 + .ra: .cfa -8 + ^
+STACK CFI INIT 2210 5d0 .cfa: $rsp 288 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
+STACK CFI INIT 27e0 5d0 .cfa: $rsp 288 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
 STACK CFI INIT 2db0 4a .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 2e00 3a .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 2e40 1c3 .cfa: $rsp 8 + .ra: .cfa -8 + ^
@@ -66,8 +66,8 @@ STACK CFI 2e47 .cfa: $rsp 40 +
 STACK CFI 2e49 .cfa: $rsp 48 +
 STACK CFI 2e4a .cfa: $rsp 56 +
 STACK CFI 2e4b .cfa: $rsp 64 + $rbx: .cfa -56 + ^ $r12: .cfa -48 + ^ $r13: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
-STACK CFI INIT 3010 1c0 .cfa: $rsp 160 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
-STACK CFI INIT 31d0 120 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT 3010 1c0 .cfa: $rsp 160 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^
+STACK CFI INIT 31d0 120 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
 STACK CFI INIT 32f0 185 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 32f1 .cfa: $rsp 16 +
 STACK CFI 32f3 .cfa: $rsp 24 +
@@ -76,61 +76,61 @@ STACK CFI 32f7 .cfa: $rsp 40 +
 STACK CFI 32f9 .cfa: $rsp 48 +
 STACK CFI 32fa .cfa: $rsp 56 +
 STACK CFI 32fb .cfa: $rsp 64 + $rbx: .cfa -56 + ^ $r12: .cfa -48 + ^ $r13: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
-STACK CFI INIT 3480 620 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
-STACK CFI INIT 3aa0 150 .cfa: $rsp 24 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
-STACK CFI INIT 3bf0 2d0 .cfa: $rsp 32 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
+STACK CFI INIT 3480 620 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
+STACK CFI INIT 3aa0 150 .cfa: $rsp 24 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^
+STACK CFI INIT 3bf0 2d0 .cfa: $rsp 32 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^
 STACK CFI INIT 3ec0 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 3ed0 20 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT 3ef0 100 .cfa: $rsp 288 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
-STACK CFI INIT 3ff0 190 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
-STACK CFI INIT 4180 120 .cfa: $rsp 128 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
+STACK CFI INIT 3ef0 100 .cfa: $rsp 288 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^
+STACK CFI INIT 3ff0 190 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^
+STACK CFI INIT 4180 120 .cfa: $rsp 128 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^
 STACK CFI INIT 42a0 e .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 42b0 e .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 42c0 9 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT 42d0 130 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
+STACK CFI INIT 42d0 130 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^
 STACK CFI INIT 4400 8 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT 4410 170 .cfa: $rsp 640 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
-STACK CFI INIT 4580 100 .cfa: $rsp 640 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
+STACK CFI INIT 4410 170 .cfa: $rsp 640 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^
+STACK CFI INIT 4580 100 .cfa: $rsp 640 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $rbx: .cfa -24 + ^
 STACK CFI INIT 4680 b .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 4681 .cfa: $rsp 16 +
 STACK CFI INIT 4690 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT 46a0 120 .cfa: $rsp 640 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
-STACK CFI INIT 47c0 c0 .cfa: $rsp 640 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
-STACK CFI INIT 4880 c0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
-STACK CFI INIT 4940 a0 .cfa: $rsp 288 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
-STACK CFI INIT 49e0 140 .cfa: $rsp 272 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
-STACK CFI INIT 4b20 260 .cfa: $rsp 272 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
-STACK CFI INIT 4d80 2e0 .cfa: $rsp 736 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
-STACK CFI INIT 5060 e0 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
-STACK CFI INIT 5140 f0 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
-STACK CFI INIT 5230 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
-STACK CFI INIT 5280 170 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
-STACK CFI INIT 53f0 320 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r13: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
-STACK CFI INIT 5710 260 .cfa: $rsp 1104 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r12: .cfa -32 + ^ $rbx: .cfa -40 + ^ 
+STACK CFI INIT 46a0 120 .cfa: $rsp 640 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^
+STACK CFI INIT 47c0 c0 .cfa: $rsp 640 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $rbx: .cfa -24 + ^
+STACK CFI INIT 4880 c0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^
+STACK CFI INIT 4940 a0 .cfa: $rsp 288 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^
+STACK CFI INIT 49e0 140 .cfa: $rsp 272 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^
+STACK CFI INIT 4b20 260 .cfa: $rsp 272 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
+STACK CFI INIT 4d80 2e0 .cfa: $rsp 736 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
+STACK CFI INIT 5060 e0 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^
+STACK CFI INIT 5140 f0 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^
+STACK CFI INIT 5230 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^
+STACK CFI INIT 5280 170 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $rbx: .cfa -24 + ^
+STACK CFI INIT 53f0 320 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r13: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^
+STACK CFI INIT 5710 260 .cfa: $rsp 1104 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r12: .cfa -32 + ^ $rbx: .cfa -40 + ^
 STACK CFI INIT 5970 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT 5980 350 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
+STACK CFI INIT 5980 350 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^
 STACK CFI INIT 5cd0 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT 5ce0 a0 .cfa: $rsp 32 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
+STACK CFI INIT 5ce0 a0 .cfa: $rsp 32 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^
 STACK CFI INIT 5d80 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT 5d90 20 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
+STACK CFI INIT 5d90 20 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
 STACK CFI INIT 5db0 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT 5dc0 120 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r13: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
-STACK CFI INIT 5ee0 2c0 .cfa: $rsp 192 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
-STACK CFI INIT 61a0 250 .cfa: $rsp 224 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
-STACK CFI INIT 63f0 520 .cfa: $rsp 1152 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
-STACK CFI INIT 6910 260 .cfa: $rsp 160 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
-STACK CFI INIT 6b70 290 .cfa: $rsp 336 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
-STACK CFI INIT 7060 110 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
-STACK CFI INIT 7170 120 .cfa: $rsp 176 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
-STACK CFI INIT 7290 180 .cfa: $rsp 112 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
+STACK CFI INIT 5dc0 120 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r13: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^
+STACK CFI INIT 5ee0 2c0 .cfa: $rsp 192 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
+STACK CFI INIT 61a0 250 .cfa: $rsp 224 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
+STACK CFI INIT 63f0 520 .cfa: $rsp 1152 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
+STACK CFI INIT 6910 260 .cfa: $rsp 160 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^
+STACK CFI INIT 6b70 290 .cfa: $rsp 336 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
+STACK CFI INIT 7060 110 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^
+STACK CFI INIT 7170 120 .cfa: $rsp 176 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
+STACK CFI INIT 7290 180 .cfa: $rsp 112 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^
 STACK CFI INIT 7410 24 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 7411 .cfa: $rsp 16 +
 STACK CFI INIT 7440 8 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 7450 9 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 7460 22 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 7461 .cfa: $rsp 16 +
-STACK CFI INIT 7490 1b0 .cfa: $rsp 784 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
-STACK CFI INIT 7640 1d0 .cfa: $rsp 1296 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
+STACK CFI INIT 7490 1b0 .cfa: $rsp 784 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^
+STACK CFI INIT 7640 1d0 .cfa: $rsp 1296 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^
 STACK CFI INIT 7810 3d .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 7811 .cfa: $rsp 16 +
 STACK CFI INIT 7850 4 .cfa: $rsp 8 + .ra: .cfa -8 + ^
@@ -141,14 +141,14 @@ STACK CFI 7873 .cfa: $rsp 24 +
 STACK CFI 7875 .cfa: $rsp 32 +
 STACK CFI 7876 .cfa: $rsp 40 +
 STACK CFI 7877 .cfa: $rsp 48 + $rbx: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
-STACK CFI INIT 7930 1b0 .cfa: $rsp 976 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
-STACK CFI INIT 7ae0 280 .cfa: $rsp 1152 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $rbx: .cfa -40 + ^ 
-STACK CFI INIT 7d60 3a0 .cfa: $rsp 112 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT 7930 1b0 .cfa: $rsp 976 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
+STACK CFI INIT 7ae0 280 .cfa: $rsp 1152 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $rbx: .cfa -40 + ^
+STACK CFI INIT 7d60 3a0 .cfa: $rsp 112 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
 STACK CFI INIT 8100 4e .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 8101 .cfa: $rsp 16 +
 STACK CFI 8102 .cfa: $rsp 24 +
 STACK CFI 8103 .cfa: $rsp 32 + $rbx: .cfa -24 + ^ $rbp: .cfa -16 + ^
-STACK CFI INIT 8500 b0 .cfa: $rsp 32 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
+STACK CFI INIT 8500 b0 .cfa: $rsp 32 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^
 STACK CFI INIT 85b0 158 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 85b1 .cfa: $rsp 16 +
 STACK CFI 85b3 .cfa: $rsp 24 +
@@ -157,12 +157,12 @@ STACK CFI 85b7 .cfa: $rsp 40 +
 STACK CFI 85b9 .cfa: $rsp 48 +
 STACK CFI 85ba .cfa: $rsp 56 +
 STACK CFI 85bb .cfa: $rsp 64 + $rbx: .cfa -56 + ^ $r12: .cfa -48 + ^ $r13: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
-STACK CFI INIT 8710 280 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
-STACK CFI INIT 8990 1b0 .cfa: $rsp 40 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $rbx: .cfa -40 + ^ 
-STACK CFI INIT 8b40 120 .cfa: $rsp 24 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
-STACK CFI INIT 8c60 310 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r13: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
+STACK CFI INIT 8710 280 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^
+STACK CFI INIT 8990 1b0 .cfa: $rsp 40 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $rbx: .cfa -40 + ^
+STACK CFI INIT 8b40 120 .cfa: $rsp 24 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $rbx: .cfa -24 + ^
+STACK CFI INIT 8c60 310 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r13: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^
 STACK CFI INIT 8f70 fa .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT 90d0 a50 .cfa: $rsp 56 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT 90d0 a50 .cfa: $rsp 56 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
 STACK CFI INIT 9b20 13 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 9b40 137 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 9b41 .cfa: $rsp 16 +
@@ -172,19 +172,19 @@ STACK CFI 9b47 .cfa: $rsp 40 +
 STACK CFI 9b49 .cfa: $rsp 48 +
 STACK CFI 9b4a .cfa: $rsp 56 +
 STACK CFI 9b4b .cfa: $rsp 64 + $rbx: .cfa -56 + ^ $r12: .cfa -48 + ^ $r13: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
-STACK CFI INIT 9c80 6f0 .cfa: $rsp 56 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT 9c80 6f0 .cfa: $rsp 56 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
 STACK CFI INIT a370 108 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI a371 .cfa: $rsp 16 +
 STACK CFI a373 .cfa: $rsp 24 +
 STACK CFI a375 .cfa: $rsp 32 +
 STACK CFI a376 .cfa: $rsp 40 +
 STACK CFI a377 .cfa: $rsp 48 + $rbx: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
-STACK CFI INIT a480 f0 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
-STACK CFI INIT a570 690 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
-STACK CFI INIT ac00 80 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
-STACK CFI INIT ac80 f0 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
-STACK CFI INIT ad70 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
-STACK CFI INIT adc0 2c0 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT a480 f0 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^
+STACK CFI INIT a570 690 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
+STACK CFI INIT ac00 80 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
+STACK CFI INIT ac80 f0 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^
+STACK CFI INIT ad70 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
+STACK CFI INIT adc0 2c0 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
 STACK CFI INIT b080 114 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI b081 .cfa: $rsp 16 +
 STACK CFI b083 .cfa: $rsp 24 +
@@ -193,44 +193,44 @@ STACK CFI b087 .cfa: $rsp 40 +
 STACK CFI b089 .cfa: $rsp 48 +
 STACK CFI b08a .cfa: $rsp 56 +
 STACK CFI b08b .cfa: $rsp 64 + $rbx: .cfa -56 + ^ $r12: .cfa -48 + ^ $r13: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
-STACK CFI INIT b1a0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^ 
+STACK CFI INIT b1a0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT b1b0 16 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT b1d0 16 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT b2d0 b0 .cfa: $rsp 1200 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $rbx: .cfa -40 + ^ 
-STACK CFI INIT b380 90 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
+STACK CFI INIT b2d0 b0 .cfa: $rsp 1200 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $rbx: .cfa -40 + ^
+STACK CFI INIT b380 90 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
 STACK CFI INIT b410 c5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT b4e0 c5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT b5b0 c0 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT b670 c0 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT b730 1 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT b740 1 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT b750 280 .cfa: $rsp 24 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
+STACK CFI INIT b750 280 .cfa: $rsp 24 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $rbx: .cfa -24 + ^
 STACK CFI INIT b9d0 e .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT bad0 70 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
-STACK CFI INIT bb40 90 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
+STACK CFI INIT bad0 70 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
+STACK CFI INIT bb40 90 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^
 STACK CFI INIT bbd0 3d .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI bbd1 .cfa: $rsp 16 +
 STACK CFI bbd2 .cfa: $rsp 24 +
 STACK CFI bbd3 .cfa: $rsp 32 + $rbx: .cfa -24 + ^ $rbp: .cfa -16 + ^
-STACK CFI INIT bc10 f0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
+STACK CFI INIT bc10 f0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^
 STACK CFI INIT bd00 3d .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI bd01 .cfa: $rsp 16 +
 STACK CFI bd02 .cfa: $rsp 24 +
 STACK CFI bd03 .cfa: $rsp 32 + $rbx: .cfa -24 + ^ $rbp: .cfa -16 + ^
-STACK CFI INIT bd40 40 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
-STACK CFI INIT c320 70 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
-STACK CFI INIT c390 330 .cfa: $rsp 8 + .ra: .cfa -8 + ^ 
-STACK CFI INIT c6c0 a0 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
+STACK CFI INIT bd40 40 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
+STACK CFI INIT c320 70 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^
+STACK CFI INIT c390 330 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT c6c0 a0 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
 STACK CFI INIT c760 2f .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT c790 2f .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT c7c0 17 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI c7c1 .cfa: $rsp 16 +
 STACK CFI INIT c7e0 17 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI c7e1 .cfa: $rsp 16 +
-STACK CFI INIT c800 160 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
-STACK CFI INIT c960 3a0 .cfa: $rsp 112 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
-STACK CFI INIT cd00 f0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
-STACK CFI INIT cdf0 120 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
+STACK CFI INIT c800 160 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^
+STACK CFI INIT c960 3a0 .cfa: $rsp 112 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
+STACK CFI INIT cd00 f0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^
+STACK CFI INIT cdf0 120 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^
 STACK CFI INIT cf10 5f .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI cf11 .cfa: $rsp 16 +
 STACK CFI cf12 .cfa: $rsp 24 +
@@ -244,14 +244,14 @@ STACK CFI cfb7 .cfa: $rsp 40 +
 STACK CFI cfb9 .cfa: $rsp 48 +
 STACK CFI cfba .cfa: $rsp 56 +
 STACK CFI cfbb .cfa: $rsp 64 + $rbx: .cfa -56 + ^ $r12: .cfa -48 + ^ $r13: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
-STACK CFI INIT d160 110 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r13: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
-STACK CFI INIT d270 320 .cfa: $rsp 208 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT d160 110 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r13: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^
+STACK CFI INIT d270 320 .cfa: $rsp 208 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
 STACK CFI INIT d590 44 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI d591 .cfa: $rsp 16 +
 STACK CFI d592 .cfa: $rsp 24 +
 STACK CFI d593 .cfa: $rsp 32 + $rbx: .cfa -24 + ^ $rbp: .cfa -16 + ^
 STACK CFI INIT d5e0 1a .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT d600 80 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
+STACK CFI INIT d600 80 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
 STACK CFI INIT d680 34 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI d681 .cfa: $rsp 16 +
 STACK CFI d682 .cfa: $rsp 24 +
@@ -265,7 +265,7 @@ STACK CFI d713 .cfa: $rsp 24 +
 STACK CFI d714 .cfa: $rsp 32 + $rbx: .cfa -24 + ^ $r14: .cfa -16 + ^
 STACK CFI INIT d7c0 16 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT d7e0 13 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT d800 120 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
+STACK CFI INIT d800 120 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^
 STACK CFI INIT d920 3f .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI d921 .cfa: $rsp 16 +
 STACK CFI d922 .cfa: $rsp 24 +
@@ -294,6 +294,6 @@ STACK CFI INIT db30 a .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT db40 a .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT db50 41 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI db51 .cfa: $rsp 16 +
-STACK CFI INIT dba0 d0 .cfa: $rsp 320 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
-STACK CFI INIT dc70 34 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
+STACK CFI INIT dba0 d0 .cfa: $rsp 320 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
+STACK CFI INIT dc70 34 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
 

--- a/symbolic-minidump/tests/snapshots/test_cfi__cfi_macho.snap
+++ b/symbolic-minidump/tests/snapshots/test_cfi__cfi_macho.snap
@@ -1,15 +1,23 @@
 ---
-created: "2019-02-20T15:42:11.796526Z"
-creator: insta@0.6.3
-source: minidump/tests/test_cfi.rs
+source: symbolic-minidump/tests/test_cfi.rs
 expression: cfi
+
 ---
 STACK CFI INIT d20 1a .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT d40 1a .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT d60 40 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
+STACK CFI INIT da0 40 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
+STACK CFI INIT de0 40 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
+STACK CFI INIT e20 50 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
 STACK CFI INIT e70 2d .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI e71 .cfa: $rsp 16 +
+STACK CFI INIT ea0 150 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT ff0 150 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
 STACK CFI INIT 1140 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 1150 2d0 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $rbx: .cfa -40 + ^ 
 STACK CFI INIT 1420 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 1430 2d0 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $rbx: .cfa -40 + ^ 
+STACK CFI INIT 1700 d0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r12: .cfa -32 + ^ $rbx: .cfa -40 + ^ 
 STACK CFI INIT 17d0 104 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 17d1 .cfa: $rsp 16 +
 STACK CFI 17d3 .cfa: $rsp 24 +
@@ -18,6 +26,7 @@ STACK CFI 17d7 .cfa: $rsp 40 +
 STACK CFI 17d9 .cfa: $rsp 48 +
 STACK CFI 17da .cfa: $rsp 56 +
 STACK CFI 17db .cfa: $rsp 64 + $rbx: .cfa -56 + ^ $r12: .cfa -48 + ^ $r13: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
+STACK CFI INIT 18e0 c0 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
 STACK CFI INIT 19a0 c8 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 19a2 .cfa: $rsp 16 +
 STACK CFI 19a4 .cfa: $rsp 24 +
@@ -30,6 +39,7 @@ STACK CFI 1a74 .cfa: $rsp 24 +
 STACK CFI 1a76 .cfa: $rsp 32 +
 STACK CFI 1a77 .cfa: $rsp 40 +
 STACK CFI 1a78 .cfa: $rsp 48 + $rbx: .cfa -40 + ^ $r12: .cfa -32 + ^ $r14: .cfa -24 + ^ $r15: .cfa -16 + ^
+STACK CFI INIT 1d30 c0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
 STACK CFI INIT 1df0 1ba .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 1df1 .cfa: $rsp 16 +
 STACK CFI 1df3 .cfa: $rsp 24 +
@@ -39,7 +49,13 @@ STACK CFI 1df9 .cfa: $rsp 48 +
 STACK CFI 1dfa .cfa: $rsp 56 +
 STACK CFI 1dfb .cfa: $rsp 64 + $rbx: .cfa -56 + ^ $r12: .cfa -48 + ^ $r13: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
 STACK CFI INIT 1fb0 7 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 1fc0 c0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
+STACK CFI INIT 2080 e0 .cfa: $rsp 112 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
+STACK CFI INIT 2160 60 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
 STACK CFI INIT 21c0 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 21d0 40 .cfa: $rsp 48 + .ra: .cfa -8 + ^ 
+STACK CFI INIT 2210 5d0 .cfa: $rsp 288 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT 27e0 5d0 .cfa: $rsp 288 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
 STACK CFI INIT 2db0 4a .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 2e00 3a .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 2e40 1c3 .cfa: $rsp 8 + .ra: .cfa -8 + ^
@@ -50,6 +66,8 @@ STACK CFI 2e47 .cfa: $rsp 40 +
 STACK CFI 2e49 .cfa: $rsp 48 +
 STACK CFI 2e4a .cfa: $rsp 56 +
 STACK CFI 2e4b .cfa: $rsp 64 + $rbx: .cfa -56 + ^ $r12: .cfa -48 + ^ $r13: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
+STACK CFI INIT 3010 1c0 .cfa: $rsp 160 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
+STACK CFI INIT 31d0 120 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
 STACK CFI INIT 32f0 185 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 32f1 .cfa: $rsp 16 +
 STACK CFI 32f3 .cfa: $rsp 24 +
@@ -58,25 +76,61 @@ STACK CFI 32f7 .cfa: $rsp 40 +
 STACK CFI 32f9 .cfa: $rsp 48 +
 STACK CFI 32fa .cfa: $rsp 56 +
 STACK CFI 32fb .cfa: $rsp 64 + $rbx: .cfa -56 + ^ $r12: .cfa -48 + ^ $r13: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
+STACK CFI INIT 3480 620 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT 3aa0 150 .cfa: $rsp 24 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
+STACK CFI INIT 3bf0 2d0 .cfa: $rsp 32 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
 STACK CFI INIT 3ec0 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 3ed0 20 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 3ef0 100 .cfa: $rsp 288 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
+STACK CFI INIT 3ff0 190 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
+STACK CFI INIT 4180 120 .cfa: $rsp 128 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
 STACK CFI INIT 42a0 e .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 42b0 e .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 42c0 9 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 42d0 130 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
 STACK CFI INIT 4400 8 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 4410 170 .cfa: $rsp 640 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
+STACK CFI INIT 4580 100 .cfa: $rsp 640 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
 STACK CFI INIT 4680 b .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 4681 .cfa: $rsp 16 +
 STACK CFI INIT 4690 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 46a0 120 .cfa: $rsp 640 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
+STACK CFI INIT 47c0 c0 .cfa: $rsp 640 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
+STACK CFI INIT 4880 c0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
+STACK CFI INIT 4940 a0 .cfa: $rsp 288 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
+STACK CFI INIT 49e0 140 .cfa: $rsp 272 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
+STACK CFI INIT 4b20 260 .cfa: $rsp 272 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT 4d80 2e0 .cfa: $rsp 736 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT 5060 e0 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
+STACK CFI INIT 5140 f0 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
+STACK CFI INIT 5230 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
+STACK CFI INIT 5280 170 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
+STACK CFI INIT 53f0 320 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r13: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
+STACK CFI INIT 5710 260 .cfa: $rsp 1104 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r12: .cfa -32 + ^ $rbx: .cfa -40 + ^ 
 STACK CFI INIT 5970 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 5980 350 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
 STACK CFI INIT 5cd0 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 5ce0 a0 .cfa: $rsp 32 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
 STACK CFI INIT 5d80 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 5d90 20 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
 STACK CFI INIT 5db0 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 5dc0 120 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r13: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
+STACK CFI INIT 5ee0 2c0 .cfa: $rsp 192 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT 61a0 250 .cfa: $rsp 224 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT 63f0 520 .cfa: $rsp 1152 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT 6910 260 .cfa: $rsp 160 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
+STACK CFI INIT 6b70 290 .cfa: $rsp 336 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT 7060 110 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
+STACK CFI INIT 7170 120 .cfa: $rsp 176 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT 7290 180 .cfa: $rsp 112 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
 STACK CFI INIT 7410 24 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 7411 .cfa: $rsp 16 +
 STACK CFI INIT 7440 8 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 7450 9 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 7460 22 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 7461 .cfa: $rsp 16 +
+STACK CFI INIT 7490 1b0 .cfa: $rsp 784 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
+STACK CFI INIT 7640 1d0 .cfa: $rsp 1296 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
 STACK CFI INIT 7810 3d .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 7811 .cfa: $rsp 16 +
 STACK CFI INIT 7850 4 .cfa: $rsp 8 + .ra: .cfa -8 + ^
@@ -87,10 +141,14 @@ STACK CFI 7873 .cfa: $rsp 24 +
 STACK CFI 7875 .cfa: $rsp 32 +
 STACK CFI 7876 .cfa: $rsp 40 +
 STACK CFI 7877 .cfa: $rsp 48 + $rbx: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
+STACK CFI INIT 7930 1b0 .cfa: $rsp 976 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT 7ae0 280 .cfa: $rsp 1152 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $rbx: .cfa -40 + ^ 
+STACK CFI INIT 7d60 3a0 .cfa: $rsp 112 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
 STACK CFI INIT 8100 4e .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 8101 .cfa: $rsp 16 +
 STACK CFI 8102 .cfa: $rsp 24 +
 STACK CFI 8103 .cfa: $rsp 32 + $rbx: .cfa -24 + ^ $rbp: .cfa -16 + ^
+STACK CFI INIT 8500 b0 .cfa: $rsp 32 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
 STACK CFI INIT 85b0 158 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 85b1 .cfa: $rsp 16 +
 STACK CFI 85b3 .cfa: $rsp 24 +
@@ -99,7 +157,12 @@ STACK CFI 85b7 .cfa: $rsp 40 +
 STACK CFI 85b9 .cfa: $rsp 48 +
 STACK CFI 85ba .cfa: $rsp 56 +
 STACK CFI 85bb .cfa: $rsp 64 + $rbx: .cfa -56 + ^ $r12: .cfa -48 + ^ $r13: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
+STACK CFI INIT 8710 280 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
+STACK CFI INIT 8990 1b0 .cfa: $rsp 40 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $rbx: .cfa -40 + ^ 
+STACK CFI INIT 8b40 120 .cfa: $rsp 24 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
+STACK CFI INIT 8c60 310 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r13: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
 STACK CFI INIT 8f70 fa .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 90d0 a50 .cfa: $rsp 56 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
 STACK CFI INIT 9b20 13 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT 9b40 137 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI 9b41 .cfa: $rsp 16 +
@@ -109,12 +172,19 @@ STACK CFI 9b47 .cfa: $rsp 40 +
 STACK CFI 9b49 .cfa: $rsp 48 +
 STACK CFI 9b4a .cfa: $rsp 56 +
 STACK CFI 9b4b .cfa: $rsp 64 + $rbx: .cfa -56 + ^ $r12: .cfa -48 + ^ $r13: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
+STACK CFI INIT 9c80 6f0 .cfa: $rsp 56 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
 STACK CFI INIT a370 108 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI a371 .cfa: $rsp 16 +
 STACK CFI a373 .cfa: $rsp 24 +
 STACK CFI a375 .cfa: $rsp 32 +
 STACK CFI a376 .cfa: $rsp 40 +
 STACK CFI a377 .cfa: $rsp 48 + $rbx: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
+STACK CFI INIT a480 f0 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $r14: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
+STACK CFI INIT a570 690 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT ac00 80 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT ac80 f0 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
+STACK CFI INIT ad70 50 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
+STACK CFI INIT adc0 2c0 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
 STACK CFI INIT b080 114 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI b081 .cfa: $rsp 16 +
 STACK CFI b083 .cfa: $rsp 24 +
@@ -123,41 +193,44 @@ STACK CFI b087 .cfa: $rsp 40 +
 STACK CFI b089 .cfa: $rsp 48 +
 STACK CFI b08a .cfa: $rsp 56 +
 STACK CFI b08b .cfa: $rsp 64 + $rbx: .cfa -56 + ^ $r12: .cfa -48 + ^ $r13: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
-STACK CFI INIT b1a0 5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT b1a0 10 .cfa: $rsp 8 + .ra: .cfa -8 + ^ 
 STACK CFI INIT b1b0 16 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT b1d0 16 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT b2d0 b0 .cfa: $rsp 1200 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $rbx: .cfa -40 + ^ 
+STACK CFI INIT b380 90 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
 STACK CFI INIT b410 c5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT b4e0 c5 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT b5b0 c0 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT b670 c0 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT b730 1 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT b740 1 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT b750 280 .cfa: $rsp 24 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $rbx: .cfa -24 + ^ 
 STACK CFI INIT b9d0 e .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT bad0 70 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
+STACK CFI INIT bb40 90 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
 STACK CFI INIT bbd0 3d .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI bbd1 .cfa: $rsp 16 +
 STACK CFI bbd2 .cfa: $rsp 24 +
 STACK CFI bbd3 .cfa: $rsp 32 + $rbx: .cfa -24 + ^ $rbp: .cfa -16 + ^
+STACK CFI INIT bc10 f0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
 STACK CFI INIT bd00 3d .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI bd01 .cfa: $rsp 16 +
 STACK CFI bd02 .cfa: $rsp 24 +
 STACK CFI bd03 .cfa: $rsp 32 + $rbx: .cfa -24 + ^ $rbp: .cfa -16 + ^
-STACK CFI INIT c390 f .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT c3a0 f .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT c3b0 22 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT c3e0 35 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT c420 6d .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT c490 f .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT c4a0 87 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT c530 2a .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT c560 25 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT c590 c8 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-STACK CFI INIT c660 5e .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT bd40 40 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
+STACK CFI INIT c320 70 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
+STACK CFI INIT c390 330 .cfa: $rsp 8 + .ra: .cfa -8 + ^ 
+STACK CFI INIT c6c0 a0 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
 STACK CFI INIT c760 2f .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT c790 2f .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT c7c0 17 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI c7c1 .cfa: $rsp 16 +
 STACK CFI INIT c7e0 17 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI c7e1 .cfa: $rsp 16 +
+STACK CFI INIT c800 160 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
+STACK CFI INIT c960 3a0 .cfa: $rsp 112 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
+STACK CFI INIT cd00 f0 .cfa: $rsp 64 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
+STACK CFI INIT cdf0 120 .cfa: $rsp 96 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
 STACK CFI INIT cf10 5f .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI cf11 .cfa: $rsp 16 +
 STACK CFI cf12 .cfa: $rsp 24 +
@@ -171,11 +244,14 @@ STACK CFI cfb7 .cfa: $rsp 40 +
 STACK CFI cfb9 .cfa: $rsp 48 +
 STACK CFI cfba .cfa: $rsp 56 +
 STACK CFI cfbb .cfa: $rsp 64 + $rbx: .cfa -56 + ^ $r12: .cfa -48 + ^ $r13: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
+STACK CFI INIT d160 110 .cfa: $rsp 80 + .ra: .cfa -8 + ^ $r15: .cfa -16 + ^ $r14: .cfa -24 + ^ $r13: .cfa -32 + ^ $r12: .cfa -40 + ^ $rbx: .cfa -48 + ^ 
+STACK CFI INIT d270 320 .cfa: $rsp 208 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^ 
 STACK CFI INIT d590 44 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI d591 .cfa: $rsp 16 +
 STACK CFI d592 .cfa: $rsp 24 +
 STACK CFI d593 .cfa: $rsp 32 + $rbx: .cfa -24 + ^ $rbp: .cfa -16 + ^
 STACK CFI INIT d5e0 1a .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT d600 80 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
 STACK CFI INIT d680 34 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI d681 .cfa: $rsp 16 +
 STACK CFI d682 .cfa: $rsp 24 +
@@ -189,6 +265,7 @@ STACK CFI d713 .cfa: $rsp 24 +
 STACK CFI d714 .cfa: $rsp 32 + $rbx: .cfa -24 + ^ $r14: .cfa -16 + ^
 STACK CFI INIT d7c0 16 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT d7e0 13 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT d800 120 .cfa: $rsp 48 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^ 
 STACK CFI INIT d920 3f .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI d921 .cfa: $rsp 16 +
 STACK CFI d922 .cfa: $rsp 24 +
@@ -217,4 +294,6 @@ STACK CFI INIT db30 a .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT db40 a .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT db50 41 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI db51 .cfa: $rsp 16 +
+STACK CFI INIT dba0 d0 .cfa: $rsp 320 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
+STACK CFI INIT dc70 34 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^ 
 


### PR DESCRIPTION
This is a WIP implementation of #368. It appears to generate reasonable-looking `STACK CFI` records, though I haven't tested them yet.

A few major questions that need feedback from the symbolic folks:

* Where should this implementation go (gimli, goblin, another symbolic- crate..?)
* What should this implementation use as the basis for its parsing/error-handling (currently using gimli for everything, bad choice for the errors)
* How should this handle *conflicting* `STACK CFI` records between the DWARF CFI sections and the compact unwinding sections? This is not theoretical -- this happens on e.g. libmozglue in release firefox distributions.

The conflicting records has been kind of useful for being able to see that my output does indeed seem reasonable, as it largely agrees with the DWARF CFI-based `STACK CFI` records. Although the compact unwind info entries seem to ignore properly adjusting .cfa during the function prelude, where registers are being saved. e.g. DWARF CFI produces this:

```
STACK CFI INIT c90 75 .cfa: $rsp 8 + .ra: .cfa -8 + ^
STACK CFI c91 .cfa: $rsp 16 +
STACK CFI c93 .cfa: $rsp 24 +
STACK CFI c94 .cfa: $rsp 32 + $rbx: .cfa -32 + ^ $r14: .cfa -24 + ^ $rbp: .cfa -16 + ^

STACK CFI INIT d10 2fa .cfa: $rsp 8 + .ra: .cfa -8 + ^
STACK CFI d11 .cfa: $rsp 16 +
STACK CFI d13 .cfa: $rsp 24 +
STACK CFI d15 .cfa: $rsp 32 +
STACK CFI d17 .cfa: $rsp 40 +
STACK CFI d19 .cfa: $rsp 48 +
STACK CFI d1a .cfa: $rsp 56 +
STACK CFI d1e .cfa: $rsp 160 + $rbx: .cfa -56 + ^ $r12: .cfa -48 + ^ $r13: .cfa -40 + ^ $r14: .cfa -32 + ^ $r15: .cfa -24 + ^ $rbp: .cfa -16 + ^
```

While compact unwind info produces this (note how the final STACK CFI records of the above agree with the below):

```
STACK CFI INIT c90 80 .cfa: $rsp 32 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r14: .cfa -24 + ^ $rbx: .cfa -32 + ^

STACK CFI INIT d10 300 .cfa: $rsp 160 + .ra: .cfa -8 + ^ $rbp: .cfa -16 + ^ $r15: .cfa -24 + ^ $r14: .cfa -32 + ^ $r13: .cfa -40 + ^ $r12: .cfa -48 + ^ $rbx: .cfa -56 + ^
```

This is a bit funky, but also kinda reasonable since these preludes necessarily shouldn't show up in a backtrace (except for maybe in the top frame, but then that frame is probably not very interesting to someone debugging a crash).