### PR TITLE
feat(py): Support BCSymbolMap on python API

### DIFF
--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -219,6 +219,7 @@ class ObjectLookup(object):
 
 class BcSymbolMap(RustObject):
     """Object representing an Apple ``.bcsymbolmap`` file."""
+
     __dealloc_func__ = lib.symbolic_bcsymbolmap_free
 
     @classmethod
@@ -226,13 +227,12 @@ class BcSymbolMap(RustObject):
         """Parses a BCSymbolMap file."""
         if isinstance(path, text_type):
             path = path.encode("utf-8")
-        return cls._from_objptr(
-            rustcall(lib.symbolic_bcsymbolmap_open, path)
-        )
+        return cls._from_objptr(rustcall(lib.symbolic_bcsymbolmap_open, path))
 
 
 class UuidMapping(RustObject):
     """Object represenging a mapping from one DebugID to another."""
+
     __dealloc_func__ = lib.symbolic_uuidmapping_free
 
     @classmethod

--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -231,7 +231,7 @@ class BcSymbolMap(RustObject):
 
 
 class UuidMapping(RustObject):
-    """Object represenging a mapping from one DebugID to another."""
+    """Object representing a mapping from one DebugID to another."""
 
     __dealloc_func__ = lib.symbolic_uuidmapping_free
 

--- a/py/symbolic/debuginfo.py
+++ b/py/symbolic/debuginfo.py
@@ -13,6 +13,8 @@ __all__ = [
     "Archive",
     "Object",
     "ObjectLookup",
+    "BcSymbolMap",
+    "UuidMapping",
     "id_from_breakpad",
     "normalize_code_id",
     "normalize_debug_id",
@@ -213,6 +215,35 @@ class ObjectLookup(object):
     def get_object(self, debug_id):
         """Finds an object by the given debug id."""
         return self.objects.get(debug_id)
+
+
+class BcSymbolMap(RustObject):
+    """Object representing an Apple ``.bcsymbolmap`` file."""
+    __dealloc_func__ = lib.symbolic_bcsymbolmap_free
+
+    @classmethod
+    def open(cls, path):
+        """Parses a BCSymbolMap file."""
+        if isinstance(path, text_type):
+            path = path.encode("utf-8")
+        return cls._from_objptr(
+            rustcall(lib.symbolic_bcsymbolmap_open, path)
+        )
+
+
+class UuidMapping(RustObject):
+    """Object represenging a mapping from one DebugID to another."""
+    __dealloc_func__ = lib.symbolic_uuidmapping_free
+
+    @classmethod
+    def from_plist(cls, debug_id, path):
+        """Parses a PList."""
+        debug_id = encode_str(debug_id)
+        if isinstance(path, text_type):
+            path = path.encode("utf-8")
+        return cls._from_objptr(
+            rustcall(lib.symbolic_uuidmapping_from_plist, debug_id, path)
+        )
 
 
 def id_from_breakpad(breakpad_id):

--- a/symbolic-cabi/include/symbolic.h
+++ b/symbolic-cabi/include/symbolic.h
@@ -104,6 +104,11 @@ typedef uint32_t SymbolicFrameTrust;
 typedef struct SymbolicArchive SymbolicArchive;
 
 /**
+ * A `BCSymbolMap`.
+ */
+typedef struct SymbolicBcSymbolMap SymbolicBcSymbolMap;
+
+/**
  * Contains stack frame information (CFI) for an image.
  */
 typedef struct SymbolicCfiCache SymbolicCfiCache;
@@ -147,6 +152,11 @@ typedef struct SymbolicUnreal4Crash SymbolicUnreal4Crash;
  * A file contained in a SymbolicUnreal4Crash.
  */
 typedef struct SymbolicUnreal4File SymbolicUnreal4File;
+
+/**
+ * A UUID mapping.
+ */
+typedef struct SymbolicUuidMapping SymbolicUuidMapping;
 
 /**
  * A length-prefixed UTF-8 string.
@@ -472,6 +482,27 @@ struct SymbolicObjectFeatures symbolic_object_get_features(const struct Symbolic
  * Frees an object returned from an archive.
  */
 void symbolic_object_free(struct SymbolicObject *object);
+
+/**
+ * Loads a BCSymbolmap from a given path
+ */
+struct SymbolicBcSymbolMap *symbolic_bcsymbolmap_open(const char *path);
+
+/**
+ * Frees the given BcSymbolMap.
+ */
+void symbolic_bcsymbolmap_free(struct SymbolicBcSymbolMap *bcsymbolmap);
+
+/**
+ * Loads a UuidMapping by parsing the PList at `path`.
+ */
+struct SymbolicUuidMapping *symbolic_uuidmapping_from_plist(const struct SymbolicStr *debug_id,
+                                                            const char *path);
+
+/**
+ * Frees the given UuidMapping.
+ */
+void symbolic_uuidmapping_free(struct SymbolicUuidMapping *mapping);
 
 /**
  * Converts a Breakpad CodeModuleId to DebugId.

--- a/symbolic-debuginfo/src/macho/bcsymbolmap.rs
+++ b/symbolic-debuginfo/src/macho/bcsymbolmap.rs
@@ -7,7 +7,7 @@ use std::iter::FusedIterator;
 use std::path::Path;
 
 use elementtree::Element;
-use symbolic_common::{DebugId, ParseDebugIdError};
+use symbolic_common::{AsSelf, DebugId, ParseDebugIdError};
 use thiserror::Error;
 
 use super::SWIFT_HIDDEN_PREFIX;
@@ -72,6 +72,14 @@ impl From<BcSymbolMapErrorKind> for BcSymbolMapError {
             kind: source,
             source: None,
         }
+    }
+}
+
+impl<'slf> AsSelf<'slf> for BcSymbolMap<'_> {
+    type Ref = BcSymbolMap<'slf>;
+
+    fn as_self(&'slf self) -> &Self::Ref {
+        self
     }
 }
 


### PR DESCRIPTION
This provides a minimal Python API for the BcSymbolMap and UuidMapping
types which is sufficient to support the formats in sentry.

Related PRs:
https://github.com/getsentry/sentry/pull/25712
https://github.com/getsentry/sentry-cli/pull/952
https://github.com/getsentry/symbolicator/pull/414