### PR TITLE
fix: Handle too many files more gracefully

### DIFF
--- a/symbolic-symcache/src/writer.rs
+++ b/symbolic-symcache/src/writer.rs
@@ -381,8 +381,10 @@ where
             return Ok(*index);
         }
 
-        if self.files.len() >= std::u16::MAX as usize {
-            return Err(SymCacheErrorKind::TooManyValues(ValueKind::File).into());
+        // TODO: Instead of failing hard when exceeding the maximum allowed number of files, we rather
+        // emit `u16::MAX` which is already treated as a sentinel value for unknown file entries.
+        if self.files.len() >= u16::MAX as usize {
+            return Ok(u16::MAX);
         }
 
         let index = self.files.len() as u16;


### PR DESCRIPTION
Instead of failing hard when hitting the max file limit, we rather emit
a sentinel for every file that exceeds the limit.

I tested this on https://symbols.electronjs.org/Electron%20Framework/8DE7618E965231A7B4CDD1C701077B9B0/Electron%20Framework.sym which previously ran into this limit and failed symcache conversion.