### PR TITLE
fix: Make clippy 1.52 happy

### DIFF
--- a/examples/symcache_debug/src/main.rs
+++ b/examples/symcache_debug/src/main.rs
@@ -37,16 +37,13 @@ fn execute(matches: &ArgMatches) -> Result<()> {
 
         let mut obj = None;
 
-        #[allow(clippy::useless_let_if_seq)]
-        {
-            if arch == Arch::Unknown && objects.len() == 1 {
-                obj = Some(&objects[0]);
-            } else {
-                for o in &objects {
-                    if o.arch() == arch {
-                        obj = Some(o);
-                        break;
-                    }
+        if arch == Arch::Unknown && objects.len() == 1 {
+            obj = Some(&objects[0]);
+        } else {
+            for o in &objects {
+                if o.arch() == arch {
+                    obj = Some(o);
+                    break;
                 }
             }
         }

--- a/symbolic-cabi/src/core.rs
+++ b/symbolic-cabi/src/core.rs
@@ -223,7 +223,6 @@ pub enum SymbolicErrorCode {
 
 impl SymbolicErrorCode {
     /// This maps all errors that can possibly happen.
-    // #[allow(clippy::cyclomatic_complexity)]
     pub fn from_error(error: &(dyn std::error::Error + 'static)) -> SymbolicErrorCode {
         let mut source = Some(error);
 

--- a/symbolic-cabi/src/lib.rs
+++ b/symbolic-cabi/src/lib.rs
@@ -1,6 +1,6 @@
 //! Exposes a C-ABI for symbolic.
 
-#![allow(clippy::cast_ptr_alignment, clippy::missing_safety_doc)]
+#![allow(clippy::missing_safety_doc)]
 
 #[macro_use]
 mod utils;

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -1,4 +1,5 @@
 //! Support for Breakpad ASCII symbols, used by the Breakpad and Crashpad libraries.
+#![allow(clippy::from_str_radix_10)]
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;
@@ -1004,6 +1005,7 @@ impl<'data> BreakpadObject<'data> {
 
     /// The code identifier of this object.
     pub fn code_id(&self) -> Option<CodeId> {
+        #[allow(clippy::manual_flatten)]
         for result in self.info_records() {
             if let Ok(BreakpadInfoRecord::CodeId { code_id, .. }) = result {
                 if !code_id.is_empty() {

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -470,10 +470,7 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             _ => Language::Unknown,
         };
 
-        let line_program = match unit.line_program {
-            Some(ref program) => Some(DwarfLineProgram::prepare(program.clone())),
-            None => None,
-        };
+        let line_program = unit.line_program.as_ref().map(|program| DwarfLineProgram::prepare(program.clone()));
 
         let producer = match entry.attr_value(constants::DW_AT_producer)? {
             Some(AttributeValue::String(string)) => Some(string),

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -470,7 +470,10 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             _ => Language::Unknown,
         };
 
-        let line_program = unit.line_program.as_ref().map(|program| DwarfLineProgram::prepare(program.clone()));
+        let line_program = unit
+            .line_program
+            .as_ref()
+            .map(|program| DwarfLineProgram::prepare(program.clone()));
 
         let producer = match entry.attr_value(constants::DW_AT_producer)? {
             Some(AttributeValue::String(string)) => Some(string),

--- a/symbolic-debuginfo/src/macho/mod.rs
+++ b/symbolic-debuginfo/src/macho/mod.rs
@@ -614,7 +614,6 @@ impl<'slf, 'd: 'slf> AsSelf<'slf> for FatMachO<'d> {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
 enum MachObjectIteratorInner<'d, 'a> {
     Single(MonoArchiveObjects<'d, MachObject<'d>>),
     Archive(FatMachObjectIterator<'d, 'a>),

--- a/symbolic-debuginfo/src/macho/mod.rs
+++ b/symbolic-debuginfo/src/macho/mod.rs
@@ -421,25 +421,23 @@ impl<'data> Dwarf<'data> for MachObject<'data> {
 
     fn raw_section(&self, section_name: &str) -> Option<DwarfSection<'data>> {
         for segment in &self.macho.segments {
-            for section in segment {
-                if let Ok((header, data)) = section {
-                    if let Ok(sec) = header.name() {
-                        if sec.len() >= 2 && &sec[2..] == section_name {
-                            // In some cases, dsymutil leaves sections headers but removes their
-                            // data from the file. While the addr and size parameters are still
-                            // set, `header.offset` is 0 in that case. We skip them just like the
-                            // section was missing to avoid loading invalid data.
-                            if header.offset == 0 {
-                                return None;
-                            }
-
-                            return Some(DwarfSection {
-                                data: Cow::Borrowed(data),
-                                address: header.addr,
-                                offset: u64::from(header.offset),
-                                align: u64::from(header.align),
-                            });
+            for (header, data) in segment.into_iter().flatten() {
+                if let Ok(sec) = header.name() {
+                    if sec.len() >= 2 && &sec[2..] == section_name {
+                        // In some cases, dsymutil leaves sections headers but removes their
+                        // data from the file. While the addr and size parameters are still
+                        // set, `header.offset` is 0 in that case. We skip them just like the
+                        // section was missing to avoid loading invalid data.
+                        if header.offset == 0 {
+                            return None;
                         }
+
+                        return Some(DwarfSection {
+                            data: Cow::Borrowed(data),
+                            address: header.addr,
+                            offset: u64::from(header.offset),
+                            align: u64::from(header.align),
+                        });
                     }
                 }
             }

--- a/symbolic-debuginfo/src/wasm.rs
+++ b/symbolic-debuginfo/src/wasm.rs
@@ -53,6 +53,7 @@ impl<'data> WasmObject<'data> {
         // we need to parse the file a second time to get the offset to the
         // code section as walrus does not expose that yet.
         let mut code_offset = 0;
+        #[allow(clippy::manual_flatten)]
         for payload in wasmparser::Parser::new(0).parse_all(data) {
             if let Ok(wasmparser::Payload::CodeSectionStart { range, .. }) = payload {
                 code_offset = range.start as u64;
@@ -62,8 +63,8 @@ impl<'data> WasmObject<'data> {
 
         Ok(WasmObject {
             wasm_module,
-            data,
             code_offset,
+            data,
         })
     }
 

--- a/symbolic-debuginfo/src/wasm.rs
+++ b/symbolic-debuginfo/src/wasm.rs
@@ -53,9 +53,8 @@ impl<'data> WasmObject<'data> {
         // we need to parse the file a second time to get the offset to the
         // code section as walrus does not expose that yet.
         let mut code_offset = 0;
-        #[allow(clippy::manual_flatten)]
-        for payload in wasmparser::Parser::new(0).parse_all(data) {
-            if let Ok(wasmparser::Payload::CodeSectionStart { range, .. }) = payload {
+        for payload in wasmparser::Parser::new(0).parse_all(data).flatten() {
+            if let wasmparser::Payload::CodeSectionStart { range, .. } = payload {
                 code_offset = range.start as u64;
                 break;
             }

--- a/symbolic-demangle/tests/test_swift.rs
+++ b/symbolic-demangle/tests/test_swift.rs
@@ -1,7 +1,6 @@
 //! Swift Demangling Tests
 //! All functions were compiled with Swift 4.0 in a file called mangling.swift
 //! see https://github.com/apple/swift/blob/master/test/SILGen/mangling.swift
-#![allow(clippy::cognitive_complexity)]
 #![cfg(feature = "swift")]
 
 #[macro_use]

--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -293,10 +293,8 @@ impl<W: Write> AsciiCfiWriter<W> {
                         r.start, r.size, r.init_rules
                     )?;
 
-                    for d in r.deltas() {
-                        if let Ok(d) = d {
-                            writeln!(self.inner, "STACK CFI {:x} {}", d.address, d.rules)?;
-                        }
+                    for d in r.deltas().flatten() {
+                        writeln!(self.inner, "STACK CFI {:x} {}", d.address, d.rules)?;
                     }
 
                     Ok(())


### PR DESCRIPTION
I just allowed the str_radix lint since it leaded to uglier code.
Similarly, I think the manual_flatten is too strict, I will file an issue upstream.