### PR TITLE
ci(periodic): Fix fail-fast config

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -11,8 +11,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    fail-fast: false
     strategy:
+      fail-fast: false
       matrix:
         rust: [nightly, beta]
     steps:


### PR DESCRIPTION
This seemed to break the entire periodic job and no one seems to get
any notifications for that.  Ugh.

#skip-changelog