### PR TITLE
build(clippy): Move common statement out of branches

### DIFF
--- a/symbolic-common/src/path.rs
+++ b/symbolic-common/src/path.rs
@@ -197,7 +197,6 @@ pub fn clean_path(path: &str) -> Cow<'_, str> {
                 if rv.is_empty() {
                     needs_separator = false;
                 }
-                continue;
             } else {
                 if !is_past_root {
                     needs_separator = false;
@@ -208,8 +207,8 @@ pub fn clean_path(path: &str) -> Cow<'_, str> {
                 }
                 rv.push_str("..");
                 needs_separator = true;
-                continue;
             }
+            continue;
         }
         if needs_separator {
             rv.push(main_separator);


### PR DESCRIPTION
Nightly clippy does not like it if these statements are repeated in
all branches.

#skip-changelog