### PR TITLE
ref(clippy): Remove unused private field

### DIFF
--- a/symbolic-debuginfo/src/sourcebundle.rs
+++ b/symbolic-debuginfo/src/sourcebundle.rs
@@ -747,7 +747,6 @@ where
 {
     manifest: SourceBundleManifest,
     writer: ZipWriter<W>,
-    finished: bool,
 }
 
 impl<W> SourceBundleWriter<W>
@@ -764,7 +763,6 @@ where
         Ok(SourceBundleWriter {
             manifest: SourceBundleManifest::new(),
             writer: ZipWriter::new(writer),
-            finished: false,
         })
     }
 
@@ -954,7 +952,6 @@ where
         self.writer
             .finish()
             .map_err(|e| SourceBundleError::new(SourceBundleErrorKind::WriteFailed, e))?;
-        self.finished = true;
         Ok(())
     }
 


### PR DESCRIPTION
This field was written but never used, and it is private.  So it was
dead code.  Thanks nightly clippy.

#skip-changelog