### PR TITLE
fix(breakpad): Handle all WIN record types

### DIFF
--- a/symbolic-debuginfo/src/breakpad.pest
+++ b/symbolic-debuginfo/src/breakpad.pest
@@ -65,7 +65,7 @@ stack_win = { "STACK WIN"
                 ~ hex // has_program_string
                 ~ text // program_string_OR_allocates_base_pointer
             }
-frame_type = { "0" | "4" }
+frame_type = { "0" | "1" | "2" | "3" | "4" | "-1" }
 
 // STACK CFI record
 // STACK CFI ("Call Frame Information") records describe how to walk the stack when execution is at a given machine instruction.

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -777,8 +777,20 @@ pub enum BreakpadStackWinRecordType {
     /// Frame pointer omitted; FPO info available.
     Fpo = 0,
 
+    /// Kernel Trap frame.
+    Trap = 1,
+
+    /// Kernel Trap frame.
+    Tss = 2,
+
+    /// Standard EBP stack frame.
+    Standard = 3,
+
     /// Frame pointer omitted; Frame data info available.
     FrameData = 4,
+
+    /// Frame that does not have any debug info.
+    Unknown = -1,
 }
 
 /// A [Windows stack frame record], used on x86.
@@ -840,10 +852,13 @@ impl<'d> BreakpadStackWinRecord<'d> {
     // Constructs a stack record directly from a Pest parser pair.
     fn from_pair(pair: pest::iterators::Pair<'d, Rule>) -> Self {
         let mut pairs = pair.into_inner();
-        let ty = if pairs.next().unwrap().as_str() == "4" {
-            BreakpadStackWinRecordType::FrameData
-        } else {
-            BreakpadStackWinRecordType::Fpo
+        let ty = match pairs.next().unwrap().as_str() {
+            "0" => BreakpadStackWinRecordType::Fpo,
+            "1" => BreakpadStackWinRecordType::Trap,
+            "2" => BreakpadStackWinRecordType::Tss,
+            "3" => BreakpadStackWinRecordType::Standard,
+            "4" => BreakpadStackWinRecordType::FrameData,
+            _ => BreakpadStackWinRecordType::Unknown,
         };
         let code_start = u32::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
         let code_size = u32::from_str_radix(pairs.next().unwrap().as_str(), 16).unwrap();
@@ -1642,6 +1657,30 @@ mod tests {
                 ),
             },
         )
+        "###);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_stack_win_record_type_3() -> Result<(), BreakpadError> {
+        let string = b"STACK WIN 3 8a10b ec b 0 c c 4 0 0 1";
+        let record = BreakpadStackWinRecord::parse(string)?;
+
+        insta::assert_debug_snapshot!(record, @r###"
+        BreakpadStackWinRecord {
+            ty: Standard,
+            code_start: 565515,
+            code_size: 236,
+            prolog_size: 11,
+            epilog_size: 0,
+            params_size: 12,
+            saved_regs_size: 12,
+            locals_size: 4,
+            max_stack_size: 0,
+            uses_base_pointer: true,
+            program_string: None,
+        }
         "###);
 
         Ok(())

--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -26,9 +26,7 @@ use std::ops::Range;
 use thiserror::Error;
 
 use symbolic_common::{Arch, ByteView, UnknownArchError};
-use symbolic_debuginfo::breakpad::{
-    BreakpadError, BreakpadObject, BreakpadStackRecord, BreakpadStackWinRecordType,
-};
+use symbolic_debuginfo::breakpad::{BreakpadError, BreakpadObject, BreakpadStackRecord};
 use symbolic_debuginfo::dwarf::gimli::{
     BaseAddresses, CfaRule, CieOrFde, DebugFrame, EhFrame, Error as GimliError,
     FrameDescriptionEntry, Reader, Register, RegisterRule, UninitializedUnwindContext,
@@ -302,10 +300,7 @@ impl<W: Write> AsciiCfiWriter<W> {
                 BreakpadStackRecord::Win(r) => writeln!(
                     self.inner,
                     "STACK WIN {} {:x} {:x} {:x} {:x} {:x} {:x} {:x} {:x} {} {}",
-                    match r.ty {
-                        BreakpadStackWinRecordType::Fpo => "0",
-                        BreakpadStackWinRecordType::FrameData => "4",
-                    },
+                    r.ty as usize,
                     r.code_start,
                     r.code_size,
                     r.prolog_size,


### PR DESCRIPTION
Breakpad officially only handles record types `0` and `4`, but we do sometimes get records of other types.