### PR TITLE
fix: Update msvc-demangler

### DIFF
--- a/symbolic-demangle/Cargo.toml
+++ b/symbolic-demangle/Cargo.toml
@@ -32,7 +32,7 @@ swift = ["cc"]
 
 [dependencies]
 cpp_demangle = { version = "0.3.2", optional = true }
-msvc-demangler = { version = "0.8.0", optional = true }
+msvc-demangler = { version = "0.9.0", optional = true }
 rustc-demangle = { version = "0.1.16", optional = true }
 symbolic-common = { version = "8.1.0", path = "../symbolic-common" }
 


### PR DESCRIPTION
This update finally includes our patches and avoids the need to pull it from a git dependency.