### PR TITLE
ref(clippy): Avoid needles references

### DIFF
--- a/examples/dump_sources/src/main.rs
+++ b/examples/dump_sources/src/main.rs
@@ -46,7 +46,7 @@ fn write_object_sources(path: &Path, output_path: &Path) -> Result<(), Box<dyn s
 fn execute(matches: &ArgMatches<'_>) {
     let output_path = Path::new(matches.value_of("output").unwrap());
     for path in matches.values_of("paths").unwrap_or_default() {
-        if let Err(e) = write_object_sources(Path::new(&path), &output_path) {
+        if let Err(e) = write_object_sources(Path::new(&path), output_path) {
             print_error(e.as_ref());
         }
 

--- a/examples/minidump_stackwalk/src/main.rs
+++ b/examples/minidump_stackwalk/src/main.rs
@@ -198,7 +198,7 @@ fn print_state(
         let mut index = 0;
         for (fi, frame) in thread.frames().iter().enumerate() {
             if let Some(module) = frame.module() {
-                if let Some(line_infos) = symbolize(&symcaches, frame, arch, fi == 0)? {
+                if let Some(line_infos) = symbolize(symcaches, frame, arch, fi == 0)? {
                     for (i, info) in line_infos.iter().enumerate() {
                         println!(
                             "{:>3}  {}!{} [{} : {} + 0x{:x}]",

--- a/symbolic-cabi/src/proguard.rs
+++ b/symbolic-cabi/src/proguard.rs
@@ -33,7 +33,7 @@ impl<'slf, 'a: 'slf> AsSelf<'slf> for Inner<'a> {
     type Ref = Inner<'slf>;
 
     fn as_self(&'slf self) -> &Self::Ref {
-        &self
+        self
     }
 }
 

--- a/symbolic-common/src/path.rs
+++ b/symbolic-common/src/path.rs
@@ -394,7 +394,7 @@ pub fn shorten_path(path: &str, length: usize) -> Cow<'_, str> {
     rv.push_str("...");
     rv.push_str(final_sep);
     for item in rest {
-        rv.push_str(&item);
+        rv.push_str(item);
     }
 
     Cow::Owned(rv)

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -1357,7 +1357,7 @@ impl<'s> BreakpadFunctionIterator<'s> {
         let mut lines = Vec::new();
         for line in record.lines() {
             let line = line?;
-            let filename = line.filename(&self.file_map).unwrap_or_default();
+            let filename = line.filename(self.file_map).unwrap_or_default();
 
             lines.push(LineInfo {
                 address: line.address,

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -787,7 +787,7 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             // Avoid constant allocations by collecting repeatedly into the same buffer and
             // draining the results out of it. This keeps the original buffer allocated and
             // allows for a single allocation per call to `resolve_lines`.
-            let lines = self.resolve_lines(&range_buf);
+            let lines = self.resolve_lines(range_buf);
 
             if inline {
                 // An inlined function must always have a parent. An empty list of funcs

--- a/symbolic-debuginfo/src/elf.rs
+++ b/symbolic-debuginfo/src/elf.rs
@@ -287,7 +287,7 @@ impl<'data> ElfObject<'data> {
             let endianness = self.elf.header.endianness().ok()?;
             let context = Ctx::new(container, endianness);
 
-            let compression = CompressionHeader::parse(&section_data, 0, context).ok()?;
+            let compression = CompressionHeader::parse(section_data, 0, context).ok()?;
             if compression.ch_type != ELFCOMPRESS_ZLIB {
                 return None;
             }

--- a/symbolic-debuginfo/src/macho/compact.rs
+++ b/symbolic-debuginfo/src/macho/compact.rs
@@ -1068,7 +1068,7 @@ impl<'a> CompactUnwindInfoIter<'a> {
         // If we get here, we must have loaded a page
         let (first_level_entry, second_level_page) = self.page_of_next_entry.as_ref().unwrap();
         let entry =
-            self.second_level_entry(&first_level_entry, &second_level_page, self.second_idx)?;
+            self.second_level_entry(first_level_entry, second_level_page, self.second_idx)?;
 
         // Advance to the next entry
         self.second_idx += 1;

--- a/symbolic-debuginfo/src/pdb.rs
+++ b/symbolic-debuginfo/src/pdb.rs
@@ -957,7 +957,7 @@ impl<'s> Unit<'s> {
 
         let mut lines = Vec::new();
         while let Some(line_info) = line_iter.next()? {
-            let rva = match line_info.offset.to_rva(&address_map) {
+            let rva = match line_info.offset.to_rva(address_map) {
                 Some(rva) => u64::from(rva.0),
                 None => continue,
             };
@@ -984,7 +984,7 @@ impl<'s> Unit<'s> {
 
         // Translate the function's address to the PE's address space. If this fails, we're
         // likely dealing with an invalid function and can skip it.
-        let address = match proc.offset.to_rva(&address_map) {
+        let address = match proc.offset.to_rva(address_map) {
             Some(addr) => u64::from(addr.0),
             None => return Ok(None),
         };

--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -847,7 +847,7 @@ impl<W: Write> AsciiCfiWriter<W> {
                     None => return Ok(writeln!(self.inner)?),
                 };
 
-                let program_string = prog_ref.to_string_lossy(&string_table)?;
+                let program_string = prog_ref.to_string_lossy(string_table)?;
 
                 writeln!(self.inner, "{}", program_string.trim())?;
             }

--- a/symbolic-minidump/src/processor.rs
+++ b/symbolic-minidump/src/processor.rs
@@ -621,7 +621,7 @@ impl SystemInfo {
             // Try to parse the Linux build string. Breakpad and Crashpad run
             // `uname -srvmo` to generate it. This roughtly resembles:
             // "Linux [version] [build...] [arch] Linux/GNU"
-            if let Some(captures) = LINUX_BUILD_RE.captures(&build) {
+            if let Some(captures) = LINUX_BUILD_RE.captures(build) {
                 let version = captures.get(1).unwrap(); // uname -r portion
                 let build = captures.get(2).unwrap(); // uname -v portion
                 return (version.as_str().into(), build.as_str().into());

--- a/symbolic-minidump/tests/test_processor.rs
+++ b/symbolic-minidump/tests/test_processor.rs
@@ -30,7 +30,7 @@ fn process_minidump_linux_cfi() -> Result<(), Error> {
             .collect::<Vec<String>>()
             .join("\n")
     };
-    let view = ByteView::from_slice(&cfi_records.as_bytes());
+    let view = ByteView::from_slice(cfi_records.as_bytes());
 
     frame_info.insert(
         "C0BCC3F19827FE653058404B2831D9E60".parse().unwrap(),

--- a/symbolic-symcache/src/cache.rs
+++ b/symbolic-symcache/src/cache.rs
@@ -705,7 +705,7 @@ impl<'a> Line<'a> {
     /// The base_dir of the line.
     pub fn base_dir(&self) -> &str {
         match self.file {
-            Some(ref record) => record.base_dir.read_str(self.data).unwrap_or(""),
+            Some(record) => record.base_dir.read_str(self.data).unwrap_or(""),
             None => "",
         }
     }
@@ -713,7 +713,7 @@ impl<'a> Line<'a> {
     /// The filename of the line.
     pub fn filename(&self) -> &'a str {
         match self.file {
-            Some(ref record) => record.filename.read_str(self.data).unwrap_or(""),
+            Some(record) => record.filename.read_str(self.data).unwrap_or(""),
             None => "",
         }
     }

--- a/symbolic-unreal/src/container.rs
+++ b/symbolic-unreal/src/container.rs
@@ -323,7 +323,7 @@ impl Iterator for Unreal4FileIterator<'_> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let meta = self.inner.next()?;
-        Some(Unreal4File::from_meta(meta, &self.bytes))
+        Some(Unreal4File::from_meta(meta, self.bytes))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -336,14 +336,14 @@ impl Iterator for Unreal4FileIterator<'_> {
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         let meta = self.inner.nth(n)?;
-        Some(Unreal4File::from_meta(meta, &self.bytes))
+        Some(Unreal4File::from_meta(meta, self.bytes))
     }
 }
 
 impl DoubleEndedIterator for Unreal4FileIterator<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         let meta = self.inner.next_back()?;
-        Some(Unreal4File::from_meta(meta, &self.bytes))
+        Some(Unreal4File::from_meta(meta, self.bytes))
     }
 }
 

--- a/symbolic-unreal/src/context.rs
+++ b/symbolic-unreal/src/context.rs
@@ -184,7 +184,7 @@ impl Unreal4ContextRuntimeProperties {
                 continue;
             }
             match tag.name() {
-                "CrashGUID" => rv.crash_guid = get_text_or_none(&child),
+                "CrashGUID" => rv.crash_guid = get_text_or_none(child),
                 "ProcessId" => rv.process_id = child.text().parse::<u32>().ok(),
                 "IsInternalBuild" => rv.is_internal_build = child.text().parse::<bool>().ok(),
                 "IsSourceDistribution" => {
@@ -192,29 +192,29 @@ impl Unreal4ContextRuntimeProperties {
                 }
                 "IsAssert" => rv.is_assert = child.text().parse::<bool>().ok(),
                 "IsEnsure" => rv.is_ensure = child.text().parse::<bool>().ok(),
-                "CrashType" => rv.crash_type = get_text_or_none(&child),
+                "CrashType" => rv.crash_type = get_text_or_none(child),
                 "SecondsSinceStart" => rv.seconds_since_start = child.text().parse::<u32>().ok(),
-                "GameName" => rv.game_name = get_text_or_none(&child),
-                "ExecutableName" => rv.executable_name = get_text_or_none(&child),
-                "BuildConfiguration" => rv.build_configuration = get_text_or_none(&child),
-                "PlatformName" => rv.platform_name = get_text_or_none(&child),
-                "EngineMode" => rv.engine_mode = get_text_or_none(&child),
-                "EngineVersion" => rv.engine_version = get_text_or_none(&child),
+                "GameName" => rv.game_name = get_text_or_none(child),
+                "ExecutableName" => rv.executable_name = get_text_or_none(child),
+                "BuildConfiguration" => rv.build_configuration = get_text_or_none(child),
+                "PlatformName" => rv.platform_name = get_text_or_none(child),
+                "EngineMode" => rv.engine_mode = get_text_or_none(child),
+                "EngineVersion" => rv.engine_version = get_text_or_none(child),
                 "LanguageLCID" => rv.language_lcid = child.text().parse::<i32>().ok(),
-                "AppDefaultLocale" => rv.app_default_locate = get_text_or_none(&child),
-                "BuildVersion" => rv.build_version = get_text_or_none(&child),
+                "AppDefaultLocale" => rv.app_default_locate = get_text_or_none(child),
+                "BuildVersion" => rv.build_version = get_text_or_none(child),
                 "IsUE4Release" => rv.is_ue4_release = child.text().parse::<bool>().ok(),
-                "UserName" => rv.username = get_text_or_none(&child),
-                "BaseDir" => rv.base_dir = get_text_or_none(&child),
-                "RootDir" => rv.root_dir = get_text_or_none(&child),
-                "MachineId" => rv.machine_id = get_text_or_none(&child),
-                "LoginId" => rv.login_id = get_text_or_none(&child),
-                "EpicAccountId" => rv.epic_account_id = get_text_or_none(&child),
-                "CallStack" => rv.legacy_call_stack = get_text_or_none(&child),
-                "PCallStack" => rv.portable_call_stack = get_text_or_none(&child),
-                "UserDescription" => rv.user_description = get_text_or_none(&child),
-                "ErrorMessage" => rv.error_message = get_text_or_none(&child),
-                "CrashReporterMessage" => rv.crash_reporter_message = get_text_or_none(&child),
+                "UserName" => rv.username = get_text_or_none(child),
+                "BaseDir" => rv.base_dir = get_text_or_none(child),
+                "RootDir" => rv.root_dir = get_text_or_none(child),
+                "MachineId" => rv.machine_id = get_text_or_none(child),
+                "LoginId" => rv.login_id = get_text_or_none(child),
+                "EpicAccountId" => rv.epic_account_id = get_text_or_none(child),
+                "CallStack" => rv.legacy_call_stack = get_text_or_none(child),
+                "PCallStack" => rv.portable_call_stack = get_text_or_none(child),
+                "UserDescription" => rv.user_description = get_text_or_none(child),
+                "ErrorMessage" => rv.error_message = get_text_or_none(child),
+                "CrashReporterMessage" => rv.crash_reporter_message = get_text_or_none(child),
                 "Misc.NumberOfCores" => rv.misc_number_of_cores = child.text().parse::<u32>().ok(),
                 "Misc.NumberOfCoresIncludingHyperthreads" => {
                     rv.misc_number_of_cores_inc_hyperthread = child.text().parse::<u32>().ok()
@@ -222,12 +222,12 @@ impl Unreal4ContextRuntimeProperties {
                 "Misc.Is64bitOperatingSystem" => {
                     rv.misc_is_64bit = child.text().parse::<bool>().ok()
                 }
-                "Misc.CPUVendor" => rv.misc_cpu_vendor = get_text_or_none(&child),
-                "Misc.CPUBrand" => rv.misc_cpu_brand = get_text_or_none(&child),
-                "Misc.PrimaryGPUBrand" => rv.misc_primary_gpu_brand = get_text_or_none(&child),
-                "Misc.OSVersionMajor" => rv.misc_os_version_major = get_text_or_none(&child),
-                "Misc.OSVersionMinor" => rv.misc_os_version_minor = get_text_or_none(&child),
-                "GameStateName" => rv.game_state_name = get_text_or_none(&child),
+                "Misc.CPUVendor" => rv.misc_cpu_vendor = get_text_or_none(child),
+                "Misc.CPUBrand" => rv.misc_cpu_brand = get_text_or_none(child),
+                "Misc.PrimaryGPUBrand" => rv.misc_primary_gpu_brand = get_text_or_none(child),
+                "Misc.OSVersionMajor" => rv.misc_os_version_major = get_text_or_none(child),
+                "Misc.OSVersionMinor" => rv.misc_os_version_minor = get_text_or_none(child),
+                "GameStateName" => rv.game_state_name = get_text_or_none(child),
                 "MemoryStats.TotalPhysical" => {
                     rv.memory_stats_total_physical = child.text().parse::<u64>().ok()
                 }
@@ -245,13 +245,13 @@ impl Unreal4ContextRuntimeProperties {
                     rv.allowed_to_be_contacted = child.text().parse::<bool>().ok()
                 }
                 "CrashReportClientVersion" => {
-                    rv.crash_reporter_client_version = get_text_or_none(&child)
+                    rv.crash_reporter_client_version = get_text_or_none(child)
                 }
-                "Modules" => rv.modules = get_text_or_none(&child),
+                "Modules" => rv.modules = get_text_or_none(child),
                 _ => {
                     rv.custom.insert(
                         tag.name().to_string(),
-                        get_text_or_none(&child).unwrap_or_default(),
+                        get_text_or_none(child).unwrap_or_default(),
                     );
                 }
             }
@@ -412,7 +412,7 @@ fn test_get_runtime_properties_no_children() {
 #[test]
 fn test_get_game_and_engine_data() {
     let actual =
-        Unreal4Context::parse(&ROOT_WITH_GAME_AND_ENGINE_DATA.as_bytes()).expect("default struct");
+        Unreal4Context::parse(ROOT_WITH_GAME_AND_ENGINE_DATA.as_bytes()).expect("default struct");
     assert_eq!(
         actual
             .engine_data

--- a/symbolic-unreal/src/logs.rs
+++ b/symbolic-unreal/src/logs.rs
@@ -61,7 +61,7 @@ impl Unreal4LogEntry {
         if let Some(first_line) = logs_utf8.lines().next() {
             // First line includes the timestamp of the following 100 and some lines until
             // log entries actually include timestamps
-            fallback_timestamp = parse_log_datetime(&first_line);
+            fallback_timestamp = parse_log_datetime(first_line);
         }
 
         let mut logs: Vec<_> = logs_utf8

--- a/symbolic-unwind/src/evaluator/mod.rs
+++ b/symbolic-unwind/src/evaluator/mod.rs
@@ -141,12 +141,12 @@ impl<'memory, A: RegisterValue, E: Endianness> Evaluator<'memory, A, E> {
         match expr {
             Expr::Value(x) => Ok(*x),
             Expr::Const(c) => {
-                self.constants.get(&c).copied().ok_or_else(|| {
+                self.constants.get(c).copied().ok_or_else(|| {
                     EvaluationError(EvaluationErrorInner::UndefinedConstant(c.clone()))
                 })
             }
             Expr::Var(v) => {
-                self.variables.get(&v).copied().ok_or_else(|| {
+                self.variables.get(v).copied().ok_or_else(|| {
                     EvaluationError(EvaluationErrorInner::UndefinedVariable(v.clone()))
                 })
             }


### PR DESCRIPTION
These are double references which the compiler silently derefed
immediately.

#skip-changelog