### PR TITLE
fix: Allow for duplicate compact unwind entries

### DIFF
--- a/symbolic-debuginfo/src/macho/compact.rs
+++ b/symbolic-debuginfo/src/macho/compact.rs
@@ -1166,9 +1166,9 @@ impl<'a> CompactUnwindInfoIter<'a> {
         first_level_entry: &FirstLevelPageEntry,
         second_level_page: &SecondLevelPage,
     ) -> Result<CompactUnwindInfoEntry> {
-        if entry.instruction_address >= next_entry_instruction_address {
+        if entry.instruction_address > next_entry_instruction_address {
             return Err(MachError::from(Error::Malformed(format!(
-                "Entry addresses are not strictly monotonic! ({} >= {})",
+                "Entry addresses are not monotonic! ({} > {})",
                 entry.instruction_address, next_entry_instruction_address
             ))));
         }

--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -416,6 +416,11 @@ impl<W: Write> AsciiCfiWriter<W> {
         let mut ctx = UninitializedUnwindContext::new();
 
         while let Some(entry) = iter.next()? {
+            if entry.len == 0 {
+                // We saw some duplicate entries (which yield entries with `len == 0`) for example
+                // in `libsystem_kernel.dylib`. In this case just skip the zero-length entry.
+                continue;
+            }
             match entry.instructions(&iter) {
                 CompactUnwindOp::None => {
                     // We have seen some of these `CompactUnwindOp::None` correspond to some tiny

--- a/symbolic-symcache/src/format.rs
+++ b/symbolic-symcache/src/format.rs
@@ -203,7 +203,7 @@ pub struct FuncRecord {
     /// The comp dir of the file record.
     pub comp_dir: Seg<u8, u8>,
 
-    /// The ID offset of the parent funciton.  Will be ~0 if the function has no parent.
+    /// The ID offset of the parent function.  Will be ~0 if the function has no parent.
     pub parent_offset: u16,
 
     /// The low bits of the ID of the symbol of this function or ~0 if no symbol.

--- a/symbolic-symcache/src/writer.rs
+++ b/symbolic-symcache/src/writer.rs
@@ -662,7 +662,7 @@ where
                 debug_assert!(parent_index < index);
 
                 let parent_offset = index - parent_index;
-                if parent_offset > std::u16::MAX.into() {
+                if parent_offset >= std::u16::MAX.into() {
                     return Err(SymCacheErrorKind::ValueTooLarge(ValueKind::ParentOffset).into());
                 }
 


### PR DESCRIPTION
`libsystem_kernel.dylib` has the following entries which would previously result in an error:
```
      [211]: function offset=0x000121c3, encoding[7]=0x00000000
      [212]: function offset=0x000121c3, encoding[28]=0x04000680
```

This also has a driveby off-by-one fix for the `parent_offset`, since `0xFFFF` is the sentinel value for "no parent".