### PR TITLE
fix: Skip over duplicated functions in SymCaches

### DIFF
--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -1266,8 +1266,8 @@ impl<'data> DwarfDebugSession<'data> {
             units: self.cell.get().units(),
             functions: Vec::new().into_iter(),
             range_buf: Vec::new(),
-            finished: false,
             seen_ranges: BTreeSet::new(),
+            finished: false,
         }
     }
 
@@ -1361,8 +1361,8 @@ impl<'s> Iterator for DwarfFileIterator<'s> {
 pub struct DwarfFunctionIterator<'s> {
     units: DwarfUnitIterator<'s>,
     functions: std::vec::IntoIter<Function<'s>>,
-    seen_ranges: BTreeSet<(u64, u64)>,
     range_buf: Vec<Range>,
+    seen_ranges: BTreeSet<(u64, u64)>,
     finished: bool,
 }
 

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -781,7 +781,8 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             // which merges templated code that is being generated multiple times in each
             // compilation unit. We make sure to detect this here, so we can avoid creating these
             // duplicates as early as possible.
-            if !seen_ranges.insert((function_address, function_size)) {
+            if !inline && !seen_ranges.insert((function_address, function_size)) {
+                skipped_depth = Some(depth);
                 continue;
             }
 

--- a/symbolic-debuginfo/tests/snapshots/test_objects__elf_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__elf_functions.snap
@@ -1,6 +1,7 @@
 ---
-source: debuginfo/tests/test_objects.rs
+source: symbolic-debuginfo/tests/test_objects.rs
 expression: "FunctionsDebug(&functions[..10], 0)"
+
 ---
 
 > 0x1ec0: _ZN12_GLOBAL__N_18callbackERKN15google_breakpad18MinidumpDescriptorEPvb (0x3b)
@@ -203,67 +204,6 @@ expression: "FunctionsDebug(&functions[..10], 0)"
 
     > 0x1d72: crash (0xb)
       0x1d72: main.cpp:23 (../linux)
-
-> 0x1f00: _ZN15google_breakpad18MinidumpDescriptorD1Ev (0x32)
-  0x1f00: minidump_descriptor.h:48 (../deps/breakpad/src/client/linux/handler)
-  0x1f08: minidump_descriptor.h:48 (../deps/breakpad/src/client/linux/handler)
-  0x1f0c: minidump_descriptor.h:48 (../deps/breakpad/src/client/linux/handler)
-  0x1f11: minidump_descriptor.h:48 (../deps/breakpad/src/client/linux/handler)
-  0x1f1a: minidump_descriptor.h:48 (../deps/breakpad/src/client/linux/handler)
-  0x1f1e: minidump_descriptor.h:48 (../deps/breakpad/src/client/linux/handler)
-  0x1f23: minidump_descriptor.h:48 (../deps/breakpad/src/client/linux/handler)
-  0x1f24: minidump_descriptor.h:48 (../deps/breakpad/src/client/linux/handler)
-  0x1f30: minidump_descriptor.h:48 (../deps/breakpad/src/client/linux/handler)
-
-  > 0x1f08: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED4Ev (0x12)
-    0x1f08: basic_string.h:543 (/usr/include/c++/5/bits)
-    0x1f0c: basic_string.h:543 (/usr/include/c++/5/bits)
-    0x1f11: basic_string.h:543 (/usr/include/c++/5/bits)
-
-    > 0x1f08: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv (0x12)
-      0x1f08: basic_string.h:179 (/usr/include/c++/5/bits)
-      0x1f0c: basic_string.h:179 (/usr/include/c++/5/bits)
-      0x1f11: basic_string.h:180 (/usr/include/c++/5/bits)
-
-      > 0x1f08: _ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE11_M_is_localEv (0x4)
-        0x1f08: basic_string.h:170 (/usr/include/c++/5/bits)
-
-        > 0x1f08: _ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13_M_local_dataEv (0x4)
-          0x1f08: basic_string.h:151 (/usr/include/c++/5/bits)
-
-      > 0x1f11: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_destroyEm (0x9)
-        0x1f11: basic_string.h:185 (/usr/include/c++/5/bits)
-
-        > 0x1f11: _ZNSt16allocator_traitsISaIcEE10deallocateERS0_Pcm (0x9)
-          0x1f11: alloc_traits.h:517 (/usr/include/c++/5/bits)
-
-          > 0x1f11: _ZN9__gnu_cxx13new_allocatorIcE10deallocateEPcm (0x9)
-            0x1f11: new_allocator.h:110 (/usr/include/c++/5/ext)
-
-  > 0x1f1a: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED4Ev (0x16)
-    0x1f1a: basic_string.h:543 (/usr/include/c++/5/bits)
-    0x1f1e: basic_string.h:543 (/usr/include/c++/5/bits)
-    0x1f24: basic_string.h:543 (/usr/include/c++/5/bits)
-
-    > 0x1f1a: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv (0x16)
-      0x1f1a: basic_string.h:179 (/usr/include/c++/5/bits)
-      0x1f1e: basic_string.h:179 (/usr/include/c++/5/bits)
-      0x1f24: basic_string.h:180 (/usr/include/c++/5/bits)
-
-      > 0x1f1a: _ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE11_M_is_localEv (0x4)
-        0x1f1a: basic_string.h:170 (/usr/include/c++/5/bits)
-
-        > 0x1f1a: _ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13_M_local_dataEv (0x4)
-          0x1f1a: basic_string.h:151 (/usr/include/c++/5/bits)
-
-      > 0x1f24: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_destroyEm (0xc)
-        0x1f24: basic_string.h:185 (/usr/include/c++/5/bits)
-
-        > 0x1f24: _ZNSt16allocator_traitsISaIcEE10deallocateERS0_Pcm (0xc)
-          0x1f24: alloc_traits.h:517 (/usr/include/c++/5/bits)
-
-          > 0x1f24: _ZN9__gnu_cxx13new_allocatorIcE10deallocateEPcm (0xc)
-            0x1f24: new_allocator.h:110 (/usr/include/c++/5/ext)
 
 > 0x1f40: _ZN15google_breakpad16ExceptionHandler21InstallHandlersLockedEv (0x122)
   0x1f40: exception_handler.cc:275 (../deps/breakpad/src/client/linux/handler)
@@ -964,4 +904,56 @@ expression: "FunctionsDebug(&functions[..10], 0)"
 
   > 0x2b42: memcpy (0x8)
     0x2b42: string3.h:53 (/usr/include/x86_64-linux-gnu/bits)
+
+> 0x2bd0: _ZN15google_breakpad16ExceptionHandler13SignalHandlerEiP9siginfo_tPv (0x1ef)
+  0x2bd0: exception_handler.cc:328 (../deps/breakpad/src/client/linux/handler)
+  0x2bfb: exception_handler.cc:336 (../deps/breakpad/src/client/linux/handler)
+  0x2c07: exception_handler.cc:337 (../deps/breakpad/src/client/linux/handler)
+  0x2c09: exception_handler.cc:336 (../deps/breakpad/src/client/linux/handler)
+  0x2c0d: exception_handler.cc:409 (../deps/breakpad/src/client/linux/handler)
+  0x2c38: exception_handler.cc:342 (../deps/breakpad/src/client/linux/handler)
+  0x2c3f: exception_handler.cc:355 (../deps/breakpad/src/client/linux/handler)
+  0x2c42: exception_handler.cc:342 (../deps/breakpad/src/client/linux/handler)
+  0x2c47: exception_handler.cc:355 (../deps/breakpad/src/client/linux/handler)
+  0x2c54: exception_handler.cc:356 (../deps/breakpad/src/client/linux/handler)
+  0x2c5c: exception_handler.cc:375 (../deps/breakpad/src/client/linux/handler)
+  0x2c63: exception_handler.cc:375 (../deps/breakpad/src/client/linux/handler)
+  0x2c66: exception_handler.cc:375 (../deps/breakpad/src/client/linux/handler)
+  0x2c92: exception_handler.cc:376 (../deps/breakpad/src/client/linux/handler)
+  0x2ca8: exception_handler.cc:375 (../deps/breakpad/src/client/linux/handler)
+  0x2cad: exception_handler.cc:384 (../deps/breakpad/src/client/linux/handler)
+  0x2cb5: exception_handler.cc:387 (../deps/breakpad/src/client/linux/handler)
+  0x2cba: exception_handler.cc:390 (../deps/breakpad/src/client/linux/handler)
+  0x2cc6: exception_handler.cc:393 (../deps/breakpad/src/client/linux/handler)
+  0x2cd8: exception_handler.cc:398 (../deps/breakpad/src/client/linux/handler)
+  0x2cec: exception_handler.cc:398 (../deps/breakpad/src/client/linux/handler)
+  0x2d0d: exception_handler.cc:398 (../deps/breakpad/src/client/linux/handler)
+  0x2d15: exception_handler.cc:402 (../deps/breakpad/src/client/linux/handler)
+  0x2d20: exception_handler.cc:355 (../deps/breakpad/src/client/linux/handler)
+  0x2d31: exception_handler.cc:356 (../deps/breakpad/src/client/linux/handler)
+  0x2d3f: exception_handler.cc:359 (../deps/breakpad/src/client/linux/handler)
+  0x2d4b: exception_handler.cc:360 (../deps/breakpad/src/client/linux/handler)
+  0x2d56: exception_handler.cc:365 (../deps/breakpad/src/client/linux/handler)
+  0x2d5e: exception_handler.cc:362 (../deps/breakpad/src/client/linux/handler)
+  0x2d62: exception_handler.cc:363 (../deps/breakpad/src/client/linux/handler)
+  0x2d6d: exception_handler.cc:365 (../deps/breakpad/src/client/linux/handler)
+  0x2d77: exception_handler.cc:370 (../deps/breakpad/src/client/linux/handler)
+  0x2d83: exception_handler.cc:371 (../deps/breakpad/src/client/linux/handler)
+  0x2d90: exception_handler.cc:385 (../deps/breakpad/src/client/linux/handler)
+  0x2da0: exception_handler.cc:398 (../deps/breakpad/src/client/linux/handler)
+  0x2dae: exception_handler.cc:368 (../deps/breakpad/src/client/linux/handler)
+  0x2dba: exception_handler.cc:409 (../deps/breakpad/src/client/linux/handler)
+
+  > 0x2c63: _ZNKSt6vectorIPN15google_breakpad16ExceptionHandlerESaIS2_EE4sizeEv (0x3)
+    0x2c63: stl_vector.h:655 (/usr/include/c++/5/bits)
+
+  > 0x2cec: sys_tgkill (0xc2)
+    0x2cec: linux_syscall_support.h:3545 (../deps/third_party/lss)
+    0x2da0: linux_syscall_support.h:3545 (../deps/third_party/lss)
+
+  > 0x2d90: InstallDefaultHandler (0x10)
+    0x2d90: exception_handler.cc:199 (../deps/breakpad/src/client/linux/handler)
+
+  > 0x2dae: InstallDefaultHandler (0xc)
+    0x2dae: exception_handler.cc:199 (../deps/breakpad/src/client/linux/handler)
 

--- a/symbolic-symcache/src/writer.rs
+++ b/symbolic-symcache/src/writer.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::io::{self, Seek, Write};
@@ -206,15 +205,10 @@ where
             .debug_session()
             .map_err(|e| SymCacheError::new(SymCacheErrorKind::BadDebugFile, e))?;
 
-        let mut seen_ranges = BTreeSet::new();
         for function in session.functions() {
             let function =
                 function.map_err(|e| SymCacheError::new(SymCacheErrorKind::BadDebugFile, e))?;
-            let fn_range = (function.address, function.size);
-            if !seen_ranges.contains(&fn_range) {
-                writer.add_function(function)?;
-                seen_ranges.insert(fn_range);
-            }
+            writer.add_function(function)?;
         }
 
         // Sort the files to efficiently add symbols from the symbol table in linear time

--- a/symbolic-symcache/tests/snapshots/test_writer__functions_linux.snap
+++ b/symbolic-symcache/tests/snapshots/test_writer__functions_linux.snap
@@ -1,6 +1,7 @@
 ---
-source: symcache/tests/test_writer.rs
+source: symbolic-symcache/tests/test_writer.rs
 expression: FunctionsDebug(&symcache)
+
 ---
             1558 _init
             1900 _ZN15google_breakpad13PageAllocator7FreeAllEv.isra.6
@@ -51,11 +52,6 @@ expression: FunctionsDebug(&symcache)
             1ec7 printf
             1ee0 printf
             1f00 _ZN15google_breakpad18MinidumpDescriptorD1Ev
-            1f00 _ZN15google_breakpad18MinidumpDescriptorD1Ev
-            1f08 _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED4Ev
-            1f08 _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv
-            1f08 _ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE11_M_is_localEv
-            1f08 _ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13_M_local_dataEv
             1f08 _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED4Ev
             1f08 _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv
             1f08 _ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE11_M_is_localEv
@@ -63,20 +59,10 @@ expression: FunctionsDebug(&symcache)
             1f11 _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_destroyEm
             1f11 _ZNSt16allocator_traitsISaIcEE10deallocateERS0_Pcm
             1f11 _ZN9__gnu_cxx13new_allocatorIcE10deallocateEPcm
-            1f11 _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_destroyEm
-            1f11 _ZNSt16allocator_traitsISaIcEE10deallocateERS0_Pcm
-            1f11 _ZN9__gnu_cxx13new_allocatorIcE10deallocateEPcm
             1f1a _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED4Ev
             1f1a _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv
             1f1a _ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE11_M_is_localEv
             1f1a _ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13_M_local_dataEv
-            1f1a _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED4Ev
-            1f1a _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv
-            1f1a _ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE11_M_is_localEv
-            1f1a _ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE13_M_local_dataEv
-            1f24 _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_destroyEm
-            1f24 _ZNSt16allocator_traitsISaIcEE10deallocateERS0_Pcm
-            1f24 _ZN9__gnu_cxx13new_allocatorIcE10deallocateEPcm
             1f24 _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_destroyEm
             1f24 _ZNSt16allocator_traitsISaIcEE10deallocateERS0_Pcm
             1f24 _ZN9__gnu_cxx13new_allocatorIcE10deallocateEPcm
@@ -700,40 +686,14 @@ expression: FunctionsDebug(&symcache)
             6dc6 ~MicrodumpWriter
             6dd6 _ZN15google_breakpad17LinuxPtraceDumperD4Ev
             6e10 _ZNSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEE15_M_range_insertIPKhEEvN9__gnu_cxx17__normal_iteratorIPhS3_EET_SB_St20forward_iterator_tag
-            6e10 _ZNSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEE15_M_range_insertIPKhEEvN9__gnu_cxx17__normal_iteratorIPhS3_EET_SB_St20forward_iterator_tag
-            6e10 _ZNSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEE15_M_range_insertIPKhEEvN9__gnu_cxx17__normal_iteratorIPhS3_EET_SB_St20forward_iterator_tag
-            6e24 _ZSt8distanceIPKhENSt15iterator_traitsIT_E15difference_typeES3_S3_
-            6e24 _ZSt10__distanceIPKhENSt15iterator_traitsIT_E15difference_typeES3_S3_St26random_access_iterator_tag
-            6e24 _ZSt8distanceIPKhENSt15iterator_traitsIT_E15difference_typeES3_S3_
-            6e24 _ZSt10__distanceIPKhENSt15iterator_traitsIT_E15difference_typeES3_S3_St26random_access_iterator_tag
             6e24 _ZSt8distanceIPKhENSt15iterator_traitsIT_E15difference_typeES3_S3_
             6e24 _ZSt10__distanceIPKhENSt15iterator_traitsIT_E15difference_typeES3_S3_St26random_access_iterator_tag
             6e4d _ZN9__gnu_cxxmiIPhSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEEEENS_17__normal_iteratorIT_T0_E15difference_typeERKSA_SD_
-            6e4d _ZN9__gnu_cxxmiIPhSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEEEENS_17__normal_iteratorIT_T0_E15difference_typeERKSA_SD_
-            6e4d _ZN9__gnu_cxxmiIPhSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEEEENS_17__normal_iteratorIT_T0_E15difference_typeERKSA_SD_
-            6e5e _ZSt22__uninitialized_move_aIPhS0_N15google_breakpad16PageStdAllocatorIhEEET0_T_S5_S4_RT1_
-            6e5e _ZSt22__uninitialized_copy_aISt13move_iteratorIPhES1_N15google_breakpad16PageStdAllocatorIhEEET0_T_S7_S6_RT1_
-            6e5e _ZSt22__uninitialized_move_aIPhS0_N15google_breakpad16PageStdAllocatorIhEEET0_T_S5_S4_RT1_
-            6e5e _ZSt22__uninitialized_copy_aISt13move_iteratorIPhES1_N15google_breakpad16PageStdAllocatorIhEEET0_T_S7_S6_RT1_
             6e5e _ZSt22__uninitialized_move_aIPhS0_N15google_breakpad16PageStdAllocatorIhEEET0_T_S5_S4_RT1_
             6e5e _ZSt22__uninitialized_copy_aISt13move_iteratorIPhES1_N15google_breakpad16PageStdAllocatorIhEEET0_T_S7_S6_RT1_
             6e70 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS5_
             6e70 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PS8_DpOS9_
             6e70 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJhEEEvPT_DpOT0_
-            6e70 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS5_
-            6e70 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PS8_DpOS9_
-            6e70 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJhEEEvPT_DpOT0_
-            6e70 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS5_
-            6e70 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PS8_DpOS9_
-            6e70 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJhEEEvPT_DpOT0_
-            6e8f _ZSt13move_backwardIPhS0_ET0_T_S2_S1_
-            6e8f _ZSt23__copy_move_backward_a2ILb1EPhS0_ET1_T0_S2_S1_
-            6e8f _ZSt22__copy_move_backward_aILb1EPhS0_ET1_T0_S2_S1_
-            6e8f _ZNSt20__copy_move_backwardILb1ELb1ESt26random_access_iterator_tagE13__copy_move_bIhEEPT_PKS3_S6_S4_
-            6e8f _ZSt13move_backwardIPhS0_ET0_T_S2_S1_
-            6e8f _ZSt23__copy_move_backward_a2ILb1EPhS0_ET1_T0_S2_S1_
-            6e8f _ZSt22__copy_move_backward_aILb1EPhS0_ET1_T0_S2_S1_
-            6e8f _ZNSt20__copy_move_backwardILb1ELb1ESt26random_access_iterator_tagE13__copy_move_bIhEEPT_PKS3_S6_S4_
             6e8f _ZSt13move_backwardIPhS0_ET0_T_S2_S1_
             6e8f _ZSt23__copy_move_backward_a2ILb1EPhS0_ET1_T0_S2_S1_
             6e8f _ZSt22__copy_move_backward_aILb1EPhS0_ET1_T0_S2_S1_
@@ -742,44 +702,14 @@ expression: FunctionsDebug(&symcache)
             6e9c _ZSt14__copy_move_a2ILb0EPKhN9__gnu_cxx17__normal_iteratorIPhSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEEEEET1_T0_SC_SB_
             6e9c _ZSt13__copy_move_aILb0EPKhPhET1_T0_S4_S3_
             6e9c _ZNSt11__copy_moveILb0ELb1ESt26random_access_iterator_tagE8__copy_mIhEEPT_PKS3_S6_S4_
-            6e9c _ZSt4copyIPKhN9__gnu_cxx17__normal_iteratorIPhSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEEEEET0_T_SC_SB_
-            6e9c _ZSt14__copy_move_a2ILb0EPKhN9__gnu_cxx17__normal_iteratorIPhSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEEEEET1_T0_SC_SB_
-            6e9c _ZSt13__copy_move_aILb0EPKhPhET1_T0_S4_S3_
-            6e9c _ZNSt11__copy_moveILb0ELb1ESt26random_access_iterator_tagE8__copy_mIhEEPT_PKS3_S6_S4_
-            6e9c _ZSt4copyIPKhN9__gnu_cxx17__normal_iteratorIPhSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEEEEET0_T_SC_SB_
-            6e9c _ZSt14__copy_move_a2ILb0EPKhN9__gnu_cxx17__normal_iteratorIPhSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEEEEET1_T0_SC_SB_
-            6e9c _ZSt13__copy_move_aILb0EPKhPhET1_T0_S4_S3_
-            6e9c _ZNSt11__copy_moveILb0ELb1ESt26random_access_iterator_tagE8__copy_mIhEEPT_PKS3_S6_S4_
-            6ec0 _ZSt7advanceIPKhmEvRT_T0_
-            6ec0 _ZSt9__advanceIPKhlEvRT_T0_St26random_access_iterator_tag
-            6ec0 _ZSt7advanceIPKhmEvRT_T0_
-            6ec0 _ZSt9__advanceIPKhlEvRT_T0_St26random_access_iterator_tag
             6ec0 _ZSt7advanceIPKhmEvRT_T0_
             6ec0 _ZSt9__advanceIPKhlEvRT_T0_St26random_access_iterator_tag
             6ec4 _ZSt22__uninitialized_copy_aIPKhPhN15google_breakpad16PageStdAllocatorIhEEET0_T_S7_S6_RT1_
-            6ec4 _ZSt22__uninitialized_copy_aIPKhPhN15google_breakpad16PageStdAllocatorIhEEET0_T_S7_S6_RT1_
-            6ec4 _ZSt22__uninitialized_copy_aIPKhPhN15google_breakpad16PageStdAllocatorIhEEET0_T_S7_S6_RT1_
-            6ed0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJRKhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS7_
-            6ed0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJRKhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PSA_DpOSB_
-            6ed0 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJRKhEEEvPT_DpOT0_
-            6ed0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJRKhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS7_
-            6ed0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJRKhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PSA_DpOSB_
-            6ed0 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJRKhEEEvPT_DpOT0_
             6ed0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJRKhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS7_
             6ed0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJRKhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PSA_DpOSB_
             6ed0 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJRKhEEEvPT_DpOT0_
             6ef2 _ZSt22__uninitialized_move_aIPhS0_N15google_breakpad16PageStdAllocatorIhEEET0_T_S5_S4_RT1_
             6ef2 _ZSt22__uninitialized_copy_aISt13move_iteratorIPhES1_N15google_breakpad16PageStdAllocatorIhEEET0_T_S7_S6_RT1_
-            6ef2 _ZSt22__uninitialized_move_aIPhS0_N15google_breakpad16PageStdAllocatorIhEEET0_T_S5_S4_RT1_
-            6ef2 _ZSt22__uninitialized_copy_aISt13move_iteratorIPhES1_N15google_breakpad16PageStdAllocatorIhEEET0_T_S7_S6_RT1_
-            6ef2 _ZSt22__uninitialized_move_aIPhS0_N15google_breakpad16PageStdAllocatorIhEEET0_T_S5_S4_RT1_
-            6ef2 _ZSt22__uninitialized_copy_aISt13move_iteratorIPhES1_N15google_breakpad16PageStdAllocatorIhEEET0_T_S7_S6_RT1_
-            6f00 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS5_
-            6f00 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PS8_DpOS9_
-            6f00 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJhEEEvPT_DpOT0_
-            6f00 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS5_
-            6f00 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PS8_DpOS9_
-            6f00 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJhEEEvPT_DpOT0_
             6f00 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS5_
             6f00 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PS8_DpOS9_
             6f00 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJhEEEvPT_DpOT0_
@@ -787,41 +717,13 @@ expression: FunctionsDebug(&symcache)
             6f1f _ZSt14__copy_move_a2ILb0EPKhN9__gnu_cxx17__normal_iteratorIPhSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEEEEET1_T0_SC_SB_
             6f1f _ZSt13__copy_move_aILb0EPKhPhET1_T0_S4_S3_
             6f1f _ZNSt11__copy_moveILb0ELb1ESt26random_access_iterator_tagE8__copy_mIhEEPT_PKS3_S6_S4_
-            6f1f _ZSt4copyIPKhN9__gnu_cxx17__normal_iteratorIPhSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEEEEET0_T_SC_SB_
-            6f1f _ZSt14__copy_move_a2ILb0EPKhN9__gnu_cxx17__normal_iteratorIPhSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEEEEET1_T0_SC_SB_
-            6f1f _ZSt13__copy_move_aILb0EPKhPhET1_T0_S4_S3_
-            6f1f _ZNSt11__copy_moveILb0ELb1ESt26random_access_iterator_tagE8__copy_mIhEEPT_PKS3_S6_S4_
-            6f1f _ZSt4copyIPKhN9__gnu_cxx17__normal_iteratorIPhSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEEEEET0_T_SC_SB_
-            6f1f _ZSt14__copy_move_a2ILb0EPKhN9__gnu_cxx17__normal_iteratorIPhSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEEEEET1_T0_SC_SB_
-            6f1f _ZSt13__copy_move_aILb0EPKhPhET1_T0_S4_S3_
-            6f1f _ZNSt11__copy_moveILb0ELb1ESt26random_access_iterator_tagE8__copy_mIhEEPT_PKS3_S6_S4_
-            6f4c _ZNKSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEE12_M_check_lenEmPKc
-            6f4c _ZNKSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEE4sizeEv
-            6f4c _ZNKSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEE12_M_check_lenEmPKc
-            6f4c _ZNKSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEE4sizeEv
             6f4c _ZNKSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEE12_M_check_lenEmPKc
             6f4c _ZNKSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEE4sizeEv
             6f76 _ZNSt12_Vector_baseIhN15google_breakpad16PageStdAllocatorIhEEE11_M_allocateEm
             6f76 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE8allocateERS2_m
             6f76 _ZN15google_breakpad16PageStdAllocatorIhE8allocateEmPKv
-            6f76 _ZNSt12_Vector_baseIhN15google_breakpad16PageStdAllocatorIhEEE11_M_allocateEm
-            6f76 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE8allocateERS2_m
-            6f76 _ZN15google_breakpad16PageStdAllocatorIhE8allocateEmPKv
-            6f76 _ZNSt12_Vector_baseIhN15google_breakpad16PageStdAllocatorIhEEE11_M_allocateEm
-            6f76 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE8allocateERS2_m
-            6f76 _ZN15google_breakpad16PageStdAllocatorIhE8allocateEmPKv
             6f8b _ZSt34__uninitialized_move_if_noexcept_aIPhS0_N15google_breakpad16PageStdAllocatorIhEEET0_T_S5_S4_RT1_
             6f8b _ZSt22__uninitialized_copy_aISt13move_iteratorIPhES1_N15google_breakpad16PageStdAllocatorIhEEET0_T_S7_S6_RT1_
-            6f8b _ZSt34__uninitialized_move_if_noexcept_aIPhS0_N15google_breakpad16PageStdAllocatorIhEEET0_T_S5_S4_RT1_
-            6f8b _ZSt22__uninitialized_copy_aISt13move_iteratorIPhES1_N15google_breakpad16PageStdAllocatorIhEEET0_T_S7_S6_RT1_
-            6f8b _ZSt34__uninitialized_move_if_noexcept_aIPhS0_N15google_breakpad16PageStdAllocatorIhEEET0_T_S5_S4_RT1_
-            6f8b _ZSt22__uninitialized_copy_aISt13move_iteratorIPhES1_N15google_breakpad16PageStdAllocatorIhEEET0_T_S7_S6_RT1_
-            6fa0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS5_
-            6fa0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PS8_DpOS9_
-            6fa0 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJhEEEvPT_DpOT0_
-            6fa0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS5_
-            6fa0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PS8_DpOS9_
-            6fa0 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJhEEEvPT_DpOT0_
             6fa0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS5_
             6fa0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PS8_DpOS9_
             6fa0 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJhEEEvPT_DpOT0_
@@ -829,36 +731,12 @@ expression: FunctionsDebug(&symcache)
             6fd0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJRKhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS7_
             6fd0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJRKhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PSA_DpOSB_
             6fd0 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJRKhEEEvPT_DpOT0_
-            6fd0 _ZSt22__uninitialized_copy_aIPKhPhN15google_breakpad16PageStdAllocatorIhEEET0_T_S7_S6_RT1_
-            6fd0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJRKhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS7_
-            6fd0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJRKhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PSA_DpOSB_
-            6fd0 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJRKhEEEvPT_DpOT0_
-            6fd0 _ZSt22__uninitialized_copy_aIPKhPhN15google_breakpad16PageStdAllocatorIhEEET0_T_S7_S6_RT1_
-            6fd0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJRKhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS7_
-            6fd0 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJRKhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PSA_DpOSB_
-            6fd0 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJRKhEEEvPT_DpOT0_
-            6ff1 _ZSt34__uninitialized_move_if_noexcept_aIPhS0_N15google_breakpad16PageStdAllocatorIhEEET0_T_S5_S4_RT1_
-            6ff1 _ZSt22__uninitialized_copy_aISt13move_iteratorIPhES1_N15google_breakpad16PageStdAllocatorIhEEET0_T_S7_S6_RT1_
-            6ff1 _ZSt34__uninitialized_move_if_noexcept_aIPhS0_N15google_breakpad16PageStdAllocatorIhEEET0_T_S5_S4_RT1_
-            6ff1 _ZSt22__uninitialized_copy_aISt13move_iteratorIPhES1_N15google_breakpad16PageStdAllocatorIhEEET0_T_S7_S6_RT1_
             6ff1 _ZSt34__uninitialized_move_if_noexcept_aIPhS0_N15google_breakpad16PageStdAllocatorIhEEET0_T_S5_S4_RT1_
             6ff1 _ZSt22__uninitialized_copy_aISt13move_iteratorIPhES1_N15google_breakpad16PageStdAllocatorIhEEET0_T_S7_S6_RT1_
             7000 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS5_
             7000 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PS8_DpOS9_
             7000 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJhEEEvPT_DpOT0_
-            7000 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS5_
-            7000 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PS8_DpOS9_
-            7000 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJhEEEvPT_DpOT0_
-            7000 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE9constructIhJhEEEDTcl12_S_constructfp_fp0_spcl7forwardIT0_Efp1_EEERS2_PT_DpOS5_
-            7000 _ZNSt16allocator_traitsIN15google_breakpad16PageStdAllocatorIhEEE12_S_constructIhJhEEENSt9enable_ifIXsrSt6__and_IJNS3_18__construct_helperIT_JDpT0_EE4typeEEE5valueEvE4typeERS2_PS8_DpOS9_
-            7000 _ZN9__gnu_cxx13new_allocatorIhE9constructIhJhEEEvPT_DpOT0_
             7074 _ZN15google_breakpad13PageAllocator5AllocEm
-            7074 _ZN15google_breakpad13PageAllocator5AllocEm
-            7074 _ZN15google_breakpad13PageAllocator5AllocEm
-            70d3 _ZN15google_breakpad13PageAllocator9GetNPagesEm
-            70d3 sys_mmap
-            70d3 _ZN15google_breakpad13PageAllocator9GetNPagesEm
-            70d3 sys_mmap
             70d3 _ZN15google_breakpad13PageAllocator9GetNPagesEm
             70d3 sys_mmap
             71f0 _ZN15google_breakpad11LinuxDumper8LateInitEv
@@ -1008,9 +886,6 @@ expression: FunctionsDebug(&symcache)
             91f6 _ZN15google_breakpad13PageAllocator9GetNPagesEm
             91f6 sys_mmap
             9350 _ZN15google_breakpad13PageAllocator5AllocEm
-            9350 _ZN15google_breakpad13PageAllocator5AllocEm
-            93b7 _ZN15google_breakpad13PageAllocator9GetNPagesEm
-            93b7 sys_mmap
             93b7 _ZN15google_breakpad13PageAllocator9GetNPagesEm
             93b7 sys_mmap
             94a0 _ZNK15google_breakpad17LinuxPtraceDumper12IsPostMortemEv

--- a/symbolic-symcache/tests/test_writer.rs
+++ b/symbolic-symcache/tests/test_writer.rs
@@ -41,7 +41,7 @@ fn test_write_header_linux() -> Result<(), Error> {
         arch: Amd64,
         has_line_info: true,
         has_file_info: true,
-        functions: 1964,
+        functions: 1838,
     }
     "###);
 


### PR DESCRIPTION
The `DwarfDebugSession::functions` Iterator can yield duplicated functions, which, combined with a ton of inlinees can blow out the `ParentOffset` limit.

This does fix the symptom of these duplicated functions, but I would say that the real fix would rather be somewhere in the Iterator that yields these values.