### PR TITLE
meta: Update Craft config

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -16,6 +16,6 @@ targets:
   - name: github
 requireNames:
   - /^symbolic-.*-py2.py3-none-macosx_10_15_x86_64.whl$/
-  - /^symbolic-.*-py2.py3-none-manylinux2010_i686.whl$/
-  - /^symbolic-.*-py2.py3-none-manylinux2010_x86_64.whl$/
+  - /^symbolic-.*-py2.py3-none-.*manylinux2010_i686.*\.whl$/
+  - /^symbolic-.*-py2.py3-none-.*manylinux2010_x86_64.whl$/
   - /^symbolic-.*.zip$/

--- a/.craft.yml
+++ b/.craft.yml
@@ -16,6 +16,6 @@ targets:
   - name: github
 requireNames:
   - /^symbolic-.*-py2.py3-none-macosx_10_15_x86_64.whl$/
-  - /^symbolic-.*-py2.py3-none-.*manylinux2010_i686.*\.whl$/
-  - /^symbolic-.*-py2.py3-none-.*manylinux2010_x86_64.whl$/
+  - /^symbolic-.*-py2\.py3-none-.*manylinux2010_i686.*\.whl$/
+  - /^symbolic-.*-py2\.py3-none-.*manylinux2010_x86_64\.whl$/
   - /^symbolic-.*.zip$/


### PR DESCRIPTION
The manylinux2010 build image now generates wheels compatible with
additional python environments. We add a wildcard to ignore these
additional environments.