### PR TITLE
fix: Write the new CFI cache version to its file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Write versioned CFI Cache files. Reading those files is only supported with symbolic versions `>= 8.2.1`, so trying to use a CFI Cache file with an older version of symbolic will fail with a `CfiErrorKind::BadFileMagic` error.
+
 ## 8.2.1
 
 **Features**:


### PR DESCRIPTION
On top of #399 , this PR actually implements writing the preamble with its version information.