### PR TITLE
fix(cfi): Don't build the MachO symbols in the loop

### DIFF
--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -411,6 +411,8 @@ impl<W: Write> AsciiCfiWriter<W> {
             }
             Ok(())
         }
+        // Preload the symbols as this is expensive to do in the loop.
+        let symbols = object.symbol_map();
 
         // Initialize an unwind context once and reuse it for the entire section.
         let mut ctx = UninitializedUnwindContext::new();
@@ -457,7 +459,6 @@ impl<W: Write> AsciiCfiWriter<W> {
                                 .fde_from_offset(&info.bases, offset, U::cie_from_offset)
                         {
                             let start_addr = entry.instruction_address.into();
-                            let symbols = object.symbol_map();
                             let sym_name = symbols.lookup(start_addr).and_then(|sym| sym.name());
                             let ptr_size = object.arch().cpu_family().pointer_size();
 


### PR DESCRIPTION
symbol_map is a Vec that is quite expensive to create, so doing it every time we encounter a dwarf FDE entry is extremely quadratic and slow. This causes macos firefox builds to timeout while trying to dump the symbols for XUL -- especially for aarch64 builds (for whatever reason). 

You can test that out by running dump_syms on the XUL inside target.dmg for this build: https://treeherder.mozilla.org/jobs?repo=try&revision=5a2fbeb4112cd87eee7bb3f1b48223fc9b3ff7b9&selectedTaskRun=O2kbKrM-RauVaLGx-7f0MA.0

This change drops dump_syms on XUL from ~2.5 minutes to ~4 seconds on my macbook pro.