### PR TITLE
feat: Add FileSystemSupplier struct

### DIFF
--- a/symbolic-minidump/Cargo.toml
+++ b/symbolic-minidump/Cargo.toml
@@ -35,7 +35,9 @@ regex = "1.3.5"
 serde = { version = "1.0.94", optional = true }
 symbolic-common = { version = "8.2.1", path = "../symbolic-common" }
 symbolic-debuginfo = { version = "8.2.1", path = "../symbolic-debuginfo" }
+symbolic-symcache = { version = "8.2.1", path = "../symbolic-symcache" }
 thiserror = "1.0.20"
+walkdir = "2.3.2"
 
 [build-dependencies]
 cc = { version = "1.0.50", features = ["parallel"] }

--- a/symbolic-minidump/src/processor.rs
+++ b/symbolic-minidump/src/processor.rs
@@ -382,14 +382,14 @@ pub trait SymbolSupplier<'a> {
 
 /// A [`SymbolSupplier`] that uses an internal [`SymCacheCreator`] to
 /// create symcaches and caches them in a map.
-pub struct SymCacheSupplier<'a, S> {
-    inner: S,
+pub struct SymCacheSupplier<'a> {
+    inner: Box<dyn SymCacheCreator<'a>>,
     symcaches: SymCaches<'a>,
 }
 
-impl<'a, S> SymCacheSupplier<'a, S> {
+impl<'a> SymCacheSupplier<'a> {
     /// Creates a new `SymCacheSupplier` from a given [`SymCacheCreator`].
-    pub fn new(inner: S) -> Self {
+    pub fn new(inner: Box<dyn SymCacheCreator<'a>>) -> Self {
         Self {
             inner,
             symcaches: SymCaches::new(),
@@ -397,7 +397,7 @@ impl<'a, S> SymCacheSupplier<'a, S> {
     }
 }
 
-impl<'a, S: SymCacheCreator<'a>> SymbolSupplier<'a> for SymCacheSupplier<'a, S> {
+impl<'a> SymbolSupplier<'a> for SymCacheSupplier<'a> {
     fn locate_symbols<'b: 'a>(
         &'b mut self,
         search_id: CodeModuleId,


### PR DESCRIPTION
This adds a struct called `FileSystemSupplier` to `symbolic_minidump` that allows retrieving debug information for a given module from the file system and caches it as a symcache. This is intended for integration with `rust-minidump` down the road (as an implementation of the `SymbolSupplier` trait).