### PR TITLE
fix: Apply BcSymbolMap names to inlinee names

### DIFF
--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -396,7 +396,7 @@ impl<'d, 'a> UnitRef<'d, 'a> {
         &self,
         entry: &Die<'d, '_>,
         language: Language,
-        bcsymbolmap: Option<&BcSymbolMap<'d>>,
+        bcsymbolmap: Option<&'d BcSymbolMap<'d>>,
     ) -> Result<Option<Name<'d>>, DwarfError> {
         let mut attrs = entry.attrs();
         let mut fallback_name = None;
@@ -408,6 +408,7 @@ impl<'d, 'a> UnitRef<'d, 'a> {
                 constants::DW_AT_linkage_name | constants::DW_AT_MIPS_linkage_name => {
                     return Ok(self
                         .string_value(attr.value())
+                        .map(|n| resolve_cow_name(bcsymbolmap, n))
                         .map(|n| Name::new(n, NameMangling::Mangled, language)));
                 }
                 constants::DW_AT_name => {
@@ -423,6 +424,7 @@ impl<'d, 'a> UnitRef<'d, 'a> {
         if let Some(attr) = fallback_name {
             return Ok(self
                 .string_value(attr.value())
+                .map(|n| resolve_cow_name(bcsymbolmap, n))
                 .map(|n| Name::new(n, NameMangling::Unmangled, language)));
         }
 

--- a/symbolic-debuginfo/src/macho/mod.rs
+++ b/symbolic-debuginfo/src/macho/mod.rs
@@ -817,6 +817,13 @@ mod tests {
             "__hidden#41_/__hidden#42_"
         );
 
+        let fn_with_inlinees = functions
+            .filter_map(|f| f.ok())
+            .find(|f| !f.inlinees.is_empty())
+            .unwrap();
+        let inlinee = fn_with_inlinees.inlinees.first().unwrap();
+        assert_eq!(&inlinee.name, "__hidden#146_");
+
         // loads the symbolmap
         let bc_symbol_map_data =
             std::fs::read("tests/fixtures/c8374b6d-6e96-34d8-ae38-efaa5fec424f.bcsymbolmap")
@@ -855,5 +862,12 @@ mod tests {
             &function.lines[0].file.path_str(),
             "/Users/philipphofmann/git-repos/sentry-cocoa/Sources/Sentry/SentryMessage.m"
         );
+
+        let fn_with_inlinees = functions
+            .filter_map(|f| f.ok())
+            .find(|f| !f.inlinees.is_empty())
+            .unwrap();
+        let inlinee = fn_with_inlinees.inlinees.first().unwrap();
+        assert_eq!(&inlinee.name, "prepareReportWriter");
     }
 }


### PR DESCRIPTION
This was missed in #414, the symbolmap was passed recursively to the function, but never actually used.