### PR TITLE
fix: Include only the relevant header file from third_party/lss

### DIFF
--- a/symbolic-minidump/Cargo.toml
+++ b/symbolic-minidump/Cargo.toml
@@ -21,7 +21,7 @@ include = [
     "/third_party/breakpad/src/**/*.h",
     "/third_party/breakpad/src/**/*.c",
     "/third_party/breakpad/src/**/*.cc",
-    "/third_party/lss/**/*",
+    "/third_party/lss/*.h",
     "/build.rs",
     "/Cargo.toml",
 ]


### PR DESCRIPTION
In particular, this omits `third_party/lss/.git`, which is currently included in the Cargo package. That file is problematic because it causes issues with vendoring `symbolic-minidump` into a Git repository (Git refuses to track it, causing Cargo to complain about a .cargo-checksum.json violation).