### PR TITLE
fix(dead_code): Allow dead code to silence warnings

### DIFF
--- a/symbolic-unreal/src/container.rs
+++ b/symbolic-unreal/src/container.rs
@@ -61,6 +61,7 @@ impl TryFromCtx<'_, Endian> for AnsiString {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, Pread)]
 struct Unreal4Header {
     pub directory_name: AnsiString,


### PR DESCRIPTION
Nightly compiler complains that uncompressed_size and file_count are
never read and thus dead code.  However this is part of the header
struct and we need them defined to read the structures correctly even
if we do not use the fields.  So allow it as dead code.

#skip-changelog