### PR TITLE
fix: Safe multibyte char string splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Avoid panic when looking for hex suffixes in multibyte character strings in the demanger ([#430](https://github.com/getsentry/symbolic/pull/430)).
+
 ## 8.3.0
 
 **Features**:

--- a/symbolic-demangle/src/lib.rs
+++ b/symbolic-demangle/src/lib.rs
@@ -485,5 +485,9 @@ mod test {
             strip_hash_suffix("hello$0123456789abcdef0123456789abcdxx"),
             "hello$0123456789abcdef0123456789abcdxx"
         );
+        assert_eq!(
+            strip_hash_suffix("hello$\u{1000}0123456789abcdef0123456789abcde"),
+            "hello$\u{1000}0123456789abcdef0123456789abcde"
+        );
     }
 }

--- a/symbolic-demangle/src/lib.rs
+++ b/symbolic-demangle/src/lib.rs
@@ -195,8 +195,8 @@ fn strip_hash_suffix(ident: &str) -> &str {
                 // boundary.
                 return &ident[..pos];
             } else if (len - pos) > 33 || !c.is_ascii_hexdigit() {
-                // if pos is more than 33 bytes from the end a multibyte char made us skip
-                // pos 32, multibyte chars are not hexdigit or $ so nothing to strip.
+                // If pos is more than 33 bytes from the end a multibyte char made us skip
+                // pos 33, multibyte chars are not hexdigit or $ so nothing to strip.
                 return ident;
             }
         }

--- a/symbolic-demangle/src/lib.rs
+++ b/symbolic-demangle/src/lib.rs
@@ -186,9 +186,7 @@ fn try_demangle_msvc(_ident: &str, _opts: DemangleOptions) -> Option<String> {
 /// otherwise returns its input.
 fn strip_hash_suffix(ident: &str) -> &str {
     let len = ident.len();
-    if len < 33 {
-        ident
-    } else {
+    if len >= 33 {
         let mut char_iter = ident.char_indices();
         while let Some((pos, c)) = char_iter.next_back() {
             if (len - pos) == 33 && c == '$' {
@@ -196,16 +194,14 @@ fn strip_hash_suffix(ident: &str) -> &str {
                 // safe because we know the current pos is on the start of the '$' char
                 // boundary.
                 return &ident[..pos];
-            } else if (len - pos) > 33 {
-                // A multibyte char made us skip pos 32, multibyte chars are not hexdigit or
-                // $ so nothing to strip.
-                return ident;
-            } else if !c.is_ascii_hexdigit() {
+            } else if (len - pos) > 33 || !c.is_ascii_hexdigit() {
+                // if pos is more than 33 bytes from the end a multibyte char made us skip
+                // pos 32, multibyte chars are not hexdigit or $ so nothing to strip.
                 return ident;
             }
         }
-        ident
     }
+    ident
 }
 
 fn try_demangle_cpp(ident: &str, opts: DemangleOptions) -> Option<String> {


### PR DESCRIPTION
This was splitting strings in an unsafe way, assuming you could always
split at 33 bytes from the end which is not true in UTF-8 strings.

Fixes SYMBOLICATOR-GE