### PR TITLE
Be incredibly lenient when parsing ELFs

### DIFF
--- a/examples/object_debug/src/main.rs
+++ b/examples/object_debug/src/main.rs
@@ -39,6 +39,7 @@ fn inspect_object<P: AsRef<Path>>(path: P) -> Result<(), Box<dyn std::error::Err
                 println!("   symbol table: {}", object.has_symbols());
                 println!("   debug info:   {}", object.has_debug_info());
                 println!("   unwind info:  {}", object.has_unwind_info());
+                println!("   is malformed: {}", object.is_malformed());
             }
             Err(e) => {
                 print!(" - ");

--- a/symbolic-debuginfo/src/base.rs
+++ b/symbolic-debuginfo/src/base.rs
@@ -694,6 +694,9 @@ pub trait ObjectLike<'data, 'object> {
 
     /// Determines whether this object contains embedded sources.
     fn has_sources(&self) -> bool;
+
+    /// Determines whether this object is malformed and was only partially parsed
+    fn is_malformed(&self) -> bool;
 }
 
 mod derive_serde {

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -902,6 +902,11 @@ impl<'data> BreakpadObject<'data> {
         false
     }
 
+    /// Determines whether this object is malformed and was only partially parsed
+    pub fn is_malformed(&self) -> bool {
+        false
+    }
+
     /// Returns an iterator over info records.
     pub fn info_records(&self) -> BreakpadInfoRecords<'data> {
         BreakpadInfoRecords {
@@ -966,6 +971,7 @@ impl fmt::Debug for BreakpadObject<'_> {
             .field("has_symbols", &self.has_symbols())
             .field("has_debug_info", &self.has_debug_info())
             .field("has_unwind_info", &self.has_unwind_info())
+            .field("is_malformed", &self.is_malformed())
             .finish()
     }
 }
@@ -1045,6 +1051,10 @@ impl<'data: 'object, 'object> ObjectLike<'data, 'object> for BreakpadObject<'dat
 
     fn has_sources(&self) -> bool {
         self.has_sources()
+    }
+
+    fn is_malformed(&self) -> bool {
+        self.is_malformed()
     }
 }
 

--- a/symbolic-debuginfo/src/elf.rs
+++ b/symbolic-debuginfo/src/elf.rs
@@ -175,17 +175,15 @@ impl<'data> ElfObject<'data> {
                 // TODO: return just the empty elf
                 .map_err(|_| ElfError::new("unable to parse program headers"))?;
 
-        // todo: is the interpreter needed for debug info? since it's used for dynamic linking it seems like this might be yes
-        // let mut interpreter = None;
-        // for ph in &obj.program_headers {
-        //     if ph.p_type == elf::program_header::PT_INTERP && ph.p_filesz != 0 {
-        //         let count = (ph.p_filesz - 1) as usize;
-        //         let offset = ph.p_offset as usize;
-        //         interpreter = data
-        //             .pread_with::<&str>(offset, ::scroll::ctx::StrCtx::Length(count))
-        //             .ok();
-        //     }
-        // }
+        for ph in &obj.program_headers {
+            if ph.p_type == elf::program_header::PT_INTERP && ph.p_filesz != 0 {
+                let count = (ph.p_filesz - 1) as usize;
+                let offset = ph.p_offset as usize;
+                obj.interpreter = data
+                    .pread_with::<&str>(offset, ::scroll::ctx::StrCtx::Length(count))
+                    .ok();
+            }
+        }
 
         obj.section_headers = return_partial_on_err!(|| SectionHeader::parse(
             data,

--- a/symbolic-debuginfo/src/elf.rs
+++ b/symbolic-debuginfo/src/elf.rs
@@ -79,7 +79,8 @@ impl<'data> ElfObject<'data> {
         )
     }
 
-    // ripped from goblin because these aren't public and we're "lazily parsing"
+    // Pulled from https://github.com/m4b/goblin/blob/master/src/elf/mod.rs#L393-L424 as it
+    // currently isn't public, but we need this to parse an ELF.
     fn gnu_hash_len(bytes: &[u8], offset: usize, ctx: Ctx) -> goblin::error::Result<usize> {
         let buckets_num = bytes.pread_with::<u32>(offset, ctx.le)? as usize;
         let min_chain = bytes.pread_with::<u32>(offset + 4, ctx.le)? as usize;
@@ -115,7 +116,8 @@ impl<'data> ElfObject<'data> {
         }
     }
 
-    // ripped from goblin because these aren't public and we're "lazily parsing"
+    // Pulled from https://github.com/m4b/goblin/blob/master/src/elf/mod.rs#L426-L434 as it
+    // currently isn't public, but we need this to parse an ELF.
     fn hash_len(
         bytes: &[u8],
         offset: usize,

--- a/symbolic-debuginfo/src/elf.rs
+++ b/symbolic-debuginfo/src/elf.rs
@@ -67,6 +67,7 @@ impl ElfError {
 pub struct ElfObject<'data> {
     elf: elf::Elf<'data>,
     data: &'data [u8],
+    is_malformed: bool,
 }
 
 impl<'data> ElfObject<'data> {
@@ -162,6 +163,7 @@ impl<'data> ElfObject<'data> {
                     return Ok(ElfObject {
                         elf: obj,
                         data,
+                        is_malformed: true,
                     });
                 }
             };
@@ -336,6 +338,7 @@ impl<'data> ElfObject<'data> {
         Ok(ElfObject {
             elf: obj,
             data,
+            is_malformed: false,
         })
     }
 
@@ -528,6 +531,11 @@ impl<'data> ElfObject<'data> {
         false
     }
 
+    /// Determines whether this object is malformed and was only partially parsed
+    pub fn is_malformed(&self) -> bool {
+        self.is_malformed
+    }
+
     /// Returns the raw data of the ELF file.
     pub fn data(&self) -> &'data [u8] {
         self.data
@@ -692,6 +700,7 @@ impl fmt::Debug for ElfObject<'_> {
             .field("has_symbols", &self.has_symbols())
             .field("has_debug_info", &self.has_debug_info())
             .field("has_unwind_info", &self.has_unwind_info())
+            .field("is_malformed", &self.is_malformed())
             .finish()
     }
 }
@@ -771,6 +780,10 @@ impl<'data: 'object, 'object> ObjectLike<'data, 'object> for ElfObject<'data> {
 
     fn has_sources(&self) -> bool {
         self.has_sources()
+    }
+
+    fn is_malformed(&self) -> bool {
+        self.is_malformed()
     }
 }
 

--- a/symbolic-debuginfo/src/macho/mod.rs
+++ b/symbolic-debuginfo/src/macho/mod.rs
@@ -336,6 +336,11 @@ impl<'d> MachObject<'d> {
         false
     }
 
+    /// Determines whether this object is malformed and was only partially parsed
+    pub fn is_malformed(&self) -> bool {
+        false
+    }
+
     /// Returns the raw data of the ELF file.
     pub fn data(&self) -> &'d [u8] {
         self.data
@@ -363,6 +368,7 @@ impl fmt::Debug for MachObject<'_> {
             .field("has_symbols", &self.has_symbols())
             .field("has_debug_info", &self.has_debug_info())
             .field("has_unwind_info", &self.has_unwind_info())
+            .field("is_malformed", &self.is_malformed())
             .finish()
     }
 }
@@ -442,6 +448,10 @@ impl<'data: 'object, 'object> ObjectLike<'data, 'object> for MachObject<'data> {
 
     fn has_sources(&self) -> bool {
         self.has_sources()
+    }
+
+    fn is_malformed(&self) -> bool {
+        self.is_malformed()
     }
 }
 

--- a/symbolic-debuginfo/src/object.rs
+++ b/symbolic-debuginfo/src/object.rs
@@ -332,6 +332,11 @@ impl<'data> Object<'data> {
         match_inner!(self, Object(ref o) => o.has_sources())
     }
 
+    /// Determines whether this object is malformed and was only partially parsed
+    pub fn is_malformed(&self) -> bool {
+        match_inner!(self, Object(ref o) => o.is_malformed())
+    }
+
     /// Returns the raw data of the underlying buffer.
     pub fn data(&self) -> &'data [u8] {
         match_inner!(self, Object(ref o) => o.data())
@@ -401,6 +406,10 @@ impl<'data: 'object, 'object> ObjectLike<'data, 'object> for Object<'data> {
 
     fn has_sources(&self) -> bool {
         self.has_sources()
+    }
+
+    fn is_malformed(&self) -> bool {
+        self.is_malformed()
     }
 }
 

--- a/symbolic-debuginfo/src/pdb.rs
+++ b/symbolic-debuginfo/src/pdb.rs
@@ -235,6 +235,11 @@ impl<'data> PdbObject<'data> {
         false
     }
 
+    /// Determines whether this object is malformed and was only partially parsed
+    pub fn is_malformed(&self) -> bool {
+        false
+    }
+
     /// Constructs a debugging session.
     pub fn debug_session(&self) -> Result<PdbDebugSession<'data>, PdbError> {
         PdbDebugSession::build(self)
@@ -269,6 +274,7 @@ impl fmt::Debug for PdbObject<'_> {
             .field("has_symbols", &self.has_symbols())
             .field("has_debug_info", &self.has_debug_info())
             .field("has_unwind_info", &self.has_unwind_info())
+            .field("is_malformed", &self.is_malformed())
             .finish()
     }
 }
@@ -348,6 +354,10 @@ impl<'data: 'object, 'object> ObjectLike<'data, 'object> for PdbObject<'data> {
 
     fn has_sources(&self) -> bool {
         self.has_sources()
+    }
+
+    fn is_malformed(&self) -> bool {
+        self.is_malformed()
     }
 }
 

--- a/symbolic-debuginfo/src/pe.rs
+++ b/symbolic-debuginfo/src/pe.rs
@@ -200,6 +200,11 @@ impl<'data> PeObject<'data> {
         false
     }
 
+    /// Determines whether this object is malformed and was only partially parsed
+    pub fn is_malformed(&self) -> bool {
+        false
+    }
+
     /// Constructs a no-op debugging session.
     pub fn debug_session(&self) -> Result<PeDebugSession<'data>, PeError> {
         Ok(PeDebugSession { _ph: PhantomData })
@@ -242,6 +247,7 @@ impl fmt::Debug for PeObject<'_> {
             .field("has_symbols", &self.has_symbols())
             .field("has_debug_info", &self.has_debug_info())
             .field("has_unwind_info", &self.has_unwind_info())
+            .field("is_malformed", &self.is_malformed())
             .finish()
     }
 }
@@ -321,6 +327,10 @@ impl<'data: 'object, 'object> ObjectLike<'data, 'object> for PeObject<'data> {
 
     fn has_sources(&self) -> bool {
         self.has_sources()
+    }
+
+    fn is_malformed(&self) -> bool {
+        self.is_malformed()
     }
 }
 

--- a/symbolic-debuginfo/src/sourcebundle.rs
+++ b/symbolic-debuginfo/src/sourcebundle.rs
@@ -339,6 +339,7 @@ impl fmt::Debug for SourceBundle<'_> {
             .field("has_debug_info", &self.has_debug_info())
             .field("has_unwind_info", &self.has_unwind_info())
             .field("has_sources", &self.has_sources())
+            .field("is_malformed", &self.is_malformed())
             .finish()
     }
 }
@@ -494,6 +495,11 @@ impl<'data> SourceBundle<'data> {
         true
     }
 
+    /// Determines whether this object is malformed and was only partially parsed
+    pub fn is_malformed(&self) -> bool {
+        false
+    }
+
     /// Returns the raw data of the source bundle.
     pub fn data(&self) -> &'data [u8] {
         self.data
@@ -580,6 +586,10 @@ impl<'data: 'object, 'object> ObjectLike<'data, 'object> for SourceBundle<'data>
 
     fn has_sources(&self) -> bool {
         self.has_sources()
+    }
+
+    fn is_malformed(&self) -> bool {
+        self.is_malformed()
     }
 }
 

--- a/symbolic-debuginfo/src/wasm.rs
+++ b/symbolic-debuginfo/src/wasm.rs
@@ -178,6 +178,11 @@ impl<'data> WasmObject<'data> {
         false
     }
 
+    /// Determines whether this object is malformed and was only partially parsed
+    pub fn is_malformed(&self) -> bool {
+        false
+    }
+
     /// Returns the raw data of the WASM file.
     pub fn data(&self) -> &'data [u8] {
         self.data
@@ -200,6 +205,7 @@ impl fmt::Debug for WasmObject<'_> {
             .field("has_symbols", &self.has_symbols())
             .field("has_debug_info", &self.has_debug_info())
             .field("has_unwind_info", &self.has_unwind_info())
+            .field("is_malformed", &self.is_malformed())
             .finish()
     }
 }
@@ -279,6 +285,10 @@ impl<'data: 'object, 'object> ObjectLike<'data, 'object> for WasmObject<'data> {
 
     fn has_sources(&self) -> bool {
         self.has_sources()
+    }
+
+    fn is_malformed(&self) -> bool {
+        self.is_malformed()
     }
 }
 

--- a/symbolic-debuginfo/tests/test_objects.rs
+++ b/symbolic-debuginfo/tests/test_objects.rs
@@ -96,6 +96,7 @@ fn test_breakpad() -> Result<(), Error> {
    ⋮        has_symbols: true,
    ⋮        has_debug_info: true,
    ⋮        has_unwind_info: true,
+   ⋮        is_malformed: false,
    ⋮    },
    ⋮)
     "###);
@@ -160,6 +161,7 @@ fn test_elf_executable() -> Result<(), Error> {
    ⋮        has_symbols: true,
    ⋮        has_debug_info: false,
    ⋮        has_unwind_info: true,
+   ⋮        is_malformed: false,
    ⋮    },
    ⋮)
     "###);
@@ -188,6 +190,7 @@ fn test_elf_debug() -> Result<(), Error> {
    ⋮        has_symbols: true,
    ⋮        has_debug_info: true,
    ⋮        has_unwind_info: false,
+   ⋮        is_malformed: false,
    ⋮    },
    ⋮)
     "###);
@@ -252,6 +255,7 @@ fn test_mach_executable() -> Result<(), Error> {
    ⋮        has_symbols: true,
    ⋮        has_debug_info: false,
    ⋮        has_unwind_info: true,
+   ⋮        is_malformed: false,
    ⋮    },
    ⋮)
     "###);
@@ -280,6 +284,7 @@ fn test_mach_dsym() -> Result<(), Error> {
    ⋮        has_symbols: true,
    ⋮        has_debug_info: true,
    ⋮        has_unwind_info: false,
+   ⋮        is_malformed: false,
    ⋮    },
    ⋮)
     "###);
@@ -347,6 +352,7 @@ fn test_pe_32() -> Result<(), Error> {
    ⋮        has_symbols: false,
    ⋮        has_debug_info: false,
    ⋮        has_unwind_info: false,
+   ⋮        is_malformed: false,
    ⋮    },
    ⋮)
     "###);
@@ -378,6 +384,7 @@ fn test_pe_64() -> Result<(), Error> {
    ⋮        has_symbols: false,
    ⋮        has_debug_info: false,
    ⋮        has_unwind_info: true,
+   ⋮        is_malformed: false,
    ⋮    },
    ⋮)
     "###);
@@ -405,6 +412,7 @@ fn test_pdb() -> Result<(), Error> {
    ⋮        has_symbols: true,
    ⋮        has_debug_info: true,
    ⋮        has_unwind_info: true,
+   ⋮        is_malformed: false,
    ⋮    },
    ⋮)
     "###);


### PR DESCRIPTION
This is a proof of concept PR to demonstrate an excessive solution that could be used to sidestep problems like the one mentioned in https://github.com/getsentry/sentry-dart/issues/591, where only a portion of an ELF is malformed but the rest of it can be perfectly parsed. The ELF parser has been changed so that malformed ELFs could still be partially parsed out instead of eagerly failing at the first error.

The PR basically copy-pastes nearly everything from goblin's ELF parser, and replaces all short-circuited errors with a macro that returns the ELF object with everything successfully parsed up until the failure. A good second iteration on this would be to merely skip unparseable pieces but not short-circuit on the first failure, allowing us to, for example parse out dynamic symbols even if regular symbol parsing fails. 

An additional field as been added to all object types to indicate whether it's malformed or not, in order to provide some feedback in the event that an ELF is malformed and cannot be fully parsed. Ideally this is properly used in other objects.

An ideal alternative to this would probably be to extend goblin's repertoire of `lazy_parse` helpers, following the idea mentioned in https://github.com/m4b/goblin/pull/254#issuecomment-770583461 instead. Following that path would allow us to properly lazily parse the file instead of just copying line-for-line what `Elf::parse()` is doing.

