### PR TITLE
ref(clippy): Some nightly clippy fixes

### DIFF
--- a/symbolic-debuginfo/src/elf.rs
+++ b/symbolic-debuginfo/src/elf.rs
@@ -351,7 +351,7 @@ impl<'data> ElfObject<'data> {
     pub fn code_id(&self) -> Option<CodeId> {
         self.find_build_id()
             .filter(|slice| !slice.is_empty())
-            .map(|slice| CodeId::from_binary(slice))
+            .map(CodeId::from_binary)
     }
 
     /// The binary's soname, if any.

--- a/symbolic-demangle/tests/utils/mod.rs
+++ b/symbolic-demangle/tests/utils/mod.rs
@@ -20,9 +20,7 @@ macro_rules! assert_demangle {
             }
         })*
 
-        if !__failures.is_empty() {
-            panic!("demangling failed: \n\n{}\n", __failures.join("\n\n"));
-        }
+        assert!(__failures.is_empty(), "demangling failed: \n\n{}\n", __failures.join("\n\n"));
     }};
     ($l:expr, $o:expr, { $($m:expr => $d:expr,)* }) => {
         assert_demangle!($l, $o, { $($m => $d),* })

--- a/symbolic-minidump/build.rs
+++ b/symbolic-minidump/build.rs
@@ -8,9 +8,7 @@ fn main() {
             .status()
             .expect("Failed to install git submodules");
 
-        if !status.success() {
-            panic!("Failed to install git submodules");
-        }
+        assert!(status.success(), "Failed to install git submodules");
     }
 
     cc::Build::new()


### PR DESCRIPTION
Apparently we should prefer direct assert!.  Also an unnecessary
closure was used.

#skip-changelog