### PR TITLE
ref: Make clippy nightly happy

### DIFF
--- a/symbolic-debuginfo/src/macho/mod.rs
+++ b/symbolic-debuginfo/src/macho/mod.rs
@@ -659,6 +659,7 @@ impl<'slf, 'd: 'slf> AsSelf<'slf> for FatMachO<'d> {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 enum MachObjectIteratorInner<'d, 'a> {
     Single(MonoArchiveObjects<'d, MachObject<'d>>),
     Archive(FatMachObjectIterator<'d, 'a>),


### PR DESCRIPTION
This is particular changes the `CompactCfiRegister` repr to shrink its own and all
dependants sizes.

This is technically a breaking change, but that enum has always been documented as "treat this opaquely".