### PR TITLE
feat(byteview): Add non-consuming mmap constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Add `ByteView::map_file_ref` constructor which does not consume the `File` passed to it. ([#448](https://github.com/getsentry/symbolic/pull/448))
+
+**Fixes**:
+
+- Support Unreal Engine 5 crash reporter. ([#449](https://github.com/getsentry/symbolic/pull/449))
+
 ## 8.4.0
 
 **Features**:

--- a/symbolic-common/src/byteview.rs
+++ b/symbolic-common/src/byteview.rs
@@ -118,7 +118,7 @@ impl<'a> ByteView<'a> {
 
     /// Constructs a `ByteView` from an open file handle by memory mapping the file.
     ///
-    /// See [`ByteView::mmap_file`] for a non-consuming version of this constructor.
+    /// See [`ByteView::map_file_ref`] for a non-consuming version of this constructor.
     ///
     /// # Example
     ///
@@ -133,7 +133,7 @@ impl<'a> ByteView<'a> {
     /// }
     /// ```
     pub fn map_file(file: File) -> Result<Self, io::Error> {
-        Self::mmap_file(&file)
+        Self::map_file_ref(&file)
     }
 
     /// Constructs a `ByteView` from an open file handle by memory mapping the file.
@@ -149,11 +149,11 @@ impl<'a> ByteView<'a> {
     ///
     /// fn main() -> Result<(), std::io::Error> {
     ///     let mut file = tempfile::tempfile()?;
-    ///     let view = ByteView::mmap_file(&file)?;
+    ///     let view = ByteView::map_file_ref(&file)?;
     ///     Ok(())
     /// }
     /// ```
-    pub fn mmap_file(file: &File) -> Result<Self, io::Error> {
+    pub fn map_file_ref(file: &File) -> Result<Self, io::Error> {
         let backing = match unsafe { Mmap::map(file) } {
             Ok(mmap) => ByteViewBacking::Mmap(mmap),
             Err(err) => {
@@ -289,7 +289,7 @@ mod tests {
         let mut tmp = NamedTempFile::new()?;
         tmp.write_all(b"1234")?;
 
-        let view = ByteView::mmap_file(tmp.as_file())?;
+        let view = ByteView::map_file_ref(tmp.as_file())?;
 
         // This deletes the file on disk.
         let path = tmp.path().to_path_buf();

--- a/symbolic-common/src/byteview.rs
+++ b/symbolic-common/src/byteview.rs
@@ -301,6 +301,7 @@ mod tests {
         file.rewind()?;
         file.read_to_end(&mut buf)?;
         assert_eq!(buf, b"1234");
+        drop(file);
 
         // Ensure the byteview can still read the file as well.
         assert_eq!(&*view, b"1234");

--- a/symbolic-common/src/byteview.rs
+++ b/symbolic-common/src/byteview.rs
@@ -118,6 +118,8 @@ impl<'a> ByteView<'a> {
 
     /// Constructs a `ByteView` from an open file handle by memory mapping the file.
     ///
+    /// See [`ByteView::mmap_file`] for a non-consuming version of this constructor.
+    ///
     /// # Example
     ///
     /// ```
@@ -131,7 +133,28 @@ impl<'a> ByteView<'a> {
     /// }
     /// ```
     pub fn map_file(file: File) -> Result<Self, io::Error> {
-        let backing = match unsafe { Mmap::map(&file) } {
+        Self::mmap_file(&file)
+    }
+
+    /// Constructs a `ByteView` from an open file handle by memory mapping the file.
+    ///
+    /// The main difference with [`ByteView::map_file`] is that this takes the [`File`] by
+    /// reference rather than consuming it.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::io::Write;
+    /// use symbolic_common::ByteView;
+    ///
+    /// fn main() -> Result<(), std::io::Error> {
+    ///     let mut file = tempfile::tempfile()?;
+    ///     let view = ByteView::mmap_file(&file)?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn mmap_file(file: &File) -> Result<Self, io::Error> {
+        let backing = match unsafe { Mmap::map(file) } {
             Ok(mmap) => ByteViewBacking::Mmap(mmap),
             Err(err) => {
                 // this is raised on empty mmaps which we want to ignore. The 1006 Windows error
@@ -234,7 +257,7 @@ unsafe impl StableDeref for ByteView<'_> {}
 mod tests {
     use super::*;
 
-    use std::io::Write;
+    use std::io::{Read, Seek, Write};
 
     use similar_asserts::assert_eq;
     use tempfile::NamedTempFile;
@@ -256,6 +279,30 @@ mod tests {
         tmp.write_all(b"1234")?;
 
         let view = ByteView::open(&tmp.path())?;
+        assert_eq!(&*view, b"1234");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_mmap_fd_reuse() -> Result<(), std::io::Error> {
+        let mut tmp = NamedTempFile::new()?;
+        tmp.write_all(b"1234")?;
+
+        let view = ByteView::mmap_file(tmp.as_file())?;
+
+        // This deletes the file on disk.
+        let path = tmp.path().to_path_buf();
+        let mut file = tmp.into_file();
+        assert!(!path.exists());
+
+        // Ensure we can still read from the the file after mmapping and deleting it on disk.
+        let mut buf = Vec::new();
+        file.rewind()?;
+        file.read_to_end(&mut buf)?;
+        assert_eq!(buf, b"1234");
+
+        // Ensure the byteview can still read the file as well.
         assert_eq!(&*view, b"1234");
 
         Ok(())


### PR DESCRIPTION
This adds constructor to mmap a File into a ByteView without consuming
the file object.