### PR TITLE
ref(symcache): Simplify Function & File lookup types

### DIFF
--- a/symbolic-symcache/src/new/compat.rs
+++ b/symbolic-symcache/src/new/compat.rs
@@ -54,7 +54,7 @@ pub struct FunctionIter<'data, 'cache> {
 }
 
 impl<'data, 'cache> Iterator for FunctionIter<'data, 'cache> {
-    type Item = Function<'data, 'cache>;
+    type Item = Function<'data>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.cache.get_function(self.function_idx).map(|file| {

--- a/symbolic-symcache/src/new/compat.rs
+++ b/symbolic-symcache/src/new/compat.rs
@@ -37,19 +37,13 @@ pub struct FileIter<'data, 'cache> {
 }
 
 impl<'data, 'cache> Iterator for FileIter<'data, 'cache> {
-    type Item = File<'data, 'cache>;
+    type Item = File<'data>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.cache
-            .files
-            .get(self.file_idx as usize)
-            .map(|raw_file| {
-                self.file_idx += 1;
-                File {
-                    cache: self.cache,
-                    file: raw_file,
-                }
-            })
+        self.cache.get_file(self.file_idx).map(|file| {
+            self.file_idx += 1;
+            file
+        })
     }
 }
 
@@ -63,15 +57,9 @@ impl<'data, 'cache> Iterator for FunctionIter<'data, 'cache> {
     type Item = Function<'data, 'cache>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.cache
-            .functions
-            .get(self.function_idx as usize)
-            .map(|raw_function| {
-                self.function_idx += 1;
-                Function {
-                    cache: self.cache,
-                    function: raw_function,
-                }
-            })
+        self.cache.get_function(self.function_idx).map(|file| {
+            self.function_idx += 1;
+            file
+        })
     }
 }

--- a/symbolic-symcache/src/new/lookup.rs
+++ b/symbolic-symcache/src/new/lookup.rs
@@ -44,14 +44,13 @@ impl<'data> SymCache<'data> {
     }
 
     pub(crate) fn get_function(&self, function_idx: u32) -> Option<Function<'data>> {
-        self.functions
-            .get(function_idx as usize)
-            .map(|function| Function {
-                name: self.get_string(function.name_idx),
-                comp_dir: self.get_string(function.comp_dir_idx),
-                entry_pc: function.entry_pc,
-                language: Language::from_u32(function.lang),
-            })
+        let raw_function = self.functions.get(function_idx as usize)?;
+        Some(Function {
+            name: self.get_string(raw_function.name_idx),
+            comp_dir: self.get_string(raw_function.comp_dir_idx),
+            entry_pc: raw_function.entry_pc,
+            language: Language::from_u32(raw_function.lang),
+        })
     }
 }
 

--- a/symbolic-symcache/src/new/lookup.rs
+++ b/symbolic-symcache/src/new/lookup.rs
@@ -34,13 +34,24 @@ impl<'data> SymCache<'data> {
         }
     }
 
-    fn get_file(&self, file_idx: u32) -> Option<File<'data, '_>> {
-        if file_idx == u32::MAX {
-            return None;
-        }
-        self.files
-            .get(file_idx as usize)
-            .map(|file| File { cache: self, file })
+    pub(crate) fn get_file(&self, file_idx: u32) -> Option<File<'data>> {
+        let raw_file = self.files.get(file_idx as usize)?;
+        Some(File {
+            comp_dir: self.get_string(raw_file.comp_dir_idx),
+            directory: self.get_string(raw_file.directory_idx),
+            path_name: self.get_string(raw_file.path_name_idx).unwrap(),
+        })
+    }
+
+    pub(crate) fn get_function(&self, function_idx: u32) -> Option<Function<'data>> {
+        self.functions
+            .get(function_idx as usize)
+            .map(|function| Function {
+                name: self.get_string(function.name_idx),
+                comp_dir: self.get_string(function.comp_dir_idx),
+                entry_pc: function.entry_pc,
+                language: Language::from_u32(function.lang),
+            })
     }
 }
 
@@ -64,25 +75,29 @@ impl<'data> SymCache<'data> {
 ///   - directory: /usr/include/
 ///   - path_name: pthread.h
 #[derive(Debug, Clone)]
-pub struct File<'data, 'cache> {
-    pub(crate) cache: &'cache SymCache<'data>,
-    pub(crate) file: &'data raw::File,
+pub struct File<'data> {
+    /// The optional compilation directory prefix.
+    pub comp_dir: Option<&'data str>,
+    /// The optional directory prefix.
+    pub directory: Option<&'data str>,
+    /// The file path.
+    pub path_name: &'data str,
 }
 
-impl<'data, 'cache> File<'data, 'cache> {
+impl<'data> File<'data> {
     /// Resolves the compilation directory of this source file.
     pub fn comp_dir(&self) -> Option<&'data str> {
-        self.cache.get_string(self.file.comp_dir_idx)
+        self.comp_dir
     }
 
     /// Resolves the parent directory of this source file.
     pub fn directory(&self) -> Option<&'data str> {
-        self.cache.get_string(self.file.directory_idx)
+        self.directory
     }
 
     /// Resolves the final path name fragment of this source file.
     pub fn path_name(&self) -> &'data str {
-        self.cache.get_string(self.file.path_name_idx).unwrap()
+        self.path_name
     }
 
     /// Resolves and concatenates the full path based on its individual fragments.
@@ -101,25 +116,32 @@ impl<'data, 'cache> File<'data, 'cache> {
 
 /// A Function definition as included in the SymCache.
 #[derive(Clone, Debug)]
-pub struct Function<'data, 'cache> {
-    pub(crate) cache: &'cache SymCache<'data>,
-    pub(crate) function: &'data raw::Function,
+pub struct Function<'data> {
+    name: Option<&'data str>,
+    comp_dir: Option<&'data str>,
+    entry_pc: u32,
+    language: Language,
 }
 
-impl<'data, 'cache> Function<'data, 'cache> {
+impl<'data> Function<'data> {
     /// The possibly mangled name/symbol of this function.
     pub fn name(&self) -> Option<&'data str> {
-        self.cache.get_string(self.function.name_idx)
+        self.name
+    }
+
+    /// The compilation directory of this function.
+    pub fn comp_dir(&self) -> Option<&'data str> {
+        self.comp_dir
     }
 
     /// The entry pc of the function.
     pub fn entry_pc(&self) -> u32 {
-        self.function.entry_pc
+        self.entry_pc
     }
 
     /// The language the function is written in.
     pub fn language(&self) -> Language {
-        Language::from_u32(self.function.lang as u32)
+        self.language
     }
 }
 
@@ -142,23 +164,13 @@ impl<'data, 'cache> SourceLocation<'data, 'cache> {
     }
 
     /// The source file corresponding to the instruction.
-    pub fn file(&self) -> Option<File<'data, 'cache>> {
+    pub fn file(&self) -> Option<File<'data>> {
         self.cache.get_file(self.source_location.file_idx)
     }
 
     /// The function corresponding to the instruction.
-    pub fn function(&self) -> Option<Function<'data, 'cache>> {
-        let function_idx = self.source_location.function_idx;
-        if function_idx == u32::MAX {
-            return None;
-        }
-        self.cache
-            .functions
-            .get(function_idx as usize)
-            .map(|function| Function {
-                cache: self.cache,
-                function,
-            })
+    pub fn function(&self) -> Option<Function<'data>> {
+        self.cache.get_function(self.source_location.function_idx)
     }
 
     // TODO: maybe forward some of the `File` and `Function` accessors, such as:

--- a/symbolic-symcache/src/new/raw.rs
+++ b/symbolic-symcache/src/new/raw.rs
@@ -134,7 +134,7 @@ mod tests {
         assert_eq!(mem::size_of::<Header>(), 80);
         assert_eq!(mem::align_of::<Header>(), 8);
 
-        assert_eq!(mem::size_of::<Function>(), 12);
+        assert_eq!(mem::size_of::<Function>(), 16);
         assert_eq!(mem::align_of::<Function>(), 4);
 
         assert_eq!(mem::size_of::<File>(), 12);

--- a/symbolic-symcache/src/new/raw.rs
+++ b/symbolic-symcache/src/new/raw.rs
@@ -53,6 +53,8 @@ pub struct Header {
 pub struct Function {
     /// The functions name (reference to a [`String`]).
     pub name_idx: u32,
+    /// The compilation directory (reference to a [`String`]).
+    pub comp_dir_idx: u32,
     /// The first address covered by this function.
     pub entry_pc: u32,
     /// The language of the function.


### PR DESCRIPTION
This changes `lookup::Function` and `lookup::File` so that the various string fields are resolved more eagerly. Consequently, these types don't need to keep a reference to the symcache and can make do with only one lifetime parameter.

Moreover, `Function` gains an additional `&str` for the compilation directory.