### PR TITLE
ref(symcache): Change internal string representation

### DIFF
--- a/symbolic-symcache/src/new/lookup.rs
+++ b/symbolic-symcache/src/new/lookup.rs
@@ -34,17 +34,17 @@ impl<'data> SymCache<'data> {
     pub(crate) fn get_file(&self, file_idx: u32) -> Option<File<'data>> {
         let raw_file = self.files.get(file_idx as usize)?;
         Some(File {
-            comp_dir: self.get_string(raw_file.comp_dir_idx),
-            directory: self.get_string(raw_file.directory_idx),
-            path_name: self.get_string(raw_file.path_name_idx).unwrap(),
+            comp_dir: self.get_string(raw_file.comp_dir_offset),
+            directory: self.get_string(raw_file.directory_offset),
+            path_name: self.get_string(raw_file.path_name_offset).unwrap(),
         })
     }
 
     pub(crate) fn get_function(&self, function_idx: u32) -> Option<Function<'data>> {
         let raw_function = self.functions.get(function_idx as usize)?;
         Some(Function {
-            name: self.get_string(raw_function.name_idx),
-            comp_dir: self.get_string(raw_function.comp_dir_idx),
+            name: self.get_string(raw_function.name_offset),
+            comp_dir: self.get_string(raw_function.comp_dir_offset),
             entry_pc: raw_function.entry_pc,
             language: Language::from_u32(raw_function.lang),
         })

--- a/symbolic-symcache/src/new/mod.rs
+++ b/symbolic-symcache/src/new/mod.rs
@@ -148,7 +148,7 @@ impl<'data> SymCache<'data> {
         }
         let len_offset = offset as usize;
         let len_size = std::mem::size_of::<u32>();
-        let len = u32::from_le_bytes(
+        let len = u32::from_ne_bytes(
             self.string_bytes
                 .get(len_offset..len_offset + len_size)?
                 .try_into()

--- a/symbolic-symcache/src/new/raw.rs
+++ b/symbolic-symcache/src/new/raw.rs
@@ -30,8 +30,6 @@ pub struct Header {
     /// CPU architecture of the object file.
     pub arch: Arch,
 
-    /// Number of included [`String`]s.
-    pub num_strings: u32,
     /// Number of included [`File`]s.
     pub num_files: u32,
     /// Number of included [`Function`]s.
@@ -49,9 +47,9 @@ pub struct Header {
 #[repr(C)]
 pub struct Function {
     /// The functions name (reference to a [`String`]).
-    pub name_idx: u32,
+    pub name_offset: u32,
     /// The compilation directory (reference to a [`String`]).
-    pub comp_dir_idx: u32,
+    pub comp_dir_offset: u32,
     /// The first address covered by this function.
     pub entry_pc: u32,
     /// The language of the function.
@@ -63,11 +61,11 @@ pub struct Function {
 #[repr(C)]
 pub struct File {
     /// The optional compilation directory prefix (reference to a [`String`]).
-    pub comp_dir_idx: u32,
+    pub comp_dir_offset: u32,
     /// The optional directory prefix (reference to a [`String`]).
-    pub directory_idx: u32,
+    pub directory_offset: u32,
     /// The file path (reference to a [`String`]).
-    pub path_name_idx: u32,
+    pub path_name_offset: u32,
 }
 
 /// A location in a source file, comprising a file, a line, a function, and
@@ -89,16 +87,6 @@ pub struct SourceLocation {
     /// The caller source location in case this location was inlined
     /// (reference to another [`SourceLocation`]).
     pub inlined_into_idx: u32,
-}
-
-/// Serialized String in the SymCache.
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-#[repr(C)]
-pub struct String {
-    /// The offset into the `string_bytes`.
-    pub string_offset: u32,
-    /// Length of the string.
-    pub string_len: u32,
 }
 
 /// A representation of a code range in the SymCache.
@@ -128,7 +116,7 @@ mod tests {
 
     #[test]
     fn test_sizeof() {
-        assert_eq!(mem::size_of::<Header>(), 68);
+        assert_eq!(mem::size_of::<Header>(), 64);
         assert_eq!(mem::align_of::<Header>(), 4);
 
         assert_eq!(mem::size_of::<Function>(), 16);
@@ -139,9 +127,6 @@ mod tests {
 
         assert_eq!(mem::size_of::<SourceLocation>(), 16);
         assert_eq!(mem::align_of::<SourceLocation>(), 4);
-
-        assert_eq!(mem::size_of::<String>(), 8);
-        assert_eq!(mem::align_of::<String>(), 4);
 
         assert_eq!(mem::size_of::<Range>(), 4);
         assert_eq!(mem::align_of::<Range>(), 4);

--- a/symbolic-symcache/src/new/writer.rs
+++ b/symbolic-symcache/src/new/writer.rs
@@ -4,7 +4,7 @@ use std::collections::btree_map;
 use std::collections::BTreeMap;
 use std::io::Write;
 
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexSet;
 use symbolic_common::{Arch, DebugId, Language};
 use symbolic_debuginfo::{DebugSession, Function, ObjectLike, Symbol};
 
@@ -26,7 +26,7 @@ pub struct SymCacheConverter {
     string_bytes: Vec<u8>,
     /// A map from [`String`]s that have been added to this `Converter` to [`StringRef`]s, i.e.,
     /// indices into the `string_bytes` vector.
-    strings: IndexMap<String, raw::String>,
+    strings: BTreeMap<String, u32>,
     /// The set of all [`raw::File`]s that have been added to this `Converter`.
     files: IndexSet<raw::File>,
     /// The set of all [`raw::Function`]s that have been added to this `Converter`.
@@ -59,26 +59,27 @@ impl SymCacheConverter {
 
     /// Insert a string into this converter.
     ///
-    /// If the string was already present, it is not added again. The returned `u32`
-    /// is the string's index in insertion order.
+    /// If the string was already present, it is not added again. A newly added string
+    /// is prefixed by its length as a `u32`. The returned `u32`
+    /// is the offset into the `string_bytes` field where the string is saved.
     fn insert_string(&mut self, s: &str) -> u32 {
         if s.is_empty() {
             return u32::MAX;
         }
-        if let Some(existing_idx) = self.strings.get_index_of(s) {
-            return existing_idx as u32;
+        if let Some(&offset) = self.strings.get(s) {
+            return offset;
         }
         let string_offset = self.string_bytes.len() as u32;
         let string_len = s.len() as u32;
+        self.string_bytes.extend(string_len.to_le_bytes());
         self.string_bytes.extend(s.bytes());
-        let (string_idx, _) = self.strings.insert_full(
-            s.to_owned(),
-            raw::String {
-                string_offset,
-                string_len,
-            },
+        // we should have written exactly `string_len + 4` bytes
+        debug_assert_eq!(
+            self.string_bytes.len(),
+            string_offset as usize + string_len as usize + std::mem::size_of::<u32>(),
         );
-        string_idx as u32
+        self.strings.insert(s.to_owned(), string_offset);
+        string_offset
     }
 
     /// Insert a file into this converter.
@@ -91,14 +92,14 @@ impl SymCacheConverter {
         directory: Option<&str>,
         comp_dir: Option<&str>,
     ) -> u32 {
-        let path_name_idx = self.insert_string(path_name);
-        let directory_idx = directory.map_or(u32::MAX, |d| self.insert_string(d));
-        let comp_dir_idx = comp_dir.map_or(u32::MAX, |cd| self.insert_string(cd));
+        let path_name_offset = self.insert_string(path_name);
+        let directory_offset = directory.map_or(u32::MAX, |d| self.insert_string(d));
+        let comp_dir_offset = comp_dir.map_or(u32::MAX, |cd| self.insert_string(cd));
 
         let (file_idx, _) = self.files.insert_full(raw::File {
-            path_name_idx,
-            directory_idx,
-            comp_dir_idx,
+            path_name_offset,
+            directory_offset,
+            comp_dir_offset,
         });
 
         file_idx as u32
@@ -115,12 +116,12 @@ impl SymCacheConverter {
         entry_pc: u32,
         lang: Language,
     ) -> u32 {
-        let name_idx = self.insert_string(name);
-        let comp_dir_idx = comp_dir.map_or(u32::MAX, |comp_dir| self.insert_string(comp_dir));
+        let name_offset = self.insert_string(name);
+        let comp_dir_offset = comp_dir.map_or(u32::MAX, |comp_dir| self.insert_string(comp_dir));
         let lang = lang as u32;
         let (fun_idx, _) = self.functions.insert_full(raw::Function {
-            name_idx,
-            comp_dir_idx,
+            name_offset,
+            comp_dir_offset,
             entry_pc,
             lang,
         });
@@ -239,8 +240,8 @@ impl SymCacheConverter {
         match self.ranges.entry(symbol.address as u32) {
             btree_map::Entry::Vacant(entry) => {
                 let function = raw::Function {
-                    name_idx,
-                    comp_dir_idx: u32::MAX,
+                    name_offset: name_idx,
+                    comp_dir_offset: u32::MAX,
                     entry_pc: symbol.address as u32,
                     lang: u32::MAX,
                 };
@@ -273,7 +274,6 @@ impl SymCacheConverter {
     pub fn serialize<W: Write>(self, writer: &mut W) -> std::io::Result<()> {
         let mut writer = WriteWrapper::new(writer);
 
-        let num_strings = self.strings.len() as u32;
         let num_files = self.files.len() as u32;
         let num_functions = self.functions.len() as u32;
         let num_source_locations = (self.source_locations.len() + self.ranges.len()) as u32;
@@ -287,7 +287,6 @@ impl SymCacheConverter {
             debug_id: self.debug_id,
             arch: self.arch,
 
-            num_strings,
             num_files,
             num_functions,
             num_source_locations,
@@ -298,9 +297,6 @@ impl SymCacheConverter {
         writer.write(&[header])?;
         writer.align()?;
 
-        for (_, s) in self.strings {
-            writer.write(&[s])?;
-        }
         writer.align()?;
 
         for f in self.files {


### PR DESCRIPTION
This changes the new symcache format so that strings are prefixed with their own length (as a `u32`) before concatenating them. Consequently, they can then be indexed by a byte offset into the big string concatenation.