### PR TITLE
fix(minidump): increase the maximum number of threads and regions

### DIFF
--- a/symbolic-minidump/cpp/processor.cpp
+++ b/symbolic-minidump/cpp/processor.cpp
@@ -7,6 +7,7 @@
 #include "cpp/memstream.h"
 #include "cpp/mmap_symbol_supplier.h"
 #include "cpp/processor.h"
+#include <limits>
 
 using google_breakpad::BasicSourceLineResolver;
 using google_breakpad::Minidump;

--- a/symbolic-minidump/cpp/processor.cpp
+++ b/symbolic-minidump/cpp/processor.cpp
@@ -10,6 +10,8 @@
 
 using google_breakpad::BasicSourceLineResolver;
 using google_breakpad::Minidump;
+using google_breakpad::MinidumpMemoryList;
+using google_breakpad::MinidumpThreadList;
 using google_breakpad::MinidumpProcessor;
 using google_breakpad::ProcessState;
 
@@ -23,6 +25,9 @@ process_state_t *process_minidump(const char *buffer,
         return nullptr;
     }
 
+    // Increase the maximum number of threads and regions.
+    MinidumpThreadList::set_max_threads(std::numeric_limits<uint32_t>::max());
+    MinidumpMemoryList::set_max_regions(std::numeric_limits<uint32_t>::max());
     ProcessState *state = new ProcessState();
     if (state == nullptr) {
         *result_out = -1;  // Memory allocation issue


### PR DESCRIPTION
We find minidump_stackwalk may miss some stack frames, especially when we handling with windows x64 minidump.

According to breakpad code, will need to increase the maximum number of threads and regions (regions affect most in my cases)
https://github.com/getsentry/breakpad/blob/92b80963f6fb698b8f4ff362186e4bfb58f594a6/src/processor/minidump_stackwalk.cc#L95-L97
