### PR TITLE
fix: Put an explicit end range into the SymCache

### DIFF
--- a/symbolic-symcache/src/new/lookup.rs
+++ b/symbolic-symcache/src/new/lookup.rs
@@ -20,11 +20,18 @@ impl<'data> SymCache<'data> {
         };
 
         let source_location_start = (self.source_locations.len() - self.ranges.len()) as u32;
-        let source_location_idx = match self.ranges.binary_search_by_key(&addr, |r| r.0) {
+        let mut source_location_idx = match self.ranges.binary_search_by_key(&addr, |r| r.0) {
             Ok(idx) => source_location_start + idx as u32,
             Err(idx) if idx == 0 => u32::MAX,
             Err(idx) => source_location_start + idx as u32 - 1,
         };
+
+        if let Some(source_location) = self.source_locations.get(source_location_idx as usize) {
+            if *source_location == raw::NO_SOURCE_LOCATION {
+                source_location_idx = u32::MAX;
+            }
+        }
+
         SourceLocationIter {
             cache: self,
             source_location_idx,

--- a/symbolic-symcache/src/new/raw.rs
+++ b/symbolic-symcache/src/new/raw.rs
@@ -14,6 +14,16 @@ pub const SYMCACHE_MAGIC: u32 = u32::from_le_bytes(SYMCACHE_MAGIC_BYTES);
 /// The byte-flipped magic, which indicates an endianness mismatch.
 pub const SYMCACHE_MAGIC_FLIPPED: u32 = SYMCACHE_MAGIC.swap_bytes();
 
+/// This [`SourceLocation`] is a sentinel value that says that no source location is present here.
+/// This is used to push an "end" range that does not resolve to a valid source location.
+/// Otherwise, the ranges would implicitly extend to infinity.
+pub const NO_SOURCE_LOCATION: SourceLocation = SourceLocation {
+    file_idx: u32::MAX,
+    line: u32::MAX,
+    function_idx: u32::MAX,
+    inlined_into_idx: u32::MAX,
+};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[repr(C)]
 pub struct Header {

--- a/symbolic-symcache/tests/breakpad.rs
+++ b/symbolic-symcache/tests/breakpad.rs
@@ -119,12 +119,8 @@ PUBLIC d00 0 public_record"#;
         .collect();
     assert_eq!(lookup_result[0].symbol(), "func_record_with_end");
 
-    let lookup_result: Vec<_> = symcache
-        .lookup(0xd99)
-        .unwrap()
-        .filter_map(Result::ok)
-        .collect();
-    assert!(lookup_result.is_empty());
+    let mut lookup_result = symcache.lookup(0xd99).unwrap().filter_map(Result::ok);
+    assert!(lookup_result.next().is_none());
 
     // The last addr belongs to a public record which implicitly extends to infinity
     let buffer = br#"MODULE mac x86_64 67E9247C814E392BA027DBDE6748FCBF0 crash

--- a/symbolic-symcache/tests/breakpad.rs
+++ b/symbolic-symcache/tests/breakpad.rs
@@ -13,7 +13,6 @@ fn test_macos() {
 
     let mut buffer = Vec::new();
     SymCacheWriter::write_object(&breakpad, Cursor::new(&mut buffer)).unwrap();
-    assert!(buffer.starts_with(b"SYMC"));
     let symcache = SymCache::parse(&buffer).unwrap();
 
     let lookup_result: Vec<_> = symcache
@@ -36,7 +35,6 @@ fn test_macos_all() {
 
     let mut buffer = Vec::new();
     SymCacheWriter::write_object(&breakpad, Cursor::new(&mut buffer)).unwrap();
-    assert!(buffer.starts_with(b"SYMC"));
     let symcache = SymCache::parse(&buffer).unwrap();
 
     let files: BTreeMap<_, _> = breakpad
@@ -79,7 +77,6 @@ fn test_windows() {
 
     let mut buffer = Vec::new();
     SymCacheWriter::write_object(&breakpad, Cursor::new(&mut buffer)).unwrap();
-    assert!(buffer.starts_with(b"SYMC"));
     let symcache = SymCache::parse(&buffer).unwrap();
 
     let lookup_result: Vec<_> = symcache
@@ -93,4 +90,57 @@ fn test_windows() {
     );
     assert_eq!(lookup_result[0].path(), "c:\\projects\\breakpad-tools\\deps\\breakpad\\src\\client\\windows\\handler\\exception_handler.cc");
     assert_eq!(lookup_result[0].line(), 846);
+}
+
+#[test]
+fn test_func_end() {
+    // The last addr belongs to a function record which has an explicit end
+    let buffer = br#"MODULE mac x86_64 67E9247C814E392BA027DBDE6748FCBF0 crash
+FILE 0 some_file
+FUNC d20 20 0 func_record_with_end
+PUBLIC d00 0 public_record"#;
+    let breakpad = BreakpadObject::parse(buffer).unwrap();
+
+    let mut buffer = Vec::new();
+    SymCacheWriter::write_object(&breakpad, Cursor::new(&mut buffer)).unwrap();
+    let symcache = SymCache::parse(&buffer).unwrap();
+
+    let lookup_result: Vec<_> = symcache
+        .lookup(0xd04)
+        .unwrap()
+        .filter_map(Result::ok)
+        .collect();
+    assert_eq!(lookup_result[0].symbol(), "public_record");
+
+    let lookup_result: Vec<_> = symcache
+        .lookup(0xd24)
+        .unwrap()
+        .filter_map(Result::ok)
+        .collect();
+    assert_eq!(lookup_result[0].symbol(), "func_record_with_end");
+
+    let lookup_result: Vec<_> = symcache
+        .lookup(0xd99)
+        .unwrap()
+        .filter_map(Result::ok)
+        .collect();
+    assert!(lookup_result.is_empty());
+
+    // The last addr belongs to a public record which implicitly extends to infinity
+    let buffer = br#"MODULE mac x86_64 67E9247C814E392BA027DBDE6748FCBF0 crash
+FILE 0 some_file
+FUNC d20 20 0 func_record_with_end
+PUBLIC d80 0 public_record"#;
+    let breakpad = BreakpadObject::parse(buffer).unwrap();
+
+    let mut buffer = Vec::new();
+    SymCacheWriter::write_object(&breakpad, Cursor::new(&mut buffer)).unwrap();
+    let symcache = SymCache::parse(&buffer).unwrap();
+
+    let lookup_result: Vec<_> = symcache
+        .lookup(0xfffffa0)
+        .unwrap()
+        .filter_map(Result::ok)
+        .collect();
+    assert_eq!(lookup_result[0].symbol(), "public_record");
 }

--- a/symbolic-symcache/tests/test_writer.rs
+++ b/symbolic-symcache/tests/test_writer.rs
@@ -102,8 +102,8 @@ fn test_write_header_macos() -> Result<(), Error> {
         arch: Amd64,
         files: 36,
         functions: 639,
-        source_locations: 6032,
-        ranges: 4590,
+        source_locations: 6033,
+        ranges: 4591,
         string_bytes: 42829,
     }
     "###);


### PR DESCRIPTION
Running the sentry-integration tests, I noticed the case that functions have an explicit *end*, which symbols do not have.

To handle this case, we optionally persist an end marker into the SymCache ranges, which we then match on to avoid returning a symbolicated symbol for lookups exceeding that end marker.