### PR TITLE
feat(minidump): Add processing options

### DIFF
--- a/symbolic-minidump/cpp/processor.cpp
+++ b/symbolic-minidump/cpp/processor.cpp
@@ -12,6 +12,7 @@
 using google_breakpad::BasicSourceLineResolver;
 using google_breakpad::Minidump;
 using google_breakpad::MinidumpMemoryList;
+using google_breakpad::MinidumpModuleList;
 using google_breakpad::MinidumpThreadList;
 using google_breakpad::MinidumpProcessor;
 using google_breakpad::ProcessState;
@@ -29,6 +30,7 @@ process_state_t *process_minidump(const char *buffer,
     // Increase the maximum number of threads and regions.
     MinidumpThreadList::set_max_threads(std::numeric_limits<uint32_t>::max());
     MinidumpMemoryList::set_max_regions(std::numeric_limits<uint32_t>::max());
+    MinidumpModuleList::set_max_modules(std::numeric_limits<uint32_t>::max());
     ProcessState *state = new ProcessState();
     if (state == nullptr) {
         *result_out = -1;  // Memory allocation issue

--- a/symbolic-minidump/cpp/processor.cpp
+++ b/symbolic-minidump/cpp/processor.cpp
@@ -7,6 +7,7 @@
 #include "cpp/memstream.h"
 #include "cpp/mmap_symbol_supplier.h"
 #include "cpp/processor.h"
+#include <limits>
 
 using google_breakpad::BasicSourceLineResolver;
 using google_breakpad::Minidump;

--- a/symbolic-minidump/cpp/processor.cpp
+++ b/symbolic-minidump/cpp/processor.cpp
@@ -10,6 +10,8 @@
 
 using google_breakpad::BasicSourceLineResolver;
 using google_breakpad::Minidump;
+using google_breakpad::MinidumpMemoryList;
+using google_breakpad::MinidumpThreadList;
 using google_breakpad::MinidumpProcessor;
 using google_breakpad::ProcessState;
 
@@ -23,6 +25,9 @@ process_state_t *process_minidump(const char *buffer,
         return nullptr;
     }
 
+    // Increase the maximum number of threads and regions.
+    MinidumpThreadList::set_max_threads(std::numeric_limits<uint32_t>::max());
+    MinidumpMemoryList::set_max_regions(std::numeric_limits<uint32_t>::max());
     ProcessState *state = new ProcessState();
     if (state == nullptr) {
         *result_out = -1;  // Memory allocation issue

--- a/symbolic-minidump/cpp/processor.cpp
+++ b/symbolic-minidump/cpp/processor.cpp
@@ -17,10 +17,13 @@ using google_breakpad::MinidumpThreadList;
 using google_breakpad::MinidumpProcessor;
 using google_breakpad::ProcessState;
 
-process_state_t *process_minidump(const char *buffer,
+process_state_t *process_minidump_internal(const char *buffer,
                                   size_t buffer_size,
                                   symbol_entry_t *symbols,
                                   size_t symbol_count,
+                                  uint32_t max_threads,
+                                  uint32_t max_memory_regions,
+                                  uint32_t max_modules,
                                   int *result_out) {
     if (buffer == nullptr) {
         *result_out = google_breakpad::PROCESS_ERROR_MINIDUMP_NOT_FOUND;
@@ -28,9 +31,9 @@ process_state_t *process_minidump(const char *buffer,
     }
 
     // Increase the maximum number of threads and regions.
-    MinidumpThreadList::set_max_threads(std::numeric_limits<uint32_t>::max());
-    MinidumpMemoryList::set_max_regions(std::numeric_limits<uint32_t>::max());
-    MinidumpModuleList::set_max_modules(std::numeric_limits<uint32_t>::max());
+    MinidumpThreadList::set_max_threads(max_threads);
+    MinidumpMemoryList::set_max_regions(max_memory_regions);
+    MinidumpModuleList::set_max_modules(max_modules);
     ProcessState *state = new ProcessState();
     if (state == nullptr) {
         *result_out = -1;  // Memory allocation issue

--- a/symbolic-minidump/cpp/processor.cpp
+++ b/symbolic-minidump/cpp/processor.cpp
@@ -17,7 +17,7 @@ using google_breakpad::MinidumpThreadList;
 using google_breakpad::MinidumpProcessor;
 using google_breakpad::ProcessState;
 
-process_state_t *process_minidump_internal(const char *buffer,
+process_state_t *process_minidump(const char *buffer,
                                   size_t buffer_size,
                                   symbol_entry_t *symbols,
                                   size_t symbol_count,

--- a/symbolic-minidump/cpp/processor.h
+++ b/symbolic-minidump/cpp/processor.h
@@ -28,7 +28,7 @@ struct symbol_entry_t {
 /// exit. The function will return NULL and an error code in result_out.
 ///
 /// Release memory of the process state with process_state_delete.
-process_state_t *process_minidump_internal(const char *buffer,
+process_state_t *process_minidump(const char *buffer,
                                   size_t buffer_size,
                                   symbol_entry_t *symbols,
                                   size_t symbol_count,

--- a/symbolic-minidump/cpp/processor.h
+++ b/symbolic-minidump/cpp/processor.h
@@ -28,10 +28,13 @@ struct symbol_entry_t {
 /// exit. The function will return NULL and an error code in result_out.
 ///
 /// Release memory of the process state with process_state_delete.
-process_state_t *process_minidump(const char *buffer,
+process_state_t *process_minidump_internal(const char *buffer,
                                   size_t buffer_size,
                                   symbol_entry_t *symbols,
                                   size_t symbol_count,
+                                  uint32_t max_threads,
+                                  uint32_t max_memory_regions,
+                                  uint32_t max_modules,
                                   int *result_out);
 
 #ifdef __cplusplus

--- a/symbolic-minidump/src/processor.rs
+++ b/symbolic-minidump/src/processor.rs
@@ -1036,6 +1036,7 @@ pub type FrameInfoMap<'a> = BTreeMap<CodeModuleId, CfiCache<'a>>;
 
 /// Options passed to breakpad when processing a minidump.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct ProcessMinidumpOptions {
     /// The maximum number of threads the minidump may contain.
     ///


### PR DESCRIPTION
This is a proposal for making the changes in https://github.com/getsentry/symbolic/pull/461 configurable.
* `process_minidump` is renamed to `process_minidump_internal` and gains 3 new parameters `max_threads`, `max_memory_regions`, `max_modules` that are used to set the respective limits in Breakpad. Defaults to current Breakpad values.
* A new `ProcessMinindumpOptions` struct that bundles `max_{threads,memory_regions,modules}`.
* A new free function `process_minidump` that has the same signature as `ProcessState::from_minidump` plus a `ProcessMinidumpOptions` parameter.
* `ProcessState::from_minidump` just calls the new `process_minidump` with default options.

The end result should be that you can use `ProcessState::from_minidump` exactly like before, but you can also use `process_minidump` if you want control over the different limits. API wise this is probably confusing; personally I would be in favor of removing `ProcessState::from_minidump` in favor of a free function (obviously a breaking change), but we could also do the reverse and add another associated function to `ProcessState` or just change the signature of `from_minidump` if we don't think a version without the `options` parameter needs to exist.