### PR TITLE
Replace walrus

### DIFF
--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -66,9 +66,10 @@ sourcebundle = [
     "zip",
 ]
 # WASM processing
-wasm = ["dwarf", "walrus", "wasmparser"]
+wasm = ["bitvec", "dwarf", "wasmparser"]
 
 [dependencies]
+bitvec = { version = "0.22", optional = true, features = ["alloc"] }
 dmsort = "1.0.1"
 elementtree = "0.5.0"
 fallible-iterator = "0.2.0"
@@ -93,9 +94,7 @@ serde_json = { version = "1.0.40", optional = true }
 smallvec = { version = "1.2.0", optional = true }
 symbolic-common = { version = "8.5.0", path = "../symbolic-common" }
 thiserror = "1.0.20"
-walrus = { version = "0.19.0", optional = true }
-# must match spec in walrus
-wasmparser = { version = "0.77.0", optional = true }
+wasmparser = { version = "0.81", optional = true }
 zip = { version = "0.5.2", optional = true, default-features = false, features = [
     "deflate",
 ] }

--- a/symbolic-debuginfo/src/object.rs
+++ b/symbolic-debuginfo/src/object.rs
@@ -581,7 +581,7 @@ pub enum SymbolIterator<'data, 'object> {
     Pdb(PdbSymbolIterator<'data, 'object>),
     Pe(PeSymbolIterator<'data, 'object>),
     SourceBundle(SourceBundleSymbolIterator<'data>),
-    Wasm(WasmSymbolIterator<'data, 'object>),
+    Wasm(WasmSymbolIterator<'data>),
 }
 
 impl<'data, 'object> Iterator for SymbolIterator<'data, 'object> {

--- a/symbolic-debuginfo/src/object.rs
+++ b/symbolic-debuginfo/src/object.rs
@@ -581,7 +581,7 @@ pub enum SymbolIterator<'data, 'object> {
     Pdb(PdbSymbolIterator<'data, 'object>),
     Pe(PeSymbolIterator<'data, 'object>),
     SourceBundle(SourceBundleSymbolIterator<'data>),
-    Wasm(WasmSymbolIterator<'data>),
+    Wasm(WasmSymbolIterator<'data, 'object>),
 }
 
 impl<'data, 'object> Iterator for SymbolIterator<'data, 'object> {

--- a/symbolic-debuginfo/src/wasm.rs
+++ b/symbolic-debuginfo/src/wasm.rs
@@ -14,6 +14,7 @@ mod parser;
 
 /// An error when dealing with [`WasmObject`](struct.WasmObject.html).
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum WasmError {
     /// Failed to read data from a WASM binary
     #[error("invalid wasm file")]

--- a/symbolic-debuginfo/src/wasm.rs
+++ b/symbolic-debuginfo/src/wasm.rs
@@ -43,17 +43,6 @@ impl<'data> WasmObject<'data> {
         data.starts_with(b"\x00asm")
     }
 
-    /// Tries to parse a WASM from the given slice.
-    pub fn parse(data: &'data [u8]) -> Result<Self, WasmError> {
-        let mut obj = parser::parse(data)?;
-
-        // The actual iterator just wraps the vec, so we reverse it and just pop off
-        // the end
-        obj.funcs.reverse();
-
-        Ok(obj)
-    }
-
     /// The container file format, which currently is always `FileFormat::Wasm`.
     pub fn file_format(&self) -> FileFormat {
         FileFormat::Wasm

--- a/symbolic-debuginfo/src/wasm.rs
+++ b/symbolic-debuginfo/src/wasm.rs
@@ -97,7 +97,8 @@ impl<'data> WasmObject<'data> {
     /// Returns an iterator over symbols in the public symbol table.
     pub fn symbols(&self) -> WasmSymbolIterator<'data, '_> {
         WasmSymbolIterator {
-            funcs: Box::new(self.funcs.clone().into_iter()),
+            funcs: self.funcs.clone().into_iter(),
+            _marker: std::marker::PhantomData,
         }
     }
 
@@ -274,7 +275,8 @@ impl<'data> Dwarf<'data> for WasmObject<'data> {
 ///
 /// Returned by [`WasmObject::symbols`](struct.WasmObject.html#method.symbols).
 pub struct WasmSymbolIterator<'data, 'object> {
-    funcs: Box<dyn Iterator<Item = Symbol<'data>> + 'object>,
+    funcs: std::vec::IntoIter<Symbol<'data>>,
+    _marker: std::marker::PhantomData<&'object u8>,
 }
 
 impl<'data, 'object> Iterator for WasmSymbolIterator<'data, 'object> {

--- a/symbolic-debuginfo/src/wasm.rs
+++ b/symbolic-debuginfo/src/wasm.rs
@@ -1,6 +1,5 @@
 //! Support for WASM Objects (WebAssembly).
 use std::borrow::Cow;
-use std::error::Error;
 use std::fmt;
 
 use thiserror::Error;
@@ -11,23 +10,17 @@ use crate::base::*;
 use crate::dwarf::{Dwarf, DwarfDebugSession, DwarfError, DwarfSection, Endian};
 use crate::shared::Parse;
 
+mod parser;
+
 /// An error when dealing with [`WasmObject`](struct.WasmObject.html).
 #[derive(Debug, Error)]
-#[error("invalid WASM file")]
-pub struct WasmError {
-    #[source]
-    source: Option<Box<dyn Error + Send + Sync + 'static>>,
-}
-
-impl WasmError {
-    /// Creates a new WASM error from an arbitrary error payload.
-    fn new<E>(source: E) -> Self
-    where
-        E: Into<Box<dyn Error + Send + Sync>>,
-    {
-        let source = Some(source.into());
-        Self { source }
-    }
+pub enum WasmError {
+    /// Failed to read data from a WASM binary
+    #[error("invalid wasm file")]
+    Read(#[from] wasmparser::BinaryReaderError),
+    /// A function in the WASM binary referenced an unknown type
+    #[error("function references unknown type")]
+    UnknownFunctionType,
 }
 
 /// Wasm object container (.wasm), used for executables and debug
@@ -35,9 +28,12 @@ impl WasmError {
 ///
 /// This can only parse binary wasm file and not wast files.
 pub struct WasmObject<'data> {
-    wasm_module: walrus::Module,
-    code_offset: u64,
+    dwarf_sections: Vec<(&'data str, &'data [u8])>,
+    funcs: Vec<Symbol<'data>>,
+    build_id: Option<&'data [u8]>,
     data: &'data [u8],
+    code_offset: u64,
+    kind: ObjectKind,
 }
 
 impl<'data> WasmObject<'data> {
@@ -48,23 +44,13 @@ impl<'data> WasmObject<'data> {
 
     /// Tries to parse a WASM from the given slice.
     pub fn parse(data: &'data [u8]) -> Result<Self, WasmError> {
-        let wasm_module = walrus::Module::from_buffer(data).map_err(WasmError::new)?;
+        let mut obj = parser::parse(data)?;
 
-        // we need to parse the file a second time to get the offset to the
-        // code section as walrus does not expose that yet.
-        let mut code_offset = 0;
-        for payload in wasmparser::Parser::new(0).parse_all(data).flatten() {
-            if let wasmparser::Payload::CodeSectionStart { range, .. } = payload {
-                code_offset = range.start as u64;
-                break;
-            }
-        }
+        // The actual iterator just wraps the vec, so we reverse it and just pop off
+        // the end
+        obj.funcs.reverse();
 
-        Ok(WasmObject {
-            wasm_module,
-            code_offset,
-            data,
-        })
+        Ok(obj)
     }
 
     /// The container file format, which currently is always `FileFormat::Wasm`.
@@ -72,31 +58,20 @@ impl<'data> WasmObject<'data> {
         FileFormat::Wasm
     }
 
-    fn get_raw_build_id(&self) -> Option<Cow<'_, [u8]>> {
-        // this section is not defined yet
-        // see https://github.com/WebAssembly/tool-conventions/issues/133
-        for (_, section) in self.wasm_module.customs.iter() {
-            if section.name() == "build_id" {
-                return Some(section.data(&Default::default()));
-            }
-        }
-        None
-    }
-
     /// The code identifier of this object.
     ///
     /// Wasm does not yet provide code IDs.
+    #[inline]
     pub fn code_id(&self) -> Option<CodeId> {
-        // see `debug_id`
-        self.get_raw_build_id()
-            .map(|data| CodeId::from_binary(&data))
+        self.build_id.map(CodeId::from_binary)
     }
 
     /// The debug information identifier of a WASM file.
     ///
     /// Wasm does not yet provide debug IDs.
+    #[inline]
     pub fn debug_id(&self) -> DebugId {
-        self.get_raw_build_id()
+        self.build_id
             .and_then(|data| {
                 data.get(..16)
                     .and_then(|first_16| Uuid::from_slice(first_16).ok())
@@ -112,12 +87,9 @@ impl<'data> WasmObject<'data> {
     }
 
     /// The kind of this object.
+    #[inline]
     pub fn kind(&self) -> ObjectKind {
-        if self.wasm_module.funcs.iter().next().is_some() {
-            ObjectKind::Library
-        } else {
-            ObjectKind::Debug
-        }
+        self.kind
     }
 
     /// The address at which the image prefers to be loaded into memory.
@@ -133,11 +105,9 @@ impl<'data> WasmObject<'data> {
     }
 
     /// Returns an iterator over symbols in the public symbol table.
-    pub fn symbols(&self) -> WasmSymbolIterator<'data, '_> {
-        let iterator = Box::new(self.wasm_module.funcs.iter()) as Box<dyn Iterator<Item = _>>;
+    pub fn symbols(&self) -> WasmSymbolIterator<'data> {
         WasmSymbolIterator {
-            funcs: iterator.peekable(),
-            _marker: std::marker::PhantomData,
+            funcs: self.funcs.clone(),
         }
     }
 
@@ -147,13 +117,11 @@ impl<'data> WasmObject<'data> {
     }
 
     /// Determines whether this object contains debug information.
+    #[inline]
     pub fn has_debug_info(&self) -> bool {
-        for (_, section) in self.wasm_module.customs.iter() {
-            if section.name() == ".debug_info" {
-                return true;
-            }
-        }
-        false
+        self.dwarf_sections
+            .iter()
+            .any(|(name, _)| *name == ".debug_info")
     }
 
     /// Constructs a debugging session.
@@ -164,13 +132,11 @@ impl<'data> WasmObject<'data> {
     }
 
     /// Determines whether this object contains stack unwinding information.
+    #[inline]
     pub fn has_unwind_info(&self) -> bool {
-        for (_, section) in self.wasm_module.customs.iter() {
-            if section.name() == ".debug_frame" {
-                return true;
-            }
-        }
-        false
+        self.dwarf_sections
+            .iter()
+            .any(|(name, _)| *name == ".debug_frame")
     }
 
     /// Determines whether this object contains embedded source.
@@ -233,7 +199,7 @@ impl<'d> Parse<'d> for WasmObject<'d> {
 impl<'data: 'object, 'object> ObjectLike<'data, 'object> for WasmObject<'data> {
     type Error = DwarfError;
     type Session = DwarfDebugSession<'data>;
-    type SymbolIterator = WasmSymbolIterator<'data, 'object>;
+    type SymbolIterator = WasmSymbolIterator<'data>;
 
     fn file_format(&self) -> FileFormat {
         self.file_format()
@@ -292,67 +258,39 @@ impl<'data: 'object, 'object> ObjectLike<'data, 'object> for WasmObject<'data> {
     }
 }
 
-impl<'d> Dwarf<'d> for WasmObject<'d> {
+impl<'data> Dwarf<'data> for WasmObject<'data> {
     fn endianity(&self) -> Endian {
         Endian::Little
     }
 
-    fn raw_section(&self, section_name: &str) -> Option<DwarfSection<'d>> {
-        for (_, section) in self.wasm_module.customs.iter() {
-            if section.name().strip_prefix('.') == Some(section_name) {
-                return Some(DwarfSection {
-                    data: Cow::Owned(section.data(&Default::default()).into_owned()),
+    fn raw_section(&self, section_name: &str) -> Option<DwarfSection<'data>> {
+        self.dwarf_sections.iter().find_map(|(name, data)| {
+            if name.strip_prefix('.') == Some(section_name) {
+                Some(DwarfSection {
+                    data: Cow::Borrowed(data),
                     // XXX: what are these going to be?
                     address: 0,
                     offset: 0,
                     align: 4,
-                });
+                })
+            } else {
+                None
             }
-        }
-
-        None
+        })
     }
 }
 
 /// An iterator over symbols in the WASM file.
 ///
 /// Returned by [`WasmObject::symbols`](struct.WasmObject.html#method.symbols).
-pub struct WasmSymbolIterator<'data, 'object> {
-    funcs: std::iter::Peekable<Box<dyn Iterator<Item = &'object walrus::Function> + 'object>>,
-    _marker: std::marker::PhantomData<&'data [u8]>,
+pub struct WasmSymbolIterator<'data> {
+    funcs: Vec<Symbol<'data>>,
 }
 
-fn get_addr_of_function(func: &walrus::Function) -> u64 {
-    if let walrus::FunctionKind::Local(ref loc) = func.kind {
-        let entry_block = loc.entry_block();
-        let seq = loc.block(entry_block);
-        seq.instrs.get(0).map_or(0, |x| x.1.data() as u64)
-    } else {
-        0
-    }
-}
-
-impl<'data, 'object> Iterator for WasmSymbolIterator<'data, 'object> {
+impl<'data> Iterator for WasmSymbolIterator<'data> {
     type Item = Symbol<'data>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            let func = self.funcs.next()?;
-            if let walrus::FunctionKind::Local(_) = func.kind {
-                let address = get_addr_of_function(func);
-                let size = self
-                    .funcs
-                    .peek()
-                    .map_or(0, |func| match get_addr_of_function(func) {
-                        0 => 0,
-                        x => x - address,
-                    });
-                return Some(Symbol {
-                    name: func.name.as_ref().map(|x| Cow::Owned(x.clone())),
-                    address,
-                    size,
-                });
-            }
-        }
+        self.funcs.pop()
     }
 }

--- a/symbolic-debuginfo/src/wasm/parser.rs
+++ b/symbolic-debuginfo/src/wasm/parser.rs
@@ -1,215 +1,218 @@
 //! Contains utilities for parsing a WASM module to retrieve the information needed by [`super::WasmObject`]
 
-use super::{WasmError, WasmObject};
+use super::WasmError;
 use crate::base::{ObjectKind, Symbol};
 use wasmparser::{ImportSectionEntryType, Payload, Validator};
 
-pub(crate) fn parse<'data>(data: &'data [u8]) -> Result<WasmObject<'data>, WasmError> {
-    let mut code_offset = 0;
-    let mut build_id = None;
-    let mut dwarf_sections = Vec::new();
-    let mut kind = ObjectKind::Debug;
+impl<'data> super::WasmObject<'data> {
+    /// Tries to parse a WASM from the given slice.
+    pub fn parse(data: &'data [u8]) -> Result<Self, WasmError> {
+        let mut code_offset = 0;
+        let mut build_id = None;
+        let mut dwarf_sections = Vec::new();
+        let mut kind = ObjectKind::Debug;
 
-    // In "normal" wasm modules the only types will be function signatures, but in the future it
-    // could contain types used for module linking, but we don't actually care about the types,
-    // just that the function references a valid signature, so we just keep a bitset of the function
-    // signatures to verify that
-    let mut func_sigs = bitvec::vec::BitVec::<bitvec::order::Lsb0, usize>::new();
-    let mut validator = Validator::new();
-    let mut funcs = Vec::<Symbol>::new();
-    let mut num_imported_funcs = 0u32;
+        // In "normal" wasm modules the only types will be function signatures, but in the future it
+        // could contain types used for module linking, but we don't actually care about the types,
+        // just that the function references a valid signature, so we just keep a bitset of the function
+        // signatures to verify that
+        let mut func_sigs = bitvec::vec::BitVec::<bitvec::order::Lsb0, usize>::new();
+        let mut validator = Validator::new();
+        let mut funcs = Vec::<Symbol>::new();
+        let mut num_imported_funcs = 0u32;
 
-    // Parse the wasm file to pull out the function and their starting address, size, and name
-    // Note that the order of the payloads here are the order that they will appear in (valid)
-    // wasm binaries, other than the sections that we need to parse to validate the module, which
-    // are at the end
-    for payload in wasmparser::Parser::new(0).parse_all(data).flatten() {
-        match payload {
-            // This should always be first, and is necessary to prepare the validator since the
-            // version determines which parts of the spec can be used
-            Payload::Version { num, range } => {
-                validator.version(num, &range)?;
-            }
-            // The type section contains, well, types, specifically, function signatures that are
-            // later referenced by the function section.
-            Payload::TypeSection(tsr) => {
-                validator.type_section(&tsr)?;
-                func_sigs.resize(tsr.get_count() as usize, false);
-                let fs = func_sigs.as_mut_bitslice();
+        // Parse the wasm file to pull out the function and their starting address, size, and name
+        // Note that the order of the payloads here are the order that they will appear in (valid)
+        // wasm binaries, other than the sections that we need to parse to validate the module, which
+        // are at the end
+        for payload in wasmparser::Parser::new(0).parse_all(data).flatten() {
+            match payload {
+                // This should always be first, and is necessary to prepare the validator since the
+                // version determines which parts of the spec can be used
+                Payload::Version { num, range } => {
+                    validator.version(num, &range)?;
+                }
+                // The type section contains, well, types, specifically, function signatures that are
+                // later referenced by the function section.
+                Payload::TypeSection(tsr) => {
+                    validator.type_section(&tsr)?;
+                    func_sigs.resize(tsr.get_count() as usize, false);
+                    let fs = func_sigs.as_mut_bitslice();
 
-                for (i, ty) in tsr.into_iter().enumerate() {
-                    if let wasmparser::TypeDef::Func(_) = ty? {
-                        fs.set(i, true);
+                    for (i, ty) in tsr.into_iter().enumerate() {
+                        if let wasmparser::TypeDef::Func(_) = ty? {
+                            fs.set(i, true);
+                        }
                     }
                 }
-            }
-            // Imported functions and local functions both use the same ID space, but imported
-            // functions are never exposed, so we just need to account for the id offset later
-            // when parsing the local functions
-            Payload::ImportSection(isr) => {
-                validator.import_section(&isr)?;
+                // Imported functions and local functions both use the same ID space, but imported
+                // functions are never exposed, so we just need to account for the id offset later
+                // when parsing the local functions
+                Payload::ImportSection(isr) => {
+                    validator.import_section(&isr)?;
 
-                for import in isr {
-                    let import = import?;
-                    if let ImportSectionEntryType::Function(id) = import.ty {
+                    for import in isr {
+                        let import = import?;
+                        if let ImportSectionEntryType::Function(id) = import.ty {
+                            if !func_sigs
+                                .as_bitslice()
+                                .get(id as usize)
+                                .as_deref()
+                                .unwrap_or(&false)
+                            {
+                                return Err(WasmError::UnknownFunctionType);
+                            }
+
+                            num_imported_funcs += 1;
+                        }
+                    }
+                }
+                // The function section declares all of the local functions present in the module
+                Payload::FunctionSection(fsr) => {
+                    validator.function_section(&fsr)?;
+
+                    if fsr.get_count() > 0 {
+                        kind = ObjectKind::Library;
+                    }
+
+                    funcs.reserve(fsr.get_count() as usize);
+
+                    // We actually don't care about the type signature of the function, other than that
+                    // they exist
+                    for id in fsr {
                         if !func_sigs
                             .as_bitslice()
-                            .get(id as usize)
+                            .get(id? as usize)
                             .as_deref()
                             .unwrap_or(&false)
                         {
                             return Err(WasmError::UnknownFunctionType);
                         }
-
-                        num_imported_funcs += 1;
                     }
                 }
-            }
-            // The function section declares all of the local functions present in the module
-            Payload::FunctionSection(fsr) => {
-                validator.function_section(&fsr)?;
-
-                if fsr.get_count() > 0 {
-                    kind = ObjectKind::Library;
+                // The code section contains the actual function bodies, this payload is emitted at
+                // the beginning of the section. This one is important as the code section offset is
+                // used to calculate relative addresses in a `DwarfDebugSession`
+                Payload::CodeSectionStart { range, count, .. } => {
+                    code_offset = range.start as u64;
+                    validator.code_section_start(count, &range)?;
                 }
+                // We get one of these for each local function body
+                Payload::CodeSectionEntry(body) => {
+                    let validator = validator.code_section_entry()?;
 
-                funcs.reserve(fsr.get_count() as usize);
+                    let (address, size) = get_function_info(body, validator)?;
 
-                // We actually don't care about the type signature of the function, other than that
-                // they exist
-                for id in fsr {
-                    if !func_sigs
-                        .as_bitslice()
-                        .get(id? as usize)
-                        .as_deref()
-                        .unwrap_or(&false)
-                    {
-                        return Err(WasmError::UnknownFunctionType);
+                    // Though we have an accurate? size of the function body, the old method of symbol
+                    // iterating with walrus extends the size of each body to be contiguous with the
+                    // next function, so we do the same, other than the final function
+                    if let Some(prev) = funcs.last_mut() {
+                        prev.size = address - prev.address;
                     }
+
+                    funcs.push(Symbol {
+                        name: None,
+                        address,
+                        size,
+                    });
                 }
-            }
-            // The code section contains the actual function bodies, this payload is emitted at
-            // the beginning of the section. This one is important as the code section offset is
-            // used to calculate relative addresses in a `DwarfDebugSession`
-            Payload::CodeSectionStart { range, count, .. } => {
-                code_offset = range.start as u64;
-                validator.code_section_start(count, &range)?;
-            }
-            // We get one of these for each local function body
-            Payload::CodeSectionEntry(body) => {
-                let validator = validator.code_section_entry()?;
-
-                let (address, size) = get_function_info(body, validator)?;
-
-                // Though we have an accurate? size of the function body, the old method of symbol
-                // iterating with walrus extends the size of each body to be contiguous with the
-                // next function, so we do the same, other than the final function
-                if let Some(prev) = funcs.last_mut() {
-                    prev.size = address - prev.address;
+                Payload::ModuleSectionStart { count, range, .. } => {
+                    validator.module_section_start(count, &range)?;
                 }
+                Payload::DataSection(dsr) => {
+                    validator.data_section(&dsr)?;
+                }
+                // There are several custom sections that we need
+                Payload::CustomSection {
+                    name,
+                    data,
+                    data_offset,
+                    ..
+                } => {
+                    match name {
+                        // this section is not defined yet
+                        // see https://github.com/WebAssembly/tool-conventions/issues/133
+                        "build_id" => {
+                            build_id = Some(data);
+                        }
+                        // All of the dwarf debug sections (.debug_frame, .debug_info etc) start with a `.`, and
+                        // are the only ones we need for walking the debug info
+                        debug if debug.starts_with('.') => {
+                            dwarf_sections.push((name, data));
+                        }
+                        // The name section contains the symbol names for items, notably functions
+                        "name" => {
+                            let nsr = wasmparser::NameSectionReader::new(data, data_offset)?;
 
-                funcs.push(Symbol {
-                    name: None,
-                    address,
-                    size,
-                });
-            }
-            Payload::ModuleSectionStart { count, range, .. } => {
-                validator.module_section_start(count, &range)?;
-            }
-            Payload::DataSection(dsr) => {
-                validator.data_section(&dsr)?;
-            }
-            // There are several custom sections that we need
-            Payload::CustomSection {
-                name,
-                data,
-                data_offset,
-                ..
-            } => {
-                match name {
-                    // this section is not defined yet
-                    // see https://github.com/WebAssembly/tool-conventions/issues/133
-                    "build_id" => {
-                        build_id = Some(data);
-                    }
-                    // All of the dwarf debug sections (.debug_frame, .debug_info etc) start with a `.`, and
-                    // are the only ones we need for walking the debug info
-                    debug if debug.starts_with('.') => {
-                        dwarf_sections.push((name, data));
-                    }
-                    // The name section contains the symbol names for items, notably functions
-                    "name" => {
-                        let nsr = wasmparser::NameSectionReader::new(data, data_offset)?;
+                            for name in nsr {
+                                if let wasmparser::Name::Function(fnames) = name? {
+                                    let mut map = fnames.get_map()?;
+                                    for _ in 0..map.get_count() {
+                                        let fname = map.read()?;
 
-                        for name in nsr {
-                            if let wasmparser::Name::Function(fnames) = name? {
-                                let mut map = fnames.get_map()?;
-                                for _ in 0..map.get_count() {
-                                    let fname = map.read()?;
-
-                                    // The names for imported functions are also in this table, but
-                                    // we don't care about them
-                                    if fname.index >= num_imported_funcs {
-                                        if let Some(func) = funcs
-                                            .get_mut((fname.index - num_imported_funcs) as usize)
-                                        {
-                                            func.name =
-                                                Some(std::borrow::Cow::Borrowed(fname.name));
+                                        // The names for imported functions are also in this table, but
+                                        // we don't care about them
+                                        if fname.index >= num_imported_funcs {
+                                            if let Some(func) = funcs.get_mut(
+                                                (fname.index - num_imported_funcs) as usize,
+                                            ) {
+                                                func.name =
+                                                    Some(std::borrow::Cow::Borrowed(fname.name));
+                                            }
                                         }
                                     }
                                 }
                             }
                         }
+                        _ => {}
                     }
-                    _ => {}
                 }
-            }
-            // Final
-            Payload::End => validator.end()?,
+                // Final
+                Payload::End => validator.end()?,
 
-            // The following sections are not used by this crate, but some (eg table/memory/global)
-            // are needed to validate the sections that we do care about, so we just validate all
-            // of the sections we don't use to be sure
-            Payload::TableSection(tsr) => {
-                validator.table_section(&tsr)?;
+                // The following sections are not used by this crate, but some (eg table/memory/global)
+                // are needed to validate the sections that we do care about, so we just validate all
+                // of the sections we don't use to be sure
+                Payload::TableSection(tsr) => {
+                    validator.table_section(&tsr)?;
+                }
+                Payload::MemorySection(msr) => {
+                    validator.memory_section(&msr)?;
+                }
+                Payload::TagSection(tsr) => {
+                    validator.tag_section(&tsr)?;
+                }
+                Payload::GlobalSection(gsr) => {
+                    validator.global_section(&gsr)?;
+                }
+                Payload::ExportSection(esr) => {
+                    validator.export_section(&esr)?;
+                }
+                Payload::StartSection { func, range } => {
+                    validator.start_section(func, &range)?;
+                }
+                Payload::ElementSection(esr) => {
+                    validator.element_section(&esr)?;
+                }
+                Payload::DataCountSection { count, range } => {
+                    validator.data_count_section(count, &range)?;
+                }
+                Payload::UnknownSection { id, range, .. } => {
+                    validator.unknown_section(id, &range)?;
+                }
+                _ => {}
             }
-            Payload::MemorySection(msr) => {
-                validator.memory_section(&msr)?;
-            }
-            Payload::TagSection(tsr) => {
-                validator.tag_section(&tsr)?;
-            }
-            Payload::GlobalSection(gsr) => {
-                validator.global_section(&gsr)?;
-            }
-            Payload::ExportSection(esr) => {
-                validator.export_section(&esr)?;
-            }
-            Payload::StartSection { func, range } => {
-                validator.start_section(func, &range)?;
-            }
-            Payload::ElementSection(esr) => {
-                validator.element_section(&esr)?;
-            }
-            Payload::DataCountSection { count, range } => {
-                validator.data_count_section(count, &range)?;
-            }
-            Payload::UnknownSection { id, range, .. } => {
-                validator.unknown_section(id, &range)?;
-            }
-            _ => {}
         }
-    }
 
-    Ok(WasmObject {
-        dwarf_sections,
-        funcs,
-        build_id,
-        data,
-        code_offset,
-        kind,
-    })
+        Ok(Self {
+            dwarf_sections,
+            funcs,
+            build_id,
+            data,
+            code_offset,
+            kind,
+        })
+    }
 }
 
 fn get_function_info(

--- a/symbolic-debuginfo/src/wasm/parser.rs
+++ b/symbolic-debuginfo/src/wasm/parser.rs
@@ -1,0 +1,252 @@
+//! Contains utilities for parsing a WASM module to retrieve the information needed by [`super::WasmObject`]
+
+use super::{WasmError, WasmObject};
+use crate::base::{ObjectKind, Symbol};
+use wasmparser::{ImportSectionEntryType, Payload, Validator};
+
+pub(crate) fn parse<'data>(data: &'data [u8]) -> Result<WasmObject<'data>, WasmError> {
+    let mut code_offset = 0;
+    let mut build_id = None;
+    let mut dwarf_sections = Vec::new();
+    let mut kind = ObjectKind::Debug;
+
+    // In "normal" wasm modules the only types will be function signatures, but in the future it
+    // could contain types used for module linking, but we don't actually care about the types,
+    // just that the function references a valid signature, so we just keep a bitset of the function
+    // signatures to verify that
+    let mut func_sigs = bitvec::vec::BitVec::<bitvec::order::Lsb0, usize>::new();
+    let mut validator = Validator::new();
+    let mut funcs = Vec::new();
+    let mut num_imported_funcs = 0u32;
+    let mut body_index = 0;
+
+    // Parse the wasm file to pull out the function and their starting address, size, and name
+    // Note that the order of the payloads here are the order that they will appear in (valid)
+    // wasm binaries, other than the sections that we need to parse to validate the module, which
+    // are at the end
+    for payload in wasmparser::Parser::new(0).parse_all(data).flatten() {
+        match payload {
+            // This should always be first, and is necessary to prepare the validator since the
+            // version determines which parts of the spec can be used
+            Payload::Version { num, range } => {
+                validator.version(num, &range)?;
+            }
+            // The type section contains, well, types, specifically, function signatures that are
+            // later referenced by the function section.
+            Payload::TypeSection(tsr) => {
+                validator.type_section(&tsr)?;
+                func_sigs.resize(tsr.get_count() as usize, false);
+                let fs = func_sigs.as_mut_bitslice();
+
+                for (i, ty) in tsr.into_iter().enumerate() {
+                    if let wasmparser::TypeDef::Func(_) = ty? {
+                        fs.set(i, true);
+                    }
+                }
+            }
+            // Imported functions and local functions both use the same ID space, but imported
+            // functions are never exposed, so we just need to account for the id offset later
+            // when parsing the local functions
+            Payload::ImportSection(isr) => {
+                validator.import_section(&isr)?;
+
+                for import in isr {
+                    let import = import?;
+                    if let ImportSectionEntryType::Function(id) = import.ty {
+                        if !func_sigs
+                            .as_bitslice()
+                            .get(id as usize)
+                            .as_deref()
+                            .unwrap_or(&false)
+                        {
+                            return Err(WasmError::UnknownFunctionType);
+                        }
+
+                        num_imported_funcs += 1;
+                    }
+                }
+            }
+            // The function section declares all of the local functions present in the module
+            Payload::FunctionSection(fsr) => {
+                validator.function_section(&fsr)?;
+
+                if fsr.get_count() > 0 {
+                    kind = ObjectKind::Library;
+                }
+
+                funcs.resize(
+                    fsr.get_count() as usize,
+                    Symbol {
+                        name: None,
+                        address: 0,
+                        size: 0,
+                    },
+                );
+
+                // We actually don't care about the type signature of the function, other than that
+                // they exist
+                for id in fsr {
+                    if !func_sigs
+                        .as_bitslice()
+                        .get(id? as usize)
+                        .as_deref()
+                        .unwrap_or(&false)
+                    {
+                        return Err(WasmError::UnknownFunctionType);
+                    }
+                }
+            }
+            // The code section contains the actual function bodies, this payload is emitted at
+            // the beginning of the section. This one is important as the code section offset is
+            // used to calculate relative addresses in a `DwarfDebugSession`
+            Payload::CodeSectionStart { range, count, .. } => {
+                code_offset = range.start as u64;
+                validator.code_section_start(count, &range)?;
+            }
+            // We get one of these for each local function body
+            Payload::CodeSectionEntry(body) => {
+                let validator = validator.code_section_entry()?;
+
+                let (address, size) = get_function_info(body, validator)?;
+
+                funcs[body_index].address = address;
+                funcs[body_index].size = size;
+
+                // Though we have an accurate? size of the function body, the old method of symbol
+                // iterating with walrus extends the size of each body to be contiguous with the
+                // next function, so we do the same, other than the final function
+                if body_index > 0 {
+                    funcs[body_index - 1].size = address - funcs[body_index - 1].address;
+                }
+
+                body_index += 1;
+            }
+            Payload::ModuleSectionStart { count, range, .. } => {
+                validator.module_section_start(count, &range)?;
+            }
+            Payload::DataSection(dsr) => {
+                validator.data_section(&dsr)?;
+            }
+            // There are several custom sections that we need
+            Payload::CustomSection {
+                name,
+                data,
+                data_offset,
+                ..
+            } => {
+                match name {
+                    // this section is not defined yet
+                    // see https://github.com/WebAssembly/tool-conventions/issues/133
+                    "build_id" => {
+                        build_id = Some(data);
+                    }
+                    // All of the dwarf debug sections (.debug_frame, .debug_info etc) start with a `.`, and
+                    // are the only ones we need for walking the debug info
+                    debug if debug.starts_with('.') => {
+                        dwarf_sections.push((name, data));
+                    }
+                    // The name section contains the symbol names for items, notably functions
+                    "name" => {
+                        let nsr = wasmparser::NameSectionReader::new(data, data_offset)?;
+
+                        for name in nsr {
+                            if let wasmparser::Name::Function(fnames) = name? {
+                                let mut map = fnames.get_map()?;
+                                for _ in 0..map.get_count() {
+                                    let fname = map.read()?;
+
+                                    // The names for imported functions are also in this table, but
+                                    // we don't care about them
+                                    if fname.index >= num_imported_funcs {
+                                        if let Some(func) = funcs
+                                            .get_mut((fname.index - num_imported_funcs) as usize)
+                                        {
+                                            func.name =
+                                                dbg!(Some(std::borrow::Cow::Borrowed(fname.name)));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            // Final
+            Payload::End => validator.end()?,
+
+            // The following sections are not used by this crate, but some (eg table/memory/global)
+            // are needed to validate the sections that we do care about, so we just validate all
+            // of the sections we don't use to be sure
+            Payload::TableSection(tsr) => {
+                validator.table_section(&tsr)?;
+            }
+            Payload::MemorySection(msr) => {
+                validator.memory_section(&msr)?;
+            }
+            Payload::TagSection(tsr) => {
+                validator.tag_section(&tsr)?;
+            }
+            Payload::GlobalSection(gsr) => {
+                validator.global_section(&gsr)?;
+            }
+            Payload::ExportSection(esr) => {
+                validator.export_section(&esr)?;
+            }
+            Payload::StartSection { func, range } => {
+                validator.start_section(func, &range)?;
+            }
+            Payload::ElementSection(esr) => {
+                validator.element_section(&esr)?;
+            }
+            Payload::DataCountSection { count, range } => {
+                validator.data_count_section(count, &range)?;
+            }
+            Payload::UnknownSection { id, range, .. } => {
+                validator.unknown_section(id, &range)?;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(WasmObject {
+        dwarf_sections,
+        funcs,
+        build_id,
+        data,
+        code_offset,
+        kind,
+    })
+}
+
+fn get_function_info(
+    body: wasmparser::FunctionBody,
+    mut validator: wasmparser::FuncValidator<wasmparser::ValidatorResources>,
+) -> Result<(u64, u64), WasmError> {
+    let mut body = body.get_binary_reader();
+
+    // locals, we _can_ just skip this, but might as well validate while we're here
+    {
+        for _ in 0..body.read_var_u32()? {
+            let pos = body.original_position();
+            let count = body.read_var_u32()?;
+            let ty = body.read_type()?;
+            validator.define_locals(pos, count, ty)?;
+        }
+    }
+
+    let function_address = body.original_position() as u64;
+
+    while !body.eof() {
+        let pos = body.original_position();
+        let inst = body.read_operator()?;
+        validator.op(pos, &inst)?;
+    }
+
+    validator.finish(body.original_position())?;
+
+    Ok((
+        function_address,
+        body.original_position() as u64 - function_address,
+    ))
+}


### PR DESCRIPTION
Opening as a draft since this PR depends on #470 

As stated in #472, this PR removes walrus due to its passively maintained status, and instead uses `wasmparser` directly. This means that not only can `wasmparser` be upgraded to follow the latest version much more easily and remove a dependency, it also means the runtime memory usage and CPU time should be greatly reduced as walrus was doing a _lot_ more work when parsing than this implementation, which (other than the bits needed for validation) only parses the sections/content actually used by this crate.

Resolves: #472