### PR TITLE
ref(clippy): Decorate with must_use

### DIFF
--- a/symbolic-unwind/src/evaluator/mod.rs
+++ b/symbolic-unwind/src/evaluator/mod.rs
@@ -103,18 +103,21 @@ impl<'memory, A, E> Evaluator<'memory, A, E> {
     }
 
     /// Sets the evaluator's memory to the given `MemoryRegion`.
+    #[must_use]
     pub fn memory(mut self, memory: MemoryRegion<'memory>) -> Self {
         self.memory = Some(memory);
         self
     }
 
     /// Sets the evaluator's constant map to the given map.
+    #[must_use]
     pub fn constants(mut self, constants: BTreeMap<Constant, A>) -> Self {
         self.constants = constants;
         self
     }
 
     /// Sets the evaluator's variable map to the given map.
+    #[must_use]
     pub fn variables(mut self, variables: BTreeMap<Variable, A>) -> Self {
         self.variables = variables;
         self


### PR DESCRIPTION
Nightly clippy wants to decorate this with must_use because they
return Self.  I'm not really sure how safe it is to add something like
this.

https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use

#skip-changelog