### PR TITLE
Make elementtree optional

### DIFF
--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -39,6 +39,7 @@ elf = [
 # Mach-o processing
 macho = [
     "dwarf",
+    "elementtree",
     "goblin/mach32",
     "goblin/mach64",
     "goblin/std",
@@ -71,7 +72,7 @@ wasm = ["bitvec", "dwarf", "wasmparser"]
 [dependencies]
 bitvec = { version = "0.22", optional = true, features = ["alloc"] }
 dmsort = "1.0.1"
-elementtree = "0.5.0"
+elementtree = { version = "0.5.0", optional = true }
 fallible-iterator = "0.2.0"
 flate2 = { version = "1.0.13", optional = true, default-features = false, features = [
     "rust_backend",


### PR DESCRIPTION
`elementtree` is only used for BCSymbolMaps, so this just makes it an optional dependency gated by `macho`. I noticed this because `elementtree` -> `string_cache` -> `phf_shared` is using an outdated version (0.8.0 vs 0.10.0).