### PR TITLE
Replace memmap

### DIFF
--- a/symbolic-common/Cargo.toml
+++ b/symbolic-common/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 
 [dependencies]
 debugid = "0.7.1"
-memmap = "0.7.0"
+memmap2 = "0.5.0"
 stable_deref_trait = "1.1.1"
 serde_ = { package = "serde", version = "1.0.88", optional = true, features = ["derive"] }
 uuid = "0.8.1"

--- a/symbolic-common/src/byteview.rs
+++ b/symbolic-common/src/byteview.rs
@@ -11,7 +11,7 @@ use std::ops::Deref;
 use std::path::Path;
 use std::sync::Arc;
 
-use memmap::Mmap;
+use memmap2::Mmap;
 
 use crate::cell::StableDeref;
 

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -39,6 +39,7 @@ elf = [
 # Mach-o processing
 macho = [
     "dwarf",
+    "elementtree",
     "goblin/mach32",
     "goblin/mach64",
     "goblin/std",
@@ -71,7 +72,7 @@ wasm = ["bitvec", "dwarf", "wasmparser"]
 [dependencies]
 bitvec = { version = "0.22", optional = true, features = ["alloc"] }
 dmsort = "1.0.1"
-elementtree = "0.5.0"
+elementtree = { version = "0.5.0", optional = true }
 fallible-iterator = "0.2.0"
 flate2 = { version = "1.0.13", optional = true, default-features = false, features = [
     "rust_backend",


### PR DESCRIPTION
`memmap` has been marked as [unmaintained](https://rustsec.org/advisories/RUSTSEC-2020-0077) for over a year now, this just replaces it with the maintained `memmap2` fork.