### PR TITLE
ci: Add Code Coverage Job

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch: false
+
+comment:
+  layout: "diff"
+  require_changes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,3 +161,28 @@ jobs:
           args: cbindgen
 
       - run: cd symbolic-cabi && make test
+
+  codecov:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    continue-on-error: true # well, its nightly and highly experimental
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: llvm-tools-preview
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - uses: Swatinem/fucov@v1
+        with:
+          args: --workspace --all-features
+
+      - uses: codecov/codecov-action@e156083f13aff6830c92fc5faa23505779fbf649
+        with:
+          directory: coverage

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Symbolic
 
-<a href="https://travis-ci.com/getsentry/symbolic"><img src="https://travis-ci.com/getsentry/symbolic.svg?branch=master" alt=""></a>
+[![Build Status](https://github.com/getsentry/symbolic/workflows/CI/badge.svg)](https://github.com/getsentry/symbolic/actions?workflow=CI)
 <a href="https://crates.io/crates/symbolic"><img src="https://img.shields.io/crates/v/symbolic.svg" alt=""></a>
 <a href="https://pypi.python.org/pypi/Symbolic"><img src="https://img.shields.io/pypi/v/symbolic.svg" alt=""></a>
 <a href="https://github.com/getsentry/symbolic/blob/master/LICENSE"><img src="https://img.shields.io/pypi/l/Symbolic.svg" alt=""></a>
+[![codecov](https://codecov.io/gh/getsentry/symbolic/branch/master/graph/badge.svg?token=suNHZfbjKW)](https://codecov.io/gh/getsentry/symbolic)
 
 [Symbolic](https://docs.rs/symbolic) is a library written in Rust which is used at
 [Sentry](https://sentry.io/) to implement symbolication of native stack traces, sourcemap handling


### PR DESCRIPTION
I was able to work around an unexplainable failure in my own action which seems to work now in sentry-rust, and I am experimenting there with `cargo-llvm-cov` as well: https://github.com/getsentry/sentry-rust/pull/398 (plus contributing some rustdoc-related fixes there and in the compiler)

For the time being, lets see how `fucov` does on this workspace.

Should fix #227