### PR TITLE
ref: Pacify nightly clippy

### DIFF
--- a/symbolic-debuginfo/src/elf.rs
+++ b/symbolic-debuginfo/src/elf.rs
@@ -972,7 +972,7 @@ impl<'data> DebugLink<'data> {
         let crc = data
             .get(nul_pos + 1..)
             .and_then(|crc| crc.get(crc.len() - 4..))
-            .ok_or_else(|| DebugLinkErrorKind::MissingCrc {
+            .ok_or(DebugLinkErrorKind::MissingCrc {
                 filename_len_with_nul: filename.len(),
             })?;
 

--- a/symbolic-demangle/src/lib.rs
+++ b/symbolic-demangle/src/lib.rs
@@ -32,6 +32,7 @@
 //! ```
 
 #![warn(missing_docs)]
+#![allow(clippy::return_self_not_must_use)]
 
 use std::borrow::Cow;
 #[cfg(feature = "swift")]

--- a/symbolic-demangle/src/lib.rs
+++ b/symbolic-demangle/src/lib.rs
@@ -32,7 +32,6 @@
 //! ```
 
 #![warn(missing_docs)]
-#![allow(clippy::return_self_not_must_use)]
 
 use std::borrow::Cow;
 #[cfg(feature = "swift")]


### PR DESCRIPTION
The `clippy::non-send-fields-in-send-ty` rule that fails on beta is either being turned off in nightly, or had some false positives that were fixes, as nightly clippy does not trigger those beta errors anymore.
I opted to just ignore the `#[must_use]` suggestion, as that would essentially be a public API change/break that I would like to avoid.