### PR TITLE
Use BTreeMap instead of HashMap for source bundle manifest

### DIFF
--- a/symbolic-debuginfo/src/sourcebundle.rs
+++ b/symbolic-debuginfo/src/sourcebundle.rs
@@ -307,7 +307,7 @@ impl Default for SourceBundleHeader {
 struct SourceBundleManifest {
     /// Descriptors for all files in this bundle.
     #[serde(default)]
-    pub files: HashMap<String, SourceFileInfo>,
+    pub files: BTreeMap<String, SourceFileInfo>,
 
     /// Arbitrary attributes to include in the bundle.
     #[serde(flatten)]
@@ -685,7 +685,7 @@ impl<'data, 'session> DebugSession<'session> for SourceBundleDebugSession<'data>
 
 /// An iterator over source files in a SourceBundle object.
 pub struct SourceBundleFileIterator<'s> {
-    files: std::collections::hash_map::Values<'s, String, SourceFileInfo>,
+    files: std::collections::btree_map::Values<'s, String, SourceFileInfo>,
 }
 
 impl<'s> Iterator for SourceBundleFileIterator<'s> {


### PR DESCRIPTION
I noticed this when reimplementing some of sentry-cli's upload-difs portions, basically the exact same input objects (in our case wasm binaries + source bundles) would always say there were missing chunks on the server, The cause of which was the use of a HashMap to store the files in the source bundle manifest, which will give non-deterministic output with the same input due to the default HashMap hash randomization. Changing to use a BTreeMap gives deterministic ordering so that the same input object will always give the same output source bundle. 

Also just want to note, the only reason that this is the case is that PR #470 changed the zip crate to remove default features, one of which is `time`, which when not present will always use [`1980-01-01` for the timestamp](https://docs.rs/zip/0.5.13/zip/write/struct.FileOptions.html#method.last_modified_time).