### PR TITLE
Fix WASM symbolication

### DIFF
--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -814,12 +814,6 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             // should avoid this problem.
             range_buf.sort_by_key(|r| r.begin);
 
-            // In WASM files emitted by emscripted, we have observed a variety of broken ranges.
-            // One of these cases also involves ranges which are not being sorted, resulting in
-            // arithmetic underflow calculating `function_size` (in debug builds). Sorting the ranges
-            // should avoid this problem.
-            range_buf.sort_by_key(|r| r.begin);
-
             let function_address = offset(range_buf[0].begin, self.inner.info.address_offset);
             let function_size = range_buf[range_buf.len() - 1].end - range_buf[0].begin;
             let function_end = function_address + function_size;

--- a/symbolic-debuginfo/src/wasm/parser.rs
+++ b/symbolic-debuginfo/src/wasm/parser.rs
@@ -221,7 +221,7 @@ fn get_function_info(
 ) -> Result<(u64, u64), WasmError> {
     let mut body = body.get_binary_reader();
 
-    let real_start = body.original_position();
+    let function_address = body.original_position() as u64;
 
     // locals, we _can_ just skip this, but might as well validate while we're here
     {
@@ -231,12 +231,6 @@ fn get_function_info(
             let ty = body.read_type()?;
             validator.define_locals(pos, count, ty)?;
         }
-    }
-
-    let function_address = body.original_position() as u64;
-
-    if function_address == 632 {
-        dbg!(real_start);
     }
 
     while !body.eof() {

--- a/symbolic-debuginfo/src/wasm/parser.rs
+++ b/symbolic-debuginfo/src/wasm/parser.rs
@@ -221,6 +221,8 @@ fn get_function_info(
 ) -> Result<(u64, u64), WasmError> {
     let mut body = body.get_binary_reader();
 
+    let real_start = body.original_position();
+
     // locals, we _can_ just skip this, but might as well validate while we're here
     {
         for _ in 0..body.read_var_u32()? {
@@ -232,6 +234,10 @@ fn get_function_info(
     }
 
     let function_address = body.original_position() as u64;
+
+    if function_address == 632 {
+        dbg!(real_start);
+    }
 
     while !body.eof() {
         let pos = body.original_position();

--- a/symbolic-debuginfo/tests/snapshots/test_objects__wasm_symbols.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__wasm_symbols.snap
@@ -1,6 +1,7 @@
 ---
 source: symbolic-debuginfo/tests/test_objects.rs
 expression: SymbolsDebug(&symbols)
+
 ---
-              8c internal_func
+              8b internal_func
 

--- a/symbolic-symcache/src/new/writer.rs
+++ b/symbolic-symcache/src/new/writer.rs
@@ -162,8 +162,8 @@ impl SymCacheConverter {
     }
 
     pub fn process_symbolic_function(&mut self, function: &Function<'_>) {
-        // skip over empty functions
-        if function.size == 0 {
+        // skip over empty functions or functions whose address is too large to fit in a u32
+        if function.size == 0 || function.address > u32::MAX as u64 {
             return;
         }
 


### PR DESCRIPTION
Well, this took me longer than I would have liked to figure out, but I _think_ this resolves an issue with (malformed?) DWARF debug info and `SymCacheConverter`.

For some background, I noticed that when sending wasm stacktraces to sentry.io, the first frame in a very short stacktrace of < 5 frames was always misattributed, but other frames were correct. At first I assumed that I had messed up the WASM parsing in #474 somehow, but when looking at the addresses/symbols reported by [`wasmtime::Trap`](https://docs.rs/wasmtime/latest/wasmtime/struct.Trap.html) and the information parsed by `WasmObject` they were almost the same, other than that both wasmtime and DWARF use the "true" function start address, whereas in the previous code and the refactor it was using the address after the function locals, which this PR fixes.

Thinking that this was maybe the reason for the misattribution, I figured I would sanity check by making a test with `SymbolCache` which I assume is what sentry is using for symbolication server side, by comparing the stacktrace reported by wasmtime, which I know is correct, versus the one spit out by the `SymbolCache`. However, again, the first frame was always misattributed.

Eventually, after adding a bunch of debugging code and trying different things, I noticed this seemingly innocuous line, https://github.com/getsentry/symbolic/blob/d05ca1662b64eced395bc65230ba87acf3120d71/symbolic-symcache/src/new/writer.rs#L175. And indeed, when adding a check for function addresses `> u32::MAX`, there were indeed _many_ of them. These addresses aren't coming from the WASM addresses that were being parsed, but rather from the DWARF debug info, and ends up being a "last one wins" situation where large addresses wrap around and stomp over lower addresses already in the list. In our scenario, the first frame in the stack trace just so happened to also be the first function in the WASM binary, with the lowest possible addresses, and _many_ DWARF functions with large addresses overwrote it.

Anyway, long story short, I added an additional check in `SymCacheConverter::process_symbolic_function` to skip functions that are larger than `u32::MAX` as a quick workaround, which means this particular WASM stacktrace is now symbolicated correctly.

I also happened to notice a copy-paste error in `DwarfUnit::functions` and removed it.

Resolves: #490 