### PR TITLE
fix: Avoid infinite loops parsing invalid wasm

### DIFF
--- a/symbolic-debuginfo/src/wasm.rs
+++ b/symbolic-debuginfo/src/wasm.rs
@@ -286,3 +286,15 @@ impl<'data, 'object> Iterator for WasmSymbolIterator<'data, 'object> {
         self.funcs.next()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_invalid_header() {
+        let data = b"\x00asm    ";
+
+        assert!(WasmObject::parse(data).is_err());
+    }
+}

--- a/symbolic-debuginfo/src/wasm/parser.rs
+++ b/symbolic-debuginfo/src/wasm/parser.rs
@@ -25,7 +25,8 @@ impl<'data> super::WasmObject<'data> {
         // Note that the order of the payloads here are the order that they will appear in (valid)
         // wasm binaries, other than the sections that we need to parse to validate the module, which
         // are at the end
-        for payload in wasmparser::Parser::new(0).parse_all(data).flatten() {
+        for payload in wasmparser::Parser::new(0).parse_all(data) {
+            let payload = payload?;
             match payload {
                 // This should always be first, and is necessary to prepare the validator since the
                 // version determines which parts of the spec can be used


### PR DESCRIPTION
When encountering an invalid wasm header, the parser yielded an error, but never advanced its parser.
The `flatten()` call meant that we tried re-parsing in a loop.

Early-returning from the parser might be a bit too harsh, given that we would want to be as lenient as possible, but lets revisit that later on when we actually have to deal with broken-but-still-somehow-valid wasm files.

CC @Jake-Shadle since you recently wrote that piece of code