### PR TITLE
ref: Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Update `goblin` which received fixes to avoid panics and unreasonable memory allocations based on invalid input.
+
 ## 8.6.0
 
 **Features**:

--- a/examples/addr2line/Cargo.toml
+++ b/examples/addr2line/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.32"
-clap = "2.33.0"
+clap = "3.0.14"
 symbolic = { path = "../../symbolic", features = ["demangle"] }

--- a/examples/addr2line/src/main.rs
+++ b/examples/addr2line/src/main.rs
@@ -151,7 +151,7 @@ In the second, addr2line reads hexadecimal addresses from standard input, and pr
                 .help("Display only the base of each file name."),
         )
         .arg(
-            Arg::new("inlines")
+            Arg::new("inlinees")
                 .short('i')
                 .long("inlinees")
                 .help("If the address belongs to a function that was inlined, the source information for all enclosing scopes back to the first non-inlined function will also be printed. For example, if \"main\" inlines \"callee1\" which inlines \"callee2\", and address is from \"callee2\", the source information for \"callee1\" and \"main\" will also be printed.")

--- a/examples/dump_cfi/Cargo.toml
+++ b/examples/dump_cfi/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.32"
-clap = "2.33.0"
+clap = "3.0.14"
 symbolic = { path = "../../symbolic", features = ["minidump"] }

--- a/examples/dump_cfi/src/main.rs
+++ b/examples/dump_cfi/src/main.rs
@@ -28,7 +28,7 @@ fn dump_cfi<P: AsRef<Path>>(path: P) -> Result<()> {
     Ok(())
 }
 
-fn execute(matches: &ArgMatches<'_>) -> Result<()> {
+fn execute(matches: &ArgMatches) -> Result<()> {
     let path = matches.value_of("path").unwrap();
     dump_cfi(path)
 }
@@ -37,7 +37,7 @@ fn main() {
     let matches = App::new("dump_cfi")
         .about("Prints CFI in Breakpad format")
         .arg(
-            Arg::with_name("path")
+            Arg::new("path")
                 .required(true)
                 .value_name("PATH")
                 .help("Path to the debug file")

--- a/examples/dump_sources/Cargo.toml
+++ b/examples/dump_sources/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "2.33.0"
+clap = "3.0.14"
 symbolic = { path = "../../symbolic" }

--- a/examples/dump_sources/src/main.rs
+++ b/examples/dump_sources/src/main.rs
@@ -43,7 +43,7 @@ fn write_object_sources(path: &Path, output_path: &Path) -> Result<(), Box<dyn s
     Ok(())
 }
 
-fn execute(matches: &ArgMatches<'_>) {
+fn execute(matches: &ArgMatches) {
     let output_path = Path::new(matches.value_of("output").unwrap());
     for path in matches.values_of("paths").unwrap_or_default() {
         if let Err(e) = write_object_sources(Path::new(&path), output_path) {
@@ -58,17 +58,17 @@ fn main() {
     let matches = App::new("object-debug")
         .about("Shows some information on object files")
         .arg(
-            Arg::with_name("paths")
+            Arg::new("paths")
                 .required(true)
-                .multiple(true)
+                .multiple_occurrences(true)
                 .value_name("PATH")
                 .help("Path to the debug file")
                 .number_of_values(1)
                 .index(1),
         )
         .arg(
-            Arg::with_name("output")
-                .short("o")
+            Arg::new("output")
+                .short('o')
                 .long("output")
                 .required(true)
                 .value_name("PATH")

--- a/examples/minidump_stackwalk/Cargo.toml
+++ b/examples/minidump_stackwalk/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "2.33.0"
+clap = "3.0.14"
 symbolic = { path = "../../symbolic", features = ["minidump", "symcache", "demangle"] }
 walkdir = "2.3.1"

--- a/examples/minidump_stackwalk/src/main.rs
+++ b/examples/minidump_stackwalk/src/main.rs
@@ -314,37 +314,37 @@ fn main() {
     let matches = App::new("symbolic-minidump")
         .about("Symbolicates a minidump")
         .arg(
-            Arg::with_name("minidump_file_path")
+            Arg::new("minidump_file_path")
                 .required(true)
                 .value_name("minidump")
                 .help("Path to the minidump file"),
         )
         .arg(
-            Arg::with_name("debug_symbols_path")
+            Arg::new("debug_symbols_path")
                 .value_name("symbols")
                 .help("Path to a folder containing debug symbols"),
         )
         .arg(
-            Arg::with_name("cfi")
-                .short("c")
+            Arg::new("cfi")
+                .short('c')
                 .long("cfi")
                 .help("Use CFI while stackwalking"),
         )
         .arg(
-            Arg::with_name("symbolize")
-                .short("s")
+            Arg::new("symbolize")
+                .short('s')
                 .long("symbolize")
                 .help("Symbolize frames (file, function and line number)"),
         )
         .arg(
-            Arg::with_name("only_crash")
-                .short("o")
+            Arg::new("only_crash")
+                .short('o')
                 .long("only-crash")
                 .help("Only output the crashed thread"),
         )
         .arg(
-            Arg::with_name("no_modules")
-                .short("n")
+            Arg::new("no_modules")
+                .short('n')
                 .long("no-modules")
                 .help("Do not output loaded modules"),
         )

--- a/examples/object_debug/Cargo.toml
+++ b/examples/object_debug/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "2.33.0"
+clap = "3.0.14"
 symbolic = { path = "../../symbolic" }

--- a/examples/object_debug/src/main.rs
+++ b/examples/object_debug/src/main.rs
@@ -52,7 +52,7 @@ fn inspect_object<P: AsRef<Path>>(path: P) -> Result<(), Box<dyn std::error::Err
     Ok(())
 }
 
-fn execute(matches: &ArgMatches<'_>) {
+fn execute(matches: &ArgMatches) {
     for path in matches.values_of("paths").unwrap_or_default() {
         if let Err(e) = inspect_object(path) {
             print_error(e.as_ref())
@@ -66,9 +66,9 @@ fn main() {
     let matches = App::new("object-debug")
         .about("Shows some information on object files")
         .arg(
-            Arg::with_name("paths")
+            Arg::new("paths")
                 .required(true)
-                .multiple(true)
+                .multiple_occurrences(true)
                 .value_name("PATH")
                 .help("Path to the debug file")
                 .number_of_values(1)

--- a/examples/symcache_debug/Cargo.toml
+++ b/examples/symcache_debug/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.32"
-clap = "2.33.0"
+clap = "3.0.14"
 symbolic = { path = "../../symbolic", features = ["symcache", "demangle"] }

--- a/examples/symcache_debug/src/main.rs
+++ b/examples/symcache_debug/src/main.rs
@@ -137,15 +137,15 @@ fn main() {
     let matches = App::new("symcache-debug")
         .about("Works with symbol files with the symcache interface")
         .arg(
-            Arg::with_name("debug_file_path")
-                .short("d")
+            Arg::new("debug_file_path")
+                .short('d')
                 .long("debug-file")
                 .value_name("PATH")
                 .help("Path to the debug info file"),
         )
         .arg(
-            Arg::with_name("write_cache_file")
-                .short("w")
+            Arg::new("write_cache_file")
+                .short('w')
                 .long("write-cache-file")
                 .help(
                     "Write the cache file from the debug info file.  If no file name is \
@@ -154,32 +154,32 @@ fn main() {
                 ),
         )
         .arg(
-            Arg::with_name("arch")
-                .short("a")
+            Arg::new("arch")
+                .short('a')
                 .long("arch")
                 .value_name("ARCH")
                 .help("The architecture of the object to work with."),
         )
         .arg(
-            Arg::with_name("report")
+            Arg::new("report")
                 .long("report")
                 .help("Spit out some debug information"),
         )
         .arg(
-            Arg::with_name("symcache_file_path")
-                .short("c")
+            Arg::new("symcache_file_path")
+                .short('c')
                 .long("symcache-file")
                 .value_name("PATH")
                 .help("Path to the symcache file"),
         )
         .arg(
-            Arg::with_name("lookup_addr")
+            Arg::new("lookup_addr")
                 .long("lookup")
                 .value_name("ADDR")
                 .help("Looks up an address in the debug file"),
         )
         .arg(
-            Arg::with_name("print_symbols")
+            Arg::new("print_symbols")
                 .long("symbols")
                 .help("Print all symbols"),
         )

--- a/examples/unreal_engine_crash/Cargo.toml
+++ b/examples/unreal_engine_crash/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "2.33.0"
+clap = "3.0.14"
 symbolic = { path = "../../symbolic", features = ["unreal"] }

--- a/examples/unreal_engine_crash/src/main.rs
+++ b/examples/unreal_engine_crash/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
     let matches = App::new("unreal-engine-crash")
         .about("Unpack an Unreal Engine crash report")
         .arg(
-            Arg::with_name("crash_file_path")
+            Arg::new("crash_file_path")
                 .required(true)
                 .value_name("crash_file_path")
                 .help("Path to the crash file"),

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -81,16 +81,16 @@ gimli = { version = "0.26.1", optional = true, default-features = false, feature
     "read",
     "std",
 ] }
-goblin = { version = "0.4.2", optional = true, default-features = false }
+goblin = { version = "0.5.1", optional = true, default-features = false }
 lazy_static = { version = "1.4.0", optional = true }
 lazycell = { version = "1.2.1", optional = true }
 nom = { version = "7.0.0", optional = true }
 nom-supreme = { version = "0.6.0", optional = true }
-parking_lot = { version = "0.11.0", optional = true }
+parking_lot = { version = "0.12.0", optional = true }
 pdb = { version = "0.7.0", optional = true }
 regex = { version = "1.3.5", optional = true }
 # keep this in sync with whatever version `goblin` uses
-scroll = { version = "0.10", optional = true }
+scroll = { version = "0.11", optional = true }
 serde = { version = "1.0.94", features = ["derive"] }
 serde_json = { version = "1.0.40", optional = true }
 smallvec = { version = "1.2.0", optional = true }


### PR DESCRIPTION
This updates `goblin` which includes a couple of fuzzer fixes.
As well as `clap` which required some changes to example executables.