### PR TITLE
fix(debuginfo): Detect SHT_X86_64_UNWIND from gold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Update `goblin` which received fixes to avoid panics and unreasonable memory allocations based on invalid input.
 - Correctly skip ELF sections with an offset of `0` instead of ignoring all following sections. This bug may have lead to missing unwind or debug information. ([#505](https://github.com/getsentry/symbolic/pull/505))
+- Detect unwind information when linking with `gold`. ([#505](https://github.com/getsentry/symbolic/pull/505))
 
 ## 8.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixes**:
 
 - Update `goblin` which received fixes to avoid panics and unreasonable memory allocations based on invalid input.
+- Correctly skip ELF sections with an offset of `0` instead of ignoring all following sections. This bug may have lead to missing unwind or debug information. ([#505](https://github.com/getsentry/symbolic/pull/505))
 
 ## 8.6.0
 

--- a/symbolic-debuginfo/src/elf.rs
+++ b/symbolic-debuginfo/src/elf.rs
@@ -590,14 +590,10 @@ impl<'data> ElfObject<'data> {
     /// Locates and reads a section in an ELF binary.
     fn find_section(&self, name: &str) -> Option<(bool, DwarfSection<'data>)> {
         for header in &self.elf.section_headers {
-            const SHT_MIPS_DWARF: u32 = 0x7000_001e;
-            const SHT_PROGBITS: u32 = elf::section_header::SHT_PROGBITS;
-            const SHT_X86_64_UNWIND: u32 = elf::section_header::SHT_X86_64_UNWIND;
-
-            if !matches!(
-                header.sh_type,
-                SHT_PROGBITS | SHT_MIPS_DWARF | SHT_X86_64_UNWIND
-            ) {
+            // The section type is usually SHT_PROGBITS, but some compilers also use
+            // SHT_X86_64_UNWIND and SHT_MIPS_DWARF. We apply the same approach as elfutils,
+            // matching against SHT_NOBITS, instead.
+            if header.sh_type == elf::section_header::SHT_NOBITS {
                 continue;
             }
 

--- a/symbolic-debuginfo/src/elf.rs
+++ b/symbolic-debuginfo/src/elf.rs
@@ -592,7 +592,12 @@ impl<'data> ElfObject<'data> {
         for header in &self.elf.section_headers {
             const SHT_MIPS_DWARF: u32 = 0x7000_001e;
             const SHT_PROGBITS: u32 = elf::section_header::SHT_PROGBITS;
-            if !matches!(header.sh_type, SHT_PROGBITS | SHT_MIPS_DWARF) {
+            const SHT_X86_64_UNWIND: u32 = elf::section_header::SHT_X86_64_UNWIND;
+
+            if !matches!(
+                header.sh_type,
+                SHT_PROGBITS | SHT_MIPS_DWARF | SHT_X86_64_UNWIND
+            ) {
                 continue;
             }
 

--- a/symbolic-debuginfo/src/elf.rs
+++ b/symbolic-debuginfo/src/elf.rs
@@ -604,7 +604,7 @@ impl<'data> ElfObject<'data> {
                     // while stripping their data from the file by setting their offset to 0. We
                     // know that no section can start at an absolute file offset of zero, so we can
                     // safely skip them in case similar things happen on linux.
-                    return None;
+                    continue;
                 }
 
                 if section_name.is_empty() {


### PR DESCRIPTION
The `gold` linker creates `.eh_frame` and related sections with type `SHT_X86_64_UNWIND` rather than `SHT_PROGBITS`. Right now, symbolic skips those sections and as a result does not detect unwind information. 

Breakpad and elfutils instead permit all section types _other than_ `SHT_NOBITS`.

See https://github.com/magma/magma/issues/10893