### PR TITLE
fix(lint): Replace use of deprecated clap API

### DIFF
--- a/examples/addr2line/Cargo.toml
+++ b/examples/addr2line/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.32"
-clap = "3.0.14"
+clap = "3.1.0"
 symbolic = { path = "../../symbolic", features = ["demangle"] }

--- a/examples/addr2line/src/main.rs
+++ b/examples/addr2line/src/main.rs
@@ -1,7 +1,7 @@
 use std::borrow::Borrow;
 
 use anyhow::{Context, Result};
-use clap::{App, Arg, ArgMatches};
+use clap::{Arg, ArgMatches, Command};
 
 use symbolic::common::{ByteView, Language, Name, NameMangling};
 use symbolic::debuginfo::{Function, Object};
@@ -117,7 +117,7 @@ addr2line has two modes of operation.
 In the first, hexadecimal addresses are specified on the command line, and addr2line displays the file name and line number for each address.
 
 In the second, addr2line reads hexadecimal addresses from standard input, and prints the file name and line number for each address on standard output. In this mode, addr2line may be used in a pipe to convert dynamically chosen addresses."#;
-    let matches = App::new("addr2line")
+    let matches = Command::new("addr2line")
         .about(about)
         .arg(
             Arg::new("demangle")

--- a/examples/dump_cfi/Cargo.toml
+++ b/examples/dump_cfi/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.32"
-clap = "3.0.14"
+clap = "3.1.0"
 symbolic = { path = "../../symbolic", features = ["minidump"] }

--- a/examples/dump_cfi/src/main.rs
+++ b/examples/dump_cfi/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use anyhow::Result;
-use clap::{App, Arg, ArgMatches};
+use clap::{Arg, ArgMatches, Command};
 
 use symbolic::common::{ByteView, DSymPathExt};
 use symbolic::debuginfo::Object;
@@ -34,7 +34,7 @@ fn execute(matches: &ArgMatches) -> Result<()> {
 }
 
 fn main() {
-    let matches = App::new("dump_cfi")
+    let matches = Command::new("dump_cfi")
         .about("Prints CFI in Breakpad format")
         .arg(
             Arg::new("path")

--- a/examples/dump_sources/Cargo.toml
+++ b/examples/dump_sources/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "3.0.14"
+clap = "3.1.0"
 symbolic = { path = "../../symbolic" }

--- a/examples/dump_sources/src/main.rs
+++ b/examples/dump_sources/src/main.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use clap::{App, Arg, ArgMatches};
+use clap::{Arg, ArgMatches, Command};
 
 use symbolic::common::{ByteView, DSymPathExt};
 use symbolic::debuginfo::sourcebundle::SourceBundleWriter;
@@ -55,7 +55,7 @@ fn execute(matches: &ArgMatches) {
 }
 
 fn main() {
-    let matches = App::new("object-debug")
+    let matches = Command::new("object-debug")
         .about("Shows some information on object files")
         .arg(
             Arg::new("paths")

--- a/examples/minidump_stackwalk/Cargo.toml
+++ b/examples/minidump_stackwalk/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "3.0.14"
+clap = "3.1.0"
 symbolic = { path = "../../symbolic", features = ["minidump", "symcache", "demangle"] }
 walkdir = "2.3.1"

--- a/examples/minidump_stackwalk/src/main.rs
+++ b/examples/minidump_stackwalk/src/main.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::io::Cursor;
 use std::path::Path;
 
-use clap::{App, Arg, ArgMatches};
+use clap::{Arg, ArgMatches, Command};
 use walkdir::WalkDir;
 
 use symbolic::common::{Arch, ByteView, InstructionInfo, SelfCell};
@@ -311,7 +311,7 @@ fn execute(matches: &ArgMatches) -> Result<(), Error> {
 }
 
 fn main() {
-    let matches = App::new("symbolic-minidump")
+    let matches = Command::new("symbolic-minidump")
         .about("Symbolicates a minidump")
         .arg(
             Arg::new("minidump_file_path")

--- a/examples/object_debug/Cargo.toml
+++ b/examples/object_debug/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "3.0.14"
+clap = "3.1.0"
 symbolic = { path = "../../symbolic" }

--- a/examples/object_debug/src/main.rs
+++ b/examples/object_debug/src/main.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use clap::{App, Arg, ArgMatches};
+use clap::{Arg, ArgMatches, Command};
 
 use symbolic::common::{ByteView, DSymPathExt};
 use symbolic::debuginfo::Archive;
@@ -63,7 +63,7 @@ fn execute(matches: &ArgMatches) {
 }
 
 fn main() {
-    let matches = App::new("object-debug")
+    let matches = Command::new("object-debug")
         .about("Shows some information on object files")
         .arg(
             Arg::new("paths")

--- a/examples/symcache_debug/Cargo.toml
+++ b/examples/symcache_debug/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.32"
-clap = "3.0.14"
+clap = "3.1.0"
 symbolic = { path = "../../symbolic", features = ["symcache", "demangle"] }

--- a/examples/symcache_debug/src/main.rs
+++ b/examples/symcache_debug/src/main.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::u64;
 
 use anyhow::{anyhow, Result};
-use clap::{App, Arg, ArgMatches};
+use clap::{Arg, ArgMatches, Command};
 
 use symbolic::common::{Arch, ByteView, DSymPathExt, Language};
 use symbolic::demangle::Demangle;
@@ -134,7 +134,7 @@ fn execute(matches: &ArgMatches) -> Result<()> {
 }
 
 fn main() {
-    let matches = App::new("symcache-debug")
+    let matches = Command::new("symcache-debug")
         .about("Works with symbol files with the symcache interface")
         .arg(
             Arg::new("debug_file_path")

--- a/examples/unreal_engine_crash/Cargo.toml
+++ b/examples/unreal_engine_crash/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "3.0.14"
+clap = "3.1.0"
 symbolic = { path = "../../symbolic", features = ["unreal"] }

--- a/examples/unreal_engine_crash/src/main.rs
+++ b/examples/unreal_engine_crash/src/main.rs
@@ -2,7 +2,7 @@ use std::cmp;
 use std::fs::File;
 use std::io::Read;
 
-use clap::{App, Arg, ArgMatches};
+use clap::{Arg, ArgMatches, Command};
 
 use symbolic::unreal::{Unreal4Crash, Unreal4FileType};
 
@@ -41,7 +41,7 @@ fn execute(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn main() {
-    let matches = App::new("unreal-engine-crash")
+    let matches = Command::new("unreal-engine-crash")
         .about("Unpack an Unreal Engine crash report")
         .arg(
             Arg::new("crash_file_path")


### PR DESCRIPTION
The clap `App` type is deprecated since version _3.1.0_ and has been replaced with `Command`.
https://docs.rs/clap/3.1.1/clap/struct.App.html

#skip-changelog
