### PR TITLE
fix(dwarf): Resolve symbol names by exact address

### DIFF
--- a/symbolic-debuginfo/src/base.rs
+++ b/symbolic-debuginfo/src/base.rs
@@ -290,7 +290,7 @@ impl<'data> SymbolMap<'data> {
         }
     }
 
-    /// Looks up a symbol in the symbol map.
+    /// Looks up the symbol covering the given address.
     pub fn lookup(&self, address: u64) -> Option<&Symbol<'data>> {
         match self.symbols.binary_search_by_key(&address, Self::key) {
             Ok(index) => Some(&self.symbols[index]),
@@ -304,6 +304,15 @@ impl<'data> SymbolMap<'data> {
                 }
             }
         }
+    }
+
+    /// Looks up a symbol by its start address.
+    pub fn lookup_exact(&self, address: u64) -> Option<&Symbol<'data>> {
+        let idx = self
+            .symbols
+            .binary_search_by_key(&address, Self::key)
+            .ok()?;
+        Some(&self.symbols[idx])
     }
 
     /// Looks up a symbol covering an entire range.


### PR DESCRIPTION
This changes the lookup of functions in the symbol table so that the symbol must have the same starting address as the function, rather than merely covering the entire function.