### PR TITLE
fix: Write STACK WIN records correctly

### DIFF
--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -856,8 +856,7 @@ impl<W: Write> AsciiCfiWriter<W> {
         prolog_size: u32,
     ) -> Result<(), CfiError> {
         let code_size = end - start;
-        let program_or_bp =
-            frame.program.is_some() && string_table.is_some() || frame.uses_base_pointer;
+        let has_program = frame.program.is_some() && string_table.is_some();
 
         write!(
             self.inner,
@@ -871,7 +870,7 @@ impl<W: Write> AsciiCfiWriter<W> {
             frame.saved_regs_size,
             frame.locals_size,
             frame.max_stack_size.unwrap_or(0),
-            if program_or_bp { 1 } else { 0 },
+            if has_program { 1 } else { 0 },
         )?;
 
         match frame.program {
@@ -886,7 +885,11 @@ impl<W: Write> AsciiCfiWriter<W> {
                 writeln!(self.inner, "{}", program_string.trim())?;
             }
             None => {
-                writeln!(self.inner, "{}", if program_or_bp { 1 } else { 0 })?;
+                writeln!(
+                    self.inner,
+                    "{}",
+                    if frame.uses_base_pointer { 1 } else { 0 }
+                )?;
             }
         }
 


### PR DESCRIPTION
The structure of STACK WIN records is described in https://github.com/google/breakpad/blob/master/docs/symbol_files.md#stack-win-records. In particular:
* The `has_program_string` flag should be 
  * For `FrameData` (type 4) records: `1` if the record has a program string, `0` otherwise;
  * For `FPO` (type 0) records: always `0`.
* The last argument should be
  * For `FrameData` records: the program string if it exists, empty otherwise;
  * For `FPO` records: `1` if the frame pointer register is used as a general-purpose register, `0` otherwise.

However, this is not what the current code does; we instead unify `has_program_string` and `uses_base_pointer` into one flag. Kudos to rust-minidump for discarding the resulting invalid records and logging this fact.