### PR TITLE
Bump the version of wasmparser to the latest version

### DIFF
--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -96,7 +96,7 @@ serde_json = { version = "1.0.40", optional = true }
 smallvec = { version = "1.2.0", optional = true }
 symbolic-common = { version = "8.6.1", path = "../symbolic-common" }
 thiserror = "1.0.20"
-wasmparser = { version = "0.82", optional = true }
+wasmparser = { version = "0.83", optional = true }
 zip = { version = "0.5.2", optional = true, default-features = false, features = [
     "deflate",
 ] }


### PR DESCRIPTION
All tests still passing on my machine with this bump. This may avoid duplicate crates for consumers of this crate.