### PR TITLE
feat: Collect referenced C# file sources

### DIFF
--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -104,6 +104,7 @@ zip = { version = "0.5.2", optional = true, default-features = false, features =
 [dev-dependencies]
 criterion = { version = "0.3.4", features = ["html_reports"] }
 insta = "1.3.0"
+tempfile = "3.1.0"
 similar-asserts = "1.0.0"
 symbolic-testutils = { path = "../symbolic-testutils" }
 

--- a/symbolic-il2cpp/src/line_mapping/from_object.rs
+++ b/symbolic-il2cpp/src/line_mapping/from_object.rs
@@ -58,9 +58,11 @@ impl ObjectLineMapping {
     ///
     /// The mapping is serialized in the form of nested objects:
     /// C++ file => C# file => C++ line => C# line
-    pub fn to_writer<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
+    ///
+    /// Returns `false` if the resulting JSON did not contain any mappings.
+    pub fn to_writer<W: Write>(&self, writer: &mut W) -> std::io::Result<bool> {
         serde_json::to_writer(writer, &self.0)?;
-        Ok(())
+        Ok(!self.0.is_empty())
     }
 }
 

--- a/symbolic-il2cpp/src/line_mapping/from_object.rs
+++ b/symbolic-il2cpp/src/line_mapping/from_object.rs
@@ -1,15 +1,19 @@
+use std::collections::BTreeMap;
+use std::io::Write;
 use std::iter::Enumerate;
 use std::str::Lines;
-use std::{collections::BTreeMap, io::Write};
 
-use symbolic_common::ByteView;
+use symbolic_common::{ByteView, DebugId};
 use symbolic_debuginfo::{DebugSession, ObjectLike};
 
 /// A line mapping extracted from an object.
 ///
 /// This is only intended as an intermediate structure for serialization,
 /// not for lookups.
-pub struct ObjectLineMapping(BTreeMap<String, BTreeMap<String, BTreeMap<u32, u32>>>);
+pub struct ObjectLineMapping {
+    mapping: BTreeMap<String, BTreeMap<String, BTreeMap<u32, u32>>>,
+    debug_id: DebugId,
+}
 
 impl ObjectLineMapping {
     /// Create a line mapping from the given `object`.
@@ -21,6 +25,7 @@ impl ObjectLineMapping {
         O: ObjectLike<'data, 'object, Error = E>,
     {
         let session = object.debug_session()?;
+        let debug_id = object.debug_id();
 
         let mut mapping = BTreeMap::new();
 
@@ -51,7 +56,7 @@ impl ObjectLineMapping {
             }
         }
 
-        Ok(Self(mapping))
+        Ok(Self { mapping, debug_id })
     }
 
     /// Serializes the line mapping to the given writer as JSON.
@@ -60,9 +65,20 @@ impl ObjectLineMapping {
     /// C++ file => C# file => C++ line => C# line
     ///
     /// Returns `false` if the resulting JSON did not contain any mappings.
-    pub fn to_writer<W: Write>(&self, writer: &mut W) -> std::io::Result<bool> {
-        serde_json::to_writer(writer, &self.0)?;
-        Ok(!self.0.is_empty())
+    pub fn to_writer<W: Write>(mut self, writer: &mut W) -> std::io::Result<bool> {
+        let is_empty = self.mapping.is_empty();
+
+        // This is a big hack: We need the files for different architectures to be different.
+        // To achieve this, we put the debug-id of the file (which is different between architectures)
+        // into the same structure as the normal map, like so:
+        // `"__debug-id__": {"00000000-0000-0000-0000-000000000000": {}}`
+        // When parsing via `LineMapping::parse`, this *looks like* a valid entry, but we will
+        // most likely never have a C++ file named `__debug-id__` ;-)
+        let value = BTreeMap::from([(self.debug_id.to_string(), Default::default())]);
+        self.mapping.insert("__debug-id__".to_owned(), value);
+
+        serde_json::to_writer(writer, &self.mapping)?;
+        Ok(!is_empty)
     }
 }
 

--- a/symbolic-il2cpp/src/line_mapping/mod.rs
+++ b/symbolic-il2cpp/src/line_mapping/mod.rs
@@ -25,6 +25,12 @@ impl LineMapping {
 
         if let serde_json::Value::Object(object) = json {
             for (cpp_file, file_map) in object {
+                // This is a sentinel value for the originating debug file, which
+                // `ObjectLineMapping::to_writer` writes to the file to make it unique
+                // (and dependent on the originating debug-id).
+                if cpp_file == "__debug-id__" {
+                    continue;
+                }
                 let mut lines = Vec::new();
                 if let serde_json::Value::Object(file_map) = file_map {
                     for (cs_file, line_map) in file_map {


### PR DESCRIPTION
Il2cpp leaves markers in its generated C++ source to the C# files certain snippets
of code come from. We follow those snippets to also bundle up the C# files they
reference, as we would want to also allow resolving the C# source later on.

The slightly unfortunate bit is that we now read all the files into memory and try to parse them, though hopefully that is not unreasonably slow.