### PR TITLE
ref: Turn minidump processor (breakpad) into optional feature (NATIVE-524)

### DIFF
--- a/symbolic-minidump/Cargo.toml
+++ b/symbolic-minidump/Cargo.toml
@@ -29,9 +29,13 @@ include = [
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+default = ["processor"]
+processor = ["lazy_static", "regex"]
+
 [dependencies]
-lazy_static = "1.4.0"
-regex = "1.3.5"
+lazy_static = { version = "1.4.0", optional = true }
+regex = { version = "1.3.5", optional = true }
 serde = { version = "1.0.94", optional = true }
 symbolic-common = { version = "8.6.1", path = "../symbolic-common" }
 symbolic-debuginfo = { version = "8.6.1", path = "../symbolic-debuginfo" }

--- a/symbolic-minidump/build.rs
+++ b/symbolic-minidump/build.rs
@@ -1,7 +1,13 @@
-use std::path::Path;
-use std::process::Command;
-
+#[cfg(not(feature = "processor"))]
 fn main() {
+    // NOOP
+}
+
+#[cfg(feature = "processor")]
+fn main() {
+    use std::path::Path;
+    use std::process::Command;
+
     if !Path::new("third_party/breakpad/src").exists() {
         let status = Command::new("git")
             .args(&["submodule", "update", "--init"])

--- a/symbolic-minidump/src/lib.rs
+++ b/symbolic-minidump/src/lib.rs
@@ -2,7 +2,10 @@
 
 #![warn(missing_docs)]
 
+#[cfg(feature = "processor")]
 mod utils;
 
 pub mod cfi;
+
+#[cfg(feature = "processor")]
 pub mod processor;

--- a/symbolic-minidump/tests/test_processor.rs
+++ b/symbolic-minidump/tests/test_processor.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "processor")]
+
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 


### PR DESCRIPTION
This feature flag makes it possible to avoid building and linking breakpad code.