### PR TITLE
feat(usym): Errors for usym[lite] parser

### DIFF
--- a/symbolic-il2cpp/Cargo.toml
+++ b/symbolic-il2cpp/Cargo.toml
@@ -20,6 +20,7 @@ scroll = "0.11"
 serde_json = "1.0.79"
 symbolic-common = { version = "8.6.1", path = "../symbolic-common" }
 symbolic-symcache = { version = "8.6.1", path = "../symbolic-symcache" }
+thiserror = "1.0.20"
 
 [dev-dependencies]
 memmap2 = "0.5.0"

--- a/symbolic-il2cpp/src/usym.rs
+++ b/symbolic-il2cpp/src/usym.rs
@@ -175,8 +175,8 @@ pub struct UsymSymbols<'a> {
     records: &'a [raw::SourceRecord],
     /// All the strings.
     ///
-    /// This is not a traditional strings section but rather a large slice of bytes with
-    /// length-prefixed strings, where the length is a little-endian u16.  The header and records
+    /// This is not a traditional strings table, but rather a large slice of bytes with
+    /// length-prefixed strings where the length is a little-endian u16.  The header and records
     /// refer to strings by byte offsets into this slice of bytes, which must fall on the
     /// the length prefixed part of the string.
     strings: &'a [u8],

--- a/symbolic-il2cpp/src/usym.rs
+++ b/symbolic-il2cpp/src/usym.rs
@@ -244,6 +244,7 @@ impl<'a> UsymSymbols<'a> {
         let strings = buf
             .get(strings_offset..)
             .ok_or_else(|| UsymError::from(UsymErrorKind::MissingStringTable))?;
+        // TODO: null byte checking at the end of the string table?
 
         let id_offset = header.id.try_into().unwrap();
         let id = match Self::get_string_from_offset(strings, id_offset)

--- a/symbolic-il2cpp/src/usym.rs
+++ b/symbolic-il2cpp/src/usym.rs
@@ -47,7 +47,7 @@ impl fmt::Display for UsymErrorKind {
         match self {
             UsymErrorKind::MisalignedBuffer => write!(f, "misaligned pointer to buffer"),
             UsymErrorKind::BadHeader => write!(f, "missing or undersized header"),
-            UsymErrorKind::BadMagic => write!(f, "missing breakpad symbol header"),
+            UsymErrorKind::BadMagic => write!(f, "missing or wrong usym magic bytes"),
             UsymErrorKind::BadVersion => write!(f, "missing or wrong version number"),
             UsymErrorKind::BadRecordCount => write!(f, "unreadable record count"),
             UsymErrorKind::BufferSmallerThanAdvertised => {
@@ -68,7 +68,7 @@ impl fmt::Display for UsymErrorKind {
     }
 }
 
-/// An error when dealing with [`BreakpadObject`](struct.BreakpadObject.html).
+/// An error when dealing with [`UsymSymbols`].
 #[derive(Debug, Error)]
 #[error("{kind}")]
 pub struct UsymError {
@@ -78,8 +78,7 @@ pub struct UsymError {
 }
 
 impl UsymError {
-    /// Creates a new Breakpad error from a known kind of error as well as an arbitrary error
-    /// payload.
+    /// Creates a new [`UsymError`] from a [`UsymErrorKind`] and an arbitrary source error payload.
     fn new<E>(kind: UsymErrorKind, source: E) -> Self
     where
         E: Into<Box<dyn Error + Send + Sync>>,

--- a/symbolic-il2cpp/src/usym.rs
+++ b/symbolic-il2cpp/src/usym.rs
@@ -20,7 +20,7 @@ pub enum UsymErrorKind {
     /// The magic string in the header is missing or malformed.
     BadMagic,
     /// The version string in the usym file's header is missing or malformed.
-    InvalidVersion,
+    BadVersion,
     /// The record count in the header can't be read.
     BadRecordCount,
     /// The size of the usym file is smaller than the amount of data it is supposed to hold
@@ -48,7 +48,7 @@ impl fmt::Display for UsymErrorKind {
             UsymErrorKind::MisalignedBuffer => write!(f, "misaligned pointer to buffer"),
             UsymErrorKind::BadHeader => write!(f, "missing or undersized header"),
             UsymErrorKind::BadMagic => write!(f, "missing breakpad symbol header"),
-            UsymErrorKind::InvalidVersion => write!(f, "invalid version number"),
+            UsymErrorKind::BadVersion => write!(f, "missing or wrong version number"),
             UsymErrorKind::BadRecordCount => write!(f, "unreadable record count"),
             UsymErrorKind::BufferSmallerThanAdvertised => {
                 write!(f, "buffer does not contain all data header claims it has")
@@ -214,7 +214,7 @@ impl<'a> UsymSymbols<'a> {
         // SAFETY: We checked the buffer is large enough above.
         let header = unsafe { &*(buf.as_ptr() as *const raw::Header) };
         if header.version != 2 {
-            return Err(UsymError::from(UsymErrorKind::InvalidVersion));
+            return Err(UsymError::from(UsymErrorKind::BadVersion));
         }
 
         let record_count: usize = header

--- a/symbolic-il2cpp/src/usymlite.rs
+++ b/symbolic-il2cpp/src/usymlite.rs
@@ -25,7 +25,7 @@ pub enum UsymLiteErrorKind {
     /// The magic string in the header is missing or malformed.
     BadMagic,
     /// The version string in the usym file's header is missing or malformed.
-    InvalidVersion,
+    BadVersion,
     /// The line count in the header can't be read.
     BadLineCount,
     /// The size of the usym file is smaller than the amount of data it is supposed to hold
@@ -55,7 +55,7 @@ impl fmt::Display for UsymLiteErrorKind {
             UsymLiteErrorKind::MisalignedBuffer => write!(f, "misaligned pointer to buffer"),
             UsymLiteErrorKind::BadHeader => write!(f, "missing or undersized header"),
             UsymLiteErrorKind::BadMagic => write!(f, "missing breakpad symbol header"),
-            UsymLiteErrorKind::InvalidVersion => write!(f, "invalid version number"),
+            UsymLiteErrorKind::BadVersion => write!(f, "missing or wrong version number"),
             UsymLiteErrorKind::BadLineCount => write!(f, "unreadable record count"),
             UsymLiteErrorKind::BufferSmallerThanAdvertised => {
                 write!(f, "buffer does not contain all data header claims it has")
@@ -172,7 +172,7 @@ impl<'a> UsymLiteSymbols<'a> {
         // SAFETY: We checked the buffer is large enough above.
         let header = unsafe { &*(buf.as_ptr() as *const UsymLiteHeader) };
         if header.version != 2 {
-            return Err(UsymLiteError::from(UsymLiteErrorKind::InvalidVersion));
+            return Err(UsymLiteError::from(UsymLiteErrorKind::BadVersion));
         }
         let line_count: usize = header
             .line_count

--- a/symbolic-il2cpp/src/usymlite.rs
+++ b/symbolic-il2cpp/src/usymlite.rs
@@ -6,13 +6,116 @@
 //! based on the native instruction pointer does not yet exist.
 
 use std::borrow::Cow;
+use std::error::Error;
 use std::ffi::CStr;
+use std::fmt;
 use std::mem;
 use std::os::raw::c_char;
 use std::ptr;
 
-use anyhow::{Error, Result};
+use thiserror::Error;
 
+/// The error type for [`UsymLiteError`].
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum UsymLiteErrorKind {
+    /// Buffer to usym file is misaligned.
+    MisalignedBuffer,
+    /// The header to the usym file is missing or undersized.
+    BadHeader,
+    /// The magic string in the header is missing or malformed.
+    BadMagic,
+    /// The version string in the usym file's header is missing or malformed.
+    InvalidVersion,
+    /// The line count in the header can't be read.
+    BadLineCount,
+    /// The size of the usym file is smaller than the amount of data it is supposed to hold
+    /// according to its header.
+    BufferSmallerThanAdvertised,
+    /// The string table is missing.
+    MissingStringTable,
+    /// The string table is not terminated by a NULL byte.
+    UnterminatedStringTable,
+    /// A valid slice to the usym's source records could not be created.
+    BadLines,
+    /// The assembly ID is missing or can't be read.
+    BadId,
+    /// The assembly name is missing or can't be read.
+    BadName,
+    /// The architecture is missing or can't be read.
+    BadOperatingSystem,
+    /// The architecture is missing or can't be read.
+    BadArchitecture,
+    /// A part of the file is not encoded in valid UTF-8.
+    BadEncoding,
+}
+
+impl fmt::Display for UsymLiteErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UsymLiteErrorKind::MisalignedBuffer => write!(f, "misaligned pointer to buffer"),
+            UsymLiteErrorKind::BadHeader => write!(f, "missing or undersized header"),
+            UsymLiteErrorKind::BadMagic => write!(f, "missing breakpad symbol header"),
+            UsymLiteErrorKind::InvalidVersion => write!(f, "invalid version number"),
+            UsymLiteErrorKind::BadLineCount => write!(f, "unreadable record count"),
+            UsymLiteErrorKind::BufferSmallerThanAdvertised => {
+                write!(f, "buffer does not contain all data header claims it has")
+            }
+            UsymLiteErrorKind::MissingStringTable => write!(f, "string table is missing"),
+            UsymLiteErrorKind::UnterminatedStringTable => {
+                write!(f, "string table does not end with a NULL byte")
+            }
+            UsymLiteErrorKind::BadLines => {
+                write!(f, "could not construct list of source records")
+            }
+            UsymLiteErrorKind::BadId => write!(f, "assembly ID is missing or unreadable"),
+            UsymLiteErrorKind::BadName => write!(f, "assembly name is missing or unreadable"),
+            UsymLiteErrorKind::BadOperatingSystem => {
+                write!(f, "operating system is missing or unreadable")
+            }
+            UsymLiteErrorKind::BadArchitecture => {
+                write!(f, "architecture is missing or unreadable")
+            }
+            UsymLiteErrorKind::BadEncoding => {
+                write!(f, "part of the file is not encoded in valid UTF-8")
+            }
+        }
+    }
+}
+
+/// An error when dealing with [`BreakpadObject`](struct.BreakpadObject.html).
+#[derive(Debug, Error)]
+#[error("{kind}")]
+pub struct UsymLiteError {
+    kind: UsymLiteErrorKind,
+    #[source]
+    source: Option<Box<dyn Error + Send + Sync + 'static>>,
+}
+
+impl UsymLiteError {
+    /// Creates a new Breakpad error from a known kind of error as well as an arbitrary error
+    /// payload.
+    fn new<E>(kind: UsymLiteErrorKind, source: E) -> Self
+    where
+        E: Into<Box<dyn Error + Send + Sync>>,
+    {
+        let source = Some(source.into());
+        Self { kind, source }
+    }
+
+    /// Returns the corresponding [`UsymLiteErrorKind`] for this error.
+    pub fn kind(&self) -> UsymLiteErrorKind {
+        self.kind
+    }
+}
+
+impl From<UsymLiteErrorKind> for UsymLiteError {
+    fn from(kind: UsymLiteErrorKind) -> Self {
+        Self { kind, source: None }
+    }
+}
+
+// TODO: Follow the same structure as usyms and introduce a raw module and other
+// types to distinguish between raw and parsed reps?
 #[derive(Debug, Clone)]
 #[repr(C)]
 struct UsymLiteHeader {
@@ -54,28 +157,33 @@ pub struct UsymLiteSymbols<'a> {
 impl<'a> UsymLiteSymbols<'a> {
     const MAGIC: &'static [u8] = b"sym-";
 
-    pub fn parse(buf: &'a [u8]) -> Result<UsymLiteSymbols<'a>> {
+    pub fn parse(buf: &'a [u8]) -> Result<UsymLiteSymbols<'a>, UsymLiteError> {
         if buf.as_ptr().align_offset(8) != 0 {
             // Alignment only really matters for performance really.
-            return Err(Error::msg("Data buffer not aligned to 8 bytes"));
+            return Err(UsymLiteError::from(UsymLiteErrorKind::MisalignedBuffer));
         }
         if buf.len() < mem::size_of::<UsymLiteHeader>() {
-            return Err(Error::msg("Data smaller than UsymLiteHeader"));
+            return Err(UsymLiteError::from(UsymLiteErrorKind::BadHeader));
         }
-        if buf.get(..4) != Some(Self::MAGIC) {
-            return Err(Error::msg("Wrong magic number"));
+        if buf.get(..Self::MAGIC.len()) != Some(Self::MAGIC) {
+            return Err(UsymLiteError::from(UsymLiteErrorKind::BadMagic));
         }
 
         // SAFETY: We checked the buffer is large enough above.
         let header = unsafe { &*(buf.as_ptr() as *const UsymLiteHeader) };
         if header.version != 2 {
-            return Err(Error::msg("Unknown version"));
+            return Err(UsymLiteError::from(UsymLiteErrorKind::InvalidVersion));
         }
-        let line_count: usize = header.line_count.try_into()?;
+        let line_count: usize = header
+            .line_count
+            .try_into()
+            .map_err(|e| UsymLiteError::new(UsymLiteErrorKind::BadLineCount, e))?;
         let stringtable_offset =
             mem::size_of::<UsymLiteHeader>() + line_count * mem::size_of::<UsymLiteLine>();
         if buf.len() < stringtable_offset {
-            return Err(Error::msg("Data smaller than number of line records"));
+            return Err(UsymLiteError::from(
+                UsymLiteErrorKind::BufferSmallerThanAdvertised,
+            ));
         }
 
         // SAFETY: We checked the buffer is at least the size_of::<UsymLiteHeader>() above.
@@ -87,14 +195,16 @@ impl<'a> UsymLiteSymbols<'a> {
             let lines_ptr = ptr::slice_from_raw_parts(lines_ptr, line_count);
             lines_ptr
                 .as_ref()
-                .ok_or_else(|| Error::msg("lines_ptr was null pointer!"))
+                .ok_or_else(|| UsymLiteError::from(UsymLiteErrorKind::BadLines))
         }?;
 
         let stringtable = buf
             .get(stringtable_offset..)
-            .ok_or_else(|| Error::msg("No string table found"))?;
+            .ok_or_else(|| UsymLiteError::from(UsymLiteErrorKind::MissingStringTable))?;
         if stringtable.last() != Some(&0u8) {
-            return Err(Error::msg("String table does not end in NULL byte"));
+            return Err(UsymLiteError::from(
+                UsymLiteErrorKind::UnterminatedStringTable,
+            ));
         }
 
         Ok(Self {
@@ -125,25 +235,22 @@ impl<'a> UsymLiteSymbols<'a> {
         Some(string)
     }
 
-    pub fn id(&self) -> Result<Cow<'a, str>> {
-        let s = self
-            .get_string(self.header.id)
-            .ok_or_else(|| Error::msg("bad offset or stringtable"))?;
-        Ok(s.to_string_lossy())
+    pub fn id(&self) -> Result<Cow<'a, str>, UsymLiteError> {
+        self.get_string(self.header.id)
+            .map(|s| s.to_string_lossy())
+            .ok_or_else(|| UsymLiteError::from(UsymLiteErrorKind::BadId))
     }
 
-    pub fn os(&self) -> Result<Cow<'a, str>> {
-        let s = self
-            .get_string(self.header.os)
-            .ok_or_else(|| Error::msg("bad offset or stringtable"))?;
-        Ok(s.to_string_lossy())
+    pub fn os(&self) -> Result<Cow<'a, str>, UsymLiteError> {
+        self.get_string(self.header.os)
+            .map(|s| s.to_string_lossy())
+            .ok_or_else(|| UsymLiteError::from(UsymLiteErrorKind::BadOperatingSystem))
     }
 
-    pub fn arch(&self) -> Result<Cow<'a, str>> {
-        let s = self
-            .get_string(self.header.arch)
-            .ok_or_else(|| Error::msg("bad offset or string table"))?;
-        Ok(s.to_string_lossy())
+    pub fn arch(&self) -> Result<Cow<'a, str>, UsymLiteError> {
+        self.get_string(self.header.arch)
+            .map(|s| s.to_string_lossy())
+            .ok_or_else(|| UsymLiteError::from(UsymLiteErrorKind::BadArchitecture))
     }
 
     pub fn get_record(&self, index: usize) -> Option<&UsymLiteLine> {
@@ -153,16 +260,16 @@ impl<'a> UsymLiteSymbols<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::File;
+    use std::{fs::File, io};
 
     use symbolic_common::ByteView;
     use symbolic_testutils::fixture;
 
     use super::*;
 
-    fn empty_usymlite() -> Result<ByteView<'static>> {
+    fn empty_usymlite() -> Result<ByteView<'static>, io::Error> {
         let file = File::open(fixture("il2cpp/empty.usymlite"))?;
-        ByteView::map_file_ref(&file).map_err(Into::into)
+        ByteView::map_file_ref(&file)
     }
 
     #[test]

--- a/symbolic-il2cpp/src/usymlite.rs
+++ b/symbolic-il2cpp/src/usymlite.rs
@@ -54,7 +54,7 @@ impl fmt::Display for UsymLiteErrorKind {
         match self {
             UsymLiteErrorKind::MisalignedBuffer => write!(f, "misaligned pointer to buffer"),
             UsymLiteErrorKind::BadHeader => write!(f, "missing or undersized header"),
-            UsymLiteErrorKind::BadMagic => write!(f, "missing breakpad symbol header"),
+            UsymLiteErrorKind::BadMagic => write!(f, "missing or wrong usymlite magic bytes"),
             UsymLiteErrorKind::BadVersion => write!(f, "missing or wrong version number"),
             UsymLiteErrorKind::BadLineCount => write!(f, "unreadable record count"),
             UsymLiteErrorKind::BufferSmallerThanAdvertised => {
@@ -82,7 +82,7 @@ impl fmt::Display for UsymLiteErrorKind {
     }
 }
 
-/// An error when dealing with [`BreakpadObject`](struct.BreakpadObject.html).
+/// An error when dealing with [`UsymLiteSymbols`].
 #[derive(Debug, Error)]
 #[error("{kind}")]
 pub struct UsymLiteError {
@@ -92,7 +92,7 @@ pub struct UsymLiteError {
 }
 
 impl UsymLiteError {
-    /// Creates a new Breakpad error from a known kind of error as well as an arbitrary error
+    /// Creates a new [`UsymLiteError`] error from a [`UsymLiteErrorKind`] and an arbitrary error
     /// payload.
     fn new<E>(kind: UsymLiteErrorKind, source: E) -> Self
     where


### PR DESCRIPTION
This starts adding in proper error types for the usym and usymlite parsers with a huge set of overly specific parsing-related members. This should hopefully help us get more useful errors out of the parsers once we start using them.

Minor refactors were also made to each parser's getters as I went through them, but they shouldn't change the existing behaviour of the code.

`anyhow` is still being used by the metadata parser and the dwarf parser in this crate, so it can't be removed yet.

Stacks on top of #527.