### PR TITLE
ref(usym): Use existing types instead of primitives for fields on UsymSymbols

### DIFF
--- a/symbolic-il2cpp/src/usym.rs
+++ b/symbolic-il2cpp/src/usym.rs
@@ -318,8 +318,8 @@ impl<'a> UsymSymbols<'a> {
     /// The ID of the assembly.
     ///
     /// This should match the ID of the debug symbols.
-    pub fn id(&self) -> Option<DebugId> {
-        DebugId::from_str(self.id).ok()
+    pub fn id(&self) -> Result<DebugId, UsymError> {
+        DebugId::from_str(self.id).map_err(|e| UsymError::new(UsymErrorKind::BadId, e))
     }
 
     /// The name of the assembly.
@@ -332,9 +332,9 @@ impl<'a> UsymSymbols<'a> {
         self.os
     }
 
-    /// The architecture name.
-    pub fn arch(&self) -> Option<Arch> {
-        Arch::from_str(self.arch).ok()
+    /// The architecture.
+    pub fn arch(&self) -> Result<Arch, UsymError> {
+        Arch::from_str(self.arch).map_err(|e| UsymError::new(UsymErrorKind::BadArchitecture, e))
     }
 
     /// Returns a [`UsymSourceRecord`] at the given index it was stored.
@@ -458,12 +458,12 @@ mod tests {
 
         assert_eq!(usyms.version(), 2);
         assert_eq!(
-            usyms.id(),
-            Some(DebugId::from_str("153d10d10db033d6aacda4e1948da97b").unwrap())
+            usyms.id().unwrap(),
+            DebugId::from_str("153d10d10db033d6aacda4e1948da97b").unwrap()
         );
         assert_eq!(usyms.name(), "UnityFramework");
         assert_eq!(usyms.os(), "mac");
-        assert_eq!(usyms.arch(), Some(Arch::Arm64));
+        assert_eq!(usyms.arch().unwrap(), Arch::Arm64);
     }
 
     #[test]

--- a/symbolic-il2cpp/src/usym.rs
+++ b/symbolic-il2cpp/src/usym.rs
@@ -7,7 +7,10 @@ use std::error::Error;
 use std::fmt;
 use std::mem;
 use std::ptr;
+use std::str::FromStr;
 
+use symbolic_common::Arch;
+use symbolic_common::DebugId;
 use thiserror::Error;
 
 /// The error type for [`UsymError`].
@@ -315,9 +318,8 @@ impl<'a> UsymSymbols<'a> {
     /// The ID of the assembly.
     ///
     /// This should match the ID of the debug symbols.
-    // TODO: Consider making this return debugid::DebugId
-    pub fn id(&self) -> &str {
-        self.id
+    pub fn id(&self) -> Option<DebugId> {
+        DebugId::from_str(self.id).ok()
     }
 
     /// The name of the assembly.
@@ -331,8 +333,8 @@ impl<'a> UsymSymbols<'a> {
     }
 
     /// The architecture name.
-    pub fn arch(&self) -> &str {
-        self.arch
+    pub fn arch(&self) -> Option<Arch> {
+        Arch::from_str(self.arch).ok()
     }
 
     /// Returns a [`UsymSourceRecord`] at the given index it was stored.
@@ -455,10 +457,13 @@ mod tests {
         let usyms = UsymSymbols::parse(&data).unwrap();
 
         assert_eq!(usyms.version(), 2);
-        assert_eq!(usyms.id(), "153d10d10db033d6aacda4e1948da97b");
+        assert_eq!(
+            usyms.id(),
+            Some(DebugId::from_str("153d10d10db033d6aacda4e1948da97b").unwrap())
+        );
         assert_eq!(usyms.name(), "UnityFramework");
         assert_eq!(usyms.os(), "mac");
-        assert_eq!(usyms.arch(), "arm64");
+        assert_eq!(usyms.arch(), Some(Arch::Arm64));
     }
 
     #[test]


### PR DESCRIPTION
We have types that represent debug IDs and architectures, so instead of returning plain strings for those UsymSymbols now returns those types. 

For the time being, those two fields are lazily converted into their respective types instead of during the parsing phase. I'm working on a different PR that explores the idea of leniently parsing as much of a usym file as possible which will explore the idea of aggressively converting these fields during parsing.

One awkward thing about this new API is that there's currently no way to access the raw debug ID or architecture if they fail to parse. If we feel that it's important to expose these I can explore adding getters for them. They probably won't be particularly useful, though.