### PR TITLE
feat(usym): Add C# to the list of languages that can be found in debugging info

### DIFF
--- a/symbolic-common/src/types.rs
+++ b/symbolic-common/src/types.rs
@@ -543,6 +543,7 @@ pub enum Language {
     ObjCpp = 6,
     Rust = 7,
     Swift = 8,
+    CSharp = 9,
 }
 
 impl Language {
@@ -569,6 +570,7 @@ impl Language {
             6 => Self::ObjCpp,
             7 => Self::Rust,
             8 => Self::Swift,
+            9 => Self::CSharp,
             _ => Self::Unknown,
         }
     }
@@ -601,6 +603,7 @@ impl Language {
             Language::ObjCpp => "objcpp",
             Language::Rust => "rust",
             Language::Swift => "swift",
+            Language::CSharp => "csharp",
         }
     }
 }
@@ -623,6 +626,7 @@ impl fmt::Display for Language {
             Language::ObjCpp => "Objective-C++",
             Language::Rust => "Rust",
             Language::Swift => "Swift",
+            Language::CSharp => "C#",
         };
 
         write!(f, "{}", formatted)


### PR DESCRIPTION
This adds C# to the list of languages that can be represented by functions in a symcache and/or functions extracted from various debugging file formats. This is in preparation for usym file parsing, whose entries should use this new language when they're converted into a symcache.