### PR TITLE
feat(usym): Add in some context on the last field in a record

### DIFF
--- a/symbolic-il2cpp/src/usym.rs
+++ b/symbolic-il2cpp/src/usym.rs
@@ -164,7 +164,9 @@ mod raw {
         pub(super) managed_file: u32,
         /// Managed code line number. This is 0 if the record does not map to any managed code.
         pub(super) managed_line: u32,
-        pub(super) _unknown: u32,
+        /// Unknown field. Normally set to FFFFFFFF, but investigations suggest that if this record
+        /// is for an inlinee function, this is set to the index of its parent record.
+        pub(super) maybe_parent_record_idx: u32,
     }
 }
 


### PR DESCRIPTION
Just a simple rename to a field to reflect what we currently do know (or what we think we know) about it so far.