### PR TITLE
ref(symcache): Make symbolic-symcache dependent on symbolic-il2cpp instead of the other way around

### DIFF
--- a/examples/symcache_debug/src/main.rs
+++ b/examples/symcache_debug/src/main.rs
@@ -10,6 +10,7 @@ use symbolic::common::{Arch, ByteView, DSymPathExt, Language, SelfCell};
 use symbolic::debuginfo::macho::BcSymbolMap;
 use symbolic::debuginfo::Archive;
 use symbolic::demangle::{Demangle, DemangleOptions};
+#[cfg(feature = "il2cpp")]
 use symbolic::il2cpp::LineMapping;
 use symbolic::symcache::transform::{self, Transformer};
 use symbolic::symcache::{SymCache, SymCacheWriter};
@@ -84,11 +85,14 @@ fn execute(matches: &ArgMatches) -> Result<()> {
             writer.add_transformer(bcsymbolmap);
         }
 
-        if let Some(linemapping_file) = matches.value_of("linemapping_file") {
-            let linemapping_path = Path::new(linemapping_file);
-            let linemapping_buffer = ByteView::open(linemapping_path)?;
-            if let Some(linemapping) = LineMapping::parse(&linemapping_buffer) {
-                writer.add_transformer(linemapping);
+        #[cfg(feature = "il2cpp")]
+        {
+            if let Some(linemapping_file) = matches.value_of("linemapping_file") {
+                let linemapping_path = Path::new(linemapping_file);
+                let linemapping_buffer = ByteView::open(linemapping_path)?;
+                if let Some(linemapping) = LineMapping::parse(&linemapping_buffer) {
+                    writer.add_transformer(linemapping);
+                }
             }
         }
 

--- a/symbolic-il2cpp/Cargo.toml
+++ b/symbolic-il2cpp/Cargo.toml
@@ -20,7 +20,6 @@ scroll = "0.11"
 serde_json = "1.0.79"
 symbolic-common = { version = "8.6.1", path = "../symbolic-common" }
 symbolic-debuginfo = { version = "8.6.1", path = "../symbolic-debuginfo" }
-symbolic-symcache = { version = "8.6.1", path = "../symbolic-symcache" }
 thiserror = "1.0.20"
 
 [dev-dependencies]

--- a/symbolic-il2cpp/src/line_mapping.rs
+++ b/symbolic-il2cpp/src/line_mapping.rs
@@ -1,6 +1,5 @@
 use indexmap::IndexSet;
 use std::collections::HashMap;
-use symbolic_symcache::transform::{self, Transformer};
 
 #[derive(Debug)]
 struct LineEntry {
@@ -63,38 +62,5 @@ impl LineMapping {
         } = lines.get(idx)?;
 
         Some((self.cs_files.get_index(*cs_file_idx)?, *cs_line))
-    }
-}
-
-fn full_path(file: &transform::File<'_>) -> String {
-    let comp_dir = file.comp_dir.as_deref().unwrap_or_default();
-    let directory = file.directory.as_deref().unwrap_or_default();
-    let path_name = &file.name;
-
-    let prefix = symbolic_common::join_path(comp_dir, directory);
-    let full_path = symbolic_common::join_path(&prefix, path_name);
-    symbolic_common::clean_path(&full_path).into_owned()
-}
-
-impl Transformer for LineMapping {
-    fn transform_function<'f>(&'f self, f: transform::Function<'f>) -> transform::Function<'f> {
-        f
-    }
-
-    fn transform_source_location<'f>(
-        &'f self,
-        mut sl: transform::SourceLocation<'f>,
-    ) -> transform::SourceLocation<'f> {
-        // TODO: this allocates, which is especially expensive since we run this transformer for
-        // every single source location (without dedupe-ing files). It might be worth caching this
-        let full_path = full_path(&sl.file);
-        if let Some((mapped_file, mapped_line)) = self.lookup(&full_path, sl.line) {
-            sl.file.name = mapped_file.into();
-            sl.file.comp_dir = None;
-            sl.file.directory = None;
-            sl.line = mapped_line;
-        }
-
-        sl
     }
 }

--- a/symbolic-symcache/Cargo.toml
+++ b/symbolic-symcache/Cargo.toml
@@ -27,6 +27,7 @@ dmsort = "1.0.1"
 fnv = "1.0.6"
 symbolic-common = { version = "8.7.0", path = "../symbolic-common" }
 symbolic-debuginfo = { version = "8.7.0", path = "../symbolic-debuginfo" }
+symbolic-il2cpp = { version = "8.7.0", path = "../symbolic-il2cpp", optional = true }
 thiserror = "1.0.20"
 indexmap = "1.7.0"
 
@@ -38,6 +39,7 @@ similar-asserts = "1.0.0"
 
 [features]
 bench = []
+il2cpp = ["symbolic-il2cpp"]
 
 [[bench]]
 name = "bench_writer"

--- a/symbolic-symcache/src/new/transform/bcsymbolmap.rs
+++ b/symbolic-symcache/src/new/transform/bcsymbolmap.rs
@@ -1,0 +1,45 @@
+//! Resolves obfuscated symbols against a BCSymbolMap before writing them to a SymCache.
+
+use std::borrow::Cow;
+
+use symbolic_debuginfo::macho::BcSymbolMap;
+
+use super::{File, Function, SourceLocation, Transformer};
+
+// This ended up as a macro which "inlines" mapping the `Cow` into the calling function, as using
+// a real function here would lead to the following borrow checker error:
+// error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'d` due to conflicting requirements
+macro_rules! map_cow {
+    ($cow:expr, $f: expr) => {
+        match $cow {
+            Cow::Borrowed(inner) => Cow::Borrowed($f(inner)),
+            Cow::Owned(inner) => Cow::Owned($f(&inner).to_owned()),
+        }
+    };
+}
+
+impl Transformer for BcSymbolMap<'_> {
+    fn transform_function<'f>(&'f self, f: Function<'f>) -> Function<'f> {
+        Function {
+            name: map_cow!(f.name, |s| self.resolve(s)),
+            comp_dir: f.comp_dir.map(|dir| map_cow!(dir, |s| self.resolve(s))),
+        }
+    }
+
+    fn transform_source_location<'f>(&'f self, sl: SourceLocation<'f>) -> SourceLocation<'f> {
+        SourceLocation {
+            file: File {
+                name: map_cow!(sl.file.name, |s| self.resolve(s)),
+                directory: sl
+                    .file
+                    .directory
+                    .map(|dir| map_cow!(dir, |s| self.resolve(s))),
+                comp_dir: sl
+                    .file
+                    .comp_dir
+                    .map(|dir| map_cow!(dir, |s| self.resolve(s))),
+            },
+            line: sl.line,
+        }
+    }
+}

--- a/symbolic-symcache/src/new/transform/il2cpp.rs
+++ b/symbolic-symcache/src/new/transform/il2cpp.rs
@@ -1,0 +1,36 @@
+//! Resolves IL2CPP-compiled native symbols into their managed equivalents using a mapping file
+//! before writing them to a SymCache.
+
+use symbolic_il2cpp::LineMapping;
+
+use super::{File, Function, SourceLocation, Transformer};
+
+fn full_path(file: &File<'_>) -> String {
+    let comp_dir = file.comp_dir.as_deref().unwrap_or_default();
+    let directory = file.directory.as_deref().unwrap_or_default();
+    let path_name = &file.name;
+
+    let prefix = symbolic_common::join_path(comp_dir, directory);
+    let full_path = symbolic_common::join_path(&prefix, path_name);
+    symbolic_common::clean_path(&full_path).into_owned()
+}
+
+impl Transformer for LineMapping {
+    fn transform_function<'f>(&'f self, f: Function<'f>) -> Function<'f> {
+        f
+    }
+
+    fn transform_source_location<'f>(&'f self, mut sl: SourceLocation<'f>) -> SourceLocation<'f> {
+        // TODO: this allocates, which is especially expensive since we run this transformer for
+        // every single source location (without dedupe-ing files). It might be worth caching this
+        let full_path = full_path(&sl.file);
+        if let Some((mapped_file, mapped_line)) = self.lookup(&full_path, sl.line) {
+            sl.file.name = mapped_file.into();
+            sl.file.comp_dir = None;
+            sl.file.directory = None;
+            sl.line = mapped_line;
+        }
+
+        sl
+    }
+}

--- a/symbolic-symcache/src/new/transform/mod.rs
+++ b/symbolic-symcache/src/new/transform/mod.rs
@@ -1,8 +1,12 @@
 //! Utilities that transform the Data to be written to a SymCache.
 
-use std::borrow::Cow;
+mod bcsymbolmap;
+pub use bcsymbolmap::*;
 
-use symbolic_debuginfo::macho::BcSymbolMap;
+#[cfg(feature = "il2cpp")]
+pub mod il2cpp;
+
+use std::borrow::Cow;
 
 /// A Function record to be written to the SymCache.
 #[non_exhaustive]
@@ -59,43 +63,5 @@ impl std::fmt::Debug for Transformers {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let len = self.0.len();
         f.debug_tuple("Transformers").field(&len).finish()
-    }
-}
-
-// This ended up as a macro which "inlines" mapping the `Cow` into the calling function, as using
-// a real function here would lead to the following borrow checker error:
-// error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'d` due to conflicting requirements
-macro_rules! map_cow {
-    ($cow:expr, $f: expr) => {
-        match $cow {
-            Cow::Borrowed(inner) => Cow::Borrowed($f(inner)),
-            Cow::Owned(inner) => Cow::Owned($f(&inner).to_owned()),
-        }
-    };
-}
-
-impl Transformer for BcSymbolMap<'_> {
-    fn transform_function<'f>(&'f self, f: Function<'f>) -> Function<'f> {
-        Function {
-            name: map_cow!(f.name, |s| self.resolve(s)),
-            comp_dir: f.comp_dir.map(|dir| map_cow!(dir, |s| self.resolve(s))),
-        }
-    }
-
-    fn transform_source_location<'f>(&'f self, sl: SourceLocation<'f>) -> SourceLocation<'f> {
-        SourceLocation {
-            file: File {
-                name: map_cow!(sl.file.name, |s| self.resolve(s)),
-                directory: sl
-                    .file
-                    .directory
-                    .map(|dir| map_cow!(dir, |s| self.resolve(s))),
-                comp_dir: sl
-                    .file
-                    .comp_dir
-                    .map(|dir| map_cow!(dir, |s| self.resolve(s))),
-            },
-            line: sl.line,
-        }
     }
 }


### PR DESCRIPTION
This reverses the dependency `symbolic-il2cpp` has on `symbolic-symcache`, so that the SymCache writer can import structs exposed by `symbolic-il2cpp` without introducing a circular dependency. This will be needed in a future PR when usym to SymCache conversion is introduced.

- `transform.rs` has been moved into its own dedicated directory, and specific `Transformer` implementations have been split off into their own dedicated submodules
- An `il2cpp` feature flag has been added to all of the other crates that integrate il2cpp functionality