### PR TITLE
ref(symcache): Transformers no longer have a 'static lifetime

### DIFF
--- a/examples/symcache_debug/src/main.rs
+++ b/examples/symcache_debug/src/main.rs
@@ -75,24 +75,14 @@ fn execute(matches: &ArgMatches) -> Result<()> {
 
         let mut writer = SymCacheWriter::new(Cursor::new(Vec::new()))?;
 
-        if let Some(bcsymbolmap_file) = matches.value_of("bcsymbolmap_file") {
-            let bcsymbolmap_path = Path::new(bcsymbolmap_file);
-            let bcsymbolmap_buffer = ByteView::open(bcsymbolmap_path)?;
-            let bcsymbolmap =
-                OwnedBcSymbolMap(SelfCell::try_new(bcsymbolmap_buffer, |s| unsafe {
-                    BcSymbolMap::parse(&*s)
-                })?);
-            writer.add_transformer(bcsymbolmap);
+        if let Some(transformer) = bcsymbolmap_transformer {
+            writer.add_transformer(transformer);
         }
 
         #[cfg(feature = "il2cpp")]
         {
-            if let Some(linemapping_file) = matches.value_of("linemapping_file") {
-                let linemapping_path = Path::new(linemapping_file);
-                let linemapping_buffer = ByteView::open(linemapping_path)?;
-                if let Some(linemapping) = LineMapping::parse(&linemapping_buffer) {
-                    writer.add_transformer(linemapping);
-                }
+            if let Some(transformer) = linemapping_transformer {
+                writer.add_transformer(transformer);
             }
         }
 

--- a/symbolic-symcache/src/new/compat.rs
+++ b/symbolic-symcache/src/new/compat.rs
@@ -55,12 +55,12 @@ impl<'data> Iterator for Functions<'data> {
 /// at the end, so that all segments are
 /// written to the underlying writer and the header is fixed up with the references. Since segments
 /// are consecutive chunks of memory, this can only be done once at the end of the writing process.
-pub struct SymCacheWriter<W> {
-    converter: SymCacheConverter,
+pub struct SymCacheWriter<'a, W> {
+    converter: SymCacheConverter<'a>,
     writer: W,
 }
 
-impl<W> SymCacheWriter<W>
+impl<'a, W> SymCacheWriter<'a, W>
 where
     W: Write + Seek,
 {
@@ -100,9 +100,9 @@ where
     /// this transformer before it is being written to the SymCache.
     pub fn add_transformer<T>(&mut self, t: T)
     where
-        T: transform::Transformer + 'static,
+        T: transform::Transformer + 'a,
     {
-        self.converter.add_transformer(t)
+        self.converter.add_transformer(t);
     }
 
     /// Processes the [`ObjectLike`], writing its functions, line information and symbols into the

--- a/symbolic-symcache/src/new/transform/mod.rs
+++ b/symbolic-symcache/src/new/transform/mod.rs
@@ -57,9 +57,9 @@ pub trait Transformer {
 
 // This is essentially just a newtype in order to implement `Debug`.
 #[derive(Default)]
-pub(crate) struct Transformers(pub Vec<Box<dyn Transformer>>);
+pub(crate) struct Transformers<'a>(pub Vec<Box<dyn Transformer + 'a>>);
 
-impl std::fmt::Debug for Transformers {
+impl<'a> std::fmt::Debug for Transformers<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let len = self.0.len();
         f.debug_tuple("Transformers").field(&len).finish()

--- a/symbolic-symcache/src/new/writer.rs
+++ b/symbolic-symcache/src/new/writer.rs
@@ -23,14 +23,14 @@ use crate::{SymCacheError, SymCacheErrorKind};
 /// This can convert data in various source formats to an intermediate representation, which can
 /// then be serialized to disk via its [`serialize`](SymCacheConverter::serialize) method.
 #[derive(Debug, Default)]
-pub struct SymCacheConverter {
+pub struct SymCacheConverter<'a> {
     /// Debug identifier of the object file.
     debug_id: DebugId,
     /// CPU architecture of the object file.
     arch: Arch,
 
     /// A list of transformers that are used to transform each function / source location.
-    transformers: transform::Transformers,
+    transformers: transform::Transformers<'a>,
 
     /// The concatenation of all strings that have been added to this `Converter`.
     string_bytes: Vec<u8>,
@@ -56,7 +56,7 @@ pub struct SymCacheConverter {
     last_addr: Option<u32>,
 }
 
-impl SymCacheConverter {
+impl<'a> SymCacheConverter<'a> {
     /// Creates a new Converter.
     pub fn new() -> Self {
         Self::default()
@@ -68,7 +68,7 @@ impl SymCacheConverter {
     /// this transformer before it is being written to the SymCache.
     pub fn add_transformer<T>(&mut self, t: T)
     where
-        T: transform::Transformer + 'static,
+        T: transform::Transformer + 'a,
     {
         self.transformers.0.push(Box::new(t));
     }

--- a/symbolic-symcache/tests/test_transformers.rs
+++ b/symbolic-symcache/tests/test_transformers.rs
@@ -46,17 +46,16 @@ fn test_transformer_symbolmap() -> Result<(), Error> {
     let object = Object::parse(&buffer)?;
 
     let mut buffer = Vec::new();
-    let writer = SymCacheWriter::new(Cursor::new(&mut buffer))?;
 
     let map_buffer = ByteView::open(
         "../symbolic-debuginfo/tests/fixtures/c8374b6d-6e96-34d8-ae38-efaa5fec424f.bcsymbolmap",
     )?;
     let bc_symbol_map = BcSymbolMap::parse(&map_buffer)?;
 
-    writer
-        .add_transformer(bc_symbol_map)
-        .process_object(&object)?
-        .finish()?;
+    let mut writer = SymCacheWriter::new(Cursor::new(&mut buffer))?;
+    writer.add_transformer(bc_symbol_map);
+    writer.process_object(&object)?;
+    let _ = writer.finish()?;
 
     let cache = SymCache::parse(&buffer)?;
 

--- a/symbolic-symcache/tests/test_transformers.rs
+++ b/symbolic-symcache/tests/test_transformers.rs
@@ -1,10 +1,9 @@
 use std::fmt;
 use std::io::Cursor;
 
-use symbolic_common::{ByteView, SelfCell};
+use symbolic_common::ByteView;
 use symbolic_debuginfo::macho::BcSymbolMap;
 use symbolic_debuginfo::Object;
-use symbolic_symcache::transform::{self, Transformer};
 use symbolic_symcache::{SymCache, SymCacheWriter};
 
 type Error = Box<dyn std::error::Error>;
@@ -39,22 +38,6 @@ impl fmt::Debug for FunctionsDebug<'_> {
     }
 }
 
-// FIXME: This is a huge pain, can't this be simpler somehow?
-struct OwnedBcSymbolMap(SelfCell<ByteView<'static>, BcSymbolMap<'static>>);
-
-impl Transformer for OwnedBcSymbolMap {
-    fn transform_function<'f>(&'f self, f: transform::Function<'f>) -> transform::Function<'f> {
-        self.0.get().transform_function(f)
-    }
-
-    fn transform_source_location<'f>(
-        &'f self,
-        sl: transform::SourceLocation<'f>,
-    ) -> transform::SourceLocation<'f> {
-        self.0.get().transform_source_location(sl)
-    }
-}
-
 #[test]
 fn test_transformer_symbolmap() -> Result<(), Error> {
     let buffer = ByteView::open(
@@ -63,20 +46,18 @@ fn test_transformer_symbolmap() -> Result<(), Error> {
     let object = Object::parse(&buffer)?;
 
     let mut buffer = Vec::new();
-    let mut writer = SymCacheWriter::new(Cursor::new(&mut buffer))?;
+    let writer = SymCacheWriter::new(Cursor::new(&mut buffer))?;
 
     let map_buffer = ByteView::open(
         "../symbolic-debuginfo/tests/fixtures/c8374b6d-6e96-34d8-ae38-efaa5fec424f.bcsymbolmap",
     )?;
-    let bc_symbol_map = OwnedBcSymbolMap(SelfCell::try_new(map_buffer, |s| unsafe {
-        BcSymbolMap::parse(&*s)
-    })?);
+    let bc_symbol_map = BcSymbolMap::parse(&map_buffer)?;
 
-    writer.add_transformer(bc_symbol_map);
+    writer
+        .add_transformer(bc_symbol_map)
+        .process_object(&object)?
+        .finish()?;
 
-    writer.process_object(&object)?;
-
-    let _ = writer.finish()?;
     let cache = SymCache::parse(&buffer)?;
 
     let sl = cache.lookup(0x5a74)?.next().unwrap()?;


### PR DESCRIPTION
While exploring ways to write tests for #543, I stumbled upon a todo which if fixed would make my life a lot easier. 

I started digging around and noticed that `Transformer`s were required to have a static lifetime: This was likely due to a suggestion made by clippy to be explicit about the lifetime on the `Box` wrapping around `Transformer`s in the symcache, and `Box`es have static lifetimes by default. This has generated some large-ish workarounds to satisfy this lifetime.

The lifetime on a `Transformer` doesn't need to be that long to begin with, so I've just simply restricted it to the lifespan of the writer it's attached to. Some shuffling needed to be done with the code instantiating these transformers to avoid issues related to data being potentially accessed in a deconstructor after it is dropped (?).