### PR TITLE
ref(symcache): Make functions non-optional

### DIFF
--- a/symbolic-symcache/src/compat.rs
+++ b/symbolic-symcache/src/compat.rs
@@ -307,16 +307,10 @@ impl<'data, 'cache> Iterator for Lookup<'data, 'cache> {
             LookupInner::Old(lookup) => lookup.next(),
             LookupInner::New { iter, lookup_addr } => {
                 let sl = iter.next()?;
-
-                let entry_pc = sl.function().entry_pc();
                 Some(Ok(old::LineInfo {
                     arch: sl.cache.arch(),
                     debug_id: sl.cache.debug_id(),
-                    sym_addr: if entry_pc == u32::MAX {
-                        u64::MAX
-                    } else {
-                        entry_pc as u64
-                    },
+                    sym_addr: sl.function().entry_pc() as u64,
                     line_addr: *lookup_addr,
                     instr_addr: *lookup_addr,
                     line: sl.line(),

--- a/symbolic-symcache/src/compat.rs
+++ b/symbolic-symcache/src/compat.rs
@@ -186,7 +186,7 @@ impl<'data> Function<'data> {
     pub fn symbol(&self) -> &'data str {
         match &self.0 {
             FunctionInner::Old(function) => function.symbol(),
-            FunctionInner::New((_, function)) => function.name().unwrap_or("?"),
+            FunctionInner::New((_, function)) => function.name(),
         }
     }
 
@@ -204,11 +204,9 @@ impl<'data> Function<'data> {
     pub fn name(&self) -> Name<'_> {
         match &self.0 {
             FunctionInner::Old(function) => function.name(),
-            FunctionInner::New((_, function)) => Name::new(
-                function.name().unwrap_or("?"),
-                NameMangling::Unknown,
-                function.language(),
-            ),
+            FunctionInner::New((_, function)) => {
+                Name::new(function.name(), NameMangling::Unknown, function.language())
+            }
         }
     }
 
@@ -310,18 +308,20 @@ impl<'data, 'cache> Iterator for Lookup<'data, 'cache> {
             LookupInner::New { iter, lookup_addr } => {
                 let sl = iter.next()?;
 
+                let entry_pc = sl.function().entry_pc();
                 Some(Ok(old::LineInfo {
                     arch: sl.cache.arch(),
                     debug_id: sl.cache.debug_id(),
-                    sym_addr: sl
-                        .function()
-                        .map(|f| f.entry_pc() as u64)
-                        .unwrap_or(u64::MAX),
+                    sym_addr: if entry_pc == u32::MAX {
+                        u64::MAX
+                    } else {
+                        entry_pc as u64
+                    },
                     line_addr: *lookup_addr,
                     instr_addr: *lookup_addr,
                     line: sl.line(),
-                    lang: sl.function().map(|f| f.language()).unwrap_or_default(),
-                    symbol: sl.function().and_then(|f| f.name()),
+                    lang: sl.function().language(),
+                    symbol: Some(sl.function().name()),
                     filename: sl.file().map(|f| f.path_name()).unwrap_or_default(),
                     base_dir: sl.file().and_then(|f| f.directory()).unwrap_or_default(),
                     comp_dir: sl.file().and_then(|f| f.comp_dir()).unwrap_or_default(),

--- a/symbolic-symcache/src/lib.rs
+++ b/symbolic-symcache/src/lib.rs
@@ -29,7 +29,8 @@
 //! ## Functions
 //!
 //! A function contains string offsets for its name and compilation directory, a u32 for its entry
-//! address, and a u32 representing the source language.
+//! address, and a u32 representing the source language. The name is non-optional, i.e., the name
+//! index should always point to a valid string.
 //!
 //! ## Address Ranges
 //!
@@ -40,7 +41,7 @@
 //! A source location in a symcache represents a possibly-inlined copy of a line in a source file.
 //! It contains a line number, a reference to a file (see above), a reference to a function (ditto),
 //! and a reference to the source location into which this source location was inlined. All of these
-//! data are optional.
+//! data except for the function are optional.
 //!
 //! ## Mapping From Ranges To Source Locations
 //!

--- a/symbolic-symcache/src/new/lookup.rs
+++ b/symbolic-symcache/src/new/lookup.rs
@@ -52,7 +52,7 @@ impl<'data> SymCache<'data> {
     pub(crate) fn get_function(&self, function_idx: u32) -> Option<Function<'data>> {
         let raw_function = self.functions.get(function_idx as usize)?;
         Some(Function {
-            name: self.get_string(raw_function.name_offset).unwrap(),
+            name: self.get_string(raw_function.name_offset).unwrap_or("?"),
             comp_dir: self.get_string(raw_function.comp_dir_offset),
             entry_pc: raw_function.entry_pc,
             language: Language::from_u32(raw_function.lang),
@@ -151,6 +151,17 @@ impl<'data> Function<'data> {
     }
 }
 
+impl<'data> Default for Function<'data> {
+    fn default() -> Self {
+        Self {
+            name: "?",
+            comp_dir: None,
+            entry_pc: u32::MAX,
+            language: Language::Unknown,
+        }
+    }
+}
+
 /// A Source Location as included in the SymCache.
 ///
 /// The source location represents a `(function, file, line, inlined_into)` tuple corresponding to
@@ -178,7 +189,7 @@ impl<'data, 'cache> SourceLocation<'data, 'cache> {
     pub fn function(&self) -> Function<'data> {
         self.cache
             .get_function(self.source_location.function_idx)
-            .unwrap()
+            .unwrap_or_default()
     }
 
     // TODO: maybe forward some of the `File` and `Function` accessors, such as:

--- a/symbolic-symcache/src/new/lookup.rs
+++ b/symbolic-symcache/src/new/lookup.rs
@@ -52,7 +52,7 @@ impl<'data> SymCache<'data> {
     pub(crate) fn get_function(&self, function_idx: u32) -> Option<Function<'data>> {
         let raw_function = self.functions.get(function_idx as usize)?;
         Some(Function {
-            name: self.get_string(raw_function.name_offset),
+            name: self.get_string(raw_function.name_offset).unwrap(),
             comp_dir: self.get_string(raw_function.comp_dir_offset),
             entry_pc: raw_function.entry_pc,
             language: Language::from_u32(raw_function.lang),
@@ -123,7 +123,7 @@ impl<'data> File<'data> {
 /// A Function definition as included in the SymCache.
 #[derive(Clone, Debug)]
 pub struct Function<'data> {
-    name: Option<&'data str>,
+    name: &'data str,
     comp_dir: Option<&'data str>,
     entry_pc: u32,
     language: Language,
@@ -131,7 +131,7 @@ pub struct Function<'data> {
 
 impl<'data> Function<'data> {
     /// The possibly mangled name/symbol of this function.
-    pub fn name(&self) -> Option<&'data str> {
+    pub fn name(&self) -> &'data str {
         self.name
     }
 
@@ -175,8 +175,10 @@ impl<'data, 'cache> SourceLocation<'data, 'cache> {
     }
 
     /// The function corresponding to the instruction.
-    pub fn function(&self) -> Option<Function<'data>> {
-        self.cache.get_function(self.source_location.function_idx)
+    pub fn function(&self) -> Function<'data> {
+        self.cache
+            .get_function(self.source_location.function_idx)
+            .unwrap()
     }
 
     // TODO: maybe forward some of the `File` and `Function` accessors, such as:


### PR DESCRIPTION
I'm splitting the work of removing the old symcache into multiple PRs; this is the first. It makes it so that
1. every `SourceLocation` must point to a function and
2. every function must have a valid name.

Both the `process_object` and `process_usym` already work this way, i.e., they should never create a `SourceLocation` without a function or a function without a name. If we nevertheless want to avoid the `unwrap`s, we could return a dummy name/dummy function instead.

#skip-changelog