### PR TITLE
ref(symcache): Gate SymCache::functions behind feature

### DIFF
--- a/examples/symcache_debug/Cargo.toml
+++ b/examples/symcache_debug/Cargo.toml
@@ -10,4 +10,4 @@ publish = false
 [dependencies]
 anyhow = "1.0.32"
 clap = "3.1.0"
-symbolic = { path = "../../symbolic", features = ["symcache", "demangle", "il2cpp"] }
+symbolic = { path = "../../symbolic", features = ["symcache", "demangle", "il2cpp", "_internal-symcache-debug"] }

--- a/symbolic-symcache/Cargo.toml
+++ b/symbolic-symcache/Cargo.toml
@@ -20,7 +20,10 @@ exclude = [
 ]
 
 [package.metadata.docs.rs]
-all-features = true
+features = [
+    "bench",
+    "il2cpp",
+]
 
 [dependencies]
 dmsort = "1.0.1"
@@ -40,6 +43,7 @@ similar-asserts = "1.0.0"
 [features]
 bench = []
 il2cpp = ["symbolic-il2cpp"]
+_internal-debug = []
 
 [[bench]]
 name = "bench_writer"

--- a/symbolic-symcache/src/compat.rs
+++ b/symbolic-symcache/src/compat.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 
-use symbolic_common::{Arch, AsSelf, DebugId, Language, Name, NameMangling};
+use symbolic_common::{Arch, AsSelf, DebugId};
+#[cfg(feature = "_internal-debug")]
+use symbolic_common::{Language, Name, NameMangling};
 
 use crate::{new, old, preamble, SymCacheError};
 
@@ -95,8 +97,7 @@ impl<'data> SymCache<'data> {
     }
 
     /// Returns an iterator over all functions.
-    #[deprecated(since = "8.6.0", note = "this will be removed in a future version")]
-    #[allow(deprecated)]
+    #[cfg(feature = "_internal-debug")]
     pub fn functions(&self) -> Functions<'data> {
         match &self.0 {
             #[allow(deprecated)]
@@ -144,6 +145,7 @@ impl<'slf, 'd: 'slf> AsSelf<'slf> for SymCache<'d> {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "_internal-debug")]
 enum FunctionInner<'data> {
     Old(old::Function<'data>),
     New((usize, new::Function<'data>)),
@@ -151,10 +153,10 @@ enum FunctionInner<'data> {
 
 /// A function in a `SymCache`.
 #[derive(Clone)]
-#[deprecated(since = "8.6.0", note = "this will be removed in a future version")]
+#[cfg(feature = "_internal-debug")]
 pub struct Function<'data>(FunctionInner<'data>);
 
-#[allow(deprecated)]
+#[cfg(feature = "_internal-debug")]
 impl<'data> Function<'data> {
     /// The ID of the function.
     pub fn id(&self) -> usize {
@@ -227,7 +229,7 @@ impl<'data> Function<'data> {
     }
 }
 
-#[allow(deprecated)]
+#[cfg(feature = "_internal-debug")]
 impl<'data> fmt::Debug for Function<'data> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
@@ -238,6 +240,7 @@ impl<'data> fmt::Debug for Function<'data> {
 }
 
 #[derive(Clone, Debug)]
+#[cfg(feature = "_internal-debug")]
 enum FunctionsInner<'data> {
     Old(old::Functions<'data>),
     New(std::iter::Enumerate<new::Functions<'data>>),
@@ -245,10 +248,10 @@ enum FunctionsInner<'data> {
 
 /// An iterator over all functions in a `SymCache`.
 #[derive(Clone)]
-#[deprecated(since = "8.6.0", note = "this will be removed in a future version")]
+#[cfg(feature = "_internal-debug")]
 pub struct Functions<'data>(FunctionsInner<'data>);
 
-#[allow(deprecated)]
+#[cfg(feature = "_internal-debug")]
 impl<'data> Iterator for Functions<'data> {
     type Item = Result<Function<'data>, SymCacheError>;
 
@@ -266,7 +269,7 @@ impl<'data> Iterator for Functions<'data> {
     }
 }
 
-#[allow(deprecated)]
+#[cfg(feature = "_internal-debug")]
 impl<'data> fmt::Debug for Functions<'data> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
@@ -334,6 +337,7 @@ impl<'data, 'cache> fmt::Debug for Lookup<'data, 'cache> {
     }
 }
 
+#[cfg(feature = "_internal-debug")]
 #[derive(Clone)]
 enum LinesInner<'data> {
     Old(old::Lines<'data>),
@@ -341,9 +345,11 @@ enum LinesInner<'data> {
 }
 
 /// An iterator over lines of a SymCache function.
+#[cfg(feature = "_internal-debug")]
 #[derive(Clone)]
 pub struct Lines<'data>(LinesInner<'data>);
 
+#[cfg(feature = "_internal-debug")]
 impl<'a> Iterator for Lines<'a> {
     type Item = Result<old::Line<'a>, SymCacheError>;
 

--- a/symbolic-symcache/src/new/compat.rs
+++ b/symbolic-symcache/src/new/compat.rs
@@ -24,6 +24,7 @@ impl<'data> SymCache<'data> {
     }
 
     /// An iterator over the functions in this SymCache.
+    #[cfg(feature = "_internal-debug")]
     pub fn functions(&self) -> Functions<'data> {
         Functions {
             cache: self.clone(),
@@ -32,12 +33,14 @@ impl<'data> SymCache<'data> {
     }
 }
 
+#[cfg(feature = "_internal-debug")]
 #[derive(Debug, Clone)]
 pub struct Functions<'data> {
     cache: SymCache<'data>,
     function_idx: u32,
 }
 
+#[cfg(feature = "_internal-debug")]
 impl<'data> Iterator for Functions<'data> {
     type Item = Function<'data>;
 

--- a/symbolic/Cargo.toml
+++ b/symbolic/Cargo.toml
@@ -17,7 +17,20 @@ minidumps, Unreal Engine 4, minified JavaScripts or ProGuard optimized Android a
 edition = "2018"
 
 [package.metadata.docs.rs]
-all-features = true
+# All features except "_internal_symcache_debug"
+features = [
+  "common-serde",
+  "debuginfo",
+  "debuginfo-serde",
+  "demangle",
+  "il2cpp",
+  "minidump",
+  "minidump-serde",
+  "sourcemap",
+  "symcache",
+  "unreal",
+  "unreal-serde"
+]
 
 [features]
 default = ["debuginfo"]
@@ -32,6 +45,7 @@ sourcemap = ["symbolic-sourcemap"]
 symcache = ["symbolic-symcache", "debuginfo"]
 unreal = ["symbolic-unreal"]
 unreal-serde = ["unreal", "common-serde", "symbolic-unreal/serde"]
+_internal-symcache-debug = ["symbolic-symcache/_internal-debug"]
 
 [dependencies]
 symbolic-common = { version = "8.7.0", path = "../symbolic-common" }


### PR DESCRIPTION
This gates the `functions` method on SymCache behind a "hidden" feature so that we don't have to maintain it as part of the public API but can still use it for debugging purposes.

#skip-changelog