### PR TITLE
fix: Make the Win-x64 CFI code more faithful

### DIFF
--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -1005,7 +1005,7 @@ impl<W: Write> AsciiCfiWriter<W> {
                             let rip_offset = stack_size + 40;
                             write!(
                                 &mut saved_regs,
-                                " $rsp: .cfa {} - ^ .ra: cfa {} - ^",
+                                " $rsp: .cfa {} - ^ .ra: .cfa {} - ^",
                                 rsp_offset, rip_offset,
                             )?;
                             stack_size += 40;

--- a/symbolic-minidump/src/cfi.rs
+++ b/symbolic-minidump/src/cfi.rs
@@ -39,7 +39,7 @@ use symbolic_debuginfo::macho::{
 };
 use symbolic_debuginfo::pdb::pdb::{self, FallibleIterator, FrameData, Rva, StringTable};
 use symbolic_debuginfo::pdb::PdbObject;
-use symbolic_debuginfo::pe::{PeObject, RuntimeFunction, UnwindOperation};
+use symbolic_debuginfo::pe::{PeObject, RuntimeFunction, StackFrameOffset, UnwindOperation};
 use symbolic_debuginfo::{Object, ObjectError, ObjectLike};
 
 /// The magic file preamble to identify cficache files.
@@ -903,6 +903,10 @@ impl<W: Write> AsciiCfiWriter<W> {
             None => return Ok(()),
         };
 
+        let mut cfa_reg = Vec::new();
+        let mut saved_regs = Vec::new();
+        let mut unwind_codes = Vec::new();
+
         for function_result in exception_data {
             let function =
                 function_result.map_err(|e| CfiError::new(CfiErrorKind::BadDebugInfo, e))?;
@@ -914,7 +918,7 @@ impl<W: Write> AsciiCfiWriter<W> {
             }
 
             // The minimal stack size is 8 for RIP
-            let mut stack_size = 8;
+            let mut stack_size: u32 = 8;
             // Special handling for machine frames
             let mut machine_frame_offset = 0;
 
@@ -922,12 +926,16 @@ impl<W: Write> AsciiCfiWriter<W> {
                 continue;
             }
 
+            cfa_reg.clear();
+            saved_regs.clear();
+
             let mut next_function = Some(function);
             while let Some(next) = next_function {
                 let unwind_info = exception_data
                     .get_unwind_info(next, sections)
                     .map_err(|e| CfiError::new(CfiErrorKind::BadDebugInfo, e))?;
 
+                unwind_codes.clear();
                 for code_result in &unwind_info {
                     // Due to variable length encoding of operator codes, there is little point in
                     // continuiing after this. Other functions in this object file can be valid, so
@@ -936,17 +944,73 @@ impl<W: Write> AsciiCfiWriter<W> {
                         Ok(code) => code,
                         Err(_) => return Ok(()),
                     };
+                    unwind_codes.push(code);
+                }
 
+                // The unwind codes are saved in reverse order.
+                for code in unwind_codes.iter().rev() {
                     match code.operation {
-                        UnwindOperation::PushNonVolatile(_) => {
+                        UnwindOperation::SaveNonVolatile(reg, offset) => {
+                            match offset {
+                                // If the Frame Register field in the UNWIND_INFO is zero,
+                                // this offset is from RSP.
+                                StackFrameOffset::RSP(offset) => {
+                                    write!(
+                                        &mut saved_regs,
+                                        " {}: .cfa {} - ^",
+                                        reg.name(),
+                                        stack_size.saturating_sub(offset)
+                                    )?;
+                                }
+                                // If the Frame Register field is nonzero, this offset is from where
+                                // RSP was located when the FP register was established.
+                                // It equals the FP register minus the FP register offset
+                                // (16 * the scaled frame register offset in the UNWIND_INFO).
+                                StackFrameOffset::FP(offset) => {
+                                    write!(
+                                        &mut saved_regs,
+                                        " {}: {} {} + ^",
+                                        reg.name(),
+                                        unwind_info.frame_register.name(),
+                                        offset.saturating_sub(unwind_info.frame_register_offset)
+                                    )?;
+                                }
+                            };
+                        }
+                        UnwindOperation::PushNonVolatile(reg) => {
+                            // $reg = .cfa - current_offset
                             stack_size += 8;
+                            write!(&mut saved_regs, " {}: .cfa {} - ^", reg.name(), stack_size)?;
                         }
                         UnwindOperation::Alloc(size) => {
                             stack_size += size;
                         }
+                        UnwindOperation::SetFPRegister => {
+                            // Establish the frame pointer register by setting the register to some
+                            // offset of the current RSP. The offset is equal to the Frame Register
+                            // offset field in the UNWIND_INFO.
+                            let offset =
+                                stack_size.saturating_sub(unwind_info.frame_register_offset);
+                            // Set the `.cfa = $fp + offset`
+                            write!(
+                                &mut cfa_reg,
+                                ".cfa: {} {} +",
+                                unwind_info.frame_register.name(),
+                                offset
+                            )?;
+                        }
+
                         UnwindOperation::PushMachineFrame(is_error) => {
-                            stack_size += if is_error { 48 } else { 40 };
+                            let rsp_offset = stack_size + 16;
+                            let rip_offset = stack_size + 40;
+                            write!(
+                                &mut saved_regs,
+                                " $rsp: .cfa {} - ^ .ra: cfa {} - ^",
+                                rsp_offset, rip_offset,
+                            )?;
+                            stack_size += 40;
                             machine_frame_offset = stack_size;
+                            stack_size += if is_error { 8 } else { 0 };
                         }
                         _ => {
                             // All other codes do not modify RSP
@@ -957,29 +1021,22 @@ impl<W: Write> AsciiCfiWriter<W> {
                 next_function = unwind_info.chained_info;
             }
 
-            writeln!(
+            if cfa_reg.is_empty() {
+                write!(&mut cfa_reg, ".cfa: $rsp {} +", stack_size)?;
+            }
+            if machine_frame_offset == 0 {
+                write!(&mut saved_regs, " .ra: .cfa 8 - ^")?;
+            }
+
+            write!(
                 self.inner,
-                "STACK CFI INIT {:x} {:x} .cfa: $rsp 8 + .ra: .cfa 8 - ^",
+                "STACK CFI INIT {:x} {:x} ",
                 function.begin_address,
                 function.end_address - function.begin_address,
             )?;
-
-            if machine_frame_offset > 0 {
-                writeln!(
-                    self.inner,
-                    "STACK CFI {:x} .cfa: $rsp {} + $rsp: .cfa {} - ^ .ra: .cfa {} - ^",
-                    function.begin_address,
-                    stack_size,
-                    stack_size - machine_frame_offset + 24, // old RSP offset
-                    stack_size - machine_frame_offset + 48, // entire frame offset
-                )?
-            } else {
-                writeln!(
-                    self.inner,
-                    "STACK CFI {:x} .cfa: $rsp {} +",
-                    function.begin_address, stack_size,
-                )?
-            }
+            self.inner.write_all(&cfa_reg)?;
+            self.inner.write_all(&saved_regs)?;
+            writeln!(self.inner)?;
         }
 
         Ok(())

--- a/symbolic-minidump/tests/snapshots/test_cfi__cfi_pe_windows.snap
+++ b/symbolic-minidump/tests/snapshots/test_cfi__cfi_pe_windows.snap
@@ -1,89 +1,48 @@
 ---
-created: "2019-04-03T18:49:08.328139Z"
-creator: insta@0.7.4
-source: minidump/tests/test_cfi.rs
+source: symbolic-minidump/tests/test_cfi.rs
+assertion_line: 105
 expression: cfi
+
 ---
-STACK CFI INIT 1010 55 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1010 .cfa: $rsp 80 +
-STACK CFI INIT 10b0 43 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 10b0 .cfa: $rsp 48 +
-STACK CFI INIT 1120 2d .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1120 .cfa: $rsp 48 +
-STACK CFI INIT 1150 18 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1150 .cfa: $rsp 64 +
-STACK CFI INIT 1170 a .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1170 .cfa: $rsp 48 +
+STACK CFI INIT 1010 55 .cfa: $rsp 80 + $rbx: .cfa 16 - ^ $rsi: .cfa 24 - ^ $rdi: .cfa 32 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 10b0 43 .cfa: $rsp 48 + $rdi: .cfa 16 - ^ $rbx: .cfa 0 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 1120 2d .cfa: $rsp 48 + .ra: .cfa 8 - ^
+STACK CFI INIT 1150 18 .cfa: $rsp 64 + .ra: .cfa 8 - ^
+STACK CFI INIT 1170 a .cfa: $rsp 48 + .ra: .cfa 8 - ^
 STACK CFI INIT 1190 21 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1190 .cfa: $rsp 8 +
-STACK CFI INIT 11bc 3c .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 11bc .cfa: $rsp 48 +
-STACK CFI INIT 11f8 2b .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 11f8 .cfa: $rsp 48 +
-STACK CFI INIT 1224 b7 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1224 .cfa: $rsp 48 +
-STACK CFI INIT 12dc 10 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 12dc .cfa: $rsp 48 +
-STACK CFI INIT 12ec 19 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 12ec .cfa: $rsp 48 +
-STACK CFI INIT 1308 17c .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1308 .cfa: $rsp 64 +
-STACK CFI INIT 1484 12 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1484 .cfa: $rsp 48 +
-STACK CFI INIT 1498 34 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1498 .cfa: $rsp 48 +
-STACK CFI INIT 14cc d1 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 14cc .cfa: $rsp 64 +
-STACK CFI INIT 15a0 71 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 15a0 .cfa: $rsp 96 +
-STACK CFI INIT 161c 3f .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 161c .cfa: $rsp 48 +
-STACK CFI INIT 167c 3f .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 167c .cfa: $rsp 48 +
-STACK CFI INIT 16dc 35 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 16dc .cfa: $rsp 48 +
-STACK CFI INIT 1728 42 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1728 .cfa: $rsp 48 +
-STACK CFI INIT 176c 20 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 176c .cfa: $rsp 80 +
-STACK CFI INIT 178c 20 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 178c .cfa: $rsp 80 +
-STACK CFI INIT 17ac 39 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 17ac .cfa: $rsp 48 +
-STACK CFI INIT 17e8 49 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 17e8 .cfa: $rsp 48 +
-STACK CFI INIT 1834 d8 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1834 .cfa: $rsp 80 +
-STACK CFI INIT 190c 99 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 190c .cfa: $rsp 32 +
-STACK CFI INIT 19a8 24 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 19a8 .cfa: $rsp 48 +
-STACK CFI INIT 19cc 2b .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 19cc .cfa: $rsp 48 +
-STACK CFI INIT 19f8 4f .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 19f8 .cfa: $rsp 48 +
-STACK CFI INIT 1a48 17 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1a48 .cfa: $rsp 48 +
-STACK CFI INIT 1a60 ac .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1a60 .cfa: $rsp 48 +
-STACK CFI INIT 1b40 1b .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1b40 .cfa: $rsp 48 +
-STACK CFI INIT 1b80 14a .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1b80 .cfa: $rsp 1488 +
-STACK CFI INIT 1cd4 52 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1cd4 .cfa: $rsp 48 +
-STACK CFI INIT 1d38 38 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1d38 .cfa: $rsp 48 +
-STACK CFI INIT 1d70 3c .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1d70 .cfa: $rsp 48 +
-STACK CFI INIT 1dac 3c .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1dac .cfa: $rsp 48 +
-STACK CFI INIT 1de8 1b9 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 1de8 .cfa: $rsp 48 +
+STACK CFI INIT 11bc 3c .cfa: $rsp 48 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 11f8 2b .cfa: $rsp 48 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 1224 b7 .cfa: $rsp 48 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 12dc 10 .cfa: $rsp 48 + .ra: .cfa 8 - ^
+STACK CFI INIT 12ec 19 .cfa: $rsp 48 + .ra: .cfa 8 - ^
+STACK CFI INIT 1308 17c .cfa: $rsp 64 + $rdi: .cfa 16 - ^ $rbx: .cfa 0 - ^ $rsi: .cfa 0 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 1484 12 .cfa: $rsp 48 + .ra: .cfa 8 - ^
+STACK CFI INIT 1498 34 .cfa: $rsp 48 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 14cc d1 .cfa: $rsp 64 + .ra: .cfa 8 - ^
+STACK CFI INIT 15a0 71 .cfa: $rsp 96 + $rbx: .cfa 16 - ^ $rsi: .cfa 24 - ^ $rdi: .cfa 32 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 161c 3f .cfa: $rsp 48 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 167c 3f .cfa: $rsp 48 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 16dc 35 .cfa: $rsp 48 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 1728 42 .cfa: $rsp 48 + $rdi: .cfa 16 - ^ $rbx: .cfa 0 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 176c 20 .cfa: $rsp 80 + .ra: .cfa 8 - ^
+STACK CFI INIT 178c 20 .cfa: $rsp 80 + .ra: .cfa 8 - ^
+STACK CFI INIT 17ac 39 .cfa: $rsp 48 + .ra: .cfa 8 - ^
+STACK CFI INIT 17e8 49 .cfa: $rsp 48 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 1834 d8 .cfa: $rsp 80 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 190c 99 .cfa: $rsp 32 + .ra: .cfa 8 - ^
+STACK CFI INIT 19a8 24 .cfa: $rsp 48 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 19cc 2b .cfa: $rsp 48 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 19f8 4f .cfa: $rsp 48 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 1a48 17 .cfa: $rsp 48 + .ra: .cfa 8 - ^
+STACK CFI INIT 1a60 ac .cfa: $rsp 48 + $rbp: .cfa 16 - ^ $rbx: .cfa 0 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 1b40 1b .cfa: $rsp 48 + .ra: .cfa 8 - ^
+STACK CFI INIT 1b80 14a .cfa: $rsp 1488 + $rbp: .cfa 16 - ^ $rbx: .cfa 0 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 1cd4 52 .cfa: $rsp 48 + .ra: .cfa 8 - ^
+STACK CFI INIT 1d38 38 .cfa: $rsp 48 + .ra: .cfa 8 - ^
+STACK CFI INIT 1d70 3c .cfa: $rsp 48 + $rdi: .cfa 16 - ^ $rbx: .cfa 0 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 1dac 3c .cfa: $rsp 48 + $rdi: .cfa 16 - ^ $rbx: .cfa 0 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 1de8 1b9 .cfa: $rsp 48 + $rsi: .cfa 16 - ^ $rdi: .cfa 24 - ^ $r14: .cfa 32 - ^ $rbx: .cfa 0 - ^ $rbp: .cfa 0 - ^ .ra: .cfa 8 - ^
 STACK CFI INIT 2090 2 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 2090 .cfa: $rsp 8 +
-STACK CFI INIT 20ac 1e .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 20ac .cfa: $rsp 48 +
-STACK CFI INIT 20ca 18 .cfa: $rsp 8 + .ra: .cfa 8 - ^
-STACK CFI 20ca .cfa: $rsp 16 +
+STACK CFI INIT 20ac 1e .cfa: $rsp 48 + $rbp: .cfa 16 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 20ca 18 .cfa: $rsp 16 + $rbp: .cfa 16 - ^ .ra: .cfa 8 - ^
 


### PR DESCRIPTION
This is trying to fix #546 by more faithfully implementing Win-x64 unwinding, specifically:
It restores all the registers that were saved, and adds support for FP-based unwinding.

I’m still struggling to make this code work correctly with `RtlDispatchException` which we somehow still can’t unwind through.