### PR TITLE
ref(symcache): Change new symcache error structure

### DIFF
--- a/symbolic-symcache/src/compat.rs
+++ b/symbolic-symcache/src/compat.rs
@@ -10,16 +10,18 @@ pub(crate) const SYMCACHE_VERSION_CUTOFF: u32 = 6;
 
 impl From<new::Error> for SymCacheError {
     fn from(new_error: new::Error) -> Self {
-        let kind = match new_error {
-            new::Error::BufferNotAligned
-            | new::Error::BadFormatLength
-            | new::Error::WrongEndianness => old::SymCacheErrorKind::BadCacheFile,
-            new::Error::HeaderTooSmall => old::SymCacheErrorKind::BadFileHeader,
-            new::Error::WrongFormat => old::SymCacheErrorKind::BadFileMagic,
-            new::Error::WrongVersion => old::SymCacheErrorKind::UnsupportedVersion,
+        let new::Error { kind, source } = new_error;
+        let kind = match kind {
+            new::ErrorKind::BufferNotAligned
+            | new::ErrorKind::BadFormatLength
+            | new::ErrorKind::WrongEndianness => old::SymCacheErrorKind::BadCacheFile,
+            new::ErrorKind::HeaderTooSmall => old::SymCacheErrorKind::BadFileHeader,
+            new::ErrorKind::WrongFormat => old::SymCacheErrorKind::BadFileMagic,
+            new::ErrorKind::WrongVersion => old::SymCacheErrorKind::UnsupportedVersion,
+            new::ErrorKind::BadDebugFile => old::SymCacheErrorKind::BadDebugFile,
         };
 
-        Self::from(kind)
+        Self { kind, source }
     }
 }
 

--- a/symbolic-symcache/src/old/error.rs
+++ b/symbolic-symcache/src/old/error.rs
@@ -91,9 +91,9 @@ impl fmt::Display for SymCacheErrorKind {
 #[derive(Debug, Error)]
 #[error("{kind}")]
 pub struct SymCacheError {
-    kind: SymCacheErrorKind,
+    pub(crate) kind: SymCacheErrorKind,
     #[source]
-    source: Option<Box<dyn Error + Send + Sync + 'static>>,
+    pub(crate) source: Option<Box<dyn Error + Send + Sync + 'static>>,
 }
 
 impl SymCacheError {


### PR DESCRIPTION
This changes the structure of the new symcache errors to the "error struct + error kind enum" pattern. The visibility changes in `new::Error` and `old::SymCacheError` are temporary to make the `From` impl work.