### PR TITLE
ref(symcache): Remove has_{file,line}_info methods

### DIFF
--- a/symbolic-cabi/src/symcache.rs
+++ b/symbolic-cabi/src/symcache.rs
@@ -129,22 +129,6 @@ ffi_fn! {
 }
 
 ffi_fn! {
-    /// Returns true if the symcache has line infos.
-    #[allow(deprecated)]
-    unsafe fn symbolic_symcache_has_line_info(symcache: *const SymbolicSymCache) -> Result<bool> {
-        Ok(SymbolicSymCache::as_rust(symcache).get().has_line_info())
-    }
-}
-
-ffi_fn! {
-    /// Returns true if the symcache has file infos.
-    #[allow(deprecated)]
-    unsafe fn symbolic_symcache_has_file_info(symcache: *const SymbolicSymCache) -> Result<bool> {
-        Ok(SymbolicSymCache::as_rust(symcache).get().has_file_info())
-    }
-}
-
-ffi_fn! {
     /// Returns the version of the cache file.
     unsafe fn symbolic_symcache_get_version(symcache: *const SymbolicSymCache) -> Result<u32> {
         Ok(SymbolicSymCache::as_rust(symcache).get().version())

--- a/symbolic-symcache/src/compat.rs
+++ b/symbolic-symcache/src/compat.rs
@@ -76,26 +76,6 @@ impl<'data> SymCache<'data> {
         }
     }
 
-    /// Returns true if line information is included.
-    #[deprecated(since = "8.6.0", note = "this will be removed in a future version")]
-    pub fn has_line_info(&self) -> bool {
-        match &self.0 {
-            #[allow(deprecated)]
-            SymCacheInner::New(symc) => symc.has_line_info(),
-            SymCacheInner::Old(symc) => symc.has_line_info(),
-        }
-    }
-
-    /// Returns true if file information is included.
-    #[deprecated(since = "8.6.0", note = "this will be removed in a future version")]
-    pub fn has_file_info(&self) -> bool {
-        match &self.0 {
-            #[allow(deprecated)]
-            SymCacheInner::New(symc) => symc.has_file_info(),
-            SymCacheInner::Old(symc) => symc.has_file_info(),
-        }
-    }
-
     /// Returns an iterator over all functions.
     #[deprecated(since = "8.6.0", note = "this will be removed in a future version")]
     #[allow(deprecated)]

--- a/symbolic-symcache/src/new/compat.rs
+++ b/symbolic-symcache/src/new/compat.rs
@@ -13,16 +13,6 @@ use super::*;
 use crate::{SymCacheError, SymCacheErrorKind};
 
 impl<'data> SymCache<'data> {
-    /// Returns true if line information is included.
-    pub fn has_line_info(&self) -> bool {
-        self.has_file_info() && self.source_locations.iter().any(|sl| sl.line > 0)
-    }
-
-    /// Returns true if file information is included.
-    pub fn has_file_info(&self) -> bool {
-        !self.files.is_empty()
-    }
-
     /// An iterator over the functions in this SymCache.
     pub fn functions(&self) -> Functions<'data> {
         Functions {


### PR DESCRIPTION
These methods are obsolete with the new symcache format.