### PR TITLE
Bump wasmparser to 0.83.0

### DIFF
--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -96,7 +96,7 @@ serde_json = { version = "1.0.40", optional = true }
 smallvec = { version = "1.2.0", optional = true }
 symbolic-common = { version = "8.6.1", path = "../symbolic-common" }
 thiserror = "1.0.20"
-wasmparser = { version = "0.82", optional = true }
+wasmparser = { version = "0.83", optional = true }
 zip = { version = "0.5.2", optional = true, default-features = false, features = [
     "deflate",
 ] }


### PR DESCRIPTION
This just bumps the dependency to wasmparser to version 0.83.0. Tests passed locally.