### PR TITLE
WIP: minidump_stackwalk without breakpad

### DIFF
--- a/examples/minidump_stackwalk/Cargo.toml
+++ b/examples/minidump_stackwalk/Cargo.toml
@@ -12,7 +12,6 @@ async-trait = "0.1.53"
 clap = "3.1.0"
 minidump = "0.10.3"
 minidump-processor = { version = "0.10.3", features = ["symbolic-syms"] }
-parking_lot = "0.12.0"
 symbolic = { path = "../../symbolic", features = ["symcache", "demangle", "minidump"] }
 thiserror = "1.0.31"
 tokio = {version = "1.18.1", features = ["macros", "rt"] }

--- a/examples/minidump_stackwalk/Cargo.toml
+++ b/examples/minidump_stackwalk/Cargo.toml
@@ -14,6 +14,7 @@ minidump = "0.10.3"
 minidump-processor = { version = "0.10.3", features = ["symbolic-syms"] }
 parking_lot = "0.12.0"
 symbolic = { path = "../../symbolic", features = ["symcache", "demangle", "minidump"] }
+thiserror = "1.0.31"
 tokio = {version = "1.18.1", features = ["macros", "rt"] }
 tracing = "0.1.34"
 tracing-subscriber = "0.3.11"

--- a/examples/minidump_stackwalk/Cargo.toml
+++ b/examples/minidump_stackwalk/Cargo.toml
@@ -8,6 +8,13 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1.53"
 clap = "3.1.0"
-symbolic = { path = "../../symbolic", features = ["minidump", "symcache", "demangle"] }
+minidump = "0.10.3"
+minidump-processor = { version = "0.10.3", features = ["symbolic-syms"] }
+parking_lot = "0.12.0"
+symbolic = { path = "../../symbolic", features = ["symcache", "demangle", "minidump"] }
+tokio = {version = "1.18.1", features = ["macros", "rt"] }
+tracing = "0.1.34"
+tracing-subscriber = "0.3.11"
 walkdir = "2.3.1"

--- a/examples/minidump_stackwalk/src/main.rs
+++ b/examples/minidump_stackwalk/src/main.rs
@@ -1,128 +1,287 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::io::Cursor;
-use std::path::Path;
+use std::path::PathBuf;
+use std::time::UNIX_EPOCH;
 
+use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
+use minidump::{Minidump, Module};
+use minidump_processor::{
+    FillSymbolError, FrameSymbolizer, FrameTrust, FrameWalker, ProcessState, StackFrame,
+    SymbolFile, SymbolProvider, SymbolStats,
+};
+use parking_lot::RwLock;
 use walkdir::WalkDir;
 
-use symbolic::common::{Arch, ByteView, InstructionInfo, SelfCell};
-use symbolic::debuginfo::{Archive, FileFormat, Object};
+use symbolic::common::{Arch, ByteView, DebugId, InstructionInfo, SelfCell};
+use symbolic::debuginfo::{Archive, FileFormat};
 use symbolic::demangle::{Demangle, DemangleOptions};
 use symbolic::minidump::cfi::CfiCache;
-use symbolic::minidump::processor::{CodeModuleId, FrameInfoMap, ProcessState, StackFrame};
 use symbolic::symcache::{Error as SymCacheError, SourceLocation, SymCache, SymCacheConverter};
 
-type SymCaches<'a> = BTreeMap<CodeModuleId, SelfCell<ByteView<'a>, SymCache<'a>>>;
+type SymCaches<'a> = BTreeMap<DebugId, Result<SelfCell<ByteView<'a>, SymCache<'a>>, SymbolError>>;
 type Error = Box<dyn std::error::Error>;
 
-fn collect_referenced_objects<P, F, T>(
-    path: P,
-    state: &ProcessState,
-    mut func: F,
-) -> Result<BTreeMap<CodeModuleId, T>, Error>
-where
-    P: AsRef<Path>,
-    F: FnMut(Object, &Path) -> Result<Option<T>, Error>,
-{
-    let search_ids: HashSet<_> = state
-        .modules()
-        .iter()
-        .filter_map(|module| module.id())
-        .collect();
+#[derive(Debug, Clone, Copy)]
+enum SymbolError {
+    NotFound,
+    Corrupt,
+    Other,
+}
 
-    let mut collected = BTreeMap::new();
-    let mut final_ids = HashSet::new();
-    for entry in WalkDir::new(path).into_iter().filter_map(Result::ok) {
-        // Folders will be recursed into automatically
-        if !entry.metadata()?.is_file() {
-            continue;
+struct LocalSymbolProvider<'a> {
+    symbols_path: PathBuf,
+    cfi: RwLock<BTreeMap<DebugId, Result<SymbolFile, SymbolError>>>,
+    symcaches: RwLock<SymCaches<'a>>,
+    use_cfi: bool,
+    symbolize: bool,
+}
+
+impl<'a> LocalSymbolProvider<'a> {
+    /// Load the CFI information from the cache.
+    ///
+    /// This reads the CFI caches from disk and returns them in a format suitable for the
+    /// processor to stackwalk.
+    #[tracing::instrument]
+    pub fn new(path: PathBuf, use_cfi: bool, symbolize: bool) -> Self {
+        Self {
+            symbols_path: path,
+            cfi: RwLock::new(BTreeMap::default()),
+            symcaches: RwLock::new(SymCaches::default()),
+            use_cfi,
+            symbolize,
+        }
+    }
+
+    #[tracing::instrument(skip(self))]
+    fn load_cfi(&self, id: DebugId) -> Result<SymbolFile, SymbolError> {
+        if !self.use_cfi {
+            return Err(SymbolError::Other);
         }
 
-        // Try to parse a potential object file. If this is not possible, then
-        // we're not dealing with an object file, thus silently skipping it
-        let buffer = ByteView::open(entry.path())?;
-        let archive = match Archive::parse(&buffer) {
-            Ok(archive) => archive,
-            Err(_) => continue,
-        };
+        let mut found = None;
 
-        for object in archive.objects() {
-            // Fail for invalid matching objects but silently skip objects
-            // without a UUID
-            let object = object?;
-            let id = CodeModuleId::from(object.debug_id());
-
-            // Make sure we haven't converted this object already
-            if !search_ids.contains(&id) || final_ids.contains(&id) {
+        for entry in WalkDir::new(&self.symbols_path)
+            .into_iter()
+            .filter_map(Result::ok)
+        {
+            tracing::trace!(path = ?entry.path());
+            // Folders will be recursed into automatically
+            if !entry.metadata().map_err(|_| SymbolError::Other)?.is_file() {
                 continue;
             }
 
-            let format = object.file_format();
-            if let Some(t) = func(object, entry.path())? {
-                collected.insert(id, t);
+            // Try to parse a potential object file. If this is not possible, then
+            // we're not dealing with an object file, thus silently skipping it
+            let buffer = ByteView::open(entry.path()).map_err(|_| SymbolError::Other)?;
+            let archive = match Archive::parse(&buffer) {
+                Ok(archive) => archive,
+                Err(_) => continue,
+            };
+
+            for object in archive.objects() {
+                // Fail for invalid matching objects but silently skip objects
+                // without a UUID
+                let object = object.map_err(|_| SymbolError::Corrupt)?;
+
+                if object.debug_id() != id {
+                    continue;
+                }
+
+                if !object.has_unwind_info() {
+                    continue;
+                }
+
+                let cfi_cache = match CfiCache::from_object(&object) {
+                    Ok(cficache) => cficache,
+                    Err(e) => {
+                        eprintln!("[cfi] {}: {}", self.symbols_path.display(), e);
+                        continue;
+                    }
+                };
+
+                if cfi_cache.as_slice().is_empty() {
+                    continue;
+                }
+
+                let symbol_file = match SymbolFile::from_bytes(cfi_cache.as_slice()) {
+                    Ok(symbol_file) => symbol_file,
+                    Err(_e) => {
+                        //let stderr: &dyn std::error::Error = &e;
+                        //tracing::error!(stderr, "Error while processing cficache");
+                        continue;
+                    }
+                };
+
+                found = Some(symbol_file);
 
                 // Keep looking if we "only" found a breakpad symbols.
                 // We should prefer native symbols if we can get them.
-                if format != FileFormat::Breakpad {
-                    final_ids.insert(id);
+                if object.file_format() != FileFormat::Breakpad {
+                    break;
                 }
+            }
+        }
+        found.ok_or(SymbolError::NotFound)
+    }
+
+    fn load_symcache(
+        &self,
+        id: DebugId,
+    ) -> Result<SelfCell<ByteView<'a>, SymCache<'a>>, SymbolError> {
+        if !self.symbolize {
+            return Err(SymbolError::Other);
+        }
+
+        let mut found = None;
+
+        for entry in WalkDir::new(&self.symbols_path)
+            .into_iter()
+            .filter_map(Result::ok)
+        {
+            // Folders will be recursed into automatically
+            if !entry.metadata().map_err(|_| SymbolError::Other)?.is_file() {
+                continue;
+            }
+
+            // Try to parse a potential object file. If this is not possible, then
+            // we're not dealing with an object file, thus silently skipping it
+            let buffer = ByteView::open(entry.path()).map_err(|_| SymbolError::Other)?;
+            let archive = match Archive::parse(&buffer) {
+                Ok(archive) => archive,
+                Err(_) => continue,
+            };
+
+            for object in archive.objects() {
+                // Fail for invalid matching objects but silently skip objects
+                // without a UUID
+                let object = object.map_err(|_| SymbolError::Corrupt)?;
+
+                if object.debug_id() != id {
+                    continue;
+                }
+
+                // Silently skip all incompatible debug symbols
+                if !object.has_debug_info() {
+                    continue;
+                }
+
+                let mut buffer = Vec::new();
+                if let Err(e) = SymCacheWriter::write_object(&object, Cursor::new(&mut buffer)) {
+                    eprintln!("[sym] {}: {}", self.symbols_path.display(), e);
+                    continue;
+                }
+
+                // Silently skip conversion errors
+                let symcache = match SelfCell::try_new(ByteView::from_vec(buffer), |ptr| {
+                    SymCache::parse(unsafe { &*ptr })
+                }) {
+                    Ok(symcache) => symcache,
+                    Err(_) => continue,
+                };
+
+                found = Some(symcache);
+
+                // Keep looking if we "only" found a breakpad symbols.
+                // We should prefer native symbols if we can get them.
+                if object.file_format() != FileFormat::Breakpad {
+                    break;
+                }
+            }
+        }
+        found.ok_or(SymbolError::NotFound)
+    }
+}
+
+#[async_trait]
+impl<'a> minidump_processor::SymbolProvider for LocalSymbolProvider<'a> {
+    #[tracing::instrument(skip(self, module, frame), fields(module.id = ?module.debug_identifier(), frame.instruction = frame.get_instruction()))]
+    async fn fill_symbol(
+        &self,
+        module: &(dyn Module + Sync),
+        frame: &mut (dyn FrameSymbolizer + Send),
+    ) -> Result<(), FillSymbolError> {
+        let id = module.debug_identifier().ok_or(FillSymbolError {})?;
+
+        let mut symcaches = self.symcaches.write();
+
+        let symcache = symcaches.entry(id).or_insert_with(|| {
+            tracing::debug!("symcache needs to be loaded");
+            self.load_symcache(id)
+        });
+
+        let symcache = match symcache {
+            Ok(symcache) => symcache,
+            Err(e) => {
+                tracing::debug!(?e, "symcache could not be loaded");
+                return Err(FillSymbolError {});
+            }
+        };
+
+        tracing::debug!("symcache successfully loaded");
+
+        let instruction = frame.get_instruction();
+        let line_info = symcache
+            .get()
+            .lookup(instruction - module.base_address())
+            .map_err(|_| FillSymbolError {})?
+            .next()
+            .ok_or(FillSymbolError {})?
+            .map_err(|_| FillSymbolError {})?;
+
+        frame.set_function(
+            line_info.function_name().as_str(),
+            line_info.function_address(),
+            0,
+        );
+
+        frame.set_source_file(line_info.filename(), line_info.line(), 0);
+
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self, module, walker), fields(module.id = ?module.debug_identifier()))]
+    async fn walk_frame(
+        &self,
+        module: &(dyn Module + Sync),
+        walker: &mut (dyn FrameWalker + Send),
+    ) -> Option<()> {
+        let id = module.debug_identifier()?;
+
+        let mut cfi = self.cfi.write();
+
+        let symbol_file = cfi.entry(id).or_insert_with(|| {
+            tracing::debug!("cfi needs to be loaded");
+            self.load_cfi(id)
+        });
+
+        match symbol_file {
+            Ok(file) => {
+                tracing::debug!("cfi successfully loaded");
+                file.walk_frame(module, walker)
+            }
+            Err(e) => {
+                tracing::debug!(?e, "cfi could not be loaded");
+                None
             }
         }
     }
 
-    Ok(collected)
-}
+    fn stats(&self) -> HashMap<String, SymbolStats> {
+        self.cfi
+            .read()
+            .iter()
+            .map(|(debug_id, sym)| {
+                let stats = SymbolStats {
+                    symbol_url: None,
+                    loaded_symbols: matches!(sym, Ok(_)),
+                    corrupt_symbols: matches!(sym, Err(SymbolError::Corrupt)),
+                };
 
-fn prepare_cfi<P>(path: P, state: &ProcessState) -> Result<FrameInfoMap<'static>, Error>
-where
-    P: AsRef<Path>,
-{
-    collect_referenced_objects(path, state, |object, path| {
-        // Silently skip all debug symbols without CFI
-        if !object.has_unwind_info() {
-            return Ok(None);
-        }
-
-        // Silently skip conversion errors
-        Ok(match CfiCache::from_object(&object) {
-            Ok(cficache) => Some(cficache),
-            Err(e) => {
-                eprintln!("[cfi] {}: {}", path.display(), e);
-                None
-            }
-        })
-    })
-}
-
-fn prepare_symcaches<P>(path: P, state: &ProcessState) -> Result<SymCaches<'static>, Error>
-where
-    P: AsRef<Path>,
-{
-    collect_referenced_objects(path, state, |object, path| {
-        // Silently skip all incompatible debug symbols
-        if !object.has_debug_info() {
-            return Ok(None);
-        }
-
-        let mut buffer = Vec::new();
-        let mut converter = SymCacheConverter::new();
-        if let Err(e) = converter.process_object(&object) {
-            eprintln!("[sym] {}: {}", path.display(), e);
-            return Ok(None);
-        }
-
-        if let Err(e) = converter.serialize(&mut Cursor::new(&mut buffer)) {
-            eprintln!("[sym] {}: {}", path.display(), e);
-            return Ok(None);
-        }
-
-        // Silently skip conversion errors
-        let result = SelfCell::try_new(ByteView::from_vec(buffer), |ptr| {
-            SymCache::parse(unsafe { &*ptr })
-        });
-
-        Ok(result.ok())
-    })
+                (debug_id.to_string(), stats)
+            })
+            .collect()
+    }
 }
 
 fn symbolize<'a>(
@@ -136,13 +295,13 @@ fn symbolize<'a>(
         None => return Ok(None),
     };
 
-    let symcache = match module.id().and_then(|id| symcaches.get(&id)) {
-        Some(symcache) => symcache,
-        None => return Ok(None),
+    let symcache = match module.debug_identifier().and_then(|id| symcaches.get(&id)) {
+        Some(Ok(symcache)) => symcache,
+        _ => return Ok(None),
     };
 
     // TODO: Extract and supply signal and IP register
-    let return_address = frame.return_address(arch);
+    let return_address = frame.resume_address;
     let caller_address = InstructionInfo::new(arch, return_address)
         .is_crashing_frame(crashing)
         .caller_address();
@@ -162,49 +321,75 @@ fn symbolize<'a>(
 struct PrintOptions {
     crashed_only: bool,
     show_modules: bool,
+    show_symbol_stats: bool,
 }
 
 #[allow(deprecated)]
 fn print_state(
     state: &ProcessState,
-    symcaches: &SymCaches,
-    cfi: &FrameInfoMap,
+    symbol_provider: &LocalSymbolProvider,
     options: PrintOptions,
 ) -> Result<(), Error> {
-    let sys = state.system_info();
-    println!("Operating system: {}", sys.os_name());
-    println!("                  {} {}", sys.os_version(), sys.os_build());
+    let sys = &state.system_info;
+    println!("Operating system: {}", sys.os);
+    println!(
+        "                  {} {}",
+        sys.os_version.as_deref().unwrap_or("unknown version"),
+        sys.os_build.as_deref().unwrap_or("unknown_build")
+    );
     println!();
 
-    println!("CPU: {}", sys.cpu_family());
-    println!("     {}", sys.cpu_info());
-    println!("     {} CPUs", sys.cpu_count());
-    println!();
-
-    if !state.assertion().is_empty() {
-        println!("Assertion:     {}", state.assertion());
+    println!("CPU: {}", sys.cpu);
+    if let Some(ref cpu_info) = sys.cpu_info {
+        println!("     {}", cpu_info);
     }
-    println!("Crash reason:  {}", state.crash_reason());
-    println!("Crash address: 0x{:x}", state.crash_address());
-    println!("Crash time:    {}", state.timestamp());
+    println!("     {} CPUs", sys.cpu_count);
+    println!();
 
-    let arch = state.system_info().cpu_arch();
-    for (ti, thread) in state.threads().iter().enumerate() {
-        let crashed = (ti as i32) != state.requesting_thread();
-        if options.crashed_only && crashed {
+    if let Some(ref assertion) = state.assertion {
+        println!("Assertion:     {}", assertion);
+    }
+    if let Some(crash_reason) = state.crash_reason {
+        println!("Crash reason:  {}", crash_reason);
+    }
+    if let Some(crash_address) = state.crash_address {
+        println!("Crash address: 0x{:x}", crash_address);
+    }
+    if let Ok(duration) = state.time.duration_since(UNIX_EPOCH) {
+        println!("Crash time:    {}", duration.as_secs());
+    }
+
+    let arch = match state.system_info.cpu {
+        minidump::system_info::Cpu::X86 => Arch::X86,
+        minidump::system_info::Cpu::X86_64 => Arch::Amd64,
+        minidump::system_info::Cpu::Ppc => Arch::Ppc,
+        minidump::system_info::Cpu::Ppc64 => Arch::Ppc64,
+        minidump::system_info::Cpu::Arm => Arch::Arm,
+        minidump::system_info::Cpu::Arm64 => Arch::Arm64,
+        minidump::system_info::Cpu::Mips => Arch::Mips,
+        minidump::system_info::Cpu::Mips64 => Arch::Mips64,
+        _ => Arch::Unknown,
+    };
+
+    for (ti, thread) in state.threads.iter().enumerate() {
+        let crashed = state.requesting_thread.map_or(false, |i| ti == i);
+
+        if options.crashed_only && !crashed {
             continue;
         }
 
         if crashed {
-            println!("\nThread {}", ti);
-        } else {
             println!("\nThread {} (crashed)", ti);
+        } else {
+            println!("\nThread {}", ti);
         }
 
         let mut index = 0;
-        for (fi, frame) in thread.frames().iter().enumerate() {
-            if let Some(module) = frame.module() {
-                if let Some(line_infos) = symbolize(symcaches, frame, arch, fi == 0)? {
+        for (fi, frame) in thread.frames.iter().enumerate() {
+            if let Some(ref module) = frame.module {
+                if let Some(line_infos) =
+                    symbolize(&symbol_provider.symcaches.read(), frame, arch, fi == 0)?
+                {
                     for (i, info) in line_infos.iter().enumerate() {
                         println!(
                             "{:>3}  {}!{} [{} : {}]",
@@ -228,18 +413,21 @@ fn print_state(
                     println!(
                         "{:>3}  {} + 0x{:x}",
                         index,
-                        module.debug_file(),
-                        frame.instruction() - module.base_address()
+                        module
+                            .debug_file()
+                            .as_deref()
+                            .unwrap_or("unknown debug file"),
+                        frame.instruction - module.base_address()
                     );
                 }
             } else {
-                println!("{:>3}  0x{:x}", index, frame.instruction());
+                println!("{:>3}  {:#x}", index, frame.instruction);
             }
 
             let mut newline = true;
-            for (name, value) in frame.registers(arch) {
+            for (name, value) in frame.context.valid_registers() {
                 newline = !newline;
-                print!("     {:>4} = {}", name, value);
+                print!("     {:>4} = {:#x}", name, value);
                 if newline {
                     println!();
                 }
@@ -249,7 +437,17 @@ fn print_state(
                 println!();
             }
 
-            println!("     Found by: {}", frame.trust());
+            let trust = match frame.trust {
+                FrameTrust::None => "none",
+                FrameTrust::Scan => "stack scanning",
+                FrameTrust::CfiScan => "call frame info with scanning",
+                FrameTrust::FramePointer => "previous frame's frame pointer",
+                FrameTrust::CallFrameInfo => "call frame info",
+                FrameTrust::PreWalked => "recovered by external stack walker",
+                FrameTrust::Context => "given as instruction pointer in context",
+            };
+
+            println!("     Found by: {}", trust);
             index += 1;
         }
     }
@@ -257,7 +455,7 @@ fn print_state(
     if options.show_modules {
         println!();
         println!("Loaded modules:");
-        for module in state.modules() {
+        for module in state.modules.iter() {
             print!(
                 "0x{:x} - 0x{:x}  {}  (",
                 module.base_address(),
@@ -265,16 +463,20 @@ fn print_state(
                 module.code_file().rsplit('/').next().unwrap(),
             );
 
-            match module.id() {
+            let id = module.debug_identifier();
+
+            match id {
                 Some(id) => print!("{}", id),
                 None => print!("<missing debug identifier>"),
             };
 
-            if !module.id().map_or(false, |id| symcaches.contains_key(&id)) {
+            if !id.map_or(false, |id| {
+                symbol_provider.symcaches.read().contains_key(&id)
+            }) {
                 print!("; no symbols");
             }
 
-            if !module.id().map_or(false, |id| cfi.contains_key(&id)) {
+            if !id.map_or(false, |id| symbol_provider.cfi.read().contains_key(&id)) {
                 print!("; no CFI");
             }
 
@@ -282,42 +484,41 @@ fn print_state(
         }
     }
 
+    if options.show_symbol_stats {
+        println!("{:#?}", symbol_provider.stats());
+    }
+
     Ok(())
 }
 
-fn execute(matches: &ArgMatches) -> Result<(), Error> {
+async fn execute(matches: &ArgMatches) -> Result<(), Error> {
     let minidump_path = matches.value_of("minidump_file_path").unwrap();
     let symbols_path = matches.value_of("debug_symbols_path").unwrap_or("invalid");
 
-    // Initially process without CFI
-    let byteview = ByteView::open(&minidump_path)?;
-    let mut state = ProcessState::from_minidump(&byteview, None)?;
+    let symbol_provider = LocalSymbolProvider::new(
+        symbols_path.into(),
+        matches.is_present("cfi"),
+        matches.is_present("symbolize"),
+    );
 
-    let cfi = if matches.is_present("cfi") {
-        // Reprocess with Call Frame Information
-        let frame_info = prepare_cfi(&symbols_path, &state)?;
-        state = ProcessState::from_minidump(&byteview, Some(&frame_info))?;
-        frame_info
-    } else {
-        Default::default()
-    };
-
-    let symcaches = if matches.is_present("symbolize") {
-        prepare_symcaches(&symbols_path, &state)?
-    } else {
-        Default::default()
-    };
+    let minidump = Minidump::read_path(minidump_path)?;
+    let process_state = minidump_processor::process_minidump(&minidump, &symbol_provider).await?;
 
     let options = PrintOptions {
         crashed_only: matches.is_present("only_crash"),
         show_modules: !matches.is_present("no_modules"),
+        show_symbol_stats: matches.is_present("symbol_stats"),
     };
-    print_state(&state, &symcaches, &cfi, options)?;
+
+    print_state(&process_state, &symbol_provider, options)?;
 
     Ok(())
 }
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
     let matches = Command::new("symbolic-minidump")
         .about("Symbolicates a minidump")
         .arg(
@@ -355,9 +556,14 @@ fn main() {
                 .long("no-modules")
                 .help("Do not output loaded modules"),
         )
+        .arg(
+            Arg::new("symbol_stats")
+                .long("symbol-stats")
+                .help("Print symbol stats"),
+        )
         .get_matches();
 
-    match execute(&matches) {
+    match execute(&matches).await {
         Ok(()) => (),
         Err(e) => println!("Error: {}", e),
     };

--- a/symbolic-symcache/src/lib.rs
+++ b/symbolic-symcache/src/lib.rs
@@ -111,14 +111,14 @@ use std::convert::TryInto;
 use std::mem;
 use std::ptr;
 
-pub use error::{Error, ErrorKind};
-pub use lookup::*;
 use symbolic_common::Arch;
 use symbolic_common::AsSelf;
 use symbolic_common::DebugId;
-pub use writer::SymCacheConverter;
 
+pub use error::{Error, ErrorKind};
+pub use lookup::*;
 use raw::align_to_eight;
+pub use writer::SymCacheConverter;
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 


### PR DESCRIPTION
I got a bit over-motivated and started to rewrite `minidump_stackwalk` based on `symbolic` + `rust_minidump`. The `LocalSymbolProvider` more or less captures the symbol-searching logic of the old implementation, except on demand. There is likely quite a lot of optimization potential in the implementation. Symbolication is also kind of done twice right now; I've experimentally integrated it into the symbol provider, but the old `symbolize` method that ran after stackwalking also still exists. Would be interesting to know how well it works if we remove the latter.