### PR TITLE
ref(symcache): Remove comp_dir from files and functions

### DIFF
--- a/symbolic-symcache/src/lookup.rs
+++ b/symbolic-symcache/src/lookup.rs
@@ -45,9 +45,7 @@ impl<'data> SymCache<'data> {
         Some(File {
             comp_dir: self.get_string(raw_file.comp_dir_offset),
             directory: self.get_string(raw_file.directory_offset),
-            path_name: self
-                .get_string(raw_file.path_name_offset)
-                .unwrap_or_default(),
+            name: self.get_string(raw_file.name_offset).unwrap_or_default(),
         })
     }
 
@@ -55,7 +53,6 @@ impl<'data> SymCache<'data> {
         let raw_function = self.functions.get(function_idx as usize)?;
         Some(Function {
             name: self.get_string(raw_function.name_offset).unwrap_or("?"),
-            comp_dir: self.get_string(raw_function.comp_dir_offset),
             entry_pc: raw_function.entry_pc,
             language: Language::from_u32(raw_function.lang),
         })
@@ -112,33 +109,17 @@ pub struct File<'data> {
     /// The optional directory prefix.
     directory: Option<&'data str>,
     /// The file path.
-    path_name: &'data str,
+    name: &'data str,
 }
 
 impl<'data> File<'data> {
-    /// Resolves the compilation directory of this source file.
-    pub fn comp_dir(&self) -> Option<&'data str> {
-        self.comp_dir
-    }
-
-    /// Resolves the parent directory of this source file.
-    pub fn directory(&self) -> Option<&'data str> {
-        self.directory
-    }
-
-    /// Resolves the final path name fragment of this source file.
-    pub fn path_name(&self) -> &'data str {
-        self.path_name
-    }
-
-    /// Resolves and concatenates the full path based on its individual fragments.
+    /// Returns this file's full path.
     pub fn full_path(&self) -> String {
-        let comp_dir = self.comp_dir().unwrap_or_default();
-        let directory = self.directory().unwrap_or_default();
-        let path_name = self.path_name();
+        let comp_dir = self.comp_dir.unwrap_or_default();
+        let directory = self.directory.unwrap_or_default();
 
         let prefix = symbolic_common::join_path(comp_dir, directory);
-        let full_path = symbolic_common::join_path(&prefix, path_name);
+        let full_path = symbolic_common::join_path(&prefix, self.name);
         let full_path = symbolic_common::clean_path(&full_path).into_owned();
 
         full_path
@@ -149,7 +130,6 @@ impl<'data> File<'data> {
 #[derive(Clone, Debug)]
 pub struct Function<'data> {
     name: &'data str,
-    comp_dir: Option<&'data str>,
     entry_pc: u32,
     language: Language,
 }
@@ -163,11 +143,6 @@ impl<'data> Function<'data> {
     /// The possibly mangled name/symbol of this function, suitable for demangling.
     pub fn name_for_demangling(&self) -> Name<'data> {
         Name::new(self.name, NameMangling::Unknown, self.language)
-    }
-
-    /// The compilation directory of this function.
-    pub fn comp_dir(&self) -> Option<&'data str> {
-        self.comp_dir
     }
 
     /// The entry pc of the function.
@@ -185,7 +160,6 @@ impl<'data> Default for Function<'data> {
     fn default() -> Self {
         Self {
             name: "?",
-            comp_dir: None,
             entry_pc: u32::MAX,
             language: Language::Unknown,
         }

--- a/symbolic-symcache/src/raw.rs
+++ b/symbolic-symcache/src/raw.rs
@@ -59,7 +59,10 @@ pub(crate) struct Function {
     /// The functions name (reference to a [`String`]).
     pub(crate) name_offset: u32,
     /// The compilation directory (reference to a [`String`]).
-    pub(crate) comp_dir_offset: u32,
+    ///
+    /// This is retained for binary compatibility; all path information
+    /// is contained in [`File`].
+    pub(crate) _comp_dir_offset: u32,
     /// The first address covered by this function.
     pub(crate) entry_pc: u32,
     /// The language of the function.
@@ -75,7 +78,7 @@ pub(crate) struct File {
     /// The optional directory prefix (reference to a [`String`]).
     pub(crate) directory_offset: u32,
     /// The file path (reference to a [`String`]).
-    pub(crate) path_name_offset: u32,
+    pub(crate) name_offset: u32,
 }
 
 /// A location in a source file, comprising a file, a line, a function, and

--- a/symbolic-symcache/src/writer.rs
+++ b/symbolic-symcache/src/writer.rs
@@ -171,13 +171,10 @@ impl<'a> SymCacheConverter<'a> {
             let strings = &mut self.strings;
             let name_offset = Self::insert_string(string_bytes, strings, &function.name);
 
-            let comp_dir_offset = function.comp_dir.map_or(u32::MAX, |comp_dir| {
-                Self::insert_string(string_bytes, strings, &comp_dir)
-            });
             let lang = language as u32;
             let (fun_idx, _) = self.functions.insert_full(raw::Function {
                 name_offset,
-                comp_dir_offset,
+                _comp_dir_offset: u32::MAX,
                 entry_pc,
                 lang,
             });
@@ -199,7 +196,7 @@ impl<'a> SymCacheConverter<'a> {
 
             let string_bytes = &mut self.string_bytes;
             let strings = &mut self.strings;
-            let path_name_offset = Self::insert_string(string_bytes, strings, &location.file.name);
+            let name_offset = Self::insert_string(string_bytes, strings, &location.file.name);
             let directory_offset = location
                 .file
                 .directory
@@ -209,7 +206,7 @@ impl<'a> SymCacheConverter<'a> {
             });
 
             let (file_idx, _) = self.files.insert_full(raw::File {
-                path_name_offset,
+                name_offset,
                 directory_offset,
                 comp_dir_offset,
             });
@@ -290,7 +287,7 @@ impl<'a> SymCacheConverter<'a> {
             btree_map::Entry::Vacant(entry) => {
                 let function = raw::Function {
                     name_offset: name_idx,
-                    comp_dir_offset: u32::MAX,
+                    _comp_dir_offset: u32::MAX,
                     entry_pc: symbol.address as u32,
                     lang: u32::MAX,
                 };
@@ -367,7 +364,7 @@ impl<'a> SymCacheConverter<'a> {
 
                     let (fun_idx, _) = self.functions.insert_full(raw::Function {
                         name_offset,
-                        comp_dir_offset: u32::MAX,
+                        _comp_dir_offset: u32::MAX,
                         entry_pc: address,
                         lang: Language::CSharp as u32,
                     });
@@ -390,14 +387,14 @@ impl<'a> SymCacheConverter<'a> {
 
             let string_bytes = &mut self.string_bytes;
             let strings = &mut self.strings;
-            let path_name_offset = Self::insert_string(string_bytes, strings, &location.file.name);
+            let name_offset = Self::insert_string(string_bytes, strings, &location.file.name);
             let directory_offset = location
                 .file
                 .directory
                 .map_or(u32::MAX, |d| Self::insert_string(string_bytes, strings, &d));
 
             let (file_idx, _) = self.files.insert_full(raw::File {
-                path_name_offset,
+                name_offset,
                 directory_offset,
                 comp_dir_offset: u32::MAX,
             });

--- a/symbolic-symcache/tests/snapshots/test_cache__lookup.snap
+++ b/symbolic-symcache/tests/snapshots/test_cache__lookup.snap
@@ -9,9 +9,6 @@ expression: result
         21,
         Function {
             name: "_ZN12_GLOBAL__N_15crashEv",
-            comp_dir: Some(
-                "/Users/travis/build/getsentry/breakpad-tools/macos",
-            ),
             entry_pc: 4294967295,
             language: Cpp,
         },
@@ -21,9 +18,6 @@ expression: result
         25,
         Function {
             name: "_ZN12_GLOBAL__N_15startEv",
-            comp_dir: Some(
-                "/Users/travis/build/getsentry/breakpad-tools/macos",
-            ),
             entry_pc: 4294967295,
             language: Cpp,
         },
@@ -33,9 +27,6 @@ expression: result
         32,
         Function {
             name: "main",
-            comp_dir: Some(
-                "/Users/travis/build/getsentry/breakpad-tools/macos",
-            ),
             entry_pc: 56224,
             language: Cpp,
         },


### PR DESCRIPTION
For functions, this simply removes the `comp_dir` field. For files, `comp_dir` is folded into the `directory` field. This increases symcache size because the `comp_dir` part of the directory is duplicated for every different directory.