### PR TITLE
ref(symcache): Use utf8 paths

### DIFF
--- a/symbolic-symcache/Cargo.toml
+++ b/symbolic-symcache/Cargo.toml
@@ -30,6 +30,7 @@ symbolic-debuginfo = { version = "8.7.1", path = "../symbolic-debuginfo" }
 symbolic-il2cpp = { version = "8.7.1", path = "../symbolic-il2cpp", optional = true }
 thiserror = "1.0.20"
 indexmap = "1.7.0"
+camino = "1.0.8"
 
 [dev-dependencies]
 insta = "1.3.0"

--- a/symbolic-symcache/src/transform/bcsymbolmap.rs
+++ b/symbolic-symcache/src/transform/bcsymbolmap.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 
+use camino::Utf8Path;
 use symbolic_debuginfo::macho::BcSymbolMap;
 
 use super::{File, Function, SourceLocation, Transformer};
@@ -18,26 +19,32 @@ macro_rules! map_cow {
     };
 }
 
+fn resolve_utf8path<'d>(map: &BcSymbolMap<'d>, path: &'d Utf8Path) -> &'d Utf8Path {
+    map.resolve(path.as_str()).into()
+}
+
 impl Transformer for BcSymbolMap<'_> {
     fn transform_function<'f>(&'f self, f: Function<'f>) -> Function<'f> {
         Function {
             name: map_cow!(f.name, |s| self.resolve(s)),
-            comp_dir: f.comp_dir.map(|dir| map_cow!(dir, |s| self.resolve(s))),
+            comp_dir: f
+                .comp_dir
+                .map(|dir| map_cow!(dir, |s| resolve_utf8path(self, s))),
         }
     }
 
     fn transform_source_location<'f>(&'f self, sl: SourceLocation<'f>) -> SourceLocation<'f> {
         SourceLocation {
             file: File {
-                name: map_cow!(sl.file.name, |s| self.resolve(s)),
+                name: map_cow!(sl.file.name, |s| resolve_utf8path(self, s)),
                 directory: sl
                     .file
                     .directory
-                    .map(|dir| map_cow!(dir, |s| self.resolve(s))),
+                    .map(|dir| map_cow!(dir, |s| resolve_utf8path(self, s))),
                 comp_dir: sl
                     .file
                     .comp_dir
-                    .map(|dir| map_cow!(dir, |s| self.resolve(s))),
+                    .map(|dir| map_cow!(dir, |s| resolve_utf8path(self, s))),
             },
             line: sl.line,
         }

--- a/symbolic-symcache/src/transform/il2cpp.rs
+++ b/symbolic-symcache/src/transform/il2cpp.rs
@@ -1,19 +1,10 @@
 //! Resolves IL2CPP-compiled native symbols into their managed equivalents using a mapping file
 //! before writing them to a SymCache.
 
+use camino::Utf8Path;
 use symbolic_il2cpp::LineMapping;
 
-use super::{File, Function, SourceLocation, Transformer};
-
-fn full_path(file: &File<'_>) -> String {
-    let comp_dir = file.comp_dir.as_deref().unwrap_or_default();
-    let directory = file.directory.as_deref().unwrap_or_default();
-    let path_name = &file.name;
-
-    let prefix = symbolic_common::join_path(comp_dir, directory);
-    let full_path = symbolic_common::join_path(&prefix, path_name);
-    symbolic_common::clean_path(&full_path).into_owned()
-}
+use super::{Function, SourceLocation, Transformer};
 
 impl Transformer for LineMapping {
     fn transform_function<'f>(&'f self, f: Function<'f>) -> Function<'f> {
@@ -23,9 +14,9 @@ impl Transformer for LineMapping {
     fn transform_source_location<'f>(&'f self, mut sl: SourceLocation<'f>) -> SourceLocation<'f> {
         // TODO: this allocates, which is especially expensive since we run this transformer for
         // every single source location (without dedupe-ing files). It might be worth caching this
-        let full_path = full_path(&sl.file);
-        if let Some((mapped_file, mapped_line)) = self.lookup(&full_path, sl.line) {
-            sl.file.name = mapped_file.into();
+        let full_path = sl.file.full_path();
+        if let Some((mapped_file, mapped_line)) = self.lookup(full_path.as_str(), sl.line) {
+            sl.file.name = <&Utf8Path>::from(mapped_file).into();
             sl.file.comp_dir = None;
             sl.file.directory = None;
             sl.line = mapped_line;


### PR DESCRIPTION
This replaces some strings in symcace::writer and symcace::transform with `Uft8Path{,Buf}`s from the `camino` crate. This lets us use a path-based API, which is useful for path normalization, while not
having to deal with non-UTF8 paths (which we don't care about anyway since all we want to do with paths is display them to the user).

Question: the `normalize_path` function lives in `symcace/lib.rs` for the simple reason that I want to use it in both the `writer` and `transform` modules, but it sticks out like a sore thumb there. On the other hand, creating a `path` just for this function and its tests seems a bit excessive. What should I do about this?