### PR TITLE
ref(symcache): Add files iterator

### DIFF
--- a/examples/symcache_debug/src/main.rs
+++ b/examples/symcache_debug/src/main.rs
@@ -13,7 +13,7 @@ use symbolic::demangle::{Demangle, DemangleOptions};
 #[cfg(feature = "il2cpp")]
 use symbolic::il2cpp::LineMapping;
 use symbolic::symcache::transform::{self, Transformer};
-use symbolic::symcache::{FunctionsDebug, SymCache, SymCacheConverter};
+use symbolic::symcache::{FilesDebug, FunctionsDebug, SymCache, SymCacheConverter};
 
 // FIXME: This is a huge pain, can't this be simpler somehow?
 struct OwnedBcSymbolMap(SelfCell<ByteView<'static>, BcSymbolMap<'static>>);
@@ -176,6 +176,11 @@ fn execute(matches: &ArgMatches) -> Result<()> {
         println!("{:?}", FunctionsDebug(&symcache));
     }
 
+    // print mode
+    if matches.is_present("print_files") {
+        println!("{:?}", FilesDebug(&symcache));
+    }
+
     Ok(())
 }
 
@@ -246,6 +251,11 @@ fn main() {
             Arg::new("print_symbols")
                 .long("symbols")
                 .help("Print all symbols"),
+        )
+        .arg(
+            Arg::new("print_files")
+                .long("files")
+                .help("Print all files"),
         )
         .get_matches();
 


### PR DESCRIPTION
This adds a `files` method to `SymCache` with behavior analogous to `functions`. It also adds an option to `symcache_debug` to print the files in a symcache. Lastly it improves the documentation on the `{Files,Functions}Debug` structs a bit.