### PR TITLE
ref: Update debugid/uuid dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Breaking changes**:
 
+- Updated the `debugid` and `uuid` dependencies to `0.8` and `1.0` respectively.
 - The `symbolic-minidump` crate has been dropped. The CFI functionality that was contained in
   `symbolic-minidump` now resides in its own crate, `symbolic-cfi`.
 

--- a/examples/minidump_stackwalk/Cargo.toml
+++ b/examples/minidump_stackwalk/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 [dependencies]
 async-trait = "0.1.53"
 clap = "3.1.0"
-minidump = "0.10.3"
-minidump-processor = { version = "0.10.3", features = ["symbolic-syms"] }
+minidump = "0.11.0"
+minidump-processor = { version = "0.11.0", features = ["symbolic-syms"] }
 symbolic = { path = "../../symbolic", features = ["symcache", "demangle", "cfi"] }
 thiserror = "1.0.31"
 tokio = {version = "1.18.1", features = ["macros", "rt"] }

--- a/symbolic-cabi/Cargo.toml
+++ b/symbolic-cabi/Cargo.toml
@@ -23,4 +23,4 @@ crate-type = ["cdylib"]
 serde_json = "1.0.40"
 apple-crash-report-parser = { version = "0.4.0", features = ["with_serde"] }
 symbolic = { version = "8.7.1", path = "../symbolic", features = ["debuginfo", "demangle", "cfi", "sourcemap", "symcache", "unreal-serde"] }
-proguard = { version = "4.0.1", features = ["uuid"] }
+proguard = { version = "5.0.0", features = ["uuid"] }

--- a/symbolic-cabi/src/core.rs
+++ b/symbolic-cabi/src/core.rs
@@ -416,5 +416,5 @@ pub unsafe extern "C" fn symbolic_uuid_is_nil(uuid: *const SymbolicUuid) -> bool
 #[no_mangle]
 pub unsafe extern "C" fn symbolic_uuid_to_str(uuid: *const SymbolicUuid) -> SymbolicStr {
     let uuid = Uuid::from_slice(&(*uuid).data[..]).unwrap_or_default();
-    SymbolicStr::from_string(uuid.to_hyphenated_ref().to_string())
+    SymbolicStr::from_string(uuid.hyphenated().to_string())
 }

--- a/symbolic-common/Cargo.toml
+++ b/symbolic-common/Cargo.toml
@@ -21,11 +21,11 @@ edition = "2018"
 all-features = true
 
 [dependencies]
-debugid = "0.7.1"
+debugid = "0.8.0"
 memmap2 = "0.5.0"
 stable_deref_trait = "1.1.1"
 serde_ = { package = "serde", version = "1.0.88", optional = true, features = ["derive"] }
-uuid = "0.8.1"
+uuid = "1.0.0"
 
 [dev-dependencies]
 symbolic-testutils = { path = "../symbolic-testutils" }

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -85,7 +85,7 @@ goblin = { version = "0.5.1", optional = true, default-features = false }
 lazy_static = { version = "1.4.0", optional = true }
 lazycell = { version = "1.2.1", optional = true }
 nom = { version = "7.0.0", optional = true }
-nom-supreme = { version = "0.6.0", optional = true }
+nom-supreme = { version = "0.8.0", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 pdb = { version = "0.7.0", optional = true }
 regex = { version = "1.3.5", optional = true }
@@ -96,8 +96,8 @@ serde_json = { version = "1.0.40", optional = true }
 smallvec = { version = "1.2.0", optional = true }
 symbolic-common = { version = "8.7.1", path = "../symbolic-common" }
 thiserror = "1.0.20"
-wasmparser = { version = "0.83", optional = true }
-zip = { version = "0.5.2", optional = true, default-features = false, features = [
+wasmparser = { version = "0.84.0", optional = true }
+zip = { version = "0.6.2", optional = true, default-features = false, features = [
     "deflate",
 ] }
 


### PR DESCRIPTION
This also updates the `wasmparser` dependency, but most importantly debugid/uuid, which constitutes a breaking change.