### PR TITLE
ref: Remove apple-crash-report-parser from symbolic-cabi

### DIFF
--- a/symbolic-cabi/Cargo.toml
+++ b/symbolic-cabi/Cargo.toml
@@ -21,6 +21,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 serde_json = "1.0.40"
-apple-crash-report-parser = { version = "0.4.0", features = ["with_serde"] }
 symbolic = { version = "8.7.1", path = "../symbolic", features = ["debuginfo", "demangle", "cfi", "sourcemap", "symcache", "unreal-serde"] }
 proguard = { version = "4.0.1", features = ["uuid"] }

--- a/symbolic-cabi/src/core.rs
+++ b/symbolic-cabi/src/core.rs
@@ -203,13 +203,6 @@ pub enum SymbolicErrorCode {
     Unreal4ErrorInvalidLogEntry = 7006,
     Unreal4ErrorBadData = 7007,
     Unreal4ErrorTrailingData = 7008,
-
-    // apple-crash-report-parser
-    AppleCrashReportParseErrorIo = 8001,
-    AppleCrashReportParseErrorInvalidIncidentIdentifier = 8002,
-    AppleCrashReportParseErrorInvalidReportVersion = 8003,
-    AppleCrashReportParseErrorInvalidTimestamp = 8004,
-    AppleCrashReportParseErrorInvalidImageIdentifier = 8005,
 }
 
 impl SymbolicErrorCode {
@@ -293,25 +286,6 @@ impl SymbolicErrorCode {
                         SymbolicErrorCode::Unreal4ErrorInvalidLogEntry
                     }
                     _ => SymbolicErrorCode::Unreal4ErrorUnknown,
-                };
-            }
-
-            use apple_crash_report_parser::ParseError;
-            if let Some(error) = error.downcast_ref::<ParseError>() {
-                return match error {
-                    ParseError::Io(_) => SymbolicErrorCode::AppleCrashReportParseErrorIo,
-                    ParseError::InvalidIncidentIdentifier(_) => {
-                        SymbolicErrorCode::AppleCrashReportParseErrorInvalidIncidentIdentifier
-                    }
-                    ParseError::InvalidImageIdentifier(_) => {
-                        SymbolicErrorCode::AppleCrashReportParseErrorInvalidImageIdentifier
-                    }
-                    ParseError::InvalidReportVersion(_) => {
-                        SymbolicErrorCode::AppleCrashReportParseErrorInvalidReportVersion
-                    }
-                    ParseError::InvalidTimestamp(_) => {
-                        SymbolicErrorCode::AppleCrashReportParseErrorInvalidTimestamp
-                    }
                 };
             }
 


### PR DESCRIPTION
This was only imported to downcast/map errors. But this isn’t being used in any other parts of the codebase, so we are mapping errors that we can never create in the first place.