### PR TITLE
fix(build): use cli git to save some ram with cargo

### DIFF
--- a/py/manylinux.sh
+++ b/py/manylinux.sh
@@ -16,6 +16,11 @@ if [ "$AUDITWHEEL_ARCH" == "i686" ]; then
   LINUX32=linux32
 fi
 
+cat > ~/.cargo/config <<EOF
+[net]
+git-fetch-with-cli = true
+EOF
+
 $LINUX32 /opt/python/cp36-cp36m/bin/python setup.py bdist_wheel
 
 # Audit wheels


### PR DESCRIPTION
see https://github.com/rust-lang/cargo/issues/9167

cargo without this setting uses `libgit2` which appears to have a pretty bad memory leak (consuming ~9GB of ram and then never freeing it) -- later leading to an out-of-memory (docker exits with code 247)

on my x86_64 linux VM emulating arm64 via qemu this reduces the maximum memory usage of the build process from ~13GB to 2.7GB

test run here: https://github.com/getsentry/symbolic/runs/6530937203?check_suite_focus=true