### PR TITLE
fix: Only skip one fn when encountering unknown Unwind Codes on Win-x64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Only skip one function when encountering unknown Unwind Codes on Windows x64. ([#588](https://github.com/getsentry/symbolic/pull/588))
+
 ## 8.7.3
 
 **Fixes**:


### PR DESCRIPTION
Actually there was a comment above the match explaining the intent, but it did not match the actual code.