### PR TITLE
feat: Improve il2cpp line mapping parser

### DIFF
--- a/symbolic-il2cpp/src/line_mapping/from_object.rs
+++ b/symbolic-il2cpp/src/line_mapping/from_object.rs
@@ -153,7 +153,7 @@ mod tests {
     use super::{SourceInfo, SourceInfos};
 
     #[test]
-    fn simple() {
+    fn one_mapping() {
         let cpp_source = b"
             Lorem ipsum dolor sit amet
             //<source_info:main.cs:17>
@@ -169,8 +169,50 @@ mod tests {
             vec![SourceInfo {
                 cpp_line: 7,
                 cs_file: "main.cs",
-                cs_line: 17
+                cs_line: 17,
             }]
+        )
+    }
+
+    #[test]
+    fn several_mappings() {
+        let cpp_source = b"
+            Lorem ipsum dolor sit amet
+            //<source_info:main.cs:17>
+            // some
+            // comments
+            actual source code 1
+            actual source code 2
+
+            //<source_info:main.cs:29>
+            actual source code 3
+
+            //<source_info:main.cs:46>
+            // more
+            // comments
+            actual source code 4";
+
+        let source_infos: Vec<_> = SourceInfos::new(cpp_source).collect();
+
+        assert_eq!(
+            source_infos,
+            vec![
+                SourceInfo {
+                    cpp_line: 6,
+                    cs_file: "main.cs",
+                    cs_line: 17,
+                },
+                SourceInfo {
+                    cpp_line: 10,
+                    cs_file: "main.cs",
+                    cs_line: 29,
+                },
+                SourceInfo {
+                    cpp_line: 15,
+                    cs_file: "main.cs",
+                    cs_line: 46,
+                }
+            ]
         )
     }
 

--- a/symbolic-il2cpp/src/line_mapping/from_object.rs
+++ b/symbolic-il2cpp/src/line_mapping/from_object.rs
@@ -122,7 +122,7 @@ impl<'data> Iterator for SourceInfos<'data> {
     fn next(&mut self) -> Option<Self::Item> {
         for (cpp_line_nr, cpp_src_line) in &mut self.lines {
             match parse_line(cpp_src_line) {
-                // A new line info mapping. Emit the previously found one, if there is one.
+                // A new source info record. Emit the previously found one, if there is one.
                 Some((cs_file, cs_line)) => {
                     if let Some((cs_file, cs_line)) = self.current.replace((cs_file, cs_line)) {
                         return Some(SourceInfo {
@@ -135,7 +135,7 @@ impl<'data> Iterator for SourceInfos<'data> {
 
                 // A comment. Just continue.
                 None if cpp_src_line.trim_start().starts_with("//") => continue,
-                // A source line. Emit the previously found source line mapping, if there is one.
+                // A source line. Emit the previously found source info record, if there is one.
                 None => {
                     if let Some((cs_file, cs_line)) = self.current.take() {
                         return Some(SourceInfo {
@@ -244,7 +244,7 @@ mod tests {
 
         let source_infos: Vec<_> = SourceInfos::new(cpp_source).collect();
 
-        // The first source_info has no source line to attach to, so it should use the line
+        // The first source info has no source line to attach to, so it should use the line
         // immediately before the second source_info.
         assert_eq!(
             source_infos,


### PR DESCRIPTION
The parser will now look for the next non-comment line when it encounters a source_info comment and take that as the cpp_line, instead of just taking the source_info comment line itself.