### PR TITLE
fix: Remove use of deprecated clap functions

### DIFF
--- a/examples/addr2line/src/main.rs
+++ b/examples/addr2line/src/main.rs
@@ -1,7 +1,9 @@
 use std::borrow::Borrow;
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use clap::{Arg, ArgMatches, Command};
+use clap::builder::ValueParser;
+use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 
 use symbolic::common::{ByteView, Language, Name, NameMangling};
 use symbolic::debuginfo::{Function, Object};
@@ -11,7 +13,7 @@ fn print_name<'a, N: Borrow<Name<'a>>>(name: Option<N>, matches: &ArgMatches) {
     match name.as_ref().map(Borrow::borrow) {
         None => print!("??"),
         Some(name) if name.as_str().is_empty() => print!("??"),
-        Some(name) if matches.is_present("demangle") => {
+        Some(name) if *matches.get_one("demangle").unwrap() => {
             print!("{}", name.try_demangle(DemangleOptions::name_only()));
         }
         Some(name) => print!("{}", name),
@@ -19,7 +21,7 @@ fn print_name<'a, N: Borrow<Name<'a>>>(name: Option<N>, matches: &ArgMatches) {
 }
 
 fn print_range(start: u64, len: Option<u64>, matches: &ArgMatches) {
-    if matches.is_present("ranges") {
+    if *matches.get_one("ranges").unwrap() {
         print!(" ({:#x} - ", start);
         match len {
             Some(len) => print!("{:#x})", start + len),
@@ -33,7 +35,7 @@ fn resolve(function: &Function<'_>, addr: u64, matches: &ArgMatches) -> Result<b
         return Ok(false);
     }
 
-    if matches.is_present("inlines") {
+    if *matches.get_one("inlines").unwrap() {
         for il in &function.inlinees {
             resolve(il, addr, matches)?;
         }
@@ -46,13 +48,13 @@ fn resolve(function: &Function<'_>, addr: u64, matches: &ArgMatches) -> Result<b
             break;
         }
 
-        if matches.is_present("functions") {
+        if *matches.get_one("functions").unwrap() {
             print_name(Some(&function.name), matches);
             print_range(function.address, Some(function.size), matches);
             print!("\n  at ");
         }
 
-        let file = if matches.is_present("basenames") {
+        let file = if *matches.get_one("basenames").unwrap() {
             line.file.name_str()
         } else {
             line.file.path_str().into()
@@ -69,19 +71,16 @@ fn resolve(function: &Function<'_>, addr: u64, matches: &ArgMatches) -> Result<b
 }
 
 fn execute(matches: &ArgMatches) -> Result<()> {
-    let path = matches.value_of("path").unwrap_or("a.out");
+    let path = matches
+        .get_one::<PathBuf>("path")
+        .cloned()
+        .unwrap_or_else(|| PathBuf::from("a.out"));
     let view = ByteView::open(path).context("failed to open file")?;
     let object = Object::parse(&view).context("failed to parse file")?;
     let session = object.debug_session().context("failed to process file")?;
     let symbol_map = object.symbol_map();
 
-    'addrs: for addr in matches.values_of("addrs").unwrap_or_default() {
-        let addr = match addr.strip_prefix("0x") {
-            Some(addr) => u64::from_str_radix(addr, 16),
-            None => addr.parse(),
-        }
-        .context("unable to parse address")?;
-
+    'addrs: for &addr in matches.get_many::<u64>("addrs").unwrap_or_default() {
         for function in session.functions() {
             let function = function.context("failed to read function")?;
             if resolve(&function, addr, matches)? {
@@ -89,7 +88,7 @@ fn execute(matches: &ArgMatches) -> Result<()> {
             }
         }
 
-        if matches.is_present("functions") {
+        if *matches.get_one("functions").unwrap() {
             if let Some(symbol) = symbol_map.lookup(addr) {
                 print_name(
                     symbol
@@ -109,6 +108,14 @@ fn execute(matches: &ArgMatches) -> Result<()> {
     Ok(())
 }
 
+fn parse_addr(addr: &str) -> anyhow::Result<u64> {
+    match addr.strip_prefix("0x") {
+        Some(addr) => u64::from_str_radix(addr, 16),
+        None => addr.parse(),
+    }
+    .context("unable to parse address")
+}
+
 fn main() {
     let about = r#"addr2line translates addresses into file names and line numbers. Given an address in an executable or an offset in a section of a relocatable object, it uses the debugging information to figure out which file name and line number are associated with it.
 
@@ -123,6 +130,7 @@ In the second, addr2line reads hexadecimal addresses from standard input, and pr
             Arg::new("demangle")
                 .short('C')
                 .long("demangle")
+                .action(ArgAction::SetTrue)
                 .help("Decode (demangle) low-level symbol names into user-level names. Besides removing any initial underscore prepended by the system, this makes C ++ function names readable.")
         )
         .arg(
@@ -130,30 +138,35 @@ In the second, addr2line reads hexadecimal addresses from standard input, and pr
                 .short('e')
                 .long("exe")
                 .number_of_values(1)
+                .value_parser(value_parser!(PathBuf))
                 .help("Specify the name of the executable for which addresses should be translated. The default file is a.out.")
         )
         .arg(
             Arg::new("functions")
                 .short('f')
                 .long("functions")
+                .action(ArgAction::SetTrue)
                 .help("Display function names as well as file and line number information."),
         )
         .arg(
             Arg::new("ranges")
                 .short('r')
                 .long("ranges")
+                .action(ArgAction::SetTrue)
                 .help("Display function address ranges in addition to function names."),
         )
         .arg(
             Arg::new("basenames")
                 .short('s')
                 .long("basenames")
+                .action(ArgAction::SetTrue)
                 .help("Display only the base of each file name."),
         )
         .arg(
             Arg::new("inlinees")
                 .short('i')
                 .long("inlinees")
+                .action(ArgAction::SetTrue)
                 .help("If the address belongs to a function that was inlined, the source information for all enclosing scopes back to the first non-inlined function will also be printed. For example, if \"main\" inlines \"callee1\" which inlines \"callee2\", and address is from \"callee2\", the source information for \"callee1\" and \"main\" will also be printed.")
         )
         .arg(
@@ -161,6 +174,7 @@ In the second, addr2line reads hexadecimal addresses from standard input, and pr
                 .required(true)
                 .takes_value(true)
                 .multiple_values(true)
+                .value_parser(ValueParser::new(parse_addr))
                 .help("Addresses to be translated."),
         )
         .get_matches();

--- a/examples/dump_cfi/src/main.rs
+++ b/examples/dump_cfi/src/main.rs
@@ -1,7 +1,7 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use clap::{Arg, ArgMatches, Command};
+use clap::{value_parser, Arg, ArgMatches, Command};
 
 use symbolic::common::{ByteView, DSymPathExt};
 use symbolic::debuginfo::Object;
@@ -29,7 +29,7 @@ fn dump_cfi<P: AsRef<Path>>(path: P) -> Result<()> {
 }
 
 fn execute(matches: &ArgMatches) -> Result<()> {
-    let path = matches.value_of("path").unwrap();
+    let path = matches.get_one::<PathBuf>("path").unwrap();
     dump_cfi(path)
 }
 
@@ -42,6 +42,7 @@ fn main() {
                 .value_name("PATH")
                 .help("Path to the debug file")
                 .number_of_values(1)
+                .value_parser(value_parser!(PathBuf))
                 .index(1),
         )
         .get_matches();

--- a/examples/dump_sources/src/main.rs
+++ b/examples/dump_sources/src/main.rs
@@ -1,6 +1,6 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use clap::{Arg, ArgMatches, Command};
+use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 
 use symbolic::common::{ByteView, DSymPathExt};
 use symbolic::debuginfo::sourcebundle::SourceBundleWriter;
@@ -44,8 +44,8 @@ fn write_object_sources(path: &Path, output_path: &Path) -> Result<(), Box<dyn s
 }
 
 fn execute(matches: &ArgMatches) {
-    let output_path = Path::new(matches.value_of("output").unwrap());
-    for path in matches.values_of("paths").unwrap_or_default() {
+    let output_path = matches.get_one::<PathBuf>("output").unwrap();
+    for path in matches.get_many::<PathBuf>("paths").unwrap_or_default() {
         if let Err(e) = write_object_sources(Path::new(&path), output_path) {
             print_error(e.as_ref());
         }
@@ -60,8 +60,9 @@ fn main() {
         .arg(
             Arg::new("paths")
                 .required(true)
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .value_name("PATH")
+                .value_parser(value_parser!(PathBuf))
                 .help("Path to the debug file")
                 .number_of_values(1)
                 .index(1),
@@ -72,6 +73,7 @@ fn main() {
                 .long("output")
                 .required(true)
                 .value_name("PATH")
+                .value_parser(value_parser!(PathBuf))
                 .help("Path to the source output folder"),
         )
         .get_matches();

--- a/examples/object_debug/src/main.rs
+++ b/examples/object_debug/src/main.rs
@@ -1,6 +1,6 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use clap::{Arg, ArgMatches, Command};
+use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 
 use symbolic::common::{ByteView, DSymPathExt};
 use symbolic::debuginfo::Archive;
@@ -53,7 +53,7 @@ fn inspect_object<P: AsRef<Path>>(path: P) -> Result<(), Box<dyn std::error::Err
 }
 
 fn execute(matches: &ArgMatches) {
-    for path in matches.values_of("paths").unwrap_or_default() {
+    for path in matches.get_many::<PathBuf>("paths").unwrap_or_default() {
         if let Err(e) = inspect_object(path) {
             print_error(e.as_ref())
         }
@@ -68,8 +68,9 @@ fn main() {
         .arg(
             Arg::new("paths")
                 .required(true)
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .value_name("PATH")
+                .value_parser(value_parser!(PathBuf))
                 .help("Path to the debug file")
                 .number_of_values(1)
                 .index(1),

--- a/examples/symcache_debug/src/main.rs
+++ b/examples/symcache_debug/src/main.rs
@@ -1,16 +1,17 @@
 use std::fs::File;
 use std::io::{Cursor, Write};
-use std::path::Path;
+use std::path::PathBuf;
+use std::str::FromStr;
 use std::u64;
 
-use anyhow::{anyhow, Result};
-use clap::{Arg, ArgMatches, Command};
+use anyhow::{anyhow, Context, Result};
+use clap::builder::ValueParser;
+use clap::{Arg, ArgAction, ArgMatches, Command};
 
 use symbolic::common::{Arch, ByteView, DSymPathExt, Language, SelfCell};
 use symbolic::debuginfo::macho::BcSymbolMap;
 use symbolic::debuginfo::Archive;
 use symbolic::demangle::{Demangle, DemangleOptions};
-#[cfg(feature = "il2cpp")]
 use symbolic::il2cpp::LineMapping;
 use symbolic::symcache::transform::{self, Transformer};
 use symbolic::symcache::{SymCache, SymCacheWriter};
@@ -36,13 +37,10 @@ fn execute(matches: &ArgMatches) -> Result<()> {
     let symcache;
 
     // load an object from the debug info file.
-    if let Some(file_path) = matches.value_of("debug_file_path") {
-        let arch = match matches.value_of("arch") {
-            Some(arch) => arch.parse()?,
-            None => Arch::Unknown,
-        };
+    if let Some(file_path) = matches.get_one::<PathBuf>("debug_file_path") {
+        let arch = matches.get_one("arch").copied().unwrap_or(Arch::Unknown);
 
-        let dsym_path = Path::new(file_path).resolve_dsym();
+        let dsym_path = file_path.resolve_dsym();
         let byteview = ByteView::open(dsym_path.as_deref().unwrap_or_else(|| file_path.as_ref()))?;
         let fat_obj = Archive::parse(&byteview)?;
         let objects_result: Result<Vec<_>, _> = fat_obj.objects().collect();
@@ -75,8 +73,7 @@ fn execute(matches: &ArgMatches) -> Result<()> {
 
         let mut writer = SymCacheWriter::new(Cursor::new(Vec::new()))?;
 
-        if let Some(bcsymbolmap_file) = matches.value_of("bcsymbolmap_file") {
-            let bcsymbolmap_path = Path::new(bcsymbolmap_file);
+        if let Some(bcsymbolmap_path) = matches.get_one::<PathBuf>("bcsymbolmap_file") {
             let bcsymbolmap_buffer = ByteView::open(bcsymbolmap_path)?;
             let bcsymbolmap =
                 OwnedBcSymbolMap(SelfCell::try_new(bcsymbolmap_buffer, |s| unsafe {
@@ -85,14 +82,10 @@ fn execute(matches: &ArgMatches) -> Result<()> {
             writer.add_transformer(bcsymbolmap);
         }
 
-        #[cfg(feature = "il2cpp")]
-        {
-            if let Some(linemapping_file) = matches.value_of("linemapping_file") {
-                let linemapping_path = Path::new(linemapping_file);
-                let linemapping_buffer = ByteView::open(linemapping_path)?;
-                if let Some(linemapping) = LineMapping::parse(&linemapping_buffer) {
-                    writer.add_transformer(linemapping);
-                }
+        if let Some(linemapping_path) = matches.get_one::<PathBuf>("linemapping_file") {
+            let linemapping_buffer = ByteView::open(linemapping_path)?;
+            if let Some(linemapping) = LineMapping::parse(&linemapping_buffer) {
+                writer.add_transformer(linemapping);
             }
         }
 
@@ -102,35 +95,33 @@ fn execute(matches: &ArgMatches) -> Result<()> {
         symcache = SymCache::parse(&buffer)?;
 
         // write mode
-        if matches.is_present("write_cache_file") {
+        if *matches.get_one("write_cache_file").unwrap() {
             let filename = matches
-                .value_of("symcache_file_path")
-                .map(str::to_owned)
-                .unwrap_or_else(|| format!("{}.symcache", file_path));
+                .get_one::<PathBuf>("symcache_file_path")
+                .cloned()
+                .unwrap_or_else(|| {
+                    let mut symcache_path = file_path.clone().into_os_string();
+                    symcache_path.push(".symcache");
+                    PathBuf::from(symcache_path)
+                });
             File::create(&filename)?.write_all(&buffer)?;
-            println!("Cache file written to {}", filename);
+            println!("Cache file written to {}", filename.display());
         }
-    } else if let Some(file_path) = matches.value_of("symcache_file_path") {
+    } else if let Some(file_path) = matches.get_one::<PathBuf>("symcache_file_path") {
         buffer = ByteView::open(file_path)?;
         symcache = SymCache::parse(&buffer)?;
     } else {
-        return Err(anyhow!("No debug file or sym cache provided"));
+        return Err(anyhow!("No debug file or symcache provided"));
     }
 
     // report
-    if matches.is_present("report") {
+    if *matches.get_one("report").unwrap() {
         println!("Cache info:");
         println!("{:#?}", &symcache);
     }
 
     // lookup mode
-    if let Some(addr) = matches.value_of("lookup_addr") {
-        let addr = if addr.len() > 2 && &addr[..2] == "0x" {
-            u64::from_str_radix(&addr[2..], 16)?
-        } else {
-            addr.parse()?
-        };
-
+    if let Some(addr) = matches.get_one::<u64>("lookup_addr").copied() {
         let m = symcache.lookup(addr)?.collect::<Vec<_>>()?;
         if m.is_empty() {
             println!("No match :(");
@@ -166,7 +157,7 @@ fn execute(matches: &ArgMatches) -> Result<()> {
     }
 
     // print mode
-    if matches.is_present("print_symbols") {
+    if *matches.get_one("print_symbols").unwrap() {
         #[allow(deprecated)]
         for func in symcache.functions() {
             let func = func?;
@@ -177,6 +168,14 @@ fn execute(matches: &ArgMatches) -> Result<()> {
     Ok(())
 }
 
+fn parse_addr(addr: &str) -> anyhow::Result<u64> {
+    match addr.strip_prefix("0x") {
+        Some(addr) => u64::from_str_radix(addr, 16),
+        None => addr.parse(),
+    }
+    .context("unable to parse address")
+}
+
 fn main() {
     let matches = Command::new("symcache-debug")
         .about("Works with symbol files with the symcache interface")
@@ -185,6 +184,7 @@ fn main() {
                 .short('d')
                 .long("debug-file")
                 .value_name("PATH")
+                .value_parser(clap::value_parser!(PathBuf))
                 .help("Path to the debug info file"),
         )
         .arg(
@@ -192,6 +192,7 @@ fn main() {
                 .short('b')
                 .long("bcsymbolmap-file")
                 .value_name("PATH")
+                .value_parser(clap::value_parser!(PathBuf))
                 .help(
                     "Path to a bcsymbolmap file that should be applied to transform the debug file",
                 ),
@@ -201,6 +202,7 @@ fn main() {
                 .short('l')
                 .long("linemapping-file")
                 .value_name("PATH")
+                .value_parser(clap::value_parser!(PathBuf))
                 .help(
                     "Path to a il2cpp `LineNumberMappings.json` file that should be applied to transform the debug file",
                 ),
@@ -209,6 +211,7 @@ fn main() {
             Arg::new("write_cache_file")
                 .short('w')
                 .long("write-cache-file")
+                .action(ArgAction::SetTrue)
                 .help(
                     "Write the cache file from the debug info file.  If no file name is \
                      provided via --symcache-file it will be written to the source file \
@@ -220,11 +223,13 @@ fn main() {
                 .short('a')
                 .long("arch")
                 .value_name("ARCH")
+                .value_parser(ValueParser::new(Arch::from_str))
                 .help("The architecture of the object to work with."),
         )
         .arg(
             Arg::new("report")
                 .long("report")
+                .action(ArgAction::SetTrue)
                 .help("Spit out some debug information"),
         )
         .arg(
@@ -232,17 +237,20 @@ fn main() {
                 .short('c')
                 .long("symcache-file")
                 .value_name("PATH")
+                .value_parser(clap::value_parser!(PathBuf))
                 .help("Path to the symcache file"),
         )
         .arg(
             Arg::new("lookup_addr")
                 .long("lookup")
                 .value_name("ADDR")
+                .value_parser(ValueParser::new(parse_addr))
                 .help("Looks up an address in the debug file"),
         )
         .arg(
             Arg::new("print_symbols")
                 .long("symbols")
+                .action(ArgAction::SetTrue)
                 .help("Print all symbols"),
         )
         .get_matches();

--- a/examples/unreal_engine_crash/src/main.rs
+++ b/examples/unreal_engine_crash/src/main.rs
@@ -1,13 +1,13 @@
-use std::cmp;
 use std::fs::File;
 use std::io::Read;
+use std::{cmp, path::PathBuf};
 
-use clap::{Arg, ArgMatches, Command};
+use clap::{value_parser, Arg, ArgMatches, Command};
 
 use symbolic::unreal::{Unreal4Crash, Unreal4FileType};
 
 fn execute(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let crash_file_path = matches.value_of("crash_file_path").unwrap();
+    let crash_file_path = matches.get_one::<PathBuf>("crash_file_path").unwrap();
 
     let mut file = File::open(crash_file_path)?;
     let mut file_content = Vec::new();
@@ -47,6 +47,7 @@ fn main() {
             Arg::new("crash_file_path")
                 .required(true)
                 .value_name("crash_file_path")
+                .value_parser(value_parser!(PathBuf))
                 .help("Path to the crash file"),
         )
         .get_matches();


### PR DESCRIPTION
* Values of options (including boolean flags) are obtained with `get_one/get_many` instead of `value_of/values_of`.
  These methods are typed, i.e., they can return numbers, paths, &c.
* Argument parsing (paths, addresses) now happens in clap code directly instead of after the fact.
* Boolean flags use `.action(ArgAction::SetTrue/SetFalse)` to control whether using the flag returns `true` or `false`.
* `.multiple_occurrences` is replaced with `.action(ArgAction::Append)`.