### PR TITLE
fix: Fix benchmarks and add them to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-features --workspace --tests --examples -- -D clippy::all
+          args: --all-features --workspace --all-targets -- -D clippy::all
 
       - run: make lint-python
 
@@ -99,7 +99,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-features
+          args: --workspace --all-features --all-targets
 
   test-python:
     strategy:

--- a/symbolic-symcache/benches/bench_writer.rs
+++ b/symbolic-symcache/benches/bench_writer.rs
@@ -4,7 +4,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 use symbolic_common::ByteView;
 use symbolic_debuginfo::Object;
-use symbolic_symcache::SymCacheWriter;
+use symbolic_symcache::SymCacheConverter;
 use symbolic_testutils::fixture;
 
 fn bench_write_linux(c: &mut Criterion) {
@@ -12,9 +12,11 @@ fn bench_write_linux(c: &mut Criterion) {
         let buffer = ByteView::open(fixture("linux/crash.debug")).expect("open");
         b.iter(|| {
             let object = Object::parse(&buffer).expect("parse");
-            SymCacheWriter::write_object(&object, Cursor::new(Vec::new()))
+            let mut converter = SymCacheConverter::new();
+            converter.process_object(&object).expect("process_object");
+            converter
+                .serialize(&mut Cursor::new(Vec::new()))
                 .expect("write_object")
-                .into_inner()
         });
     });
 }
@@ -26,9 +28,11 @@ fn bench_write_macos(c: &mut Criterion) {
 
         b.iter(|| {
             let object = Object::parse(&buffer).expect("parse");
-            SymCacheWriter::write_object(&object, Cursor::new(Vec::new()))
+            let mut converter = SymCacheConverter::new();
+            converter.process_object(&object).expect("process_object");
+            converter
+                .serialize(&mut Cursor::new(Vec::new()))
                 .expect("write_object")
-                .into_inner()
         });
     });
 }
@@ -38,9 +42,11 @@ fn bench_write_breakpad(c: &mut Criterion) {
         let buffer = ByteView::open(fixture("windows/crash.sym")).expect("open");
         b.iter(|| {
             let object = Object::parse(&buffer).expect("parse");
-            SymCacheWriter::write_object(&object, Cursor::new(Vec::new()))
+            let mut converter = SymCacheConverter::new();
+            converter.process_object(&object).expect("process_object");
+            converter
+                .serialize(&mut Cursor::new(Vec::new()))
                 .expect("write_object")
-                .into_inner()
         });
     });
 }


### PR DESCRIPTION
This makes sure that clippy and cargo test also run on benchmarks in CI so they stay up to date with the code.