### PR TITLE
Fix print_files argument of the symcache_debug example.

### DIFF
--- a/examples/symcache_debug/src/main.rs
+++ b/examples/symcache_debug/src/main.rs
@@ -259,6 +259,7 @@ fn main() {
         .arg(
             Arg::new("print_files")
                 .long("files")
+                .action(ArgAction::SetTrue)
                 .help("Print all files"),
         )
         .get_matches();


### PR DESCRIPTION
Without this SetTrue, running the example panics at the end because we try to unwrap a None value.

```
% cargo run --release -p symcache_debug -- -w -d ../dump_syms/testmozglue.txt
    Finished release [optimized + debuginfo] target(s) in 0.04s
     Running `target/release/symcache_debug -w -d ../dump_syms/testmozglue.txt`
Cache file written to ../dump_syms/testmozglue.txt.symcache
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', examples/symcache_debug/src/main.rs:167:40
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

```rust
    // print mode
    if *matches.get_one("print_symbols").unwrap() {
        println!("{:?}", FunctionsDebug(&symcache));
    }

    // print mode
    if *matches.get_one("print_files").unwrap() { // <-- here
        println!("{:?}", FilesDebug(&symcache));
    }
```