### PR TITLE
fix: Always generate .ra CFI on MIPS

### DIFF
--- a/examples/minidump_stackwalk/Cargo.toml
+++ b/examples/minidump_stackwalk/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 [dependencies]
 async-trait = "0.1.53"
 clap = "3.1.0"
-minidump = { path = "../../../rust-minidump/minidump" }
-minidump-processor = {  path = "../../../rust-minidump/minidump-processor", features = ["symbolic-syms"] }
+minidump = "0.11.0"
+minidump-processor = { version = "0.11.0", features = ["symbolic-syms"] }
 symbolic = { path = "../../symbolic", features = ["symcache", "demangle", "cfi"] }
 thiserror = "1.0.31"
 tokio = {version = "1.18.1", features = ["macros", "rt"] }

--- a/examples/minidump_stackwalk/Cargo.toml
+++ b/examples/minidump_stackwalk/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 [dependencies]
 async-trait = "0.1.53"
 clap = "3.1.0"
-minidump = "0.11.0"
-minidump-processor = { version = "0.11.0", features = ["symbolic-syms"] }
+minidump = { path = "../../../rust-minidump/minidump" }
+minidump-processor = {  path = "../../../rust-minidump/minidump-processor", features = ["symbolic-syms"] }
 symbolic = { path = "../../symbolic", features = ["symcache", "demangle", "cfi"] }
 thiserror = "1.0.31"
 tokio = {version = "1.18.1", features = ["macros", "rt"] }

--- a/examples/minidump_stackwalk/src/main.rs
+++ b/examples/minidump_stackwalk/src/main.rs
@@ -295,6 +295,7 @@ impl<'a> minidump_processor::SymbolProvider for LocalSymbolProvider<'a> {
         module: &(dyn Module + Sync),
         walker: &mut (dyn FrameWalker + Send),
     ) -> Option<()> {
+        tracing::info!("walk_frame called");
         if !self.use_cfi {
             return None;
         }
@@ -575,7 +576,7 @@ async fn execute(matches: &ArgMatches) -> Result<(), Error> {
 
     let options = PrintOptions {
         crashed_only: *matches.get_one("only_crash").unwrap(),
-        show_modules: *matches.get_one("no_modules").unwrap(),
+        show_modules: *matches.get_one("show_modules").unwrap(),
     };
 
     let (cfi_files, symcaches) = symbol_provider.into_inner();

--- a/examples/minidump_stackwalk/src/main.rs
+++ b/examples/minidump_stackwalk/src/main.rs
@@ -295,7 +295,6 @@ impl<'a> minidump_processor::SymbolProvider for LocalSymbolProvider<'a> {
         module: &(dyn Module + Sync),
         walker: &mut (dyn FrameWalker + Send),
     ) -> Option<()> {
-        tracing::info!("walk_frame called");
         if !self.use_cfi {
             return None;
         }
@@ -576,7 +575,7 @@ async fn execute(matches: &ArgMatches) -> Result<(), Error> {
 
     let options = PrintOptions {
         crashed_only: *matches.get_one("only_crash").unwrap(),
-        show_modules: *matches.get_one("show_modules").unwrap(),
+        show_modules: *matches.get_one("no_modules").unwrap(),
     };
 
     let (cfi_files, symcaches) = symbol_provider.into_inner();

--- a/examples/minidump_stackwalk/src/main.rs
+++ b/examples/minidump_stackwalk/src/main.rs
@@ -270,7 +270,7 @@ impl<'a> minidump_processor::SymbolProvider for LocalSymbolProvider<'a> {
         let source_location = symcache
             .get()
             .lookup(instruction - module.base_address())
-            .next()
+            .last()
             .ok_or(FillSymbolError {})?;
 
         frame.set_function(
@@ -575,7 +575,7 @@ async fn execute(matches: &ArgMatches) -> Result<(), Error> {
 
     let options = PrintOptions {
         crashed_only: *matches.get_one("only_crash").unwrap(),
-        show_modules: *matches.get_one("no_modules").unwrap(),
+        show_modules: *matches.get_one("show_modules").unwrap(),
     };
 
     let (cfi_files, symcaches) = symbol_provider.into_inner();

--- a/symbolic-cfi/src/lib.rs
+++ b/symbolic-cfi/src/lib.rs
@@ -273,7 +273,7 @@ impl<U> UnwindInfo<U> {
         let arch = object.arch();
         let load_address = object.load_address();
 
-        // CFI information can have relative offsets to the virtual address of the respective debug
+        // CFI can have relative offsets to the virtual address of the respective debug
         // section (either `.eh_frame` or `.debug_frame`). We need to supply this offset to the
         // entries iterator before starting to interpret instructions. The other base addresses are
         // not needed for CFI.
@@ -746,18 +746,24 @@ impl<W: Write> AsciiCfiWriter<W> {
                 // Print only registers that have changed rules to their previous occurrence to
                 // reduce the number of rules per row. Then, cache the new occurrence for the next
                 // row.
-                let mut did_write_ra = false;
+                let mut ra_written = false;
                 for &(register, ref rule) in row.registers() {
                     if !rule_cache.get(&register).map_or(false, |c| c == &rule) {
                         rule_cache.insert(register, rule);
                         if register == ra {
-                            did_write_ra = true;
+                            ra_written = true;
                         }
                         written |=
                             Self::write_register_rule(&mut line, info.arch, register, rule, ra)?;
                     }
                 }
-                if row.start_address() == start && !did_write_ra {
+                // On MIPS: if no explicit rule was encountered for the return address,
+                // emit a rule stating that the return address should be recovered from the
+                // $ra register.
+                if row.start_address() == start
+                    && !ra_written
+                    && matches!(info.arch, Arch::Mips | Arch::Mips64)
+                {
                     write!(line, " .ra: $ra")?;
                 }
 


### PR DESCRIPTION
this is just a hack so far, it needs to be cleaned up so its more reliable, and obviously should only be used when we are dealing with MIPS.