### PR TITLE
Fix argument name in addr2line example

### DIFF
--- a/examples/addr2line/src/main.rs
+++ b/examples/addr2line/src/main.rs
@@ -35,7 +35,7 @@ fn resolve(function: &Function<'_>, addr: u64, matches: &ArgMatches) -> Result<b
         return Ok(false);
     }
 
-    if *matches.get_one("inlines").unwrap() {
+    if *matches.get_one("inlinees").unwrap() {
         for il in &function.inlinees {
             resolve(il, addr, matches)?;
         }


### PR DESCRIPTION
This fixes a panic.

I used this example to find discrepancies between native debug files and .sym files, as follows:

```
% cargo run --release -p addr2line -- -Cfi --exe ~/Downloads/libmozglue.dylib.dSYM/Contents/Resources/DWARF/libmozglue.dylib 0x54a7c
[...]
% cargo run --release -p addr2line -- -Cfi --exe ../dump_syms/testmozglue.txt 0x54a7c
[...]
```

It was quite helpful during debugging.