### PR TITLE
Re-generate crash.inlines.sym with correct information

### DIFF
--- a/symbolic-debuginfo/tests/snapshots/test_objects__breakpad_functions_mac_with_inlines.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__breakpad_functions_mac_with_inlines.snap
@@ -27,7 +27,7 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0xd8a: minidump_file_writer.cc:102 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
   0xd8c: minidump_file_writer.cc:101 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
 
-  > 0xd6a: google_breakpad::MinidumpFileWriter::~MinidumpFileWriter() (0x20)
+  > 0xd6a: google_breakpad::MinidumpFileWriter::Close() (0x20)
     0xd6a: minidump_file_writer.cc:127 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
     0xd71: minidump_file_writer.cc:133 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
     0xd7d: minidump_file_writer.cc:140 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
@@ -51,7 +51,7 @@ expression: "FunctionsDebug(&functions[..10], 0)"
     0xde4: minidump_file_writer.cc:100 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
     0xdea: minidump_file_writer.cc:101 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
 
-    > 0xdea: google_breakpad::MinidumpFileWriter::~MinidumpFileWriter() (0x20)
+    > 0xdea: google_breakpad::MinidumpFileWriter::Close() (0x20)
       0xdea: minidump_file_writer.cc:127 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
       0xdf1: minidump_file_writer.cc:133 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
       0xdfd: minidump_file_writer.cc:140 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
@@ -90,30 +90,30 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0xf97: minidump_file_writer.cc:179 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
   0xfa9: minidump_file_writer.cc:174 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
 
-  > 0xefa: google_breakpad::MinidumpFileWriter::CopyStringToMDString(wchar_t const*, unsigned int, google_breakpad::TypedMDRVA<MDString>*) (0x25)
+  > 0xefa: google_breakpad::TypedMDRVA<MDString>::CopyIndexAfterObject(unsigned int, void const*, unsigned long) (0x25)
     0xefa: minidump_file_writer-inl.h:83 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
     0xf0e: minidump_file_writer-inl.h:84 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
     0xf12: minidump_file_writer-inl.h:84 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
 
-    > 0xf12: google_breakpad::TypedMDRVA<MDString>::CopyIndexAfterObject(unsigned int, void const*, unsigned long) (0xd)
+    > 0xf12: google_breakpad::MinidumpFileWriter::Copy(unsigned int, void const*, long) (0xd)
       0xf12: minidump_file_writer.cc:313 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
 
-  > 0xf23: google_breakpad::MinidumpFileWriter::CopyStringToMDString(wchar_t const*, unsigned int, google_breakpad::TypedMDRVA<MDString>*) (0x44)
+  > 0xf23: google_breakpad::TypedMDRVA<MDString>::CopyIndexAfterObject(unsigned int, void const*, unsigned long) (0x44)
     0xf23: minidump_file_writer-inl.h:86 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
     0xf2a: minidump_file_writer-inl.h:85 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
     0xf2f: minidump_file_writer-inl.h:86 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
     0xf34: minidump_file_writer-inl.h:84 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
 
-    > 0xf34: google_breakpad::TypedMDRVA<MDString>::CopyIndexAfterObject(unsigned int, void const*, unsigned long) (0x33)
+    > 0xf34: google_breakpad::MinidumpFileWriter::Copy(unsigned int, void const*, long) (0x33)
       0xf34: minidump_file_writer.cc:316 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
       0xf41: minidump_file_writer.cc:327 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
       0xf50: minidump_file_writer.cc:328 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
 
-  > 0xfa9: google_breakpad::MinidumpFileWriter::CopyStringToMDString(wchar_t const*, unsigned int, google_breakpad::TypedMDRVA<MDString>*) (0x3e)
+  > 0xfa9: google_breakpad::TypedMDRVA<MDString>::CopyIndexAfterObject(unsigned int, void const*, unsigned long) (0x3e)
     0xfa9: minidump_file_writer-inl.h:83 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
     0xfc8: minidump_file_writer-inl.h:84 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
 
-    > 0xfc8: google_breakpad::TypedMDRVA<MDString>::CopyIndexAfterObject(unsigned int, void const*, unsigned long) (0x1f)
+    > 0xfc8: google_breakpad::MinidumpFileWriter::Copy(unsigned int, void const*, long) (0x1f)
       0xfc8: minidump_file_writer.cc:313 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
 
 > 0xff0: google_breakpad::MinidumpFileWriter::CopyStringToMDString(char const*, unsigned int, google_breakpad::TypedMDRVA<MDString>*) (0x147)
@@ -132,30 +132,30 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x10e7: minidump_file_writer.cc:205 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
   0x10f9: minidump_file_writer.cc:201 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
 
-  > 0x1049: google_breakpad::MinidumpFileWriter::CopyStringToMDString(char const*, unsigned int, google_breakpad::TypedMDRVA<MDString>*) (0x1e)
+  > 0x1049: google_breakpad::TypedMDRVA<MDString>::CopyIndexAfterObject(unsigned int, void const*, unsigned long) (0x1e)
     0x1049: minidump_file_writer-inl.h:83 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
     0x1058: minidump_file_writer-inl.h:84 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
     0x105b: minidump_file_writer-inl.h:84 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
 
-    > 0x105b: google_breakpad::TypedMDRVA<MDString>::CopyIndexAfterObject(unsigned int, void const*, unsigned long) (0xc)
+    > 0x105b: google_breakpad::MinidumpFileWriter::Copy(unsigned int, void const*, long) (0xc)
       0x105b: minidump_file_writer.cc:313 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
 
-  > 0x106b: google_breakpad::MinidumpFileWriter::CopyStringToMDString(char const*, unsigned int, google_breakpad::TypedMDRVA<MDString>*) (0x48)
+  > 0x106b: google_breakpad::TypedMDRVA<MDString>::CopyIndexAfterObject(unsigned int, void const*, unsigned long) (0x48)
     0x106b: minidump_file_writer-inl.h:86 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
     0x1072: minidump_file_writer-inl.h:85 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
     0x1076: minidump_file_writer-inl.h:86 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
     0x107b: minidump_file_writer-inl.h:84 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
 
-    > 0x107b: google_breakpad::TypedMDRVA<MDString>::CopyIndexAfterObject(unsigned int, void const*, unsigned long) (0x38)
+    > 0x107b: google_breakpad::MinidumpFileWriter::Copy(unsigned int, void const*, long) (0x38)
       0x107b: minidump_file_writer.cc:316 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
       0x108c: minidump_file_writer.cc:327 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
       0x109b: minidump_file_writer.cc:328 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
 
-  > 0x10f9: google_breakpad::MinidumpFileWriter::CopyStringToMDString(char const*, unsigned int, google_breakpad::TypedMDRVA<MDString>*) (0x3e)
+  > 0x10f9: google_breakpad::TypedMDRVA<MDString>::CopyIndexAfterObject(unsigned int, void const*, unsigned long) (0x3e)
     0x10f9: minidump_file_writer-inl.h:83 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
     0x1118: minidump_file_writer-inl.h:84 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
 
-    > 0x1118: google_breakpad::TypedMDRVA<MDString>::CopyIndexAfterObject(unsigned int, void const*, unsigned long) (0x1f)
+    > 0x1118: google_breakpad::MinidumpFileWriter::Copy(unsigned int, void const*, long) (0x1f)
       0x1118: minidump_file_writer.cc:313 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
 
 > 0x1140: google_breakpad::MinidumpFileWriter::WriteString(wchar_t const*, unsigned int, MDLocationDescriptor*) (0x5)

--- a/symbolic-testutils/fixtures/macos/crash.inlines.sym
+++ b/symbolic-testutils/fixtures/macos/crash.inlines.sym
@@ -10,9 +10,9 @@ FILE 6 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/mac
 FILE 7 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits
 FILE 8 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/mac/handler/dynamic_images.cc
 FILE 9 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/vector
-FILE 10 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/new
-FILE 11 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__split_buffer
-FILE 12 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory
+FILE 10 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory
+FILE 11 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/new
+FILE 12 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__split_buffer
 FILE 13 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/string
 FILE 14 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/iterator
 FILE 15 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/mac/handler/exception_handler.cc
@@ -30,369 +30,456 @@ FILE 26 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/ma
 FILE 27 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/file_id.cc
 FILE 28 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/macho_id.cc
 FILE 29 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/macho_utilities.cc
-FILE 30 /usr/include/libkern/i386/_OSByteOrder.h
-FILE 31 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/macho_walker.cc
-FILE 32 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/string_utilities.cc
-FILE 33 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/MachIPC.mm
-FILE 34 /Users/travis/build/getsentry/breakpad-tools/macos/main.cpp
+FILE 30 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/byteswap.h
+FILE 31 /usr/include/libkern/i386/_OSByteOrder.h
+FILE 32 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/macho_walker.cc
+FILE 33 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/string_utilities.cc
+FILE 34 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/MachIPC.mm
+FILE 35 /Users/travis/build/getsentry/breakpad-tools/macos/main.cpp
 INLINE_ORIGIN 0 google_breakpad::MinidumpFileWriter::MinidumpFileWriter()
-INLINE_ORIGIN 1 google_breakpad::MinidumpFileWriter::~MinidumpFileWriter()
+INLINE_ORIGIN 1 google_breakpad::MinidumpFileWriter::Close()
 INLINE_ORIGIN 2 google_breakpad::MinidumpFileWriter::~MinidumpFileWriter()
-INLINE_ORIGIN 3 google_breakpad::MinidumpFileWriter::CopyStringToMDString(wchar_t const*, unsigned int, google_breakpad::TypedMDRVA<MDString>*)
-INLINE_ORIGIN 4 google_breakpad::TypedMDRVA<MDString>::CopyIndexAfterObject(unsigned int, void const*, unsigned long)
-INLINE_ORIGIN 5 google_breakpad::MinidumpFileWriter::CopyStringToMDString(char const*, unsigned int, google_breakpad::TypedMDRVA<MDString>*)
-INLINE_ORIGIN 6 bool google_breakpad::MinidumpFileWriter::WriteStringCore<wchar_t>(wchar_t const*, unsigned int, MDLocationDescriptor*)
-INLINE_ORIGIN 7 google_breakpad::TypedMDRVA<MDString>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 8 google_breakpad::TypedMDRVA<MDString>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 9 google_breakpad::UntypedMDRVA::UntypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 10 google_breakpad::TypedMDRVA<MDString>::~TypedMDRVA()
+INLINE_ORIGIN 3 google_breakpad::TypedMDRVA<MDString>::CopyIndexAfterObject(unsigned int, void const*, unsigned long)
+INLINE_ORIGIN 4 google_breakpad::MinidumpFileWriter::Copy(unsigned int, void const*, long)
+INLINE_ORIGIN 5 google_breakpad::TypedMDRVA<MDString>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 6 google_breakpad::TypedMDRVA<MDString>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 7 google_breakpad::UntypedMDRVA::UntypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 8 google_breakpad::MinidumpFileWriter::position() const
+INLINE_ORIGIN 9 google_breakpad::TypedMDRVA<MDString>::AllocateObjectAndArray(unsigned long, unsigned long)
+INLINE_ORIGIN 10 google_breakpad::UntypedMDRVA::location() const
 INLINE_ORIGIN 11 google_breakpad::TypedMDRVA<MDString>::~TypedMDRVA()
-INLINE_ORIGIN 12 google_breakpad::TypedMDRVA<MDString>::Flush()
-INLINE_ORIGIN 13 bool google_breakpad::MinidumpFileWriter::WriteStringCore<char>(char const*, unsigned int, MDLocationDescriptor*)
-INLINE_ORIGIN 14 google_breakpad::MinidumpFileWriter::WriteMemory(void const*, unsigned long, MDMemoryDescriptor*)
-INLINE_ORIGIN 15 google_breakpad::UntypedMDRVA::UntypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 16 google_breakpad::UntypedMDRVA::Allocate(unsigned long)
-INLINE_ORIGIN 17 google_breakpad::UntypedMDRVA::Copy(unsigned int, void const*, unsigned long)
-INLINE_ORIGIN 18 google_breakpad::CrashGenerationClient::RequestDumpForException(int, int, int, unsigned int)
-INLINE_ORIGIN 19 google_breakpad::MachMsgPortDescriptor::MachMsgPortDescriptor(unsigned int)
+INLINE_ORIGIN 12 google_breakpad::TypedMDRVA<MDString>::~TypedMDRVA()
+INLINE_ORIGIN 13 google_breakpad::TypedMDRVA<MDString>::Flush()
+INLINE_ORIGIN 14 google_breakpad::UntypedMDRVA::UntypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 15 google_breakpad::UntypedMDRVA::Copy(void const*, unsigned long)
+INLINE_ORIGIN 16 google_breakpad::MinidumpFileWriter::Allocate(unsigned long)
+INLINE_ORIGIN 17 google_breakpad::MachMsgPortDescriptor::MachMsgPortDescriptor(unsigned int)
+INLINE_ORIGIN 18 google_breakpad::MachMsgPortDescriptor::MachMsgPortDescriptor(unsigned int)
+INLINE_ORIGIN 19 google_breakpad::ReceivePort::GetPort() const
 INLINE_ORIGIN 20 google_breakpad::MachReceiveMessage::MachReceiveMessage()
 INLINE_ORIGIN 21 google_breakpad::MachReceiveMessage::MachReceiveMessage()
-INLINE_ORIGIN 22 void std::__1::__sort<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
+INLINE_ORIGIN 22 google_breakpad::MachMessage::MachMessage()
 INLINE_ORIGIN 23 std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>::operator()(google_breakpad::DynamicImageRef const&, google_breakpad::DynamicImageRef const&) const
-INLINE_ORIGIN 24 unsigned int std::__1::__sort3<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
-INLINE_ORIGIN 25 google_breakpad::DynamicImageRef::operator<(google_breakpad::DynamicImageRef const&) const
+INLINE_ORIGIN 24 google_breakpad::DynamicImageRef::operator<(google_breakpad::DynamicImageRef const&) const
+INLINE_ORIGIN 25 unsigned int std::__1::__sort3<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
 INLINE_ORIGIN 26 google_breakpad::DynamicImage::operator<(google_breakpad::DynamicImage const&)
-INLINE_ORIGIN 27 void std::__1::__insertion_sort_3<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
-INLINE_ORIGIN 28 unsigned int std::__1::__sort4<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
-INLINE_ORIGIN 29 std::__1::enable_if<(is_move_constructible<google_breakpad::DynamicImageRef>::value)&&(is_move_assignable<google_breakpad::DynamicImageRef>::value), void>::type std::__1::swap<google_breakpad::DynamicImageRef>(google_breakpad::DynamicImageRef&, google_breakpad::DynamicImageRef&)
-INLINE_ORIGIN 30 google_breakpad::DynamicImageRef::DynamicImageRef(google_breakpad::DynamicImageRef const&)
-INLINE_ORIGIN 31 unsigned int std::__1::__sort5<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
-INLINE_ORIGIN 32 bool std::__1::__insertion_sort_incomplete<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
-INLINE_ORIGIN 33 void google_breakpad::ReadImageInfo<google_breakpad::MachO64>(google_breakpad::DynamicImages&, unsigned long long)
+INLINE_ORIGIN 27 google_breakpad::DynamicImage::GetLoadAddress() const
+INLINE_ORIGIN 28 std::__1::enable_if<(is_move_constructible<google_breakpad::DynamicImageRef>::value)&&(is_move_assignable<google_breakpad::DynamicImageRef>::value), void>::type std::__1::swap<google_breakpad::DynamicImageRef>(google_breakpad::DynamicImageRef&, google_breakpad::DynamicImageRef&)
+INLINE_ORIGIN 29 void std::__1::__insertion_sort_3<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
+INLINE_ORIGIN 30 unsigned int std::__1::__sort4<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
+INLINE_ORIGIN 31 google_breakpad::DynamicImageRef::DynamicImageRef(google_breakpad::DynamicImageRef const&)
+INLINE_ORIGIN 32 google_breakpad::DynamicImageRef::DynamicImageRef(google_breakpad::DynamicImageRef const&)
+INLINE_ORIGIN 33 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::vector()
 INLINE_ORIGIN 34 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::vector()
-INLINE_ORIGIN 35 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::vector()
-INLINE_ORIGIN 36 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::~vector()
+INLINE_ORIGIN 35 std::__1::__vector_base<unsigned char, std::__1::allocator<unsigned char> >::__vector_base()
+INLINE_ORIGIN 36 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::operator[](unsigned long)
 INLINE_ORIGIN 37 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::~vector()
-INLINE_ORIGIN 38 std::__1::__vector_base<unsigned char, std::__1::allocator<unsigned char> >::~__vector_base()
-INLINE_ORIGIN 39 std::__1::__vector_base<unsigned char, std::__1::allocator<unsigned char> >::clear()
-INLINE_ORIGIN 40 std::__1::allocator_traits<std::__1::allocator<unsigned char> >::deallocate(std::__1::allocator<unsigned char>&, unsigned char*, unsigned long)
-INLINE_ORIGIN 41 std::__1::allocator<unsigned char>::deallocate(unsigned char*, unsigned long)
-INLINE_ORIGIN 42 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::reserve(unsigned long)
-INLINE_ORIGIN 43 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::capacity() const
-INLINE_ORIGIN 44 std::__1::__split_buffer<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<google_breakpad::DynamicImageRef>&)
-INLINE_ORIGIN 45 std::__1::__split_buffer<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<google_breakpad::DynamicImageRef>&)
-INLINE_ORIGIN 46 std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::allocate(std::__1::allocator<google_breakpad::DynamicImageRef>&, unsigned long)
-INLINE_ORIGIN 47 std::__1::allocator<google_breakpad::DynamicImageRef>::allocate(unsigned long, void const*)
-INLINE_ORIGIN 48 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__swap_out_circular_buffer(std::__1::__split_buffer<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef>&>&)
-INLINE_ORIGIN 49 void std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::__construct_backward<google_breakpad::DynamicImageRef*>(std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*&)
-INLINE_ORIGIN 50 void std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef const&>(std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef const&)
-INLINE_ORIGIN 51 void std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::__construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef const&>(std::__1::integral_constant<bool, true>, std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef const&)
-INLINE_ORIGIN 52 void std::__1::allocator<google_breakpad::DynamicImageRef>::construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef const&>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef const&)
-INLINE_ORIGIN 53 std::__1::__split_buffer<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef>&>::~__split_buffer()
-INLINE_ORIGIN 54 std::__1::__split_buffer<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef>&>::~__split_buffer()
-INLINE_ORIGIN 55 std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::deallocate(std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, unsigned long)
-INLINE_ORIGIN 56 std::__1::allocator<google_breakpad::DynamicImageRef>::deallocate(google_breakpad::DynamicImageRef*, unsigned long)
-INLINE_ORIGIN 57 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string()
-INLINE_ORIGIN 58 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string()
-INLINE_ORIGIN 59 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::operator=(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&&)
-INLINE_ORIGIN 60 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__move_assign(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::integral_constant<bool, true>)
-INLINE_ORIGIN 61 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::clear()
-INLINE_ORIGIN 62 google_breakpad::DynamicImageRef::DynamicImageRef(google_breakpad::DynamicImage*)
-INLINE_ORIGIN 63 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::push_back(google_breakpad::DynamicImageRef&&)
-INLINE_ORIGIN 64 void std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>(std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef&&)
-INLINE_ORIGIN 65 void std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::__construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>(std::__1::integral_constant<bool, true>, std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef&&)
-INLINE_ORIGIN 66 void std::__1::allocator<google_breakpad::DynamicImageRef>::construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef&&)
-INLINE_ORIGIN 67 google_breakpad::DynamicImage::~DynamicImage()
-INLINE_ORIGIN 68 google_breakpad::DynamicImage::~DynamicImage()
-INLINE_ORIGIN 69 void std::__1::sort<google_breakpad::DynamicImageRef>(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>)
-INLINE_ORIGIN 70 void std::__1::sort<google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*)
-INLINE_ORIGIN 71 std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> std::__1::unique<std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> >(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>)
-INLINE_ORIGIN 72 std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> std::__1::unique<std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef> >(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>)
-INLINE_ORIGIN 73 std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> std::__1::adjacent_find<std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&>(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
-INLINE_ORIGIN 74 std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>::operator()(google_breakpad::DynamicImageRef const&, google_breakpad::DynamicImageRef const&) const
-INLINE_ORIGIN 75 google_breakpad::DynamicImageRef::operator==(google_breakpad::DynamicImageRef const&) const
-INLINE_ORIGIN 76 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::erase(std::__1::__wrap_iter<google_breakpad::DynamicImageRef const*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef const*>)
-INLINE_ORIGIN 77 google_breakpad::DynamicImageRef* std::__1::move<google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*)
-INLINE_ORIGIN 78 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__destruct_at_end(google_breakpad::DynamicImageRef*)
-INLINE_ORIGIN 79 std::__1::__vector_base<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__destruct_at_end(google_breakpad::DynamicImageRef*)
-INLINE_ORIGIN 80 void google_breakpad::ReadImageInfo<google_breakpad::MachO32>(google_breakpad::DynamicImages&, unsigned long long)
-INLINE_ORIGIN 81 google_breakpad::ReadTaskMemory(unsigned int, unsigned long long, unsigned long, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >&)
-INLINE_ORIGIN 82 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::resize(unsigned long)
-INLINE_ORIGIN 83 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__destruct_at_end(unsigned char*)
-INLINE_ORIGIN 84 google_breakpad::ReadTaskString(unsigned int, unsigned long long)
-INLINE_ORIGIN 85 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string(char const*)
-INLINE_ORIGIN 86 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string(char const*)
-INLINE_ORIGIN 87 std::__1::__compressed_pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__rep, std::__1::allocator<char> >::__compressed_pair()
-INLINE_ORIGIN 88 std::__1::__compressed_pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__rep, std::__1::allocator<char> >::__compressed_pair()
-INLINE_ORIGIN 89 google_breakpad::DynamicImage::CalculateMemoryAndVersionInfo()
-INLINE_ORIGIN 90 bool google_breakpad::FindTextSection<google_breakpad::MachO64>(google_breakpad::DynamicImage&)
-INLINE_ORIGIN 91 bool google_breakpad::FindTextSection<google_breakpad::MachO32>(google_breakpad::DynamicImage&)
-INLINE_ORIGIN 92 google_breakpad::DynamicImage::GetFileType()
-INLINE_ORIGIN 93 unsigned int google_breakpad::GetFileTypeFromHeader<google_breakpad::MachO64>(google_breakpad::DynamicImage&)
-INLINE_ORIGIN 94 google_breakpad::DynamicImages::DynamicImages(unsigned int)
-INLINE_ORIGIN 95 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::vector()
-INLINE_ORIGIN 96 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::vector()
-INLINE_ORIGIN 97 google_breakpad::DynamicImages::ReadImageInfoForTask()
-INLINE_ORIGIN 98 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::~vector()
-INLINE_ORIGIN 99 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::~vector()
-INLINE_ORIGIN 100 std::__1::__vector_base<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::~__vector_base()
-INLINE_ORIGIN 101 std::__1::__vector_base<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::clear()
-INLINE_ORIGIN 102 google_breakpad::DynamicImages::GetExecutableImage()
-INLINE_ORIGIN 103 google_breakpad::DynamicImages::GetImage(int)
-INLINE_ORIGIN 104 google_breakpad::DynamicImages::GetExecutableImageIndex()
-INLINE_ORIGIN 105 google_breakpad::DynamicImages::GetImageCount() const
-INLINE_ORIGIN 106 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__append(unsigned long)
-INLINE_ORIGIN 107 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__recommend(unsigned long) const
-INLINE_ORIGIN 108 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::capacity() const
-INLINE_ORIGIN 109 unsigned long const& std::__1::max<unsigned long>(unsigned long const&, unsigned long const&)
-INLINE_ORIGIN 110 unsigned long const& std::__1::max<unsigned long, std::__1::__less<unsigned long, unsigned long> >(unsigned long const&, unsigned long const&, std::__1::__less<unsigned long, unsigned long>)
-INLINE_ORIGIN 111 std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<unsigned char>&)
-INLINE_ORIGIN 112 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__construct_at_end(unsigned long)
-INLINE_ORIGIN 113 void std::__1::allocator_traits<std::__1::allocator<unsigned char> >::construct<unsigned char, >(std::__1::allocator<unsigned char>&, unsigned char*, &&)
-INLINE_ORIGIN 114 void std::__1::allocator_traits<std::__1::allocator<unsigned char> >::__construct<unsigned char, >(std::__1::integral_constant<bool, true>, std::__1::allocator<unsigned char>&, unsigned char*, &&)
-INLINE_ORIGIN 115 std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<unsigned char>&)
-INLINE_ORIGIN 116 std::__1::allocator_traits<std::__1::allocator<unsigned char> >::allocate(std::__1::allocator<unsigned char>&, unsigned long)
-INLINE_ORIGIN 117 std::__1::allocator<unsigned char>::allocate(unsigned long, void const*)
-INLINE_ORIGIN 118 std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>::__construct_at_end(unsigned long)
-INLINE_ORIGIN 119 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__swap_out_circular_buffer(std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>&)
-INLINE_ORIGIN 120 std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>::~__split_buffer()
-INLINE_ORIGIN 121 std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>::~__split_buffer()
-INLINE_ORIGIN 122 google_breakpad::DynamicImage::DynamicImage(unsigned char*, unsigned long, unsigned long long, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, unsigned long, unsigned int, int)
-INLINE_ORIGIN 123 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::vector<unsigned char*>(std::__1::enable_if<(__is_forward_iterator<unsigned char*>::value)&&(is_constructible<unsigned char, std::__1::iterator_traits<unsigned char*>::reference>::value), unsigned char*>::type)
-INLINE_ORIGIN 124 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::vector<unsigned char*>(std::__1::enable_if<(__is_forward_iterator<unsigned char*>::value)&&(is_constructible<unsigned char, std::__1::iterator_traits<unsigned char*>::reference>::value), unsigned char*>::type)
-INLINE_ORIGIN 125 std::__1::enable_if<__is_forward_iterator<unsigned char*>::value, void>::type std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__construct_at_end<unsigned char*>(unsigned char*, unsigned char*, unsigned long)
-INLINE_ORIGIN 126 void std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__push_back_slow_path<google_breakpad::DynamicImageRef>(google_breakpad::DynamicImageRef&&)
-INLINE_ORIGIN 127 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__recommend(unsigned long) const
-INLINE_ORIGIN 128 google_breakpad::ExceptionHandler::ExceptionHandler(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool (*)(void*), bool (*)(char const*, char const*, void*, bool), void*, bool, char const*)
-INLINE_ORIGIN 129 google_breakpad::scoped_ptr<sigaction>::scoped_ptr(sigaction*)
-INLINE_ORIGIN 130 google_breakpad::ExceptionHandler::set_dump_path(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)
-INLINE_ORIGIN 131 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::c_str() const
-INLINE_ORIGIN 132 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::data() const
-INLINE_ORIGIN 133 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__get_pointer() const
-INLINE_ORIGIN 134 google_breakpad::CrashGenerationClient::CrashGenerationClient(char const*)
-INLINE_ORIGIN 135 google_breakpad::scoped_ptr<google_breakpad::CrashGenerationClient>::~scoped_ptr()
-INLINE_ORIGIN 136 google_breakpad::scoped_ptr<sigaction>::~scoped_ptr()
-INLINE_ORIGIN 137 google_breakpad::ExceptionHandler::ExceptionHandler(bool (*)(void*, int, int, int, unsigned int), void*, bool)
-INLINE_ORIGIN 138 google_breakpad::ExceptionHandler::~ExceptionHandler()
-INLINE_ORIGIN 139 google_breakpad::ExceptionHandler::Teardown()
-INLINE_ORIGIN 140 google_breakpad::ExceptionHandler::WriteMinidump(bool)
-INLINE_ORIGIN 141 google_breakpad::ExceptionHandler::UpdateNextID()
-INLINE_ORIGIN 142 google_breakpad::ExceptionHandler::WriteMinidump(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, bool (*)(char const*, char const*, void*, bool), void*)
-INLINE_ORIGIN 143 google_breakpad::ExceptionHandler::WriteMinidumpForChild(unsigned int, unsigned int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool (*)(char const*, char const*, void*, bool), void*)
-INLINE_ORIGIN 144 google_breakpad::ScopedTaskSuspend::ScopedTaskSuspend(unsigned int)
-INLINE_ORIGIN 145 google_breakpad::ScopedTaskSuspend::~ScopedTaskSuspend()
-INLINE_ORIGIN 146 google_breakpad::ExceptionHandler::WriteMinidumpWithException(int, int, int, __darwin_ucontext*, unsigned int, bool, bool)
-INLINE_ORIGIN 147 google_breakpad::ExceptionHandler::IsOutOfProcess() const
-INLINE_ORIGIN 148 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::empty() const
-INLINE_ORIGIN 149 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::size() const
-INLINE_ORIGIN 150 google_breakpad::ExceptionHandler::WaitForMessage(void*)
-INLINE_ORIGIN 151 google_breakpad::ExceptionHandler::UninstallHandler(bool)
-INLINE_ORIGIN 152 google_breakpad::ExceptionHandler::InstallHandler()
-INLINE_ORIGIN 153 std::bad_alloc::bad_alloc(std::bad_alloc const&)
-INLINE_ORIGIN 154 google_breakpad::MinidumpGenerator::MinidumpGenerator()
-INLINE_ORIGIN 155 google_breakpad::wasteful_vector<MDMemoryDescriptor>::wasteful_vector(google_breakpad::PageAllocator*, unsigned int)
-INLINE_ORIGIN 156 google_breakpad::wasteful_vector<MDMemoryDescriptor>::wasteful_vector(google_breakpad::PageAllocator*, unsigned int)
-INLINE_ORIGIN 157 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::reserve(unsigned long)
-INLINE_ORIGIN 158 std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::__split_buffer(unsigned long, unsigned long, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&)
-INLINE_ORIGIN 159 std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::__split_buffer(unsigned long, unsigned long, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&)
-INLINE_ORIGIN 160 std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::allocate(google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, unsigned long)
-INLINE_ORIGIN 161 google_breakpad::PageAllocator::PageAllocator()
-INLINE_ORIGIN 162 google_breakpad::PageStdAllocator<MDMemoryDescriptor>::allocate(unsigned long, void const*)
-INLINE_ORIGIN 163 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::vector(google_breakpad::PageStdAllocator<MDMemoryDescriptor> const&)
-INLINE_ORIGIN 164 std::__1::__vector_base<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__vector_base(google_breakpad::PageStdAllocator<MDMemoryDescriptor> const&)
-INLINE_ORIGIN 165 std::__1::__compressed_pair<MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__compressed_pair(MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>)
-INLINE_ORIGIN 166 std::__1::__compressed_pair<MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__compressed_pair(MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>)
-INLINE_ORIGIN 167 google_breakpad::PageAllocator::Alloc(unsigned long)
-INLINE_ORIGIN 168 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__swap_out_circular_buffer(std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>&)
-INLINE_ORIGIN 169 void std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__construct_backward<MDMemoryDescriptor*>(google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor*, MDMemoryDescriptor*&)
-INLINE_ORIGIN 170 void std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::construct<MDMemoryDescriptor, MDMemoryDescriptor>(google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor&&)
-INLINE_ORIGIN 171 void std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__construct<MDMemoryDescriptor, MDMemoryDescriptor>(std::__1::integral_constant<bool, true>, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor&&)
-INLINE_ORIGIN 172 google_breakpad::wasteful_vector<MDMemoryDescriptor>::~wasteful_vector()
-INLINE_ORIGIN 173 google_breakpad::wasteful_vector<MDMemoryDescriptor>::~wasteful_vector()
-INLINE_ORIGIN 174 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::~vector()
-INLINE_ORIGIN 175 std::__1::__vector_base<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::~__vector_base()
-INLINE_ORIGIN 176 std::__1::__vector_base<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::clear()
-INLINE_ORIGIN 177 std::__1::__vector_base<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__destruct_at_end(MDMemoryDescriptor*)
-INLINE_ORIGIN 178 google_breakpad::PageAllocator::~PageAllocator()
-INLINE_ORIGIN 179 google_breakpad::PageAllocator::~PageAllocator()
-INLINE_ORIGIN 180 google_breakpad::MinidumpGenerator::GatherSystemInformation()
-INLINE_ORIGIN 181 google_breakpad::MinidumpGenerator::MinidumpGenerator(unsigned int, unsigned int)
-INLINE_ORIGIN 182 google_breakpad::MinidumpGenerator::~MinidumpGenerator()
-INLINE_ORIGIN 183 google_breakpad::MinidumpGenerator::~MinidumpGenerator()
-INLINE_ORIGIN 184 google_breakpad::MinidumpGenerator::UniqueNameInDirectory(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*)
-INLINE_ORIGIN 185 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::append(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)
-INLINE_ORIGIN 186 google_breakpad::MinidumpGenerator::Write(char const*)
-INLINE_ORIGIN 187 google_breakpad::TypedMDRVA<MDRawHeader>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 188 google_breakpad::TypedMDRVA<MDRawHeader>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 189 google_breakpad::TypedMDRVA<MDRawDirectory>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 190 google_breakpad::TypedMDRVA<MDRawDirectory>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 191 google_breakpad::TypedMDRVA<MDRawDirectory>::~TypedMDRVA()
-INLINE_ORIGIN 192 google_breakpad::TypedMDRVA<MDRawDirectory>::~TypedMDRVA()
-INLINE_ORIGIN 193 google_breakpad::TypedMDRVA<MDRawHeader>::~TypedMDRVA()
-INLINE_ORIGIN 194 google_breakpad::TypedMDRVA<MDRawHeader>::~TypedMDRVA()
-INLINE_ORIGIN 195 google_breakpad::MinidumpGenerator::WriteThreadListStream(MDRawDirectory*)
-INLINE_ORIGIN 196 google_breakpad::TypedMDRVA<MDRawThreadList>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 197 google_breakpad::TypedMDRVA<MDRawThreadList>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 198 google_breakpad::TypedMDRVA<MDRawThreadList>::~TypedMDRVA()
-INLINE_ORIGIN 199 google_breakpad::TypedMDRVA<MDRawThreadList>::~TypedMDRVA()
-INLINE_ORIGIN 200 google_breakpad::MinidumpGenerator::WriteMemoryListStream(MDRawDirectory*)
-INLINE_ORIGIN 201 google_breakpad::TypedMDRVA<MDRawMemoryList>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 202 google_breakpad::TypedMDRVA<MDRawMemoryList>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 203 google_breakpad::MinidumpGenerator::GetThreadState(unsigned int, unsigned int*, unsigned int*)
-INLINE_ORIGIN 204 unsigned long const& std::__1::min<unsigned long>(unsigned long const&, unsigned long const&)
-INLINE_ORIGIN 205 unsigned long const& std::__1::min<unsigned long, std::__1::__less<unsigned long, unsigned long> >(unsigned long const&, unsigned long const&, std::__1::__less<unsigned long, unsigned long>)
-INLINE_ORIGIN 206 google_breakpad::MinidumpGenerator::CurrentPCForStack(unsigned int*)
-INLINE_ORIGIN 207 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::push_back(MDMemoryDescriptor const&)
-INLINE_ORIGIN 208 void std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::construct<MDMemoryDescriptor, MDMemoryDescriptor const&>(google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor const&)
-INLINE_ORIGIN 209 void std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__construct<MDMemoryDescriptor, MDMemoryDescriptor const&>(std::__1::integral_constant<bool, true>, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor const&)
-INLINE_ORIGIN 210 google_breakpad::TypedMDRVA<MDRawMemoryList>::~TypedMDRVA()
-INLINE_ORIGIN 211 google_breakpad::TypedMDRVA<MDRawMemoryList>::~TypedMDRVA()
-INLINE_ORIGIN 212 google_breakpad::MinidumpGenerator::WriteSystemInfoStream(MDRawDirectory*)
-INLINE_ORIGIN 213 google_breakpad::TypedMDRVA<MDRawSystemInfo>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 214 google_breakpad::TypedMDRVA<MDRawSystemInfo>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 215 google_breakpad::TypedMDRVA<MDRawSystemInfo>::~TypedMDRVA()
-INLINE_ORIGIN 216 google_breakpad::TypedMDRVA<MDRawSystemInfo>::~TypedMDRVA()
-INLINE_ORIGIN 217 google_breakpad::MinidumpGenerator::WriteModuleListStream(MDRawDirectory*)
-INLINE_ORIGIN 218 google_breakpad::TypedMDRVA<MDRawModuleList>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 219 google_breakpad::TypedMDRVA<MDRawModuleList>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 220 google_breakpad::TypedMDRVA<MDRawModuleList>::~TypedMDRVA()
-INLINE_ORIGIN 221 google_breakpad::TypedMDRVA<MDRawModuleList>::~TypedMDRVA()
-INLINE_ORIGIN 222 google_breakpad::MinidumpGenerator::WriteMiscInfoStream(MDRawDirectory*)
-INLINE_ORIGIN 223 google_breakpad::TypedMDRVA<MDRawMiscInfo>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 224 google_breakpad::TypedMDRVA<MDRawMiscInfo>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 225 google_breakpad::TypedMDRVA<MDRawMiscInfo>::~TypedMDRVA()
-INLINE_ORIGIN 226 google_breakpad::TypedMDRVA<MDRawMiscInfo>::~TypedMDRVA()
-INLINE_ORIGIN 227 google_breakpad::MinidumpGenerator::WriteBreakpadInfoStream(MDRawDirectory*)
-INLINE_ORIGIN 228 google_breakpad::TypedMDRVA<MDRawBreakpadInfo>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 229 google_breakpad::TypedMDRVA<MDRawBreakpadInfo>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 230 google_breakpad::TypedMDRVA<MDRawBreakpadInfo>::~TypedMDRVA()
-INLINE_ORIGIN 231 google_breakpad::TypedMDRVA<MDRawBreakpadInfo>::~TypedMDRVA()
-INLINE_ORIGIN 232 google_breakpad::MinidumpGenerator::WriteStackFromStartAddress(unsigned long long, MDMemoryDescriptor*)
-INLINE_ORIGIN 233 google_breakpad::MinidumpGenerator::WriteStack(unsigned int*, MDMemoryDescriptor*)
-INLINE_ORIGIN 234 google_breakpad::MinidumpGenerator::WriteContextX86(unsigned int*, MDLocationDescriptor*)
-INLINE_ORIGIN 235 google_breakpad::TypedMDRVA<MDRawContextX86>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 236 google_breakpad::TypedMDRVA<MDRawContextX86>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 237 google_breakpad::TypedMDRVA<MDRawContextX86>::~TypedMDRVA()
-INLINE_ORIGIN 238 google_breakpad::TypedMDRVA<MDRawContextX86>::~TypedMDRVA()
-INLINE_ORIGIN 239 google_breakpad::MinidumpGenerator::WriteContextX86_64(unsigned int*, MDLocationDescriptor*)
-INLINE_ORIGIN 240 google_breakpad::TypedMDRVA<MDRawContextAMD64>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 241 google_breakpad::TypedMDRVA<MDRawContextAMD64>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 242 google_breakpad::TypedMDRVA<MDRawContextAMD64>::~TypedMDRVA()
-INLINE_ORIGIN 243 google_breakpad::TypedMDRVA<MDRawContextAMD64>::~TypedMDRVA()
-INLINE_ORIGIN 244 google_breakpad::MinidumpGenerator::WriteThreadStream(unsigned int, MDRawThread*)
-INLINE_ORIGIN 245 google_breakpad::MinidumpGenerator::WriteExceptionStream(MDRawDirectory*)
-INLINE_ORIGIN 246 google_breakpad::TypedMDRVA<MDRawExceptionStream>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 247 google_breakpad::TypedMDRVA<MDRawExceptionStream>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 248 google_breakpad::TypedMDRVA<MDRawExceptionStream>::~TypedMDRVA()
-INLINE_ORIGIN 249 google_breakpad::TypedMDRVA<MDRawExceptionStream>::~TypedMDRVA()
-INLINE_ORIGIN 250 google_breakpad::MinidumpGenerator::WriteModuleStream(unsigned int, MDRawModule*)
-INLINE_ORIGIN 251 google_breakpad::MinidumpGenerator::WriteCVRecord(MDRawModule*, int, char const*, bool)
-INLINE_ORIGIN 252 google_breakpad::TypedMDRVA<MDCVInfoPDB70>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 253 google_breakpad::TypedMDRVA<MDCVInfoPDB70>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
-INLINE_ORIGIN 254 google_breakpad::TypedMDRVA<MDCVInfoPDB70>::~TypedMDRVA()
-INLINE_ORIGIN 255 google_breakpad::TypedMDRVA<MDCVInfoPDB70>::~TypedMDRVA()
-INLINE_ORIGIN 256 google_breakpad::DynamicImages::~DynamicImages()
-INLINE_ORIGIN 257 std::__1::__compressed_pair<MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::__compressed_pair(MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&)
-INLINE_ORIGIN 258 std::__1::__compressed_pair<MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::__compressed_pair(MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&)
-INLINE_ORIGIN 259 void std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__push_back_slow_path<MDMemoryDescriptor const&>(MDMemoryDescriptor const&)
-INLINE_ORIGIN 260 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__recommend(unsigned long) const
-INLINE_ORIGIN 261 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::capacity() const
-INLINE_ORIGIN 262 std::__1::__vector_base<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__alloc()
-INLINE_ORIGIN 263 std::__1::__compressed_pair<MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::second()
-INLINE_ORIGIN 264 std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::~__split_buffer()
-INLINE_ORIGIN 265 std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::~__split_buffer()
-INLINE_ORIGIN 266 std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::clear()
-INLINE_ORIGIN 267 std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::__destruct_at_end(MDMemoryDescriptor*)
-INLINE_ORIGIN 268 std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::__destruct_at_end(MDMemoryDescriptor*, std::__1::integral_constant<bool, false>)
-INLINE_ORIGIN 269 isLegalUTF8Sequence
-INLINE_ORIGIN 270 ConvertUTF8toUTF16
-INLINE_ORIGIN 271 ConvertUTF8toUTF32
-INLINE_ORIGIN 272 google_breakpad::UTF8ToUTF16(char const*, std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >*)
-INLINE_ORIGIN 273 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::clear()
-INLINE_ORIGIN 274 std::__1::__vector_base<unsigned short, std::__1::allocator<unsigned short> >::clear()
-INLINE_ORIGIN 275 std::__1::__vector_base<unsigned short, std::__1::allocator<unsigned short> >::__destruct_at_end(unsigned short*)
-INLINE_ORIGIN 276 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::capacity() const
-INLINE_ORIGIN 277 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::resize(unsigned long)
-INLINE_ORIGIN 278 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__destruct_at_end(unsigned short*)
-INLINE_ORIGIN 279 google_breakpad::UTF32ToUTF16(wchar_t const*, std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >*)
-INLINE_ORIGIN 280 google_breakpad::UTF16ToUTF8(std::__1::vector<unsigned short, std::__1::allocator<unsigned short> > const&, bool)
-INLINE_ORIGIN 281 google_breakpad::scoped_array<unsigned char>::~scoped_array()
-INLINE_ORIGIN 282 google_breakpad::scoped_array<unsigned short>::~scoped_array()
-INLINE_ORIGIN 283 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::insert(std::__1::__wrap_iter<unsigned short const*>, unsigned long, unsigned short const&)
-INLINE_ORIGIN 284 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__recommend(unsigned long) const
-INLINE_ORIGIN 285 std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<unsigned short>&)
-INLINE_ORIGIN 286 std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<unsigned short>&)
-INLINE_ORIGIN 287 std::__1::allocator_traits<std::__1::allocator<unsigned short> >::allocate(std::__1::allocator<unsigned short>&, unsigned long)
-INLINE_ORIGIN 288 std::__1::allocator<unsigned short>::allocate(unsigned long, void const*)
-INLINE_ORIGIN 289 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__construct_at_end(unsigned long, unsigned short const&)
-INLINE_ORIGIN 290 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::construct<unsigned short, unsigned short const&>(std::__1::allocator<unsigned short>&, unsigned short*, unsigned short const&)
-INLINE_ORIGIN 291 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct<unsigned short, unsigned short const&>(std::__1::integral_constant<bool, true>, std::__1::allocator<unsigned short>&, unsigned short*, unsigned short const&)
-INLINE_ORIGIN 292 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__move_range(unsigned short*, unsigned short*, unsigned short*)
-INLINE_ORIGIN 293 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::construct<unsigned short, unsigned short>(std::__1::allocator<unsigned short>&, unsigned short*, unsigned short&&)
-INLINE_ORIGIN 294 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct<unsigned short, unsigned short>(std::__1::integral_constant<bool, true>, std::__1::allocator<unsigned short>&, unsigned short*, unsigned short&&)
-INLINE_ORIGIN 295 unsigned short* std::__1::move_backward<unsigned short*, unsigned short*>(unsigned short*, unsigned short*, unsigned short*)
-INLINE_ORIGIN 296 unsigned short* std::__1::fill_n<unsigned short*, unsigned long, unsigned short>(unsigned short*, unsigned long, unsigned short const&)
-INLINE_ORIGIN 297 std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>::__construct_at_end(unsigned long, unsigned short const&)
-INLINE_ORIGIN 298 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__swap_out_circular_buffer(std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>&, unsigned short*)
-INLINE_ORIGIN 299 std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>::~__split_buffer()
-INLINE_ORIGIN 300 std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>::~__split_buffer()
-INLINE_ORIGIN 301 std::__1::allocator_traits<std::__1::allocator<unsigned short> >::deallocate(std::__1::allocator<unsigned short>&, unsigned short*, unsigned long)
-INLINE_ORIGIN 302 std::__1::allocator<unsigned short>::deallocate(unsigned short*, unsigned long)
-INLINE_ORIGIN 303 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__append(unsigned long)
-INLINE_ORIGIN 304 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__construct_at_end(unsigned long)
-INLINE_ORIGIN 305 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::construct<unsigned short, >(std::__1::allocator<unsigned short>&, unsigned short*, &&)
-INLINE_ORIGIN 306 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct<unsigned short, >(std::__1::integral_constant<bool, true>, std::__1::allocator<unsigned short>&, unsigned short*, &&)
-INLINE_ORIGIN 307 std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>::__construct_at_end(unsigned long)
-INLINE_ORIGIN 308 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__swap_out_circular_buffer(std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>&)
-INLINE_ORIGIN 309 google_breakpad::FileID::FileID(char const*)
-INLINE_ORIGIN 310 MacFileUtilities::MachoID::MachoID(char const*)
-INLINE_ORIGIN 311 MacFileUtilities::MachoID::MachoID(char const*, void*, unsigned long)
-INLINE_ORIGIN 312 MacFileUtilities::MachoID::WalkerCB(MacFileUtilities::MachoWalker*, load_command*, long long, bool, void*)
-INLINE_ORIGIN 313 breakpad_swap_uuid_command(breakpad_uuid_command*)
-INLINE_ORIGIN 314 ByteSwap(unsigned int)
-INLINE_ORIGIN 315 breakpad_swap_load_command(load_command*)
-INLINE_ORIGIN 316 breakpad_swap_dylib_command(dylib_command*)
-INLINE_ORIGIN 317 breakpad_swap_segment_command(segment_command*)
-INLINE_ORIGIN 318 ByteSwap(int)
-INLINE_ORIGIN 319 breakpad_swap_segment_command_64(segment_command_64*)
-INLINE_ORIGIN 320 ByteSwap(unsigned long long)
-INLINE_ORIGIN 321 breakpad_swap_fat_header(fat_header*)
-INLINE_ORIGIN 322 breakpad_swap_fat_arch(fat_arch*, unsigned int)
-INLINE_ORIGIN 323 breakpad_swap_mach_header(mach_header*)
-INLINE_ORIGIN 324 breakpad_swap_mach_header_64(mach_header_64*)
-INLINE_ORIGIN 325 breakpad_swap_section(section*, unsigned int)
-INLINE_ORIGIN 326 breakpad_swap_section_64(section_64*, unsigned int)
-INLINE_ORIGIN 327 MacFileUtilities::MachoWalker::MachoWalker(char const*, bool (*)(MacFileUtilities::MachoWalker*, load_command*, long long, bool, void*), void*)
-INLINE_ORIGIN 328 MacFileUtilities::MachoWalker::MachoWalker(void*, unsigned long, bool (*)(MacFileUtilities::MachoWalker*, load_command*, long long, bool, void*), void*)
-INLINE_ORIGIN 329 MacFileUtilities::MachoWalker::~MachoWalker()
-INLINE_ORIGIN 330 MacFileUtilities::MachoWalker::WalkHeader(int, int)
-INLINE_ORIGIN 331 MacFileUtilities::MachoWalker::WalkHeader64AtOffset(long long)
-INLINE_ORIGIN 332 MacFileUtilities::MachoWalker::FindHeader(int, int, long long&)
-INLINE_ORIGIN 333 MacFileUtilities::MachoWalker::WalkHeaderAtOffset(long long)
-INLINE_ORIGIN 334 MacFileUtilities::MachoWalker::WalkHeaderCore(long long, unsigned int, bool)
-INLINE_ORIGIN 335 MacStringUtils::ConvertToString(__CFString const*)
-INLINE_ORIGIN 336 MacStringUtils::IntegerValueAtIndex(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, unsigned int)
-INLINE_ORIGIN 337 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::find_first_not_of(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, unsigned long) const
-INLINE_ORIGIN 338 unsigned long std::__1::__str_find_first_not_of<char, unsigned long, std::__1::char_traits<char>, (unsigned long)18446744073709551615>(char const*, unsigned long, char const*, unsigned long, unsigned long)
-INLINE_ORIGIN 339 std::__1::char_traits<char>::find(char const*, unsigned long, char const&)
-INLINE_ORIGIN 340 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::find_first_of(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, unsigned long) const
-INLINE_ORIGIN 341 unsigned long std::__1::__str_find_first_of<char, unsigned long, std::__1::char_traits<char>, (unsigned long)18446744073709551615>(char const*, unsigned long, char const*, unsigned long, unsigned long)
-INLINE_ORIGIN 342 char const* std::__1::__find_first_of_ce<char const*, char const*, bool (*)(char, char)>(char const*, char const*, char const*, char const*, bool (*)(char, char))
-INLINE_ORIGIN 343 google_breakpad::MachSendMessage::MachSendMessage(int)
-INLINE_ORIGIN 344 google_breakpad::MachMessage::SetData(void*, int)
-INLINE_ORIGIN 345 google_breakpad::MachMessage::CalculateSize()
-INLINE_ORIGIN 346 google_breakpad::MachMessage::GetDataLength()
-INLINE_ORIGIN 347 google_breakpad::MachSendMessage::MachSendMessage(int)
-INLINE_ORIGIN 348 google_breakpad::MachMessage::AddDescriptor(google_breakpad::MachMsgPortDescriptor const&)
-INLINE_ORIGIN 349 google_breakpad::MachMessage::GetTranslatedPort(int)
-INLINE_ORIGIN 350 google_breakpad::ReceivePort::ReceivePort(char const*)
-INLINE_ORIGIN 351 google_breakpad::ReceivePort::ReceivePort()
-INLINE_ORIGIN 352 google_breakpad::ReceivePort::ReceivePort(unsigned int)
-INLINE_ORIGIN 353 google_breakpad::ReceivePort::~ReceivePort()
-INLINE_ORIGIN 354 google_breakpad::MachPortSender::MachPortSender(char const*)
-INLINE_ORIGIN 355 google_breakpad::MachPortSender::MachPortSender(unsigned int)
-INLINE_ORIGIN 356 main
-INLINE_ORIGIN 357 (anonymous namespace)::start()
+INLINE_ORIGIN 38 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::~vector()
+INLINE_ORIGIN 39 std::__1::__vector_base<unsigned char, std::__1::allocator<unsigned char> >::~__vector_base()
+INLINE_ORIGIN 40 std::__1::__vector_base<unsigned char, std::__1::allocator<unsigned char> >::clear()
+INLINE_ORIGIN 41 std::__1::__vector_base<unsigned char, std::__1::allocator<unsigned char> >::__destruct_at_end(unsigned char*)
+INLINE_ORIGIN 42 std::__1::allocator_traits<std::__1::allocator<unsigned char> >::deallocate(std::__1::allocator<unsigned char>&, unsigned char*, unsigned long)
+INLINE_ORIGIN 43 std::__1::allocator<unsigned char>::deallocate(unsigned char*, unsigned long)
+INLINE_ORIGIN 44 std::__1::__deallocate(void*)
+INLINE_ORIGIN 45 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::reserve(unsigned long)
+INLINE_ORIGIN 46 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::capacity() const
+INLINE_ORIGIN 47 std::__1::__vector_base<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::capacity() const
+INLINE_ORIGIN 48 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::size() const
+INLINE_ORIGIN 49 std::__1::__split_buffer<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<google_breakpad::DynamicImageRef>&)
+INLINE_ORIGIN 50 std::__1::__split_buffer<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<google_breakpad::DynamicImageRef>&)
+INLINE_ORIGIN 51 std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::allocate(std::__1::allocator<google_breakpad::DynamicImageRef>&, unsigned long)
+INLINE_ORIGIN 52 std::__1::allocator<google_breakpad::DynamicImageRef>::allocate(unsigned long, void const*)
+INLINE_ORIGIN 53 std::__1::__allocate(unsigned long)
+INLINE_ORIGIN 54 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__swap_out_circular_buffer(std::__1::__split_buffer<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef>&>&)
+INLINE_ORIGIN 55 void std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::__construct_backward<google_breakpad::DynamicImageRef*>(std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*&)
+INLINE_ORIGIN 56 void std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef const&>(std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef const&)
+INLINE_ORIGIN 57 void std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::__construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef const&>(std::__1::integral_constant<bool, true>, std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef const&)
+INLINE_ORIGIN 58 void std::__1::allocator<google_breakpad::DynamicImageRef>::construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef const&>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef const&)
+INLINE_ORIGIN 59 std::__1::enable_if<(is_move_constructible<google_breakpad::DynamicImageRef*>::value)&&(is_move_assignable<google_breakpad::DynamicImageRef*>::value), void>::type std::__1::swap<google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*&, google_breakpad::DynamicImageRef*&)
+INLINE_ORIGIN 60 std::__1::__split_buffer<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef>&>::~__split_buffer()
+INLINE_ORIGIN 61 std::__1::__split_buffer<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef>&>::~__split_buffer()
+INLINE_ORIGIN 62 std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::deallocate(std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, unsigned long)
+INLINE_ORIGIN 63 std::__1::allocator<google_breakpad::DynamicImageRef>::deallocate(google_breakpad::DynamicImageRef*, unsigned long)
+INLINE_ORIGIN 64 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::push_back(google_breakpad::DynamicImageRef&&)
+INLINE_ORIGIN 65 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string()
+INLINE_ORIGIN 66 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string()
+INLINE_ORIGIN 67 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__zero()
+INLINE_ORIGIN 68 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::operator=(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&&)
+INLINE_ORIGIN 69 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__move_assign(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::integral_constant<bool, true>)
+INLINE_ORIGIN 70 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::clear()
+INLINE_ORIGIN 71 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__is_long() const
+INLINE_ORIGIN 72 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__set_short_size(unsigned long)
+INLINE_ORIGIN 73 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__get_long_pointer()
+INLINE_ORIGIN 74 std::__1::char_traits<char>::assign(char&, char const&)
+INLINE_ORIGIN 75 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__set_long_size(unsigned long)
+INLINE_ORIGIN 76 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::shrink_to_fit()
+INLINE_ORIGIN 77 google_breakpad::DynamicImage::DynamicImage(unsigned char*, unsigned long, unsigned long long, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, unsigned long, unsigned int, int)
+INLINE_ORIGIN 78 google_breakpad::DynamicImage::IsValid()
+INLINE_ORIGIN 79 google_breakpad::DynamicImageRef::DynamicImageRef(google_breakpad::DynamicImage*)
+INLINE_ORIGIN 80 google_breakpad::DynamicImageRef::DynamicImageRef(google_breakpad::DynamicImage*)
+INLINE_ORIGIN 81 void std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>(std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef&&)
+INLINE_ORIGIN 82 void std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::__construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>(std::__1::integral_constant<bool, true>, std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef&&)
+INLINE_ORIGIN 83 void std::__1::allocator<google_breakpad::DynamicImageRef>::construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef&&)
+INLINE_ORIGIN 84 google_breakpad::DynamicImage::~DynamicImage()
+INLINE_ORIGIN 85 google_breakpad::DynamicImage::~DynamicImage()
+INLINE_ORIGIN 86 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::end()
+INLINE_ORIGIN 87 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::begin()
+INLINE_ORIGIN 88 void std::__1::sort<google_breakpad::DynamicImageRef>(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>)
+INLINE_ORIGIN 89 void std::__1::sort<google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*)
+INLINE_ORIGIN 90 void std::__1::sort<google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef> >(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>)
+INLINE_ORIGIN 91 std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> std::__1::unique<std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> >(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>)
+INLINE_ORIGIN 92 std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> std::__1::unique<std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef> >(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>)
+INLINE_ORIGIN 93 std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> std::__1::adjacent_find<std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&>(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
+INLINE_ORIGIN 94 bool std::__1::operator!=<google_breakpad::DynamicImageRef*>(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> const&, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> const&)
+INLINE_ORIGIN 95 std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>::operator()(google_breakpad::DynamicImageRef const&, google_breakpad::DynamicImageRef const&) const
+INLINE_ORIGIN 96 google_breakpad::DynamicImageRef::operator==(google_breakpad::DynamicImageRef const&) const
+INLINE_ORIGIN 97 google_breakpad::DynamicImageRef::operator google_breakpad::DynamicImage*()
+INLINE_ORIGIN 98 std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>::operator++()
+INLINE_ORIGIN 99 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::erase(std::__1::__wrap_iter<google_breakpad::DynamicImageRef const*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef const*>)
+INLINE_ORIGIN 100 bool std::__1::operator!=<google_breakpad::DynamicImageRef const*>(std::__1::__wrap_iter<google_breakpad::DynamicImageRef const*> const&, std::__1::__wrap_iter<google_breakpad::DynamicImageRef const*> const&)
+INLINE_ORIGIN 101 google_breakpad::DynamicImageRef* std::__1::move<google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*)
+INLINE_ORIGIN 102 std::__1::enable_if<(is_same<std::__1::remove_const<google_breakpad::DynamicImageRef>::type, google_breakpad::DynamicImageRef>::value)&&(is_trivially_copy_assignable<google_breakpad::DynamicImageRef>::value), google_breakpad::DynamicImageRef*>::type std::__1::__move<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*)
+INLINE_ORIGIN 103 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__destruct_at_end(google_breakpad::DynamicImageRef*)
+INLINE_ORIGIN 104 std::__1::__vector_base<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__destruct_at_end(google_breakpad::DynamicImageRef*)
+INLINE_ORIGIN 105 std::__1::__vector_base<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__alloc()
+INLINE_ORIGIN 106 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::resize(unsigned long)
+INLINE_ORIGIN 107 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::size() const
+INLINE_ORIGIN 108 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__destruct_at_end(unsigned char*)
+INLINE_ORIGIN 109 google_breakpad::GetMemoryRegionSize(unsigned int, unsigned long long, unsigned long long*)
+INLINE_ORIGIN 110 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string(char const*)
+INLINE_ORIGIN 111 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::basic_string(char const*)
+INLINE_ORIGIN 112 std::__1::__compressed_pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__rep, std::__1::allocator<char> >::__compressed_pair()
+INLINE_ORIGIN 113 std::__1::__compressed_pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__rep, std::__1::allocator<char> >::__compressed_pair()
+INLINE_ORIGIN 114 std::__1::__libcpp_compressed_pair_imp<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__rep, std::__1::allocator<char>, (unsigned int)2>::__libcpp_compressed_pair_imp()
+INLINE_ORIGIN 115 std::__1::char_traits<char>::length(char const*)
+INLINE_ORIGIN 116 google_breakpad::DynamicImage::Is64Bit()
+INLINE_ORIGIN 117 bool google_breakpad::FindTextSection<google_breakpad::MachO64>(google_breakpad::DynamicImage&)
+INLINE_ORIGIN 118 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::operator[](unsigned long) const
+INLINE_ORIGIN 119 bool google_breakpad::FindTextSection<google_breakpad::MachO32>(google_breakpad::DynamicImage&)
+INLINE_ORIGIN 120 unsigned int google_breakpad::GetFileTypeFromHeader<google_breakpad::MachO64>(google_breakpad::DynamicImage&)
+INLINE_ORIGIN 121 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::vector()
+INLINE_ORIGIN 122 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::vector()
+INLINE_ORIGIN 123 std::__1::__vector_base<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__vector_base()
+INLINE_ORIGIN 124 google_breakpad::DynamicImages::ReadImageInfoForTask()
+INLINE_ORIGIN 125 google_breakpad::DynamicImages::GetDyldAllImageInfosPointer()
+INLINE_ORIGIN 126 google_breakpad::DynamicImages::Is64Bit()
+INLINE_ORIGIN 127 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::~vector()
+INLINE_ORIGIN 128 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::~vector()
+INLINE_ORIGIN 129 std::__1::__vector_base<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::~__vector_base()
+INLINE_ORIGIN 130 std::__1::__vector_base<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::clear()
+INLINE_ORIGIN 131 google_breakpad::DynamicImages::GetImage(int)
+INLINE_ORIGIN 132 google_breakpad::DynamicImages::GetExecutableImageIndex()
+INLINE_ORIGIN 133 google_breakpad::DynamicImages::GetImageCount() const
+INLINE_ORIGIN 134 google_breakpad::DynamicImage::GetFileType()
+INLINE_ORIGIN 135 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__recommend(unsigned long) const
+INLINE_ORIGIN 136 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::capacity() const
+INLINE_ORIGIN 137 std::__1::__vector_base<unsigned char, std::__1::allocator<unsigned char> >::capacity() const
+INLINE_ORIGIN 138 unsigned long const& std::__1::max<unsigned long>(unsigned long const&, unsigned long const&)
+INLINE_ORIGIN 139 unsigned long const& std::__1::max<unsigned long, std::__1::__less<unsigned long, unsigned long> >(unsigned long const&, unsigned long const&, std::__1::__less<unsigned long, unsigned long>)
+INLINE_ORIGIN 140 std::__1::__less<unsigned long, unsigned long>::operator()(unsigned long const&, unsigned long const&) const
+INLINE_ORIGIN 141 std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<unsigned char>&)
+INLINE_ORIGIN 142 std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<unsigned char>&)
+INLINE_ORIGIN 143 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__construct_at_end(unsigned long)
+INLINE_ORIGIN 144 void std::__1::allocator_traits<std::__1::allocator<unsigned char> >::construct<unsigned char, >(std::__1::allocator<unsigned char>&, unsigned char*, &&)
+INLINE_ORIGIN 145 void std::__1::allocator_traits<std::__1::allocator<unsigned char> >::__construct<unsigned char, >(std::__1::integral_constant<bool, true>, std::__1::allocator<unsigned char>&, unsigned char*, &&)
+INLINE_ORIGIN 146 void std::__1::allocator<unsigned char>::construct<unsigned char, >(unsigned char*, &&)
+INLINE_ORIGIN 147 std::__1::allocator_traits<std::__1::allocator<unsigned char> >::allocate(std::__1::allocator<unsigned char>&, unsigned long)
+INLINE_ORIGIN 148 std::__1::allocator<unsigned char>::allocate(unsigned long, void const*)
+INLINE_ORIGIN 149 std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>::__construct_at_end(unsigned long)
+INLINE_ORIGIN 150 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__swap_out_circular_buffer(std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>&)
+INLINE_ORIGIN 151 std::__1::enable_if<(is_move_constructible<unsigned char*>::value)&&(is_move_assignable<unsigned char*>::value), void>::type std::__1::swap<unsigned char*>(unsigned char*&, unsigned char*&)
+INLINE_ORIGIN 152 std::__1::enable_if<((is_same<std::__1::allocator<unsigned char>, std::__1::allocator<unsigned char> >::value)||(!(__has_construct<std::__1::allocator<unsigned char>, unsigned char*, unsigned char>::value)))&&(is_trivially_move_constructible<unsigned char>::value), void>::type std::__1::allocator_traits<std::__1::allocator<unsigned char> >::__construct_backward<unsigned char>(std::__1::allocator<unsigned char>&, unsigned char*, unsigned char*, unsigned char*&)
+INLINE_ORIGIN 153 std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>::~__split_buffer()
+INLINE_ORIGIN 154 std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>::~__split_buffer()
+INLINE_ORIGIN 155 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::vector<unsigned char*>(std::__1::enable_if<(__is_forward_iterator<unsigned char*>::value)&&(is_constructible<unsigned char, std::__1::iterator_traits<unsigned char*>::reference>::value), unsigned char*>::type)
+INLINE_ORIGIN 156 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::vector<unsigned char*>(std::__1::enable_if<(__is_forward_iterator<unsigned char*>::value)&&(is_constructible<unsigned char, std::__1::iterator_traits<unsigned char*>::reference>::value), unsigned char*>::type)
+INLINE_ORIGIN 157 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::allocate(unsigned long)
+INLINE_ORIGIN 158 std::__1::enable_if<__is_forward_iterator<unsigned char*>::value, void>::type std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__construct_at_end<unsigned char*>(unsigned char*, unsigned char*, unsigned long)
+INLINE_ORIGIN 159 std::__1::enable_if<((is_same<std::__1::allocator<unsigned char>, std::__1::allocator<unsigned char> >::value)||(!(__has_construct<std::__1::allocator<unsigned char>, unsigned char*, unsigned char>::value)))&&(is_trivially_move_constructible<unsigned char>::value), void>::type std::__1::allocator_traits<std::__1::allocator<unsigned char> >::__construct_range_forward<unsigned char>(std::__1::allocator<unsigned char>&, unsigned char*, unsigned char*, unsigned char*&)
+INLINE_ORIGIN 160 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__recommend(unsigned long) const
+INLINE_ORIGIN 161 google_breakpad::scoped_ptr<sigaction>::scoped_ptr(sigaction*)
+INLINE_ORIGIN 162 google_breakpad::scoped_ptr<sigaction>::scoped_ptr(sigaction*)
+INLINE_ORIGIN 163 google_breakpad::ExceptionHandler::set_dump_path(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)
+INLINE_ORIGIN 164 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::c_str() const
+INLINE_ORIGIN 165 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::data() const
+INLINE_ORIGIN 166 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__get_pointer() const
+INLINE_ORIGIN 167 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__get_short_pointer() const
+INLINE_ORIGIN 168 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__get_long_pointer() const
+INLINE_ORIGIN 169 google_breakpad::CrashGenerationClient::CrashGenerationClient(char const*)
+INLINE_ORIGIN 170 google_breakpad::CrashGenerationClient::CrashGenerationClient(char const*)
+INLINE_ORIGIN 171 google_breakpad::scoped_ptr<google_breakpad::CrashGenerationClient>::reset(google_breakpad::CrashGenerationClient*)
+INLINE_ORIGIN 172 google_breakpad::scoped_ptr<google_breakpad::CrashGenerationClient>::~scoped_ptr()
+INLINE_ORIGIN 173 google_breakpad::scoped_ptr<google_breakpad::CrashGenerationClient>::~scoped_ptr()
+INLINE_ORIGIN 174 google_breakpad::scoped_ptr<sigaction>::~scoped_ptr()
+INLINE_ORIGIN 175 google_breakpad::scoped_ptr<sigaction>::~scoped_ptr()
+INLINE_ORIGIN 176 google_breakpad::ExceptionHandler::Teardown()
+INLINE_ORIGIN 177 google_breakpad::ExceptionHandler::SendMessageToHandlerThread(google_breakpad::HandlerThreadMessage)
+INLINE_ORIGIN 178 google_breakpad::ExceptionHandler::ExceptionHandler(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool (*)(void*), bool (*)(char const*, char const*, void*, bool), void*, bool, char const*)
+INLINE_ORIGIN 179 google_breakpad::ExceptionHandler::~ExceptionHandler()
+INLINE_ORIGIN 180 google_breakpad::ScopedTaskSuspend::ScopedTaskSuspend(unsigned int)
+INLINE_ORIGIN 181 google_breakpad::ScopedTaskSuspend::ScopedTaskSuspend(unsigned int)
+INLINE_ORIGIN 182 google_breakpad::MinidumpGenerator::SetExceptionInformation(int, int, int, unsigned int)
+INLINE_ORIGIN 183 google_breakpad::ScopedTaskSuspend::~ScopedTaskSuspend()
+INLINE_ORIGIN 184 google_breakpad::ScopedTaskSuspend::~ScopedTaskSuspend()
+INLINE_ORIGIN 185 google_breakpad::ExceptionHandler::IsOutOfProcess() const
+INLINE_ORIGIN 186 google_breakpad::scoped_ptr<google_breakpad::CrashGenerationClient>::get() const
+INLINE_ORIGIN 187 google_breakpad::scoped_ptr<google_breakpad::CrashGenerationClient>::operator->() const
+INLINE_ORIGIN 188 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::empty() const
+INLINE_ORIGIN 189 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::size() const
+INLINE_ORIGIN 190 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__get_short_size() const
+INLINE_ORIGIN 191 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__get_long_size() const
+INLINE_ORIGIN 192 google_breakpad::ExceptionHandler::SuspendThreads()
+INLINE_ORIGIN 193 google_breakpad::breakpad_exc_server(mach_msg_header_t*, mach_msg_header_t*)
+INLINE_ORIGIN 194 google_breakpad::ExceptionHandler::ResumeThreads()
+INLINE_ORIGIN 195 google_breakpad::scoped_ptr<sigaction>::get() const
+INLINE_ORIGIN 196 google_breakpad::scoped_ptr<sigaction>::reset(sigaction*)
+INLINE_ORIGIN 197 google_breakpad::scoped_ptr<sigaction>::swap(google_breakpad::scoped_ptr<sigaction>&)
+INLINE_ORIGIN 198 std::bad_alloc::bad_alloc(std::bad_alloc const&)
+INLINE_ORIGIN 199 std::bad_alloc::bad_alloc(std::bad_alloc const&)
+INLINE_ORIGIN 200 google_breakpad::wasteful_vector<MDMemoryDescriptor>::wasteful_vector(google_breakpad::PageAllocator*, unsigned int)
+INLINE_ORIGIN 201 google_breakpad::wasteful_vector<MDMemoryDescriptor>::wasteful_vector(google_breakpad::PageAllocator*, unsigned int)
+INLINE_ORIGIN 202 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::reserve(unsigned long)
+INLINE_ORIGIN 203 std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::__split_buffer(unsigned long, unsigned long, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&)
+INLINE_ORIGIN 204 std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::__split_buffer(unsigned long, unsigned long, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&)
+INLINE_ORIGIN 205 std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::allocate(google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, unsigned long)
+INLINE_ORIGIN 206 google_breakpad::PageStdAllocator<MDMemoryDescriptor>::allocate(unsigned long, void const*)
+INLINE_ORIGIN 207 google_breakpad::PageAllocator::PageAllocator()
+INLINE_ORIGIN 208 google_breakpad::PageAllocator::PageAllocator()
+INLINE_ORIGIN 209 google_breakpad::PageAllocator::Alloc(unsigned long)
+INLINE_ORIGIN 210 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::vector(google_breakpad::PageStdAllocator<MDMemoryDescriptor> const&)
+INLINE_ORIGIN 211 std::__1::__vector_base<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__vector_base(google_breakpad::PageStdAllocator<MDMemoryDescriptor> const&)
+INLINE_ORIGIN 212 std::__1::__compressed_pair<MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__compressed_pair(MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>)
+INLINE_ORIGIN 213 std::__1::__compressed_pair<MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__compressed_pair(MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>)
+INLINE_ORIGIN 214 std::__1::__libcpp_compressed_pair_imp<MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>, (unsigned int)0>::__libcpp_compressed_pair_imp(MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>)
+INLINE_ORIGIN 215 google_breakpad::PageAllocator::GetNPages(unsigned long)
+INLINE_ORIGIN 216 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__swap_out_circular_buffer(std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>&)
+INLINE_ORIGIN 217 void std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__construct_backward<MDMemoryDescriptor*>(google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor*, MDMemoryDescriptor*&)
+INLINE_ORIGIN 218 std::__1::enable_if<(is_move_constructible<MDMemoryDescriptor*>::value)&&(is_move_assignable<MDMemoryDescriptor*>::value), void>::type std::__1::swap<MDMemoryDescriptor*>(MDMemoryDescriptor*&, MDMemoryDescriptor*&)
+INLINE_ORIGIN 219 void std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::construct<MDMemoryDescriptor, MDMemoryDescriptor>(google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor&&)
+INLINE_ORIGIN 220 void std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__construct<MDMemoryDescriptor, MDMemoryDescriptor>(std::__1::integral_constant<bool, true>, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor&&)
+INLINE_ORIGIN 221 void std::__1::allocator<MDMemoryDescriptor>::construct<MDMemoryDescriptor, MDMemoryDescriptor>(MDMemoryDescriptor*, MDMemoryDescriptor&&)
+INLINE_ORIGIN 222 google_breakpad::wasteful_vector<MDMemoryDescriptor>::~wasteful_vector()
+INLINE_ORIGIN 223 google_breakpad::wasteful_vector<MDMemoryDescriptor>::~wasteful_vector()
+INLINE_ORIGIN 224 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::~vector()
+INLINE_ORIGIN 225 std::__1::__vector_base<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::~__vector_base()
+INLINE_ORIGIN 226 std::__1::__vector_base<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::clear()
+INLINE_ORIGIN 227 std::__1::__vector_base<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__destruct_at_end(MDMemoryDescriptor*)
+INLINE_ORIGIN 228 std::__1::__vector_base<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__alloc()
+INLINE_ORIGIN 229 google_breakpad::PageAllocator::~PageAllocator()
+INLINE_ORIGIN 230 google_breakpad::PageAllocator::~PageAllocator()
+INLINE_ORIGIN 231 google_breakpad::PageAllocator::FreeAll()
+INLINE_ORIGIN 232 google_breakpad::DynamicImages::GetCPUType()
+INLINE_ORIGIN 233 google_breakpad::DynamicImages::~DynamicImages()
+INLINE_ORIGIN 234 google_breakpad::MinidumpGenerator::~MinidumpGenerator()
+INLINE_ORIGIN 235 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::append(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)
+INLINE_ORIGIN 236 google_breakpad::TypedMDRVA<MDRawHeader>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 237 google_breakpad::TypedMDRVA<MDRawHeader>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 238 google_breakpad::TypedMDRVA<MDRawDirectory>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 239 google_breakpad::TypedMDRVA<MDRawDirectory>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 240 google_breakpad::TypedMDRVA<MDRawHeader>::Allocate()
+INLINE_ORIGIN 241 google_breakpad::TypedMDRVA<MDRawDirectory>::AllocateArray(unsigned long)
+INLINE_ORIGIN 242 google_breakpad::UntypedMDRVA::position() const
+INLINE_ORIGIN 243 google_breakpad::TypedMDRVA<MDRawDirectory>::CopyIndex(unsigned int, MDRawDirectory*)
+INLINE_ORIGIN 244 google_breakpad::TypedMDRVA<MDRawDirectory>::~TypedMDRVA()
+INLINE_ORIGIN 245 google_breakpad::TypedMDRVA<MDRawDirectory>::~TypedMDRVA()
+INLINE_ORIGIN 246 google_breakpad::TypedMDRVA<MDRawDirectory>::Flush()
+INLINE_ORIGIN 247 google_breakpad::TypedMDRVA<MDRawHeader>::~TypedMDRVA()
+INLINE_ORIGIN 248 google_breakpad::TypedMDRVA<MDRawHeader>::~TypedMDRVA()
+INLINE_ORIGIN 249 google_breakpad::TypedMDRVA<MDRawHeader>::Flush()
+INLINE_ORIGIN 250 google_breakpad::TypedMDRVA<MDRawThreadList>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 251 google_breakpad::TypedMDRVA<MDRawThreadList>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 252 google_breakpad::TypedMDRVA<MDRawThreadList>::~TypedMDRVA()
+INLINE_ORIGIN 253 google_breakpad::TypedMDRVA<MDRawThreadList>::~TypedMDRVA()
+INLINE_ORIGIN 254 google_breakpad::TypedMDRVA<MDRawThreadList>::AllocateObjectAndArray(unsigned long, unsigned long)
+INLINE_ORIGIN 255 google_breakpad::TypedMDRVA<MDRawThreadList>::CopyIndexAfterObject(unsigned int, void const*, unsigned long)
+INLINE_ORIGIN 256 google_breakpad::TypedMDRVA<MDRawThreadList>::Flush()
+INLINE_ORIGIN 257 google_breakpad::TypedMDRVA<MDRawMemoryList>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 258 google_breakpad::TypedMDRVA<MDRawMemoryList>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 259 google_breakpad::MinidumpGenerator::GetThreadState(unsigned int, unsigned int*, unsigned int*)
+INLINE_ORIGIN 260 unsigned long const& std::__1::min<unsigned long>(unsigned long const&, unsigned long const&)
+INLINE_ORIGIN 261 unsigned long const& std::__1::min<unsigned long, std::__1::__less<unsigned long, unsigned long> >(unsigned long const&, unsigned long const&, std::__1::__less<unsigned long, unsigned long>)
+INLINE_ORIGIN 262 google_breakpad::MinidumpGenerator::CurrentPCForStack(unsigned int*)
+INLINE_ORIGIN 263 google_breakpad::MinidumpGenerator::CurrentPCForStackX86(unsigned int*)
+INLINE_ORIGIN 264 google_breakpad::MinidumpGenerator::CurrentPCForStackX86_64(unsigned int*)
+INLINE_ORIGIN 265 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::push_back(MDMemoryDescriptor const&)
+INLINE_ORIGIN 266 void std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::construct<MDMemoryDescriptor, MDMemoryDescriptor const&>(google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor const&)
+INLINE_ORIGIN 267 void std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__construct<MDMemoryDescriptor, MDMemoryDescriptor const&>(std::__1::integral_constant<bool, true>, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor const&)
+INLINE_ORIGIN 268 void std::__1::allocator<MDMemoryDescriptor>::construct<MDMemoryDescriptor, MDMemoryDescriptor const&>(MDMemoryDescriptor*, MDMemoryDescriptor const&)
+INLINE_ORIGIN 269 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::size() const
+INLINE_ORIGIN 270 google_breakpad::TypedMDRVA<MDRawMemoryList>::AllocateObjectAndArray(unsigned long, unsigned long)
+INLINE_ORIGIN 271 google_breakpad::TypedMDRVA<MDRawMemoryList>::CopyIndexAfterObject(unsigned int, void const*, unsigned long)
+INLINE_ORIGIN 272 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::operator[](unsigned long)
+INLINE_ORIGIN 273 google_breakpad::TypedMDRVA<MDRawMemoryList>::~TypedMDRVA()
+INLINE_ORIGIN 274 google_breakpad::TypedMDRVA<MDRawMemoryList>::~TypedMDRVA()
+INLINE_ORIGIN 275 google_breakpad::TypedMDRVA<MDRawMemoryList>::Flush()
+INLINE_ORIGIN 276 google_breakpad::TypedMDRVA<MDRawSystemInfo>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 277 google_breakpad::TypedMDRVA<MDRawSystemInfo>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 278 google_breakpad::TypedMDRVA<MDRawSystemInfo>::Allocate()
+INLINE_ORIGIN 279 google_breakpad::TypedMDRVA<MDRawSystemInfo>::~TypedMDRVA()
+INLINE_ORIGIN 280 google_breakpad::TypedMDRVA<MDRawSystemInfo>::~TypedMDRVA()
+INLINE_ORIGIN 281 google_breakpad::TypedMDRVA<MDRawSystemInfo>::Flush()
+INLINE_ORIGIN 282 google_breakpad::TypedMDRVA<MDRawModuleList>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 283 google_breakpad::TypedMDRVA<MDRawModuleList>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 284 google_breakpad::TypedMDRVA<MDRawModuleList>::AllocateObjectAndArray(unsigned long, unsigned long)
+INLINE_ORIGIN 285 google_breakpad::MinidumpGenerator::FindExecutableModule()
+INLINE_ORIGIN 286 google_breakpad::TypedMDRVA<MDRawModuleList>::CopyIndexAfterObject(unsigned int, void const*, unsigned long)
+INLINE_ORIGIN 287 google_breakpad::TypedMDRVA<MDRawModuleList>::~TypedMDRVA()
+INLINE_ORIGIN 288 google_breakpad::TypedMDRVA<MDRawModuleList>::~TypedMDRVA()
+INLINE_ORIGIN 289 google_breakpad::TypedMDRVA<MDRawModuleList>::Flush()
+INLINE_ORIGIN 290 google_breakpad::TypedMDRVA<MDRawMiscInfo>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 291 google_breakpad::TypedMDRVA<MDRawMiscInfo>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 292 google_breakpad::TypedMDRVA<MDRawMiscInfo>::Allocate()
+INLINE_ORIGIN 293 google_breakpad::TypedMDRVA<MDRawMiscInfo>::~TypedMDRVA()
+INLINE_ORIGIN 294 google_breakpad::TypedMDRVA<MDRawMiscInfo>::~TypedMDRVA()
+INLINE_ORIGIN 295 google_breakpad::TypedMDRVA<MDRawMiscInfo>::Flush()
+INLINE_ORIGIN 296 google_breakpad::TypedMDRVA<MDRawBreakpadInfo>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 297 google_breakpad::TypedMDRVA<MDRawBreakpadInfo>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 298 google_breakpad::TypedMDRVA<MDRawBreakpadInfo>::Allocate()
+INLINE_ORIGIN 299 google_breakpad::TypedMDRVA<MDRawBreakpadInfo>::~TypedMDRVA()
+INLINE_ORIGIN 300 google_breakpad::TypedMDRVA<MDRawBreakpadInfo>::~TypedMDRVA()
+INLINE_ORIGIN 301 google_breakpad::TypedMDRVA<MDRawBreakpadInfo>::Flush()
+INLINE_ORIGIN 302 google_breakpad::MinidumpGenerator::WriteStackX86(unsigned int*, MDMemoryDescriptor*)
+INLINE_ORIGIN 303 google_breakpad::MinidumpGenerator::WriteStackX86_64(unsigned int*, MDMemoryDescriptor*)
+INLINE_ORIGIN 304 google_breakpad::TypedMDRVA<MDRawContextX86>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 305 google_breakpad::TypedMDRVA<MDRawContextX86>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 306 google_breakpad::TypedMDRVA<MDRawContextX86>::Allocate()
+INLINE_ORIGIN 307 google_breakpad::TypedMDRVA<MDRawContextX86>::~TypedMDRVA()
+INLINE_ORIGIN 308 google_breakpad::TypedMDRVA<MDRawContextX86>::~TypedMDRVA()
+INLINE_ORIGIN 309 google_breakpad::TypedMDRVA<MDRawContextX86>::Flush()
+INLINE_ORIGIN 310 google_breakpad::TypedMDRVA<MDRawContextAMD64>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 311 google_breakpad::TypedMDRVA<MDRawContextAMD64>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 312 google_breakpad::TypedMDRVA<MDRawContextAMD64>::Allocate()
+INLINE_ORIGIN 313 google_breakpad::TypedMDRVA<MDRawContextAMD64>::~TypedMDRVA()
+INLINE_ORIGIN 314 google_breakpad::TypedMDRVA<MDRawContextAMD64>::~TypedMDRVA()
+INLINE_ORIGIN 315 google_breakpad::TypedMDRVA<MDRawContextAMD64>::Flush()
+INLINE_ORIGIN 316 google_breakpad::MinidumpGenerator::WriteStack(unsigned int*, MDMemoryDescriptor*)
+INLINE_ORIGIN 317 google_breakpad::MinidumpGenerator::WriteContext(unsigned int*, MDLocationDescriptor*)
+INLINE_ORIGIN 318 google_breakpad::TypedMDRVA<MDRawExceptionStream>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 319 google_breakpad::TypedMDRVA<MDRawExceptionStream>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 320 google_breakpad::TypedMDRVA<MDRawExceptionStream>::Allocate()
+INLINE_ORIGIN 321 google_breakpad::TypedMDRVA<MDRawExceptionStream>::~TypedMDRVA()
+INLINE_ORIGIN 322 google_breakpad::TypedMDRVA<MDRawExceptionStream>::~TypedMDRVA()
+INLINE_ORIGIN 323 google_breakpad::TypedMDRVA<MDRawExceptionStream>::Flush()
+INLINE_ORIGIN 324 google_breakpad::DynamicImage::GetFilePath()
+INLINE_ORIGIN 325 google_breakpad::DynamicImage::GetVMAddrSlide() const
+INLINE_ORIGIN 326 google_breakpad::DynamicImage::GetVMSize() const
+INLINE_ORIGIN 327 google_breakpad::DynamicImage::GetVersion()
+INLINE_ORIGIN 328 google_breakpad::DynamicImage::GetCPUType()
+INLINE_ORIGIN 329 google_breakpad::TypedMDRVA<MDCVInfoPDB70>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 330 google_breakpad::TypedMDRVA<MDCVInfoPDB70>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
+INLINE_ORIGIN 331 google_breakpad::TypedMDRVA<MDCVInfoPDB70>::AllocateObjectAndArray(unsigned long, unsigned long)
+INLINE_ORIGIN 332 google_breakpad::TypedMDRVA<MDCVInfoPDB70>::CopyIndexAfterObject(unsigned int, void const*, unsigned long)
+INLINE_ORIGIN 333 google_breakpad::TypedMDRVA<MDCVInfoPDB70>::~TypedMDRVA()
+INLINE_ORIGIN 334 google_breakpad::TypedMDRVA<MDCVInfoPDB70>::~TypedMDRVA()
+INLINE_ORIGIN 335 google_breakpad::TypedMDRVA<MDCVInfoPDB70>::Flush()
+INLINE_ORIGIN 336 std::__1::__compressed_pair<MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::__compressed_pair(MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&)
+INLINE_ORIGIN 337 std::__1::__compressed_pair<MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::__compressed_pair(MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&)
+INLINE_ORIGIN 338 std::__1::__libcpp_compressed_pair_imp<MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, (unsigned int)0>::__libcpp_compressed_pair_imp(MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&)
+INLINE_ORIGIN 339 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__recommend(unsigned long) const
+INLINE_ORIGIN 340 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::capacity() const
+INLINE_ORIGIN 341 std::__1::__vector_base<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::capacity() const
+INLINE_ORIGIN 342 std::__1::__compressed_pair<MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::second()
+INLINE_ORIGIN 343 std::__1::__libcpp_compressed_pair_imp<MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>, (unsigned int)0>::second()
+INLINE_ORIGIN 344 std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::~__split_buffer()
+INLINE_ORIGIN 345 std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::~__split_buffer()
+INLINE_ORIGIN 346 std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::clear()
+INLINE_ORIGIN 347 std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::__destruct_at_end(MDMemoryDescriptor*)
+INLINE_ORIGIN 348 std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::__destruct_at_end(MDMemoryDescriptor*, std::__1::integral_constant<bool, false>)
+INLINE_ORIGIN 349 std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::__alloc()
+INLINE_ORIGIN 350 isLegalUTF8
+INLINE_ORIGIN 351 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::begin()
+INLINE_ORIGIN 352 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::clear()
+INLINE_ORIGIN 353 std::__1::__vector_base<unsigned short, std::__1::allocator<unsigned short> >::clear()
+INLINE_ORIGIN 354 std::__1::__vector_base<unsigned short, std::__1::allocator<unsigned short> >::__destruct_at_end(unsigned short*)
+INLINE_ORIGIN 355 std::__1::__vector_base<unsigned short, std::__1::allocator<unsigned short> >::__alloc()
+INLINE_ORIGIN 356 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::operator[](unsigned long)
+INLINE_ORIGIN 357 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::capacity() const
+INLINE_ORIGIN 358 std::__1::__vector_base<unsigned short, std::__1::allocator<unsigned short> >::capacity() const
+INLINE_ORIGIN 359 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::resize(unsigned long)
+INLINE_ORIGIN 360 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::size() const
+INLINE_ORIGIN 361 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__destruct_at_end(unsigned short*)
+INLINE_ORIGIN 362 bool std::__1::operator!=<unsigned short const*>(std::__1::__wrap_iter<unsigned short const*> const&, std::__1::__wrap_iter<unsigned short const*> const&)
+INLINE_ORIGIN 363 std::__1::__wrap_iter<unsigned short const*>::operator++()
+INLINE_ORIGIN 364 google_breakpad::scoped_array<unsigned char>::~scoped_array()
+INLINE_ORIGIN 365 google_breakpad::scoped_array<unsigned char>::~scoped_array()
+INLINE_ORIGIN 366 google_breakpad::scoped_array<unsigned short>::~scoped_array()
+INLINE_ORIGIN 367 google_breakpad::scoped_array<unsigned short>::~scoped_array()
+INLINE_ORIGIN 368 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__recommend(unsigned long) const
+INLINE_ORIGIN 369 std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<unsigned short>&)
+INLINE_ORIGIN 370 std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<unsigned short>&)
+INLINE_ORIGIN 371 std::__1::allocator_traits<std::__1::allocator<unsigned short> >::allocate(std::__1::allocator<unsigned short>&, unsigned long)
+INLINE_ORIGIN 372 std::__1::allocator<unsigned short>::allocate(unsigned long, void const*)
+INLINE_ORIGIN 373 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__move_range(unsigned short*, unsigned short*, unsigned short*)
+INLINE_ORIGIN 374 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__construct_at_end(unsigned long, unsigned short const&)
+INLINE_ORIGIN 375 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::construct<unsigned short, unsigned short const&>(std::__1::allocator<unsigned short>&, unsigned short*, unsigned short const&)
+INLINE_ORIGIN 376 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct<unsigned short, unsigned short const&>(std::__1::integral_constant<bool, true>, std::__1::allocator<unsigned short>&, unsigned short*, unsigned short const&)
+INLINE_ORIGIN 377 void std::__1::allocator<unsigned short>::construct<unsigned short, unsigned short const&>(unsigned short*, unsigned short const&)
+INLINE_ORIGIN 378 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::construct<unsigned short, unsigned short>(std::__1::allocator<unsigned short>&, unsigned short*, unsigned short&&)
+INLINE_ORIGIN 379 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct<unsigned short, unsigned short>(std::__1::integral_constant<bool, true>, std::__1::allocator<unsigned short>&, unsigned short*, unsigned short&&)
+INLINE_ORIGIN 380 void std::__1::allocator<unsigned short>::construct<unsigned short, unsigned short>(unsigned short*, unsigned short&&)
+INLINE_ORIGIN 381 unsigned short* std::__1::move_backward<unsigned short*, unsigned short*>(unsigned short*, unsigned short*, unsigned short*)
+INLINE_ORIGIN 382 std::__1::enable_if<(is_same<std::__1::remove_const<unsigned short>::type, unsigned short>::value)&&(is_trivially_copy_assignable<unsigned short>::value), unsigned short*>::type std::__1::__move_backward<unsigned short, unsigned short>(unsigned short*, unsigned short*, unsigned short*)
+INLINE_ORIGIN 383 unsigned short* std::__1::fill_n<unsigned short*, unsigned long, unsigned short>(unsigned short*, unsigned long, unsigned short const&)
+INLINE_ORIGIN 384 unsigned short* std::__1::__fill_n<unsigned short*, unsigned long, unsigned short>(unsigned short*, unsigned long, unsigned short const&)
+INLINE_ORIGIN 385 std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>::__construct_at_end(unsigned long, unsigned short const&)
+INLINE_ORIGIN 386 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__swap_out_circular_buffer(std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>&, unsigned short*)
+INLINE_ORIGIN 387 std::__1::enable_if<((is_same<std::__1::allocator<unsigned short>, std::__1::allocator<unsigned short> >::value)||(!(__has_construct<std::__1::allocator<unsigned short>, unsigned short*, unsigned short>::value)))&&(is_trivially_move_constructible<unsigned short>::value), void>::type std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct_backward<unsigned short>(std::__1::allocator<unsigned short>&, unsigned short*, unsigned short*, unsigned short*&)
+INLINE_ORIGIN 388 std::__1::enable_if<((is_same<std::__1::allocator<unsigned short>, std::__1::allocator<unsigned short> >::value)||(!(__has_construct<std::__1::allocator<unsigned short>, unsigned short*, unsigned short>::value)))&&(is_trivially_move_constructible<unsigned short>::value), void>::type std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct_forward<unsigned short>(std::__1::allocator<unsigned short>&, unsigned short*, unsigned short*, unsigned short*&)
+INLINE_ORIGIN 389 std::__1::enable_if<(is_move_constructible<unsigned short*>::value)&&(is_move_assignable<unsigned short*>::value), void>::type std::__1::swap<unsigned short*>(unsigned short*&, unsigned short*&)
+INLINE_ORIGIN 390 std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>::~__split_buffer()
+INLINE_ORIGIN 391 std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>::~__split_buffer()
+INLINE_ORIGIN 392 std::__1::allocator_traits<std::__1::allocator<unsigned short> >::deallocate(std::__1::allocator<unsigned short>&, unsigned short*, unsigned long)
+INLINE_ORIGIN 393 std::__1::allocator<unsigned short>::deallocate(unsigned short*, unsigned long)
+INLINE_ORIGIN 394 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__construct_at_end(unsigned long)
+INLINE_ORIGIN 395 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::construct<unsigned short, >(std::__1::allocator<unsigned short>&, unsigned short*, &&)
+INLINE_ORIGIN 396 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct<unsigned short, >(std::__1::integral_constant<bool, true>, std::__1::allocator<unsigned short>&, unsigned short*, &&)
+INLINE_ORIGIN 397 void std::__1::allocator<unsigned short>::construct<unsigned short, >(unsigned short*, &&)
+INLINE_ORIGIN 398 std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>::__construct_at_end(unsigned long)
+INLINE_ORIGIN 399 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__swap_out_circular_buffer(std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>&)
+INLINE_ORIGIN 400 google_breakpad::FileID::FileID(char const*)
+INLINE_ORIGIN 401 MacFileUtilities::MachoID::MachoID(char const*)
+INLINE_ORIGIN 402 MacFileUtilities::MachoID::MachoID(char const*, void*, unsigned long)
+INLINE_ORIGIN 403 MacFileUtilities::MachoID::Update(MacFileUtilities::MachoWalker*, long long, unsigned long)
+INLINE_ORIGIN 404 ByteSwap(unsigned int)
+INLINE_ORIGIN 405 _OSSwapInt32(unsigned int)
+INLINE_ORIGIN 406 ByteSwap(int)
+INLINE_ORIGIN 407 ByteSwap(unsigned long long)
+INLINE_ORIGIN 408 _OSSwapInt64(unsigned long long)
+INLINE_ORIGIN 409 MacFileUtilities::MachoWalker::MachoWalker(char const*, bool (*)(MacFileUtilities::MachoWalker*, load_command*, long long, bool, void*), void*)
+INLINE_ORIGIN 410 MacFileUtilities::MachoWalker::MachoWalker(void*, unsigned long, bool (*)(MacFileUtilities::MachoWalker*, load_command*, long long, bool, void*), void*)
+INLINE_ORIGIN 411 MacFileUtilities::MachoWalker::~MachoWalker()
+INLINE_ORIGIN 412 MacFileUtilities::MachoWalker::WalkHeader64AtOffset(long long)
+INLINE_ORIGIN 413 MacFileUtilities::MachoWalker::ReadBytes(void*, unsigned long, long long)
+INLINE_ORIGIN 414 google_breakpad::scoped_array<unsigned char>::operator[](long) const
+INLINE_ORIGIN 415 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::find_first_not_of(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, unsigned long) const
+INLINE_ORIGIN 416 unsigned long std::__1::__str_find_first_not_of<char, unsigned long, std::__1::char_traits<char>, (unsigned long)18446744073709551615>(char const*, unsigned long, char const*, unsigned long, unsigned long)
+INLINE_ORIGIN 417 std::__1::char_traits<char>::find(char const*, unsigned long, char const&)
+INLINE_ORIGIN 418 std::__1::char_traits<char>::to_int_type(char)
+INLINE_ORIGIN 419 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::substr(unsigned long, unsigned long) const
+INLINE_ORIGIN 420 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::find_first_of(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, unsigned long) const
+INLINE_ORIGIN 421 unsigned long std::__1::__str_find_first_of<char, unsigned long, std::__1::char_traits<char>, (unsigned long)18446744073709551615>(char const*, unsigned long, char const*, unsigned long, unsigned long)
+INLINE_ORIGIN 422 char const* std::__1::__find_first_of_ce<char const*, char const*, bool (*)(char, char)>(char const*, char const*, char const*, char const*, bool (*)(char, char))
+INLINE_ORIGIN 423 std::__1::char_traits<char>::eq(char, char)
+INLINE_ORIGIN 424 google_breakpad::MachMessage::MachMessage()
+INLINE_ORIGIN 425 google_breakpad::MachMessage::SetDescriptorCount(int)
+INLINE_ORIGIN 426 google_breakpad::MachMessage::SetMessageID(int)
+INLINE_ORIGIN 427 google_breakpad::MachMessage::SetData(void*, int)
+INLINE_ORIGIN 428 google_breakpad::MachMessage::CalculateSize()
+INLINE_ORIGIN 429 google_breakpad::MachMessage::GetDataLength()
+INLINE_ORIGIN 430 google_breakpad::MachMessage::GetDataPacket()
+INLINE_ORIGIN 431 google_breakpad::MachSendMessage::MachSendMessage(int)
+INLINE_ORIGIN 432 google_breakpad::MachMessage::SetDescriptor(int, google_breakpad::MachMsgPortDescriptor const&)
+INLINE_ORIGIN 433 google_breakpad::MachMessage::GetDescriptorCount() const
+INLINE_ORIGIN 434 google_breakpad::MachMessage::GetDescriptor(int)
+INLINE_ORIGIN 435 google_breakpad::MachMsgPortDescriptor::GetMachPort() const
+INLINE_ORIGIN 436 google_breakpad::ReceivePort::ReceivePort(char const*)
+INLINE_ORIGIN 437 google_breakpad::ReceivePort::ReceivePort()
+INLINE_ORIGIN 438 google_breakpad::ReceivePort::ReceivePort(unsigned int)
+INLINE_ORIGIN 439 google_breakpad::ReceivePort::~ReceivePort()
+INLINE_ORIGIN 440 google_breakpad::MachPortSender::MachPortSender(char const*)
+INLINE_ORIGIN 441 google_breakpad::MachPortSender::MachPortSender(unsigned int)
+INLINE_ORIGIN 442 (anonymous namespace)::start()
+INLINE_ORIGIN 443 (anonymous namespace)::crash()
 PUBLIC 0 0 _mh_execute_header
 FUNC d20 1a 0 google_breakpad::MinidumpFileWriter::MinidumpFileWriter()
 d20 6 93 0
@@ -425,9 +512,8 @@ dbd c 140 0
 dc9 6 142 0
 dcf 2 146 0
 FUNC de0 34 0 google_breakpad::MinidumpFileWriter::~MinidumpFileWriter()
-INLINE 0 99 0 2 de4 26
+INLINE 0 99 0 2 de4 26 e0c 8
 INLINE 1 101 0 1 dea 20
-INLINE 0 99 0 2 e0c 8
 de0 4 99 0
 de4 6 100 0
 dea 7 127 0
@@ -449,12 +535,8 @@ e78 4 118 0
 e7c 2 122 0
 e7e 1f 116 0
 FUNC ea0 147 0 google_breakpad::MinidumpFileWriter::CopyStringToMDString(wchar_t const*, unsigned int, google_breakpad::TypedMDRVA<MDString>*)
-INLINE 0 174 0 3 efa 25
-INLINE 1 84 1 4 f12 d
-INLINE 0 174 0 3 f23 44
-INLINE 1 84 1 4 f34 33
-INLINE 0 174 0 3 fa9 3e
-INLINE 1 84 1 4 fc8 1f
+INLINE 0 174 0 3 efa 25 f23 44 fa9 3e
+INLINE 1 84 1 4 f12 d f34 33 fc8 1f
 ea0 16 150 0
 eb6 1a 160 0
 ed0 a 161 0
@@ -478,12 +560,8 @@ f97 12 179 0
 fa9 1f 83 1
 fc8 1f 313 0
 FUNC ff0 147 0 google_breakpad::MinidumpFileWriter::CopyStringToMDString(char const*, unsigned int, google_breakpad::TypedMDRVA<MDString>*)
-INLINE 0 201 0 5 1049 1e
-INLINE 1 84 1 4 105b c
-INLINE 0 201 0 5 106b 48
-INLINE 1 84 1 4 107b 38
-INLINE 0 201 0 5 10f9 3e
-INLINE 1 84 1 4 1118 1f
+INLINE 0 201 0 3 1049 1e 106b 48 10f9 3e
+INLINE 1 84 1 4 105b c 107b 38 1118 1f
 ff0 16 183 0
 1006 1a 189 0
 1020 10 190 0
@@ -509,35 +587,18 @@ ff0 16 183 0
 FUNC 1140 5 0 google_breakpad::MinidumpFileWriter::WriteString(wchar_t const*, unsigned int, MDLocationDescriptor*)
 1140 5 245 0
 FUNC 1150 2cc 0 bool google_breakpad::MinidumpFileWriter::WriteStringCore<wchar_t>(wchar_t const*, unsigned int, MDLocationDescriptor*)
-INLINE 0 222 0 6 119f 26
-INLINE 1 212 2 7 119f 26
-INLINE 2 210 2 8 119f c
-INLINE 3 160 2 9 11a4 3
-INLINE 0 223 0 6 11c5 a
-INLINE 0 223 0 6 11d1 17
-INLINE 0 234 0 6 1213 55
-INLINE 1 84 1 4 1223 c
-INLINE 1 84 1 4 1237 31
-INLINE 0 237 0 6 1268 f
-INLINE 0 241 0 6 128b 47
-INLINE 1 214 2 10 128b 47
-INLINE 2 217 2 11 1292 40
-INLINE 3 92 1 12 1297 29
-INLINE 3 92 1 12 12c5 d
-INLINE 0 223 0 6 131e 1f
-INLINE 0 241 0 6 133d 1f
-INLINE 1 214 2 10 133d 1f
-INLINE 2 217 2 11 133d 1f
-INLINE 3 92 1 12 133d 1f
-INLINE 0 234 0 6 135c 3e
-INLINE 1 84 1 4 137b 1f
-INLINE 0 241 0 6 139c 8
-INLINE 1 214 2 10 139c 8
-INLINE 0 241 0 6 13a7 75
-INLINE 1 214 2 10 13a7 75
-INLINE 2 217 2 11 13b6 5e
-INLINE 3 92 1 12 13bb 45
-INLINE 3 92 1 12 1405 f
+INLINE 0 222 0 5 119f 26
+INLINE 1 212 2 6 119f 26
+INLINE 2 210 2 7 119f c
+INLINE 3 160 2 8 11a4 3
+INLINE 0 223 0 9 11c5 a 11d1 17 131e 1f
+INLINE 0 234 0 3 1213 55 135c 3e
+INLINE 1 84 1 4 1223 c 1237 31 137b 1f
+INLINE 0 237 0 10 1268 f
+INLINE 0 241 0 11 128b 47 133d 1f 139c 8 13a7 75
+INLINE 1 214 2 12 128b 47 133d 1f 139c 8 13a7 75
+INLINE 2 217 2 13 1292 40 133d 1f 13b6 5e
+INLINE 3 92 1 4 1297 29 12c5 d 133d 1f 13bb 45 1405 f
 1150 10 210 0
 1160 9 211 0
 1169 9 212 0
@@ -596,35 +657,18 @@ INLINE 3 92 1 12 1405 f
 FUNC 1420 5 0 google_breakpad::MinidumpFileWriter::WriteString(char const*, unsigned int, MDLocationDescriptor*)
 1420 5 250 0
 FUNC 1430 2cc 0 bool google_breakpad::MinidumpFileWriter::WriteStringCore<char>(char const*, unsigned int, MDLocationDescriptor*)
-INLINE 0 222 0 13 147f 26
-INLINE 1 212 2 7 147f 26
-INLINE 2 210 2 8 147f c
-INLINE 3 160 2 9 1484 3
-INLINE 0 223 0 13 14a5 a
-INLINE 0 223 0 13 14b1 17
-INLINE 0 234 0 13 14f3 55
-INLINE 1 84 1 4 1503 c
-INLINE 1 84 1 4 1517 31
-INLINE 0 237 0 13 1548 f
-INLINE 0 241 0 13 156b 47
-INLINE 1 214 2 10 156b 47
-INLINE 2 217 2 11 1572 40
-INLINE 3 92 1 12 1577 29
-INLINE 3 92 1 12 15a5 d
-INLINE 0 223 0 13 15fe 1f
-INLINE 0 241 0 13 161d 1f
-INLINE 1 214 2 10 161d 1f
-INLINE 2 217 2 11 161d 1f
-INLINE 3 92 1 12 161d 1f
-INLINE 0 234 0 13 163c 3e
-INLINE 1 84 1 4 165b 1f
-INLINE 0 241 0 13 167c 8
-INLINE 1 214 2 10 167c 8
-INLINE 0 241 0 13 1687 75
-INLINE 1 214 2 10 1687 75
-INLINE 2 217 2 11 1696 5e
-INLINE 3 92 1 12 169b 45
-INLINE 3 92 1 12 16e5 f
+INLINE 0 222 0 5 147f 26
+INLINE 1 212 2 6 147f 26
+INLINE 2 210 2 7 147f c
+INLINE 3 160 2 8 1484 3
+INLINE 0 223 0 9 14a5 a 14b1 17 15fe 1f
+INLINE 0 234 0 3 14f3 55 163c 3e
+INLINE 1 84 1 4 1503 c 1517 31 165b 1f
+INLINE 0 237 0 10 1548 f
+INLINE 0 241 0 11 156b 47 161d 1f 167c 8 1687 75
+INLINE 1 214 2 12 156b 47 161d 1f 167c 8 1687 75
+INLINE 2 217 2 13 1572 40 161d 1f 1696 5e
+INLINE 3 92 1 4 1577 29 15a5 d 161d 1f 169b 45 16e5 f
 1430 10 210 0
 1440 9 211 0
 1449 9 212 0
@@ -682,11 +726,10 @@ INLINE 3 92 1 12 16e5 f
 16f4 8 217 2
 FUNC 1700 c4 0 google_breakpad::MinidumpFileWriter::WriteMemory(void const*, unsigned long, MDMemoryDescriptor*)
 INLINE 0 257 0 14 171f 18
-INLINE 1 161 2 15 171f 18
-INLINE 2 160 2 9 1723 3
-INLINE 0 265 0 14 1743 e
-INLINE 0 261 0 14 1751 e
-INLINE 0 265 0 14 1766 a
+INLINE 1 161 2 7 171f 18
+INLINE 2 160 2 8 1723 3
+INLINE 0 265 0 10 1743 e 1766 a
+INLINE 0 261 0 15 1751 e
 1700 11 254 0
 1711 5 255 0
 1716 9 256 0
@@ -706,9 +749,7 @@ INLINE 0 265 0 14 1766 a
 1786 1f 255 0
 17a5 1f 256 0
 FUNC 17d0 104 0 google_breakpad::UntypedMDRVA::Allocate(unsigned long)
-INLINE 0 339 0 16 17f0 9
-INLINE 0 339 0 16 17fc 62
-INLINE 0 339 0 16 1896 3e
+INLINE 0 339 0 16 17f0 9 17fc 62 1896 3e
 17d0 11 336 0
 17e1 b 337 0
 17ec 4 338 0
@@ -758,8 +799,7 @@ FUNC 19a0 c8 0 google_breakpad::MinidumpFileWriter::Copy(unsigned int, void cons
 1a2a 1f 312 0
 1a49 1f 313 0
 FUNC 1a70 f3 0 google_breakpad::UntypedMDRVA::Copy(unsigned int, void const*, unsigned long)
-INLINE 0 347 0 17 1aa2 37
-INLINE 0 347 0 17 1b44 1f
+INLINE 0 347 0 4 1aa2 37 1b44 1f
 1a70 e 343 0
 1a7e 5 344 0
 1a83 5 345 0
@@ -775,18 +815,15 @@ INLINE 0 347 0 17 1b44 1f
 1b25 1f 346 0
 1b44 1f 313 0
 FUNC 1b70 1b3 0 google_breakpad::CrashGenerationClient::RequestDumpForException(int, int, int, unsigned int)
-INLINE 0 47 3 18 1bc3 14
-INLINE 1 117 4 19 1bc3 14
-INLINE 0 48 3 18 1be9 14
-INLINE 1 117 4 19 1be9 14
-INLINE 0 49 3 18 1c14 14
-INLINE 1 117 4 19 1c14 14
-INLINE 0 50 3 18 1c3a 3
-INLINE 0 50 3 18 1c3d 14
-INLINE 1 117 4 19 1c3d 14
-INLINE 0 66 3 18 1caa d
-INLINE 1 239 4 20 1caa d
-INLINE 2 239 4 21 1caa d
+INLINE 0 47 3 17 1bc3 14
+INLINE 1 117 4 18 1bc3 14 1be9 14 1c14 14 1c3d 14
+INLINE 0 48 3 17 1be9 14
+INLINE 0 49 3 17 1c14 14
+INLINE 0 50 3 19 1c3a 3
+INLINE 0 50 3 17 1c3d 14
+INLINE 0 66 3 20 1caa d
+INLINE 1 239 4 21 1caa d
+INLINE 2 239 4 22 1caa d
 1b70 33 41 3
 1ba3 5 44 3
 1ba8 12 46 3
@@ -820,12 +857,11 @@ INLINE 2 239 4 21 1caa d
 1cc8 9 69 3
 1cd1 52 70 3
 FUNC 1d30 bb 0 google_breakpad::ReadTaskMemory(unsigned int, unsigned long long, unsigned long, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >&)
-INLINE 0 207 8 81 1d7e 20
-INLINE 1 1996 9 82 1d7e d
-INLINE 0 208 8 81 1d9e 5
-INLINE 0 207 8 81 1da5 d
-INLINE 1 2000 9 82 1da9 9
-INLINE 2 814 9 83 1da9 9
+INLINE 0 207 8 106 1d7e 20 1da5 d
+INLINE 1 1996 9 107 1d7e d
+INLINE 0 208 8 36 1d9e 5
+INLINE 1 2000 9 108 1da9 9
+INLINE 2 814 9 41 1da9 9
 1d30 17 185 8
 1d47 5 186 8
 1d4c 3 192 8
@@ -847,15 +883,11 @@ INLINE 2 814 9 83 1da9 9
 1dc5 19 211 8
 1dde d 213 8
 FUNC 1df0 1ba 0 google_breakpad::DynamicImage::CalculateMemoryAndVersionInfo()
-INLINE 0 310 8 89 1e1e 5
-INLINE 0 311 8 89 1e23 b
-INLINE 1 247 8 90 1e23 3
-INLINE 0 313 8 89 1e2e 1b
-INLINE 0 313 8 89 1e4c 98
-INLINE 1 271 8 91 1e9f 4
-INLINE 0 311 8 89 1ee4 1b
-INLINE 0 311 8 89 1f02 99
-INLINE 1 271 8 90 1f5c 4
+INLINE 0 310 8 116 1e1e 5
+INLINE 0 311 8 117 1e23 b 1ee4 1b 1f02 99
+INLINE 1 247 8 118 1e23 3
+INLINE 0 313 8 119 1e2e 1b 1e4c 98
+INLINE 1 271 8 27 1e9f 4 1f5c 4
 1df0 e 301 8
 1dfe 20 305 8
 1e1e 5 162 6
@@ -905,28 +937,27 @@ INLINE 1 271 8 90 1f5c 4
 1f92 9 258 8
 1f9b f 314 8
 FUNC 1fb0 7 0 google_breakpad::DynamicImage::GetFileType()
-INLINE 0 329 8 92 1fb0 6
-INLINE 1 323 8 93 1fb0 3
+INLINE 0 329 8 120 1fb0 6
+INLINE 1 323 8 118 1fb0 3
 1fb0 3 1510 9
 1fb3 3 324 8
 1fb6 1 332 8
 FUNC 1fc0 b8 0 google_breakpad::DynamicImages::DynamicImages(unsigned int)
-INLINE 0 341 8 94 1fdc 18
-INLINE 1 485 9 95 1fdc 18
-INLINE 2 484 9 96 1fdc 18
-INLINE 0 342 8 94 1ff4 44
-INLINE 1 514 8 97 1ff4 1e
-INLINE 1 514 8 97 2016 a
-INLINE 1 517 8 97 2020 6
-INLINE 0 343 8 94 2045 2b
-INLINE 1 458 9 98 2045 2b
-INLINE 2 458 9 99 2045 2b
-INLINE 3 452 9 100 204d 1e
-INLINE 4 369 9 101 204d 1e
-INLINE 5 425 9 79 2056 11
-INLINE 3 453 9 100 206b 5
-INLINE 4 1508 10 55 206b 5
-INLINE 5 1743 10 56 206b 5
+INLINE 0 341 8 121 1fdc 18
+INLINE 1 485 9 122 1fdc 18
+INLINE 2 484 9 123 1fdc 18
+INLINE 0 342 8 124 1ff4 44
+INLINE 1 514 8 125 1ff4 1e 2016 a
+INLINE 1 517 8 126 2020 6
+INLINE 0 343 8 127 2045 2b
+INLINE 1 458 9 128 2045 2b
+INLINE 2 458 9 129 2045 2b
+INLINE 3 452 9 130 204d 1e
+INLINE 4 369 9 104 204d 1e
+INLINE 5 425 9 105 2056 11
+INLINE 3 453 9 62 206b 5
+INLINE 4 1508 10 63 206b 5
+INLINE 5 1743 10 44 206b 5
 1fc0 c 341 8
 1fcc 2 339 8
 1fce a 340 8
@@ -944,7 +975,7 @@ INLINE 5 1743 10 56 206b 5
 204d 9 424 9
 2056 11 0 9
 2067 4 425 9
-206b d 177 10
+206b d 177 11
 FUNC 2080 d6 0 google_breakpad::DynamicImages::DetermineTaskCPUType(unsigned int)
 2080 16 552 8
 2096 10 553 8
@@ -960,9 +991,8 @@ FUNC 2080 d6 0 google_breakpad::DynamicImages::DetermineTaskCPUType(unsigned int
 212c b 571 8
 2137 1f 560 8
 FUNC 2160 52 0 google_breakpad::DynamicImages::ReadImageInfoForTask()
-INLINE 0 514 8 97 2168 1e
-INLINE 0 514 8 97 218a a
-INLINE 0 517 8 97 2194 6
+INLINE 0 514 8 125 2168 1e 218a a
+INLINE 0 517 8 126 2194 6
 2160 8 513 8
 2168 8 391 8
 2170 16 392 8
@@ -982,194 +1012,112 @@ FUNC 21d0 34 0 google_breakpad::DynamicImages::GetDyldAllImageInfosPointer()
 21fc 8 406 8
 FUNC 2210 5d0 0 void google_breakpad::ReadImageInfo<google_breakpad::MachO64>(google_breakpad::DynamicImages&, unsigned long long)
 INLINE 0 424 8 33 2224 17
-INLINE 1 485 9 34 2224 17
-INLINE 2 484 9 35 2224 17
-INLINE 0 432 8 33 2255 8
+INLINE 1 485 9 34 2224 17 2261 11 241f 12
+INLINE 2 484 9 35 2224 17 2261 11 241f 12
+INLINE 0 432 8 36 2255 8
 INLINE 0 439 8 33 2261 11
-INLINE 1 485 9 34 2261 11
-INLINE 2 484 9 35 2261 11
-INLINE 0 511 8 33 2294 1b
-INLINE 1 458 9 36 2294 1b
-INLINE 2 458 9 37 2294 1b
-INLINE 3 452 9 38 229e c
-INLINE 4 369 9 39 229e c
-INLINE 3 453 9 38 22aa 5
-INLINE 4 1508 10 40 22aa 5
-INLINE 5 1743 10 41 22aa 5
-INLINE 0 511 8 33 22af 24
-INLINE 1 458 9 36 22af 24
-INLINE 2 458 9 37 22af 24
-INLINE 3 452 9 38 22bc 12
-INLINE 4 369 9 39 22bc 12
-INLINE 3 453 9 38 22ce 5
-INLINE 4 1508 10 40 22ce 5
-INLINE 5 1743 10 41 22ce 5
-INLINE 0 447 8 33 22e5 5
-INLINE 0 448 8 33 22ef 55
-INLINE 1 1535 9 42 22ef 16
-INLINE 2 645 9 43 22ef 16
-INLINE 1 1538 9 42 230e 5
-INLINE 1 1538 9 42 2313 8
-INLINE 2 310 12 44 2313 8
-INLINE 3 311 12 45 2313 8
-INLINE 4 1500 10 46 2313 8
-INLINE 5 1741 10 47 2313 8
-INLINE 1 1538 9 42 231b 6
-INLINE 1 1538 9 42 2321 3
-INLINE 2 310 12 44 2321 3
-INLINE 1 1538 9 42 2324 6
-INLINE 1 1538 9 42 232a 6
-INLINE 2 310 12 44 232a 6
-INLINE 1 1539 9 42 2330 14
-INLINE 2 893 9 48 2330 14
-INLINE 0 448 8 33 2347 aa
-INLINE 1 1539 9 42 2347 9d
-INLINE 2 893 9 48 2347 20
-INLINE 3 1630 10 49 2347 d
-INLINE 4 1514 10 50 2347 d
-INLINE 5 1668 10 51 2347 d
-INLINE 6 1752 10 52 2347 d
-INLINE 7 210 6 30 2347 d
-INLINE 3 1630 10 49 2358 4
-INLINE 4 1514 10 50 2358 4
-INLINE 5 1668 10 51 2358 4
-INLINE 6 1752 10 52 2358 4
-INLINE 7 210 6 30 2358 4
-INLINE 2 894 9 48 2367 5
-INLINE 2 893 9 48 236f 5e
-INLINE 3 1630 10 49 2375 47
-INLINE 4 1514 10 50 2375 47
-INLINE 5 1668 10 51 2375 47
-INLINE 6 1752 10 52 2375 47
-INLINE 7 210 6 30 2375 47
-INLINE 3 1630 10 49 23c0 4
-INLINE 4 1514 10 50 23c0 4
-INLINE 5 1668 10 51 23c0 4
-INLINE 6 1752 10 52 23c0 4
-INLINE 7 210 6 30 23c0 4
-INLINE 2 894 9 48 23cd d
-INLINE 2 895 9 48 23da 5
-INLINE 2 896 9 48 23df 5
-INLINE 1 1540 9 42 23e4 d
-INLINE 2 340 12 53 23e4 d
-INLINE 3 343 12 54 23e9 8
-INLINE 4 1508 10 55 23e9 8
-INLINE 5 1743 10 56 23e9 8
-INLINE 0 495 8 33 23fa 5
+INLINE 0 511 8 37 2294 1b 22af 24 2799 1b 27b4 24
+INLINE 1 458 9 38 2294 1b 22af 24 261a 21 277e 1b 2799 1b 27b4 24
+INLINE 2 458 9 39 2294 1b 22af 24 261a 21 277e 1b 2799 1b 27b4 24
+INLINE 3 452 9 40 229e c 22bc 12 262a c 2788 c 27a3 c 27c1 12
+INLINE 4 369 9 41 229e c 22bc 12 262a c 2788 c 27a3 c 27c1 12
+INLINE 3 453 9 42 22aa 5 22ce 5 2636 5 2794 5 27af 5 27d3 5
+INLINE 4 1508 10 43 22aa 5 22ce 5 2636 5 2794 5 27af 5 27d3 5
+INLINE 5 1743 10 44 22aa 5 22ce 5 23e9 8 2636 5 2794 5 27af 5 27d3 5
+INLINE 0 447 8 36 22e5 5
+INLINE 0 448 8 45 22ef 55 2347 aa
+INLINE 1 1535 9 46 22ef 16
+INLINE 2 645 9 47 22ef 16
+INLINE 1 1538 9 48 230e 5 231b 6 2324 6
+INLINE 1 1538 9 49 2313 8 2321 3 232a 6
+INLINE 2 310 12 50 2313 8 2321 3 232a 6
+INLINE 3 311 12 51 2313 8
+INLINE 4 1500 10 52 2313 8
+INLINE 5 1741 10 53 2313 8
+INLINE 1 1539 9 54 2330 14 2347 9d
+INLINE 2 893 9 55 2330 14 2347 20 236f 5e
+INLINE 3 1630 10 56 2347 d 2358 4 2375 47 23c0 4
+INLINE 4 1514 10 57 2347 d 2358 4 2375 47 23c0 4
+INLINE 5 1668 10 58 2347 d 2358 4 2375 47 23c0 4
+INLINE 6 1752 10 31 2347 d 2358 4 2375 47 23c0 4
+INLINE 7 210 6 32 2347 d 2358 4 2375 47 23c0 4
+INLINE 2 894 9 59 2367 5 23cd d
+INLINE 2 895 9 59 23da 5
+INLINE 2 896 9 59 23df 5
+INLINE 1 1540 9 60 23e4 d
+INLINE 2 340 12 61 23e4 d
+INLINE 3 343 12 62 23e9 8
+INLINE 4 1508 10 63 23e9 8
+INLINE 0 495 8 64 23fa 5 25a1 20 25f9 17
 INLINE 0 454 8 33 241f 12
-INLINE 1 485 9 34 241f 12
-INLINE 2 484 9 35 241f 12
-INLINE 0 462 8 33 244e 5
-INLINE 0 476 8 33 2476 11
-INLINE 1 1945 13 57 2476 11
-INLINE 2 1949 13 58 2476 11
-INLINE 0 481 8 33 24a5 6b
-INLINE 1 2476 13 59 24a5 6b
-INLINE 2 2462 13 60 24a5 21
-INLINE 3 3163 13 61 24a5 7
-INLINE 3 3171 13 61 24ac 9
-INLINE 3 3165 13 61 24b5 5
-INLINE 3 3165 13 61 24ba 3
-INLINE 3 3166 13 61 24bd 9
-INLINE 2 2463 13 60 24c6 c
-INLINE 2 2466 13 60 24f9 17
-INLINE 0 486 8 33 252a 5
-INLINE 0 486 8 33 255a 23
-INLINE 0 494 8 33 2585 d
-INLINE 0 495 8 33 2594 d
-INLINE 1 208 6 62 2594 d
-INLINE 0 495 8 33 25a1 20
-INLINE 1 1609 9 63 25ad 3
-INLINE 2 1514 10 64 25ad 3
-INLINE 3 1668 10 65 25ad 3
-INLINE 4 1752 10 66 25ad 3
-INLINE 5 210 6 30 25ad 3
-INLINE 0 497 8 33 25c1 29
-INLINE 1 109 6 67 25c1 29
-INLINE 2 109 6 68 25cd 1d
-INLINE 3 458 9 36 25cd 1d
-INLINE 4 458 9 37 25cd 1d
-INLINE 5 452 9 38 25db a
-INLINE 6 369 9 39 25db a
-INLINE 5 453 9 38 25e5 5
-INLINE 6 1508 10 40 25e5 5
-INLINE 7 1743 10 41 25e5 5
-INLINE 0 495 8 33 25f9 17
-INLINE 0 499 8 33 261a 21
-INLINE 1 458 9 36 261a 21
-INLINE 2 458 9 37 261a 21
-INLINE 3 452 9 38 262a c
-INLINE 4 369 9 39 262a c
-INLINE 3 453 9 38 2636 5
-INLINE 4 1508 10 40 2636 5
-INLINE 5 1743 10 41 2636 5
-INLINE 0 502 8 33 2655 4
-INLINE 0 502 8 33 265e 3
-INLINE 0 502 8 33 2661 9
-INLINE 0 502 8 33 266a 5
-INLINE 1 4066 5 69 266a 5
-INLINE 2 4050 5 70 266a 5
-INLINE 0 508 8 33 266f 3
-INLINE 0 509 8 33 2672 4
-INLINE 0 508 8 33 2676 69
-INLINE 1 2235 5 71 2676 69
-INLINE 2 2214 5 72 2676 24
-INLINE 3 1085 5 73 2676 5
-INLINE 3 1088 5 73 267f 6
-INLINE 3 1090 5 73 2685 b
-INLINE 4 665 5 74 2685 b
-INLINE 5 219 6 75 2689 3
-INLINE 5 218 6 75 268c 4
-INLINE 2 2216 5 72 269e 5
-INLINE 2 2221 5 72 26a3 9
-INLINE 2 2223 5 72 26b0 4
-INLINE 2 2221 5 72 26b4 10
-INLINE 2 2221 5 72 26c4 3
-INLINE 2 2222 5 72 26c9 12
-INLINE 3 665 5 74 26c9 12
-INLINE 4 218 6 75 26cc 4
-INLINE 4 219 6 75 26d0 3
-INLINE 2 2224 5 72 26db 4
-INLINE 0 510 8 33 26df 6
-INLINE 0 508 8 33 26e5 3
-INLINE 0 510 8 33 26e8 4b
-INLINE 1 1696 9 76 26e8 9
-INLINE 1 1697 9 76 26f1 17
-INLINE 2 1913 5 77 26f1 17
-INLINE 1 1697 9 76 2708 4
-INLINE 2 814 9 78 2708 4
-INLINE 1 1697 9 76 270c 4
-INLINE 2 1913 5 77 270c 4
-INLINE 1 1697 9 76 2710 23
-INLINE 2 814 9 78 2710 23
-INLINE 3 425 9 79 2719 11
-INLINE 0 481 8 33 2737 8
-INLINE 1 2476 13 59 2737 8
-INLINE 2 2463 13 60 2737 8
-INLINE 0 499 8 33 277e 1b
-INLINE 1 458 9 36 277e 1b
-INLINE 2 458 9 37 277e 1b
-INLINE 3 452 9 38 2788 c
-INLINE 4 369 9 39 2788 c
-INLINE 3 453 9 38 2794 5
-INLINE 4 1508 10 40 2794 5
-INLINE 5 1743 10 41 2794 5
-INLINE 0 511 8 33 2799 1b
-INLINE 1 458 9 36 2799 1b
-INLINE 2 458 9 37 2799 1b
-INLINE 3 452 9 38 27a3 c
-INLINE 4 369 9 39 27a3 c
-INLINE 3 453 9 38 27af 5
-INLINE 4 1508 10 40 27af 5
-INLINE 5 1743 10 41 27af 5
-INLINE 0 511 8 33 27b4 24
-INLINE 1 458 9 36 27b4 24
-INLINE 2 458 9 37 27b4 24
-INLINE 3 452 9 38 27c1 12
-INLINE 4 369 9 39 27c1 12
-INLINE 3 453 9 38 27d3 5
-INLINE 4 1508 10 40 27d3 5
-INLINE 5 1743 10 41 27d3 5
+INLINE 0 462 8 36 244e 5
+INLINE 0 476 8 65 2476 11
+INLINE 1 1945 13 66 2476 11
+INLINE 2 1949 13 67 2476 11
+INLINE 0 481 8 68 24a5 6b 2737 8
+INLINE 1 2476 13 69 24a5 6b 2737 8
+INLINE 2 2462 13 70 24a5 21
+INLINE 3 3163 13 71 24a5 7
+INLINE 3 3171 13 72 24ac 9
+INLINE 3 3165 13 73 24b5 5
+INLINE 3 3165 13 74 24ba 3
+INLINE 3 3166 13 75 24bd 9
+INLINE 2 2463 13 76 24c6 c 2737 8
+INLINE 2 2466 13 67 24f9 17
+INLINE 0 486 8 36 252a 5
+INLINE 0 486 8 77 255a 23
+INLINE 0 494 8 78 2585 d
+INLINE 0 495 8 79 2594 d
+INLINE 1 208 6 80 2594 d
+INLINE 1 1609 9 81 25ad 3
+INLINE 2 1514 10 82 25ad 3
+INLINE 3 1668 10 83 25ad 3
+INLINE 4 1752 10 31 25ad 3
+INLINE 5 210 6 32 25ad 3
+INLINE 0 497 8 84 25c1 29
+INLINE 1 109 6 85 25c1 29
+INLINE 2 109 6 37 25cd 1d
+INLINE 3 458 9 38 25cd 1d
+INLINE 4 458 9 39 25cd 1d
+INLINE 5 452 9 40 25db a
+INLINE 6 369 9 41 25db a
+INLINE 5 453 9 42 25e5 5
+INLINE 6 1508 10 43 25e5 5
+INLINE 7 1743 10 44 25e5 5
+INLINE 0 499 8 37 261a 21 277e 1b
+INLINE 0 502 8 86 2655 4 2661 9
+INLINE 0 502 8 87 265e 3
+INLINE 0 502 8 88 266a 5
+INLINE 1 4066 5 89 266a 5
+INLINE 2 4050 5 90 266a 5
+INLINE 0 508 8 87 266f 3
+INLINE 0 509 8 86 2672 4
+INLINE 0 508 8 91 2676 69 26e5 3
+INLINE 1 2235 5 92 2676 69
+INLINE 2 2214 5 93 2676 24
+INLINE 3 1085 5 94 2676 5
+INLINE 3 1088 5 94 267f 6
+INLINE 3 1090 5 95 2685 b
+INLINE 4 665 5 96 2685 b
+INLINE 5 219 6 97 2689 3
+INLINE 5 218 6 27 268c 4
+INLINE 2 2216 5 94 269e 5
+INLINE 2 2221 5 98 26a3 9 26b4 10
+INLINE 2 2223 5 98 26b0 4
+INLINE 2 2221 5 94 26c4 3
+INLINE 2 2222 5 95 26c9 12
+INLINE 3 665 5 96 26c9 12
+INLINE 4 218 6 27 26cc 4
+INLINE 4 219 6 97 26d0 3
+INLINE 2 2224 5 98 26db 4
+INLINE 0 510 8 86 26df 6
+INLINE 0 510 8 99 26e8 4b
+INLINE 1 1696 9 100 26e8 9
+INLINE 1 1697 9 101 26f1 17 270c 4
+INLINE 2 1913 5 102 26f1 17 270c 4
+INLINE 1 1697 9 103 2708 4 2710 23
+INLINE 2 814 9 104 2708 4 2710 23
+INLINE 3 425 9 105 2719 11
 2210 14 413 8
 2224 17 433 9
 223b 16 425 8
@@ -1186,43 +1134,43 @@ INLINE 5 1743 10 41 27d3 5
 2299 5 450 9
 229e 7 424 9
 22a5 5 425 9
-22aa 5 177 10
+22aa 5 177 11
 22af 8 453 9
 22b7 5 450 9
 22bc a 424 9
 22c6 8 425 9
-22ce 5 177 10
+22ce 5 177 11
 22d3 12 511 8
 22e5 5 1501 9
 22ea 5 448 8
 22ef 16 372 9
 2305 9 1535 9
 230e 5 642 9
-2313 8 169 10
+2313 8 169 11
 231b 6 642 9
-2321 3 312 11
+2321 3 312 12
 2324 6 642 9
-232a 6 313 11
-2330 14 1630 12
+232a 6 313 12
+2330 14 1630 10
 2344 c 448 8
 2350 4 210 6
-2354 4 1630 12
+2354 4 1630 10
 2358 4 210 6
-235c 4 1631 12
-2360 7 1628 12
+235c 4 1631 10
+2360 7 1628 10
 2367 8 3618 7
-236f 11 1630 12
+236f 11 1630 10
 2380 3c 210 6
-23bc 4 1630 12
+23bc 4 1630 10
 23c0 4 210 6
-23c4 4 1630 12
-23c8 5 1628 12
+23c4 4 1630 10
+23c8 5 1628 10
 23cd 8 3617 7
 23d5 5 3618 7
 23da 5 3618 7
 23df 5 3618 7
-23e4 5 342 11
-23e9 8 177 10
+23e4 5 342 12
+23e9 8 177 11
 23f1 9 450 8
 23fa 5 1606 9
 23ff 21 450 8
@@ -1271,7 +1219,7 @@ INLINE 5 1743 10 41 27d3 5
 25d1 a 450 9
 25db 6 424 9
 25e1 4 425 9
-25e5 5 177 10
+25e5 5 177 11
 25ea f 497 8
 25f9 17 1616 9
 2610 10 499 8
@@ -1279,7 +1227,7 @@ INLINE 5 1743 10 41 27d3 5
 2625 5 450 9
 262a 7 424 9
 2631 5 425 9
-2636 5 177 10
+2636 5 177 11
 263b 1a 450 8
 2655 9 1484 9
 265e 3 1468 9
@@ -1324,207 +1272,125 @@ INLINE 5 1743 10 41 27d3 5
 2783 5 450 9
 2788 7 424 9
 278f 5 425 9
-2794 5 177 10
+2794 5 177 11
 2799 5 453 9
 279e 5 450 9
 27a3 7 424 9
 27aa 5 425 9
-27af 5 177 10
+27af 5 177 11
 27b4 8 453 9
 27bc 5 450 9
 27c1 a 424 9
 27cb 8 425 9
-27d3 d 177 10
+27d3 d 177 11
 FUNC 27e0 5d0 0 void google_breakpad::ReadImageInfo<google_breakpad::MachO32>(google_breakpad::DynamicImages&, unsigned long long)
-INLINE 0 424 8 80 27f4 17
-INLINE 1 485 9 34 27f4 17
-INLINE 2 484 9 35 27f4 17
-INLINE 0 432 8 80 2825 8
-INLINE 0 439 8 80 2831 11
-INLINE 1 485 9 34 2831 11
-INLINE 2 484 9 35 2831 11
-INLINE 0 511 8 80 2863 1b
-INLINE 1 458 9 36 2863 1b
-INLINE 2 458 9 37 2863 1b
-INLINE 3 452 9 38 286d c
-INLINE 4 369 9 39 286d c
-INLINE 3 453 9 38 2879 5
-INLINE 4 1508 10 40 2879 5
-INLINE 5 1743 10 41 2879 5
-INLINE 0 511 8 80 287e 24
-INLINE 1 458 9 36 287e 24
-INLINE 2 458 9 37 287e 24
-INLINE 3 452 9 38 288b 12
-INLINE 4 369 9 39 288b 12
-INLINE 3 453 9 38 289d 5
-INLINE 4 1508 10 40 289d 5
-INLINE 5 1743 10 41 289d 5
-INLINE 0 447 8 80 28b4 5
-INLINE 0 448 8 80 28be 5a
-INLINE 1 1535 9 42 28be 16
-INLINE 2 645 9 43 28be 16
-INLINE 1 1538 9 42 28dd 5
-INLINE 1 1538 9 42 28e2 d
-INLINE 2 310 12 44 28e2 d
-INLINE 3 311 12 45 28e2 d
-INLINE 4 1500 10 46 28e2 d
-INLINE 5 1741 10 47 28ea 5
-INLINE 1 1538 9 42 28ef 6
-INLINE 1 1538 9 42 28f5 3
-INLINE 2 310 12 44 28f5 3
-INLINE 1 1538 9 42 28f8 6
-INLINE 1 1538 9 42 28fe 6
-INLINE 2 310 12 44 28fe 6
-INLINE 1 1539 9 42 2904 14
-INLINE 2 893 9 48 2904 14
-INLINE 0 448 8 80 291b a6
-INLINE 1 1539 9 42 291b 99
-INLINE 2 893 9 48 291b 1c
-INLINE 3 1630 10 49 291b 9
-INLINE 4 1514 10 50 291b 9
-INLINE 5 1668 10 51 291b 9
-INLINE 6 1752 10 52 291b 9
-INLINE 7 210 6 30 291b 9
-INLINE 3 1630 10 49 2928 4
-INLINE 4 1514 10 50 2928 4
-INLINE 5 1668 10 51 2928 4
-INLINE 6 1752 10 52 2928 4
-INLINE 7 210 6 30 2928 4
-INLINE 2 894 9 48 2937 5
-INLINE 2 893 9 48 293f 5e
-INLINE 3 1630 10 49 2945 47
-INLINE 4 1514 10 50 2945 47
-INLINE 5 1668 10 51 2945 47
-INLINE 6 1752 10 52 2945 47
-INLINE 7 210 6 30 2945 47
-INLINE 3 1630 10 49 2990 4
-INLINE 4 1514 10 50 2990 4
-INLINE 5 1668 10 51 2990 4
-INLINE 6 1752 10 52 2990 4
-INLINE 7 210 6 30 2990 4
-INLINE 2 894 9 48 299d d
-INLINE 2 895 9 48 29aa 5
-INLINE 2 896 9 48 29af 5
-INLINE 1 1540 9 42 29b4 d
-INLINE 2 340 12 53 29b4 d
-INLINE 3 343 12 54 29b9 8
-INLINE 4 1508 10 55 29b9 8
-INLINE 5 1743 10 56 29b9 8
-INLINE 0 495 8 80 29ca 5
-INLINE 0 454 8 80 29ef 12
-INLINE 1 485 9 34 29ef 12
-INLINE 2 484 9 35 29ef 12
-INLINE 0 462 8 80 2a1e 5
-INLINE 0 476 8 80 2a46 11
-INLINE 1 1945 13 57 2a46 11
-INLINE 2 1949 13 58 2a46 11
-INLINE 0 481 8 80 2a75 6b
-INLINE 1 2476 13 59 2a75 6b
-INLINE 2 2462 13 60 2a75 21
-INLINE 3 3163 13 61 2a75 7
-INLINE 3 3171 13 61 2a7c 9
-INLINE 3 3165 13 61 2a85 5
-INLINE 3 3165 13 61 2a8a 3
-INLINE 3 3166 13 61 2a8d 9
-INLINE 2 2463 13 60 2a96 c
-INLINE 2 2466 13 60 2ac9 17
-INLINE 0 486 8 80 2afa 5
-INLINE 0 486 8 80 2b2a 23
-INLINE 0 494 8 80 2b55 d
-INLINE 0 495 8 80 2b64 d
-INLINE 1 208 6 62 2b64 d
-INLINE 0 495 8 80 2b71 20
-INLINE 1 1609 9 63 2b7d 3
-INLINE 2 1514 10 64 2b7d 3
-INLINE 3 1668 10 65 2b7d 3
-INLINE 4 1752 10 66 2b7d 3
-INLINE 5 210 6 30 2b7d 3
-INLINE 0 497 8 80 2b91 29
-INLINE 1 109 6 67 2b91 29
-INLINE 2 109 6 68 2b9d 1d
-INLINE 3 458 9 36 2b9d 1d
-INLINE 4 458 9 37 2b9d 1d
-INLINE 5 452 9 38 2bab a
-INLINE 6 369 9 39 2bab a
-INLINE 5 453 9 38 2bb5 5
-INLINE 6 1508 10 40 2bb5 5
-INLINE 7 1743 10 41 2bb5 5
-INLINE 0 495 8 80 2bc9 17
-INLINE 0 499 8 80 2bea 21
-INLINE 1 458 9 36 2bea 21
-INLINE 2 458 9 37 2bea 21
-INLINE 3 452 9 38 2bfa c
-INLINE 4 369 9 39 2bfa c
-INLINE 3 453 9 38 2c06 5
-INLINE 4 1508 10 40 2c06 5
-INLINE 5 1743 10 41 2c06 5
-INLINE 0 502 8 80 2c25 4
-INLINE 0 502 8 80 2c2e 3
-INLINE 0 502 8 80 2c31 9
-INLINE 0 502 8 80 2c3a 5
-INLINE 1 4066 5 69 2c3a 5
-INLINE 2 4050 5 70 2c3a 5
-INLINE 0 508 8 80 2c3f 3
-INLINE 0 509 8 80 2c42 4
-INLINE 0 508 8 80 2c46 69
-INLINE 1 2235 5 71 2c46 69
-INLINE 2 2214 5 72 2c46 24
-INLINE 3 1085 5 73 2c46 5
-INLINE 3 1088 5 73 2c4f 6
-INLINE 3 1090 5 73 2c55 b
-INLINE 4 665 5 74 2c55 b
-INLINE 5 219 6 75 2c59 3
-INLINE 5 218 6 75 2c5c 4
-INLINE 2 2216 5 72 2c6e 5
-INLINE 2 2221 5 72 2c73 9
-INLINE 2 2223 5 72 2c80 4
-INLINE 2 2221 5 72 2c84 10
-INLINE 2 2221 5 72 2c94 3
-INLINE 2 2222 5 72 2c99 12
-INLINE 3 665 5 74 2c99 12
-INLINE 4 218 6 75 2c9c 4
-INLINE 4 219 6 75 2ca0 3
-INLINE 2 2224 5 72 2cab 4
-INLINE 0 510 8 80 2caf 6
-INLINE 0 508 8 80 2cb5 3
-INLINE 0 510 8 80 2cb8 4b
-INLINE 1 1696 9 76 2cb8 9
-INLINE 1 1697 9 76 2cc1 17
-INLINE 2 1913 5 77 2cc1 17
-INLINE 1 1697 9 76 2cd8 4
-INLINE 2 814 9 78 2cd8 4
-INLINE 1 1697 9 76 2cdc 4
-INLINE 2 1913 5 77 2cdc 4
-INLINE 1 1697 9 76 2ce0 23
-INLINE 2 814 9 78 2ce0 23
-INLINE 3 425 9 79 2ce9 11
-INLINE 0 481 8 80 2d07 8
-INLINE 1 2476 13 59 2d07 8
-INLINE 2 2463 13 60 2d07 8
-INLINE 0 499 8 80 2d4e 1b
-INLINE 1 458 9 36 2d4e 1b
-INLINE 2 458 9 37 2d4e 1b
-INLINE 3 452 9 38 2d58 c
-INLINE 4 369 9 39 2d58 c
-INLINE 3 453 9 38 2d64 5
-INLINE 4 1508 10 40 2d64 5
-INLINE 5 1743 10 41 2d64 5
-INLINE 0 511 8 80 2d69 1b
-INLINE 1 458 9 36 2d69 1b
-INLINE 2 458 9 37 2d69 1b
-INLINE 3 452 9 38 2d73 c
-INLINE 4 369 9 39 2d73 c
-INLINE 3 453 9 38 2d7f 5
-INLINE 4 1508 10 40 2d7f 5
-INLINE 5 1743 10 41 2d7f 5
-INLINE 0 511 8 80 2d84 24
-INLINE 1 458 9 36 2d84 24
-INLINE 2 458 9 37 2d84 24
-INLINE 3 452 9 38 2d91 12
-INLINE 4 369 9 39 2d91 12
-INLINE 3 453 9 38 2da3 5
-INLINE 4 1508 10 40 2da3 5
-INLINE 5 1743 10 41 2da3 5
+INLINE 0 424 8 33 27f4 17
+INLINE 1 485 9 34 27f4 17 2831 11 29ef 12
+INLINE 2 484 9 35 27f4 17 2831 11 29ef 12
+INLINE 0 432 8 36 2825 8
+INLINE 0 439 8 33 2831 11
+INLINE 0 511 8 37 2863 1b 287e 24 2d69 1b 2d84 24
+INLINE 1 458 9 38 2863 1b 287e 24 2bea 21 2d4e 1b 2d69 1b 2d84 24
+INLINE 2 458 9 39 2863 1b 287e 24 2bea 21 2d4e 1b 2d69 1b 2d84 24
+INLINE 3 452 9 40 286d c 288b 12 2bfa c 2d58 c 2d73 c 2d91 12
+INLINE 4 369 9 41 286d c 288b 12 2bfa c 2d58 c 2d73 c 2d91 12
+INLINE 3 453 9 42 2879 5 289d 5 2c06 5 2d64 5 2d7f 5 2da3 5
+INLINE 4 1508 10 43 2879 5 289d 5 2c06 5 2d64 5 2d7f 5 2da3 5
+INLINE 5 1743 10 44 2879 5 289d 5 29b9 8 2c06 5 2d64 5 2d7f 5 2da3 5
+INLINE 0 447 8 36 28b4 5
+INLINE 0 448 8 45 28be 5a 291b a6
+INLINE 1 1535 9 46 28be 16
+INLINE 2 645 9 47 28be 16
+INLINE 1 1538 9 48 28dd 5 28ef 6 28f8 6
+INLINE 1 1538 9 49 28e2 d 28f5 3 28fe 6
+INLINE 2 310 12 50 28e2 d 28f5 3 28fe 6
+INLINE 3 311 12 51 28e2 d
+INLINE 4 1500 10 52 28e2 d
+INLINE 5 1741 10 53 28ea 5
+INLINE 1 1539 9 54 2904 14 291b 99
+INLINE 2 893 9 55 2904 14 291b 1c 293f 5e
+INLINE 3 1630 10 56 291b 9 2928 4 2945 47 2990 4
+INLINE 4 1514 10 57 291b 9 2928 4 2945 47 2990 4
+INLINE 5 1668 10 58 291b 9 2928 4 2945 47 2990 4
+INLINE 6 1752 10 31 291b 9 2928 4 2945 47 2990 4
+INLINE 7 210 6 32 291b 9 2928 4 2945 47 2990 4
+INLINE 2 894 9 59 2937 5 299d d
+INLINE 2 895 9 59 29aa 5
+INLINE 2 896 9 59 29af 5
+INLINE 1 1540 9 60 29b4 d
+INLINE 2 340 12 61 29b4 d
+INLINE 3 343 12 62 29b9 8
+INLINE 4 1508 10 63 29b9 8
+INLINE 0 495 8 64 29ca 5 2b71 20 2bc9 17
+INLINE 0 454 8 33 29ef 12
+INLINE 0 462 8 36 2a1e 5
+INLINE 0 476 8 65 2a46 11
+INLINE 1 1945 13 66 2a46 11
+INLINE 2 1949 13 67 2a46 11
+INLINE 0 481 8 68 2a75 6b 2d07 8
+INLINE 1 2476 13 69 2a75 6b 2d07 8
+INLINE 2 2462 13 70 2a75 21
+INLINE 3 3163 13 71 2a75 7
+INLINE 3 3171 13 72 2a7c 9
+INLINE 3 3165 13 73 2a85 5
+INLINE 3 3165 13 74 2a8a 3
+INLINE 3 3166 13 75 2a8d 9
+INLINE 2 2463 13 76 2a96 c 2d07 8
+INLINE 2 2466 13 67 2ac9 17
+INLINE 0 486 8 36 2afa 5
+INLINE 0 486 8 77 2b2a 23
+INLINE 0 494 8 78 2b55 d
+INLINE 0 495 8 79 2b64 d
+INLINE 1 208 6 80 2b64 d
+INLINE 1 1609 9 81 2b7d 3
+INLINE 2 1514 10 82 2b7d 3
+INLINE 3 1668 10 83 2b7d 3
+INLINE 4 1752 10 31 2b7d 3
+INLINE 5 210 6 32 2b7d 3
+INLINE 0 497 8 84 2b91 29
+INLINE 1 109 6 85 2b91 29
+INLINE 2 109 6 37 2b9d 1d
+INLINE 3 458 9 38 2b9d 1d
+INLINE 4 458 9 39 2b9d 1d
+INLINE 5 452 9 40 2bab a
+INLINE 6 369 9 41 2bab a
+INLINE 5 453 9 42 2bb5 5
+INLINE 6 1508 10 43 2bb5 5
+INLINE 7 1743 10 44 2bb5 5
+INLINE 0 499 8 37 2bea 21 2d4e 1b
+INLINE 0 502 8 86 2c25 4 2c31 9
+INLINE 0 502 8 87 2c2e 3
+INLINE 0 502 8 88 2c3a 5
+INLINE 1 4066 5 89 2c3a 5
+INLINE 2 4050 5 90 2c3a 5
+INLINE 0 508 8 87 2c3f 3
+INLINE 0 509 8 86 2c42 4
+INLINE 0 508 8 91 2c46 69 2cb5 3
+INLINE 1 2235 5 92 2c46 69
+INLINE 2 2214 5 93 2c46 24
+INLINE 3 1085 5 94 2c46 5
+INLINE 3 1088 5 94 2c4f 6
+INLINE 3 1090 5 95 2c55 b
+INLINE 4 665 5 96 2c55 b
+INLINE 5 219 6 97 2c59 3
+INLINE 5 218 6 27 2c5c 4
+INLINE 2 2216 5 94 2c6e 5
+INLINE 2 2221 5 98 2c73 9 2c84 10
+INLINE 2 2223 5 98 2c80 4
+INLINE 2 2221 5 94 2c94 3
+INLINE 2 2222 5 95 2c99 12
+INLINE 3 665 5 96 2c99 12
+INLINE 4 218 6 27 2c9c 4
+INLINE 4 219 6 97 2ca0 3
+INLINE 2 2224 5 98 2cab 4
+INLINE 0 510 8 86 2caf 6
+INLINE 0 510 8 99 2cb8 4b
+INLINE 1 1696 9 100 2cb8 9
+INLINE 1 1697 9 101 2cc1 17 2cdc 4
+INLINE 2 1913 5 102 2cc1 17 2cdc 4
+INLINE 1 1697 9 103 2cd8 4 2ce0 23
+INLINE 2 814 9 104 2cd8 4 2ce0 23
+INLINE 3 425 9 105 2ce9 11
 27e0 14 413 8
 27f4 17 433 9
 280b 16 425 8
@@ -1541,44 +1407,44 @@ INLINE 5 1743 10 41 2da3 5
 2868 5 450 9
 286d 7 424 9
 2874 5 425 9
-2879 5 177 10
+2879 5 177 11
 287e 8 453 9
 2886 5 450 9
 288b a 424 9
 2895 8 425 9
-289d 5 177 10
+289d 5 177 11
 28a2 12 511 8
 28b4 5 1501 9
 28b9 5 448 8
 28be 16 372 9
 28d4 9 1535 9
 28dd 5 642 9
-28e2 8 1741 12
-28ea 5 169 10
+28e2 8 1741 10
+28ea 5 169 11
 28ef 6 642 9
-28f5 3 312 11
+28f5 3 312 12
 28f8 6 642 9
-28fe 6 313 11
-2904 14 1630 12
+28fe 6 313 12
+2904 14 1630 10
 2918 8 448 8
 2920 4 210 6
-2924 4 1630 12
+2924 4 1630 10
 2928 4 210 6
-292c 4 1631 12
-2930 7 1628 12
+292c 4 1631 10
+2930 7 1628 10
 2937 8 3618 7
-293f 11 1630 12
+293f 11 1630 10
 2950 3c 210 6
-298c 4 1630 12
+298c 4 1630 10
 2990 4 210 6
-2994 4 1630 12
-2998 5 1628 12
+2994 4 1630 10
+2998 5 1628 10
 299d 8 3617 7
 29a5 5 3618 7
 29aa 5 3618 7
 29af 5 3618 7
-29b4 5 342 11
-29b9 8 177 10
+29b4 5 342 12
+29b9 8 177 11
 29c1 9 450 8
 29ca 5 1606 9
 29cf 21 450 8
@@ -1625,7 +1491,7 @@ INLINE 5 1743 10 41 2da3 5
 2ba1 a 450 9
 2bab 6 424 9
 2bb1 4 425 9
-2bb5 5 177 10
+2bb5 5 177 11
 2bba f 497 8
 2bc9 17 1616 9
 2be0 10 499 8
@@ -1633,7 +1499,7 @@ INLINE 5 1743 10 41 2da3 5
 2bf5 5 450 9
 2bfa 7 424 9
 2c01 5 425 9
-2c06 5 177 10
+2c06 5 177 11
 2c0b 1a 450 8
 2c25 9 1484 9
 2c2e 3 1468 9
@@ -1678,32 +1544,29 @@ INLINE 5 1743 10 41 2da3 5
 2d53 5 450 9
 2d58 7 424 9
 2d5f 5 425 9
-2d64 5 177 10
+2d64 5 177 11
 2d69 5 453 9
 2d6e 5 450 9
 2d73 7 424 9
 2d7a 5 425 9
-2d7f 5 177 10
+2d7f 5 177 11
 2d84 8 453 9
 2d8c 5 450 9
 2d91 a 424 9
 2d9b 8 425 9
-2da3 d 177 10
+2da3 d 177 11
 FUNC 2db0 4a 0 google_breakpad::DynamicImages::GetExecutableImage()
-INLINE 0 529 8 102 2db0 8
-INLINE 1 254 6 103 2db0 8
-INLINE 0 526 8 102 2db8 11
-INLINE 1 538 8 104 2db8 7
-INLINE 2 250 6 105 2db8 7
-INLINE 0 526 8 102 2dcb c
-INLINE 1 541 8 104 2dcb 9
-INLINE 2 255 6 103 2dcb 9
-INLINE 1 542 8 104 2dd4 3
-INLINE 2 329 8 92 2dd4 3
-INLINE 3 323 8 93 2dd4 3
-INLINE 0 526 8 102 2ddd a
-INLINE 0 529 8 102 2df5 4
-INLINE 1 255 6 103 2df5 4
+INLINE 0 529 8 131 2db0 8 2df5 4
+INLINE 1 254 6 48 2db0 8
+INLINE 0 526 8 132 2db8 11 2dcb c 2ddd a
+INLINE 1 538 8 133 2db8 7
+INLINE 2 250 6 48 2db8 7
+INLINE 1 541 8 131 2dcb 9
+INLINE 2 255 6 97 2dcb 9
+INLINE 1 542 8 134 2dd4 3
+INLINE 2 329 8 120 2dd4 3
+INLINE 3 323 8 118 2dd4 3
+INLINE 1 255 6 97 2df5 4
 2db0 8 642 9
 2db8 7 642 9
 2dbf a 540 8
@@ -1717,13 +1580,13 @@ INLINE 1 255 6 103 2df5 4
 2df5 4 224 6
 2df9 1 533 8
 FUNC 2e00 3a 0 google_breakpad::DynamicImages::GetExecutableImageIndex()
-INLINE 0 538 8 104 2e00 14
-INLINE 1 250 6 105 2e00 14
-INLINE 0 541 8 104 2e1d 7
-INLINE 1 255 6 103 2e1d 7
-INLINE 0 542 8 104 2e24 9
-INLINE 1 329 8 92 2e24 9
-INLINE 2 323 8 93 2e24 9
+INLINE 0 538 8 133 2e00 14
+INLINE 1 250 6 48 2e00 14
+INLINE 0 541 8 131 2e1d 7
+INLINE 1 255 6 97 2e1d 7
+INLINE 0 542 8 134 2e24 9
+INLINE 1 329 8 120 2e24 9
+INLINE 2 323 8 118 2e24 9
 2e00 14 642 9
 2e14 c 540 8
 2e20 4 224 6
@@ -1731,58 +1594,34 @@ INLINE 2 323 8 93 2e24 9
 2e2d c 540 8
 2e39 1 548 8
 FUNC 2e40 1c3 0 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__append(unsigned long)
-INLINE 0 1041 9 106 2e64 6
-INLINE 0 1041 9 106 2e6a 34
-INLINE 1 965 9 107 2e77 a
-INLINE 2 645 9 108 2e77 a
-INLINE 1 968 9 107 2e97 3
-INLINE 2 2656 5 109 2e97 3
-INLINE 3 2648 5 110 2e97 3
-INLINE 0 1041 9 106 2e9e 9
-INLINE 0 1041 9 106 2ea7 14
-INLINE 1 310 12 111 2ea7 14
-INLINE 0 1037 9 106 2ebb 7e
-INLINE 1 984 9 112 2ecb 8
-INLINE 2 1514 10 113 2ecb 8
-INLINE 3 1668 10 114 2ecb 8
-INLINE 1 984 9 112 2ef0 3
-INLINE 2 1514 10 113 2ef0 3
-INLINE 3 1668 10 114 2ef0 3
-INLINE 1 984 9 112 2eff 4
-INLINE 2 1514 10 113 2eff 4
-INLINE 3 1668 10 114 2eff 4
-INLINE 1 984 9 112 2f0f 4
-INLINE 2 1514 10 113 2f0f 4
-INLINE 3 1668 10 114 2f0f 4
-INLINE 1 984 9 112 2f1f 4
-INLINE 2 1514 10 113 2f1f 4
-INLINE 3 1668 10 114 2f1f 4
-INLINE 0 1041 9 106 2f39 11
-INLINE 0 1041 9 106 2f4a 11
-INLINE 1 310 12 111 2f4a 11
-INLINE 2 311 12 115 2f4a e
-INLINE 3 1500 10 116 2f4a e
-INLINE 4 1741 10 117 2f4a e
-INLINE 0 1042 9 106 2f5b 53
-INLINE 1 203 12 118 2f6e 5
-INLINE 2 1514 10 113 2f6e 5
-INLINE 3 1668 10 114 2f6e 5
-INLINE 1 203 12 118 2f89 1b
-INLINE 2 1514 10 113 2f89 1b
-INLINE 3 1668 10 114 2f89 1b
-INLINE 0 1041 9 106 2fae 3
-INLINE 1 310 12 111 2fae 3
-INLINE 0 1043 9 106 2fb1 28
-INLINE 1 894 9 119 2fb1 3
-INLINE 1 893 9 119 2fb8 16
-INLINE 1 894 9 119 2fce 3
-INLINE 1 895 9 119 2fd1 4
-INLINE 1 896 9 119 2fd5 4
-INLINE 0 1044 9 106 2fd9 1b
-INLINE 1 340 12 120 2fd9 1b
-INLINE 2 343 12 121 2fde 16
-INLINE 3 1508 10 40 2fde 16
-INLINE 4 1743 10 41 2fde 16
+INLINE 0 1041 9 107 2e64 6 2e9e 9 2f39 11
+INLINE 0 1041 9 135 2e6a 34
+INLINE 1 965 9 136 2e77 a
+INLINE 2 645 9 137 2e77 a
+INLINE 1 968 9 138 2e97 3
+INLINE 2 2656 5 139 2e97 3
+INLINE 3 2648 5 140 2e97 3
+INLINE 0 1041 9 141 2ea7 14 2f4a 11 2fae 3
+INLINE 1 310 12 142 2ea7 14 2f4a 11 2fae 3
+INLINE 0 1037 9 143 2ebb 7e
+INLINE 1 984 9 144 2ecb 8 2ef0 3 2eff 4 2f0f 4 2f1f 4
+INLINE 2 1514 10 145 2ecb 8 2ef0 3 2eff 4 2f0f 4 2f1f 4 2f6e 5 2f89 1b
+INLINE 3 1668 10 146 2ecb 8 2ef0 3 2eff 4 2f0f 4 2f1f 4 2f6e 5 2f89 1b
+INLINE 2 311 12 147 2f4a e
+INLINE 3 1500 10 148 2f4a e
+INLINE 4 1741 10 53 2f4a e
+INLINE 0 1042 9 149 2f5b 53
+INLINE 1 203 12 144 2f6e 5 2f89 1b
+INLINE 0 1043 9 150 2fb1 28
+INLINE 1 894 9 151 2fb1 3 2fce 3
+INLINE 1 893 9 152 2fb8 16
+INLINE 1 895 9 151 2fd1 4
+INLINE 1 896 9 151 2fd5 4
+INLINE 0 1044 9 153 2fd9 1b
+INLINE 1 340 12 154 2fd9 1b
+INLINE 2 343 12 42 2fde 16
+INLINE 3 1508 10 43 2fde 16
+INLINE 4 1743 10 44 2fde 16
 2e40 11 1035 9
 2e51 13 1036 9
 2e64 6 642 9
@@ -1794,81 +1633,71 @@ INLINE 4 1743 10 41 2fde 16
 2e97 3 702 5
 2e9a 4 968 9
 2e9e 9 642 9
-2ea7 14 311 11
+2ea7 14 311 12
 2ebb 15 981 9
-2ed0 3 1752 12
+2ed0 3 1752 10
 2ed3 b 985 9
 2ede 3 986 9
 2ee1 5 988 9
 2ee6 a 981 9
-2ef0 3 1752 12
+2ef0 3 1752 10
 2ef3 c 985 9
-2eff 4 1752 12
+2eff 4 1752 10
 2f03 c 985 9
-2f0f 4 1752 12
+2f0f 4 1752 10
 2f13 c 985 9
-2f1f 4 1752 12
+2f1f 4 1752 10
 2f23 b 985 9
 2f2e b 988 9
 2f39 11 642 9
-2f4a e 169 10
-2f58 3 312 11
-2f5b 15 201 11
-2f70 3 1752 12
-2f73 3 204 11
-2f76 3 205 11
-2f79 a 206 11
-2f83 d 201 11
-2f90 14 1752 12
-2fa4 4 204 11
-2fa8 6 206 11
-2fae 3 313 11
+2f4a e 169 11
+2f58 3 312 12
+2f5b 15 201 12
+2f70 3 1752 10
+2f73 3 204 12
+2f76 3 205 12
+2f79 a 206 12
+2f83 d 201 12
+2f90 14 1752 10
+2fa4 4 204 12
+2fa8 6 206 12
+2fae 3 313 12
 2fb1 3 3617 7
 2fb4 4 893 9
-2fb8 3 1647 12
-2fbb 3 1648 12
-2fbe 5 1649 12
-2fc3 b 1650 12
+2fb8 3 1647 10
+2fbb 3 1648 10
+2fbe 5 1649 10
+2fc3 b 1650 10
 2fce 3 3618 7
 2fd1 4 3618 7
 2fd5 4 3618 7
-2fd9 5 342 11
-2fde 16 177 10
+2fd9 5 342 12
+2fde 16 177 11
 2ff4 f 1045 9
 FUNC 3010 1bb 0 google_breakpad::ReadTaskString(unsigned int, unsigned long long)
-INLINE 0 162 8 84 3023 bf
-INLINE 0 168 8 84 30f6 11
+INLINE 0 162 8 109 3023 bf
+INLINE 0 168 8 33 30f6 11
 INLINE 1 485 9 34 30f6 11
 INLINE 2 484 9 35 30f6 11
-INLINE 0 171 8 84 311a 19
-INLINE 1 1945 13 57 311a 19
-INLINE 2 1949 13 58 311a 19
-INLINE 0 176 8 84 3133 19
-INLINE 1 1945 13 57 3133 19
-INLINE 2 1949 13 58 3133 19
-INLINE 0 173 8 84 314c 5
-INLINE 0 173 8 84 3151 2d
-INLINE 1 2019 13 85 3151 2d
-INLINE 2 1364 13 86 3151 17
-INLINE 3 2421 10 87 3151 17
-INLINE 4 2421 10 88 3151 17
-INLINE 2 2021 13 86 3168 8
-INLINE 0 174 8 84 317e 1b
-INLINE 1 458 9 36 317e 1b
-INLINE 2 458 9 37 317e 1b
-INLINE 3 452 9 38 3188 c
-INLINE 4 369 9 39 3188 c
-INLINE 3 453 9 38 3194 5
-INLINE 4 1508 10 40 3194 5
-INLINE 5 1743 10 41 3194 5
-INLINE 0 174 8 84 31a8 1b
-INLINE 1 458 9 36 31a8 1b
-INLINE 2 458 9 37 31a8 1b
-INLINE 3 452 9 38 31b2 c
-INLINE 4 369 9 39 31b2 c
-INLINE 3 453 9 38 31be 5
-INLINE 4 1508 10 40 31be 5
-INLINE 5 1743 10 41 31be 5
+INLINE 0 171 8 65 311a 19
+INLINE 1 1945 13 66 311a 19 3133 19
+INLINE 2 1949 13 67 311a 19 3133 19
+INLINE 0 176 8 65 3133 19
+INLINE 0 173 8 36 314c 5
+INLINE 0 173 8 110 3151 2d
+INLINE 1 2019 13 111 3151 2d
+INLINE 2 1364 13 112 3151 17
+INLINE 3 2421 10 113 3151 17
+INLINE 4 2421 10 114 3151 17
+INLINE 2 2021 13 115 3168 8
+INLINE 0 174 8 37 317e 1b 31a8 1b
+INLINE 1 458 9 38 317e 1b 31a8 1b
+INLINE 2 458 9 39 317e 1b 31a8 1b
+INLINE 3 452 9 40 3188 c 31b2 c
+INLINE 4 369 9 41 3188 c 31b2 c
+INLINE 3 453 9 42 3194 5 31be 5
+INLINE 4 1508 10 43 3194 5 31be 5
+INLINE 5 1743 10 44 3194 5 31be 5
 3010 13 156 8
 3023 5 92 8
 3028 8 94 8
@@ -1896,48 +1725,45 @@ INLINE 5 1743 10 41 31be 5
 311a 19 1798 13
 3133 19 1798 13
 314c 5 1501 9
-3151 17 2242 12
+3151 17 2242 10
 3168 8 644 13
 3170 e 2021 13
 317e 5 453 9
 3183 5 450 9
 3188 7 424 9
 318f 5 425 9
-3194 5 177 10
+3194 5 177 11
 3199 f 177 8
 31a8 5 453 9
 31ad 5 450 9
 31b2 7 424 9
 31b9 5 425 9
-31be d 177 10
+31be d 177 11
 FUNC 31d0 116 0 google_breakpad::DynamicImage::DynamicImage(unsigned char*, unsigned long, unsigned long long, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, unsigned long, unsigned int, int)
-INLINE 0 118 6 122 31fc 69
-INLINE 1 1164 9 123 31fc 69
-INLINE 2 524 9 124 31fc 17
-INLINE 2 1171 9 124 3225 8
-INLINE 2 1172 9 124 322d 8
-INLINE 3 1024 9 125 322d 8
-INLINE 2 1171 9 124 3235 11
-INLINE 2 1172 9 124 3246 1f
-INLINE 3 1024 9 125 3246 1f
-INLINE 0 130 6 122 32c7 17
-INLINE 1 458 9 36 32c7 17
-INLINE 2 458 9 37 32c7 17
-INLINE 3 452 9 38 32cf a
-INLINE 4 369 9 39 32cf a
-INLINE 3 453 9 38 32d9 5
-INLINE 4 1508 10 40 32d9 5
-INLINE 5 1743 10 41 32d9 5
+INLINE 0 118 6 155 31fc 69
+INLINE 1 1164 9 156 31fc 69
+INLINE 2 524 9 35 31fc 17
+INLINE 2 1171 9 157 3225 8 3235 11
+INLINE 2 1172 9 158 322d 8 3246 1f
+INLINE 3 1024 9 159 322d 8 3246 1f
+INLINE 0 130 6 37 32c7 17
+INLINE 1 458 9 38 32c7 17
+INLINE 2 458 9 39 32c7 17
+INLINE 3 452 9 40 32cf a
+INLINE 4 369 9 41 32cf a
+INLINE 3 453 9 42 32d9 5
+INLINE 4 1508 10 43 32d9 5
+INLINE 5 1743 10 44 32d9 5
 31d0 2c 128 6
 31fc 17 433 9
 3213 12 1169 9
 3225 8 931 9
-322d 8 1618 12
+322d 8 1618 10
 3235 7 932 9
 323c a 933 9
-3246 10 1615 12
-3256 b 1617 12
-3261 4 1618 12
+3246 10 1615 10
+3256 b 1617 10
+3261 4 1618 10
 3265 4 119 6
 3269 4 120 6
 326d 4 125 6
@@ -1951,59 +1777,40 @@ INLINE 5 1743 10 41 32d9 5
 32ca 5 450 9
 32cf 6 424 9
 32d5 4 425 9
-32d9 d 177 10
+32d9 d 177 11
 FUNC 32f0 185 0 void std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__push_back_slow_path<google_breakpad::DynamicImageRef>(google_breakpad::DynamicImageRef&&)
-INLINE 0 1575 9 126 3301 e
-INLINE 0 1575 9 126 3312 3c
-INLINE 1 965 9 127 3323 11
-INLINE 2 645 9 43 3323 11
-INLINE 1 968 9 127 3347 3
-INLINE 2 2656 5 109 3347 3
-INLINE 3 2648 5 110 3347 3
-INLINE 0 1575 9 126 334e 10
-INLINE 0 1575 9 126 335e c
-INLINE 1 310 12 44 335e c
-INLINE 0 1575 9 126 3374 e
-INLINE 0 1575 9 126 3382 18
-INLINE 1 310 12 44 3382 18
-INLINE 2 311 12 45 3382 10
-INLINE 3 1500 10 46 3382 10
-INLINE 4 1741 10 47 338a 8
-INLINE 0 1577 9 126 339a 7
-INLINE 1 1514 10 64 339a 7
-INLINE 2 1668 10 65 339a 7
-INLINE 3 1752 10 66 339a 7
-INLINE 4 210 6 30 339a 7
-INLINE 0 1579 9 126 33a6 a5
-INLINE 1 893 9 48 33a6 97
-INLINE 2 1630 10 49 33c6 e
-INLINE 3 1514 10 50 33c6 e
-INLINE 4 1668 10 51 33c6 e
-INLINE 5 1752 10 52 33c6 e
-INLINE 6 210 6 30 33c6 e
-INLINE 2 1630 10 49 33d8 4
-INLINE 3 1514 10 50 33d8 4
-INLINE 4 1668 10 51 33d8 4
-INLINE 5 1752 10 52 33d8 4
-INLINE 6 210 6 30 33d8 4
-INLINE 2 1630 10 49 33eb 41
-INLINE 3 1514 10 50 33eb 41
-INLINE 4 1668 10 51 33eb 41
-INLINE 5 1752 10 52 33eb 41
-INLINE 6 210 6 30 33eb 41
-INLINE 2 1630 10 49 3430 4
-INLINE 3 1514 10 50 3430 4
-INLINE 4 1668 10 51 3430 4
-INLINE 5 1752 10 52 3430 4
-INLINE 6 210 6 30 3430 4
-INLINE 1 894 9 48 343d 6
-INLINE 1 895 9 48 3443 4
-INLINE 1 896 9 48 3447 4
-INLINE 0 1580 9 126 344b 1b
-INLINE 1 340 12 53 344b 1b
-INLINE 2 343 12 54 3450 16
-INLINE 3 1508 10 55 3450 16
-INLINE 4 1743 10 56 3450 16
+INLINE 0 1575 9 48 3301 e 334e 10 3374 e
+INLINE 0 1575 9 160 3312 3c
+INLINE 1 965 9 46 3323 11
+INLINE 2 645 9 47 3323 11
+INLINE 1 968 9 138 3347 3
+INLINE 2 2656 5 139 3347 3
+INLINE 3 2648 5 140 3347 3
+INLINE 0 1575 9 49 335e c 3382 18
+INLINE 1 310 12 50 335e c 3382 18
+INLINE 2 311 12 51 3382 10
+INLINE 3 1500 10 52 3382 10
+INLINE 4 1741 10 53 338a 8
+INLINE 0 1577 9 81 339a 7
+INLINE 1 1514 10 82 339a 7
+INLINE 2 1668 10 83 339a 7
+INLINE 3 1752 10 31 339a 7
+INLINE 4 210 6 32 339a 7
+INLINE 0 1579 9 54 33a6 a5
+INLINE 1 893 9 55 33a6 97
+INLINE 2 1630 10 56 33c6 e 33d8 4 33eb 41 3430 4
+INLINE 3 1514 10 57 33c6 e 33d8 4 33eb 41 3430 4
+INLINE 4 1668 10 58 33c6 e 33d8 4 33eb 41 3430 4
+INLINE 5 1752 10 31 33c6 e 33d8 4 33eb 41 3430 4
+INLINE 6 210 6 32 33c6 e 33d8 4 33eb 41 3430 4
+INLINE 1 894 9 59 343d 6
+INLINE 1 895 9 59 3443 4
+INLINE 1 896 9 59 3447 4
+INLINE 0 1580 9 60 344b 1b
+INLINE 1 340 12 61 344b 1b
+INLINE 2 343 12 62 3450 16
+INLINE 3 1508 10 63 3450 16
+INLINE 4 1743 10 44 3450 16
 32f0 11 1573 9
 3301 e 642 9
 330f 3 1575 9
@@ -2015,238 +1822,92 @@ INLINE 4 1743 10 56 3450 16
 3347 3 702 5
 334a 4 968 9
 334e 10 642 9
-335e 16 311 11
+335e 16 311 12
 3374 e 642 9
-3382 8 1741 12
-338a 8 169 10
-3392 4 312 11
-3396 4 313 11
+3382 8 1741 10
+338a 8 169 11
+3392 4 312 12
+3396 4 313 12
 339a 7 210 6
 33a1 5 1578 9
-33a6 c 1628 12
-33b2 1e 1630 12
+33a6 c 1628 10
+33b2 1e 1630 10
 33d0 4 210 6
-33d4 4 1630 12
+33d4 4 1630 10
 33d8 4 210 6
-33dc 4 1631 12
-33e0 5 1628 12
-33e5 b 1630 12
+33dc 4 1631 10
+33e0 5 1628 10
+33e5 b 1630 10
 33f0 3c 210 6
-342c 4 1630 12
+342c 4 1630 10
 3430 4 210 6
-3434 4 1630 12
-3438 5 1628 12
+3434 4 1630 10
+3438 5 1628 10
 343d 3 3617 7
 3440 3 3618 7
 3443 4 3618 7
 3447 4 3618 7
-344b 5 342 11
-3450 16 177 10
+344b 5 342 12
+3450 16 177 11
 3466 f 1580 9
 FUNC 3480 5f9 0 void std::__1::__sort<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
-INLINE 0 3951 5 22 3505 3
-INLINE 1 702 5 23 3505 3
-INLINE 0 3891 5 22 3517 3f
-INLINE 1 3605 5 24 3517 15
-INLINE 2 702 5 23 3517 15
-INLINE 3 214 6 25 3528 4
-INLINE 4 167 6 26 3528 4
-INLINE 1 3627 5 24 352c 4
-INLINE 2 702 5 23 352c 4
-INLINE 3 214 6 25 352c 4
-INLINE 4 167 6 26 352c 4
-INLINE 1 3605 5 24 3530 3
-INLINE 2 702 5 23 3530 3
-INLINE 3 214 6 25 3530 3
-INLINE 1 3619 5 24 3533 9
-INLINE 2 702 5 23 3533 9
-INLINE 3 214 6 25 3536 6
-INLINE 4 167 6 26 3536 6
-INLINE 1 3621 5 24 3545 11
-INLINE 0 3914 5 22 3564 d
-INLINE 1 702 5 23 3564 d
-INLINE 2 214 6 25 3567 a
-INLINE 0 3920 5 22 357a 1a
-INLINE 1 702 5 23 3581 13
-INLINE 0 3891 5 22 35a8 48
-INLINE 1 3610 5 24 35b5 7
-INLINE 1 3612 5 24 35bc c
-INLINE 2 702 5 23 35bc c
-INLINE 3 214 6 25 35c4 4
-INLINE 4 167 6 26 35c4 4
-INLINE 1 3614 5 24 35ce a
-INLINE 1 3625 5 24 35d8 8
-INLINE 1 3627 5 24 35e0 3
-INLINE 2 702 5 23 35e0 3
-INLINE 1 3629 5 24 35e9 7
-INLINE 0 3922 5 22 360b 7
-INLINE 0 3941 5 22 3620 7
-INLINE 0 3937 5 22 3627 7
-INLINE 1 702 5 23 3627 7
-INLINE 2 214 6 25 362a 4
-INLINE 3 167 6 26 362a 4
-INLINE 0 3935 5 22 362e 5
-INLINE 1 702 5 23 362e 5
-INLINE 0 3937 5 22 3641 13
-INLINE 1 702 5 23 3641 13
-INLINE 0 3937 5 22 3658 4
-INLINE 1 702 5 23 3658 4
-INLINE 2 214 6 25 3658 4
-INLINE 0 3902 5 22 36dc 3
-INLINE 1 702 5 23 36dc 3
-INLINE 0 3920 5 22 36df 3
-INLINE 1 702 5 23 36df 3
-INLINE 0 3902 5 22 36e2 4
-INLINE 1 702 5 23 36e2 4
-INLINE 0 3920 5 22 36e6 4
-INLINE 1 702 5 23 36e6 4
-INLINE 2 214 6 25 36e6 4
-INLINE 3 167 6 26 36e6 4
-INLINE 0 3902 5 22 36ea d
-INLINE 1 702 5 23 36ea d
-INLINE 2 214 6 25 36ea d
-INLINE 3 167 6 26 36ea 4
-INLINE 0 3953 5 22 36fc 10
-INLINE 0 3977 5 22 3719 d
-INLINE 0 3973 5 22 372f 8
-INLINE 1 702 5 23 372f 8
-INLINE 2 214 6 25 3733 4
-INLINE 3 167 6 26 3733 4
-INLINE 0 3970 5 22 373e e
-INLINE 1 702 5 23 373e e
-INLINE 2 214 6 25 3748 4
-INLINE 0 3973 5 22 3752 12
-INLINE 1 702 5 23 3752 12
-INLINE 0 3987 5 22 377b c
-INLINE 1 702 5 23 377b c
-INLINE 2 214 6 25 3783 4
-INLINE 3 167 6 26 3783 4
-INLINE 0 3989 5 22 378d 8
-INLINE 0 3855 5 22 3814 b
-INLINE 1 702 5 23 3814 b
-INLINE 2 214 6 25 381b 4
-INLINE 3 167 6 26 381b 4
-INLINE 0 3856 5 22 3829 c
-INLINE 0 3870 5 22 3835 59
-INLINE 1 3733 5 27 3835 59
-INLINE 2 3612 5 24 3835 4
-INLINE 3 702 5 23 3835 4
-INLINE 2 3605 5 24 3839 8
-INLINE 3 702 5 23 3839 8
-INLINE 4 214 6 25 383d 4
-INLINE 5 167 6 26 383d 4
-INLINE 2 3612 5 24 3841 4
-INLINE 3 702 5 23 3841 4
-INLINE 4 214 6 25 3841 4
-INLINE 5 167 6 26 3841 4
-INLINE 2 3605 5 24 3845 3
-INLINE 3 702 5 23 3845 3
-INLINE 4 214 6 25 3845 3
-INLINE 2 3627 5 24 3848 a
-INLINE 3 702 5 23 3848 a
-INLINE 4 214 6 25 384c 6
-INLINE 5 167 6 26 384c 6
-INLINE 2 3621 5 24 3857 6
-INLINE 2 3610 5 24 3862 8
-INLINE 2 3614 5 24 386f a
-INLINE 2 3625 5 24 3879 8
-INLINE 2 3629 5 24 3886 8
-INLINE 0 3870 5 22 3896 21
-INLINE 1 3736 5 27 38a6 d
-INLINE 2 702 5 23 38a6 d
-INLINE 0 3870 5 22 38ba d
-INLINE 1 3736 5 27 38ba 7
-INLINE 2 702 5 23 38ba 7
-INLINE 3 214 6 25 38bd 4
-INLINE 4 167 6 26 38bd 4
-INLINE 0 3870 5 22 38d3 2c
-INLINE 1 3745 5 27 38e2 5
-INLINE 2 702 5 23 38e2 5
-INLINE 1 3745 5 27 38eb 6
-INLINE 2 702 5 23 38eb 6
-INLINE 3 214 6 25 38eb 6
-INLINE 0 3859 5 22 390e 2e
-INLINE 1 3605 5 24 390e c
-INLINE 2 702 5 23 390e c
-INLINE 3 214 6 25 3916 4
-INLINE 4 167 6 26 3916 4
-INLINE 1 3627 5 24 391a 4
-INLINE 2 702 5 23 391a 4
-INLINE 3 214 6 25 391a 4
-INLINE 4 167 6 26 391a 4
-INLINE 1 3605 5 24 391e 3
-INLINE 2 702 5 23 391e 3
-INLINE 3 214 6 25 391e 3
-INLINE 1 3619 5 24 3921 9
-INLINE 2 702 5 23 3921 9
-INLINE 3 214 6 25 3924 6
-INLINE 4 167 6 26 3924 6
-INLINE 1 3621 5 24 3933 9
-INLINE 0 3862 5 22 3965 2b
-INLINE 1 3642 5 28 3965 2b
-INLINE 2 3612 5 24 3965 4
-INLINE 3 702 5 23 3965 4
-INLINE 2 3605 5 24 3969 8
-INLINE 3 702 5 23 3969 8
-INLINE 4 214 6 25 396d 4
-INLINE 5 167 6 26 396d 4
-INLINE 2 3612 5 24 3971 4
-INLINE 3 702 5 23 3971 4
-INLINE 4 214 6 25 3971 4
-INLINE 5 167 6 26 3971 4
-INLINE 2 3605 5 24 3975 3
-INLINE 3 702 5 23 3975 3
-INLINE 4 214 6 25 3975 3
-INLINE 2 3627 5 24 3978 a
-INLINE 3 702 5 23 3978 a
-INLINE 4 214 6 25 397c 6
-INLINE 5 167 6 26 397c 6
-INLINE 2 3621 5 24 3987 9
-INLINE 0 3859 5 22 3990 33
-INLINE 1 3610 5 24 3999 7
-INLINE 1 3612 5 24 39a0 c
-INLINE 2 702 5 23 39a0 c
-INLINE 3 214 6 25 39a8 4
-INLINE 4 167 6 26 39a8 4
-INLINE 1 3614 5 24 39b6 d
-INLINE 0 3862 5 22 39c3 1f
-INLINE 1 3642 5 28 39c3 1a
-INLINE 2 3610 5 24 39c8 8
-INLINE 2 3614 5 24 39d5 8
-INLINE 1 3645 5 28 39dd 5
-INLINE 2 3617 7 29 39dd 5
-INLINE 3 210 6 30 39dd 5
-INLINE 0 3859 5 22 39e2 21
-INLINE 1 3625 5 24 39e2 8
-INLINE 1 3627 5 24 39ea 3
-INLINE 2 702 5 23 39ea 3
-INLINE 1 3629 5 24 39f7 c
-INLINE 0 3862 5 22 3a03 76
-INLINE 1 3642 5 28 3a03 15
-INLINE 2 3625 5 24 3a03 8
-INLINE 2 3629 5 24 3a10 8
-INLINE 1 3645 5 28 3a18 3
-INLINE 2 3617 7 29 3a18 3
-INLINE 3 210 6 30 3a18 3
-INLINE 1 3643 5 28 3a1b a
-INLINE 2 702 5 23 3a1b a
-INLINE 1 3645 5 28 3a25 3
-INLINE 2 3617 7 29 3a25 3
-INLINE 3 210 6 30 3a25 3
-INLINE 1 3643 5 28 3a28 7
-INLINE 2 702 5 23 3a28 7
-INLINE 3 214 6 25 3a2b 4
-INLINE 4 167 6 26 3a2b 4
-INLINE 1 3645 5 28 3a39 7
-INLINE 1 3647 5 28 3a40 8
-INLINE 2 702 5 23 3a40 8
-INLINE 1 3651 5 28 3a48 4
-INLINE 2 702 5 23 3a48 4
-INLINE 3 214 6 25 3a48 4
-INLINE 4 167 6 26 3a48 4
+INLINE 0 3951 5 23 3505 3
+INLINE 1 702 5 24 3505 3 3564 d 3581 13 3627 7 362e 5 3641 13 3658 4 36dc 3 36df 3 36e2 4 36e6 4 36ea d 372f 8 373e e 3752 12 377b c 3814 b
+INLINE 0 3891 5 25 3517 3f 35a8 48
+INLINE 1 3605 5 23 3517 15 3530 3 390e c 391e 3
+INLINE 2 702 5 24 3517 15 352c 4 3530 3 3533 9 35bc c 35e0 3 38a6 d 38ba 7 38e2 5 38eb 6 390e c 391a 4 391e 3 3921 9 39a0 c 39ea 3 3a1b a 3a28 7 3a40 8 3a48 4 3a5e 4
+INLINE 3 214 6 26 3528 4 352c 4 3530 3 3536 6 35c4 4 38bd 4 38eb 6 3916 4 391a 4 391e 3 3924 6 39a8 4 3a2b 4 3a48 4
+INLINE 4 167 6 27 3528 4 352c 4 3536 6 35c4 4 38bd 4 3916 4 391a 4 3924 6 39a8 4 3a2b 4 3a48 4
+INLINE 1 3627 5 23 352c 4 35e0 3 391a 4 39ea 3
+INLINE 1 3619 5 23 3533 9 3921 9
+INLINE 1 3621 5 28 3545 11 3933 9
+INLINE 0 3914 5 23 3564 d
+INLINE 2 214 6 26 3567 a 362a 4 3658 4 36e6 4 36ea d 3733 4 3748 4 3783 4 381b 4
+INLINE 0 3920 5 23 357a 1a 36df 3 36e6 4
+INLINE 1 3610 5 28 35b5 7 3999 7
+INLINE 1 3612 5 23 35bc c 39a0 c
+INLINE 1 3614 5 28 35ce a 39b6 d
+INLINE 1 3625 5 28 35d8 8 39e2 8
+INLINE 1 3629 5 28 35e9 7 39f7 c
+INLINE 0 3922 5 28 360b 7
+INLINE 0 3941 5 28 3620 7
+INLINE 0 3937 5 23 3627 7 3641 13 3658 4
+INLINE 3 167 6 27 362a 4 36e6 4 36ea 4 3733 4 3783 4 381b 4
+INLINE 0 3935 5 23 362e 5
+INLINE 0 3902 5 23 36dc 3 36e2 4 36ea d
+INLINE 0 3953 5 28 36fc 10
+INLINE 0 3977 5 28 3719 d
+INLINE 0 3973 5 23 372f 8 3752 12
+INLINE 0 3970 5 23 373e e
+INLINE 0 3987 5 23 377b c
+INLINE 0 3989 5 28 378d 8
+INLINE 0 3855 5 23 3814 b
+INLINE 0 3856 5 28 3829 c
+INLINE 0 3870 5 29 3835 59 3896 21 38ba d 38d3 2c
+INLINE 1 3733 5 25 3835 59
+INLINE 2 3612 5 23 3835 4 3841 4 3965 4 3971 4
+INLINE 3 702 5 24 3835 4 3839 8 3841 4 3845 3 3848 a 3965 4 3969 8 3971 4 3975 3 3978 a
+INLINE 2 3605 5 23 3839 8 3845 3 3969 8 3975 3
+INLINE 4 214 6 26 383d 4 3841 4 3845 3 384c 6 396d 4 3971 4 3975 3 397c 6
+INLINE 5 167 6 27 383d 4 3841 4 384c 6 396d 4 3971 4 397c 6
+INLINE 2 3627 5 23 3848 a 3978 a
+INLINE 2 3621 5 28 3857 6 3987 9
+INLINE 2 3610 5 28 3862 8 39c8 8
+INLINE 2 3614 5 28 386f a 39d5 8
+INLINE 2 3625 5 28 3879 8 3a03 8
+INLINE 2 3629 5 28 3886 8 3a10 8
+INLINE 1 3736 5 23 38a6 d 38ba 7
+INLINE 1 3745 5 23 38e2 5 38eb 6
+INLINE 0 3859 5 25 390e 2e 3990 33 39e2 21
+INLINE 0 3862 5 30 3965 2b 39c3 1f 3a03 76
+INLINE 1 3642 5 25 3965 2b 39c3 1a 3a03 15
+INLINE 1 3645 5 28 39dd 5 3a18 3 3a25 3 3a39 7
+INLINE 2 3617 7 31 39dd 5 3a18 3 3a25 3
+INLINE 3 210 6 32 39dd 5 3a18 3 3a25 3
+INLINE 1 3643 5 23 3a1b a 3a28 7
+INLINE 1 3647 5 23 3a40 8
+INLINE 1 3651 5 23 3a48 4 3a5e 4
 INLINE 1 3649 5 28 3a56 8
-INLINE 1 3651 5 28 3a5e 4
-INLINE 2 702 5 23 3a5e 4
 INLINE 1 3653 5 28 3a6c d
 3480 1a 3839 5
 349a 16 4022 5
@@ -2463,75 +2124,42 @@ INLINE 1 3653 5 28 3a6c d
 3a6c 4 3618 7
 3a70 9 3619 7
 FUNC 3aa0 142 0 unsigned int std::__1::__sort5<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
-INLINE 0 3668 5 31 3aa0 d5
-INLINE 1 3642 5 28 3aa0 50
-INLINE 2 3605 5 24 3aa0 d
-INLINE 3 702 5 23 3aa0 d
-INLINE 4 214 6 25 3aa9 4
-INLINE 5 167 6 26 3aa9 4
-INLINE 2 3627 5 24 3aad 4
-INLINE 3 702 5 23 3aad 4
-INLINE 4 214 6 25 3aad 4
-INLINE 5 167 6 26 3aad 4
-INLINE 2 3605 5 24 3ab1 3
-INLINE 3 702 5 23 3ab1 3
-INLINE 4 214 6 25 3ab1 3
-INLINE 2 3619 5 24 3ab4 9
-INLINE 3 702 5 23 3ab4 9
-INLINE 4 214 6 25 3ab7 6
-INLINE 5 167 6 26 3ab7 6
-INLINE 2 3621 5 24 3ac2 d
-INLINE 2 3610 5 24 3ad4 6
-INLINE 2 3612 5 24 3ada a
-INLINE 3 702 5 23 3ada a
-INLINE 4 214 6 25 3ae0 4
-INLINE 5 167 6 26 3ae0 4
-INLINE 2 3614 5 24 3aea 6
-INLINE 1 3643 5 28 3af0 a
-INLINE 2 702 5 23 3af0 a
-INLINE 1 3642 5 28 3afa 1f
-INLINE 2 3625 5 24 3afa 6
-INLINE 2 3627 5 24 3b00 8
-INLINE 3 702 5 23 3b00 8
-INLINE 2 3629 5 24 3b0e b
-INLINE 1 3645 5 28 3b19 11
-INLINE 2 3617 7 29 3b19 11
-INLINE 3 210 6 30 3b19 11
-INLINE 1 3643 5 28 3b2a 7
-INLINE 2 702 5 23 3b2a 7
-INLINE 3 214 6 25 3b2d 4
-INLINE 4 167 6 26 3b2d 4
-INLINE 1 3645 5 28 3b37 6
-INLINE 1 3647 5 28 3b3d a
-INLINE 2 702 5 23 3b3d a
-INLINE 3 214 6 25 3b43 4
-INLINE 4 167 6 26 3b43 4
+INLINE 0 3668 5 30 3aa0 d5
+INLINE 1 3642 5 25 3aa0 50 3afa 1f
+INLINE 2 3605 5 23 3aa0 d 3ab1 3
+INLINE 3 702 5 24 3aa0 d 3aad 4 3ab1 3 3ab4 9 3ada a 3b00 8
+INLINE 4 214 6 26 3aa9 4 3aad 4 3ab1 3 3ab7 6 3ae0 4
+INLINE 5 167 6 27 3aa9 4 3aad 4 3ab7 6 3ae0 4
+INLINE 2 3627 5 23 3aad 4 3b00 8
+INLINE 2 3619 5 23 3ab4 9
+INLINE 2 3621 5 28 3ac2 d
+INLINE 2 3610 5 28 3ad4 6
+INLINE 2 3612 5 23 3ada a
+INLINE 2 3614 5 28 3aea 6
+INLINE 1 3643 5 23 3af0 a 3b2a 7
+INLINE 2 702 5 24 3af0 a 3b2a 7 3b3d a 3b53 a
+INLINE 2 3625 5 28 3afa 6
+INLINE 2 3629 5 28 3b0e b
+INLINE 1 3645 5 28 3b19 11 3b37 6
+INLINE 2 3617 7 31 3b19 11
+INLINE 3 210 6 32 3b19 11
+INLINE 3 214 6 26 3b2d 4 3b43 4 3b59 4
+INLINE 4 167 6 27 3b2d 4 3b43 4 3b59 4
+INLINE 1 3647 5 23 3b3d a
 INLINE 1 3649 5 28 3b4d 6
-INLINE 1 3651 5 28 3b53 a
-INLINE 2 702 5 23 3b53 a
-INLINE 3 214 6 25 3b59 4
-INLINE 4 167 6 26 3b59 4
+INLINE 1 3651 5 23 3b53 a
 INLINE 1 3653 5 28 3b63 6
-INLINE 0 3669 5 31 3b75 a
-INLINE 1 702 5 23 3b75 a
-INLINE 2 214 6 25 3b7b 4
-INLINE 3 167 6 26 3b7b 4
-INLINE 0 3671 5 31 3b85 6
-INLINE 0 3673 5 31 3b8b a
-INLINE 1 702 5 23 3b8b a
-INLINE 2 214 6 25 3b91 4
-INLINE 3 167 6 26 3b91 4
-INLINE 0 3675 5 31 3b9b 6
-INLINE 0 3677 5 31 3ba1 a
-INLINE 1 702 5 23 3ba1 a
-INLINE 2 214 6 25 3ba7 4
-INLINE 3 167 6 26 3ba7 4
-INLINE 0 3679 5 31 3bb1 6
-INLINE 0 3681 5 31 3bb7 a
-INLINE 1 702 5 23 3bb7 a
-INLINE 2 214 6 25 3bbd 4
-INLINE 3 167 6 26 3bbd 4
-INLINE 0 3683 5 31 3bc7 6
+INLINE 0 3669 5 23 3b75 a
+INLINE 1 702 5 24 3b75 a 3b8b a 3ba1 a 3bb7 a
+INLINE 2 214 6 26 3b7b 4 3b91 4 3ba7 4 3bbd 4
+INLINE 3 167 6 27 3b7b 4 3b91 4 3ba7 4 3bbd 4
+INLINE 0 3671 5 28 3b85 6
+INLINE 0 3673 5 23 3b8b a
+INLINE 0 3675 5 28 3b9b 6
+INLINE 0 3677 5 23 3ba1 a
+INLINE 0 3679 5 28 3bb1 6
+INLINE 0 3681 5 23 3bb7 a
+INLINE 0 3683 5 28 3bc7 6
 3aa0 6 213 6
 3aa6 3 214 6
 3aa9 4 141 6
@@ -2609,129 +2237,47 @@ INLINE 0 3683 5 31 3bc7 6
 3bdb 3 3680 5
 3bde 4 3689 5
 FUNC 3bf0 2b3 0 bool std::__1::__insertion_sort_incomplete<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
-INLINE 0 3762 5 32 3c1c b
-INLINE 1 702 5 23 3c1c b
-INLINE 2 214 6 25 3c23 4
-INLINE 3 167 6 26 3c23 4
-INLINE 0 3763 5 32 3c31 c
-INLINE 0 3777 5 32 3c3d 31
-INLINE 1 3612 5 24 3c3d 3
-INLINE 2 702 5 23 3c3d 3
-INLINE 1 3605 5 24 3c40 8
-INLINE 2 702 5 23 3c40 8
-INLINE 3 214 6 25 3c44 4
-INLINE 4 167 6 26 3c44 4
-INLINE 1 3612 5 24 3c48 4
-INLINE 2 702 5 23 3c48 4
-INLINE 3 214 6 25 3c48 4
-INLINE 4 167 6 26 3c48 4
-INLINE 1 3605 5 24 3c4c 3
-INLINE 2 702 5 23 3c4c 3
-INLINE 3 214 6 25 3c4c 3
-INLINE 1 3627 5 24 3c4f e
-INLINE 2 702 5 23 3c4f e
-INLINE 3 214 6 25 3c53 a
-INLINE 4 167 6 26 3c53 a
-INLINE 1 3621 5 24 3c66 8
-INLINE 0 3766 5 32 3c6e 35
-INLINE 1 3605 5 24 3c6e b
-INLINE 2 702 5 23 3c6e b
-INLINE 3 214 6 25 3c75 4
-INLINE 4 167 6 26 3c75 4
-INLINE 1 3627 5 24 3c79 4
-INLINE 2 702 5 23 3c79 4
-INLINE 3 214 6 25 3c79 4
-INLINE 4 167 6 26 3c79 4
-INLINE 1 3605 5 24 3c7d 3
-INLINE 2 702 5 23 3c7d 3
-INLINE 3 214 6 25 3c7d 3
-INLINE 1 3619 5 24 3c80 e
-INLINE 2 702 5 23 3c80 e
-INLINE 3 214 6 25 3c84 a
-INLINE 4 167 6 26 3c84 a
-INLINE 1 3621 5 24 3c97 c
-INLINE 0 3769 5 32 3cc0 2d
-INLINE 1 3642 5 28 3cc0 2d
-INLINE 2 3612 5 24 3cc0 3
-INLINE 3 702 5 23 3cc0 3
-INLINE 2 3605 5 24 3cc3 8
-INLINE 3 702 5 23 3cc3 8
-INLINE 4 214 6 25 3cc7 4
-INLINE 5 167 6 26 3cc7 4
-INLINE 2 3612 5 24 3ccb 4
-INLINE 3 702 5 23 3ccb 4
-INLINE 4 214 6 25 3ccb 4
-INLINE 5 167 6 26 3ccb 4
-INLINE 2 3605 5 24 3ccf 3
-INLINE 3 702 5 23 3ccf 3
-INLINE 4 214 6 25 3ccf 3
-INLINE 2 3627 5 24 3cd2 a
-INLINE 3 702 5 23 3cd2 a
-INLINE 4 214 6 25 3cd6 6
-INLINE 5 167 6 26 3cd6 6
-INLINE 2 3621 5 24 3ce5 8
-INLINE 0 3777 5 32 3ced 23
-INLINE 1 3610 5 24 3cf6 8
-INLINE 1 3614 5 24 3d07 9
-INLINE 0 3766 5 32 3d10 32
-INLINE 1 3610 5 24 3d19 8
-INLINE 1 3612 5 24 3d21 b
-INLINE 2 702 5 23 3d21 b
-INLINE 3 214 6 25 3d28 4
-INLINE 4 167 6 26 3d28 4
-INLINE 1 3614 5 24 3d36 c
-INLINE 0 3769 5 32 3d42 29
-INLINE 1 3642 5 28 3d42 21
-INLINE 2 3610 5 24 3d4b 8
-INLINE 2 3614 5 24 3d5c 7
-INLINE 1 3645 5 28 3d63 8
-INLINE 2 3617 7 29 3d63 8
-INLINE 3 210 6 30 3d63 8
-INLINE 0 3777 5 32 3d6b 19
-INLINE 1 3625 5 24 3d6b 7
-INLINE 1 3629 5 24 3d77 d
-INLINE 0 3782 5 32 3da2 11
-INLINE 1 702 5 23 3da2 11
-INLINE 0 3782 5 32 3dba 7
-INLINE 1 702 5 23 3dba 7
-INLINE 2 214 6 25 3dbd 4
-INLINE 3 167 6 26 3dbd 4
-INLINE 0 3791 5 32 3de1 5
-INLINE 1 702 5 23 3de1 5
-INLINE 0 3791 5 32 3dea 6
-INLINE 1 702 5 23 3dea 6
-INLINE 2 214 6 25 3dea 6
-INLINE 0 3766 5 32 3e12 1b
-INLINE 1 3625 5 24 3e12 7
-INLINE 1 3627 5 24 3e19 4
-INLINE 2 702 5 23 3e19 4
-INLINE 1 3629 5 24 3e23 a
-INLINE 0 3769 5 32 3e2d 6c
-INLINE 1 3642 5 28 3e2d 14
-INLINE 2 3625 5 24 3e2d 7
-INLINE 2 3629 5 24 3e39 8
-INLINE 1 3645 5 28 3e41 3
-INLINE 2 3617 7 29 3e41 3
-INLINE 3 210 6 30 3e41 3
-INLINE 1 3643 5 28 3e44 a
-INLINE 2 702 5 23 3e44 a
-INLINE 1 3645 5 28 3e56 3
-INLINE 2 3617 7 29 3e56 3
-INLINE 3 210 6 30 3e56 3
-INLINE 1 3643 5 28 3e59 8
-INLINE 2 702 5 23 3e59 8
-INLINE 3 214 6 25 3e5d 4
-INLINE 4 167 6 26 3e5d 4
-INLINE 1 3645 5 28 3e67 8
-INLINE 1 3647 5 28 3e6f 8
-INLINE 2 702 5 23 3e6f 8
-INLINE 1 3651 5 28 3e77 4
-INLINE 2 702 5 23 3e77 4
-INLINE 3 214 6 25 3e77 4
-INLINE 4 167 6 26 3e77 4
+INLINE 0 3762 5 23 3c1c b
+INLINE 1 702 5 24 3c1c b 3da2 11 3dba 7 3de1 5 3dea 6
+INLINE 2 214 6 26 3c23 4 3dbd 4 3dea 6
+INLINE 3 167 6 27 3c23 4 3dbd 4
+INLINE 0 3763 5 28 3c31 c
+INLINE 0 3777 5 25 3c3d 31 3ced 23 3d6b 19
+INLINE 1 3612 5 23 3c3d 3 3c48 4 3d21 b
+INLINE 2 702 5 24 3c3d 3 3c40 8 3c48 4 3c4c 3 3c4f e 3c6e b 3c79 4 3c7d 3 3c80 e 3d21 b 3e19 4 3e44 a 3e59 8 3e6f 8 3e77 4 3e89 3
+INLINE 1 3605 5 23 3c40 8 3c4c 3 3c6e b 3c7d 3
+INLINE 3 214 6 26 3c44 4 3c48 4 3c4c 3 3c53 a 3c75 4 3c79 4 3c7d 3 3c84 a 3d28 4 3e5d 4 3e77 4
+INLINE 4 167 6 27 3c44 4 3c48 4 3c53 a 3c75 4 3c79 4 3c84 a 3d28 4 3e5d 4 3e77 4
+INLINE 1 3627 5 23 3c4f e 3c79 4 3e19 4
+INLINE 1 3621 5 28 3c66 8 3c97 c
+INLINE 0 3766 5 25 3c6e 35 3d10 32 3e12 1b
+INLINE 1 3619 5 23 3c80 e
+INLINE 0 3769 5 30 3cc0 2d 3d42 29 3e2d 6c
+INLINE 1 3642 5 25 3cc0 2d 3d42 21 3e2d 14
+INLINE 2 3612 5 23 3cc0 3 3ccb 4
+INLINE 3 702 5 24 3cc0 3 3cc3 8 3ccb 4 3ccf 3 3cd2 a
+INLINE 2 3605 5 23 3cc3 8 3ccf 3
+INLINE 4 214 6 26 3cc7 4 3ccb 4 3ccf 3 3cd6 6
+INLINE 5 167 6 27 3cc7 4 3ccb 4 3cd6 6
+INLINE 2 3627 5 23 3cd2 a
+INLINE 2 3621 5 28 3ce5 8
+INLINE 1 3610 5 28 3cf6 8 3d19 8
+INLINE 1 3614 5 28 3d07 9 3d36 c
+INLINE 2 3610 5 28 3d4b 8
+INLINE 2 3614 5 28 3d5c 7
+INLINE 1 3645 5 28 3d63 8 3e41 3 3e56 3 3e67 8
+INLINE 2 3617 7 31 3d63 8 3e41 3 3e56 3
+INLINE 3 210 6 32 3d63 8 3e41 3 3e56 3
+INLINE 1 3625 5 28 3d6b 7 3e12 7
+INLINE 1 3629 5 28 3d77 d 3e23 a
+INLINE 0 3782 5 23 3da2 11 3dba 7
+INLINE 0 3791 5 23 3de1 5 3dea 6
+INLINE 2 3625 5 28 3e2d 7
+INLINE 2 3629 5 28 3e39 8
+INLINE 1 3643 5 23 3e44 a 3e59 8
+INLINE 1 3647 5 23 3e6f 8
+INLINE 1 3651 5 23 3e77 4 3e89 3
 INLINE 1 3649 5 28 3e81 8
-INLINE 1 3651 5 28 3e89 3
-INLINE 2 702 5 23 3e89 3
 INLINE 1 3653 5 28 3e92 7
 3bf0 a 3755 5
 3bfa 22 3756 5
@@ -2874,27 +2420,25 @@ FUNC 3ef0 fc 0 google_breakpad::ForwardException(unsigned int, unsigned int, int
 3fc2 20 458 15
 3fe2 a 459 15
 FUNC 3ff0 18d 0 google_breakpad::ExceptionHandler::ExceptionHandler(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool (*)(void*), bool (*)(char const*, char const*, void*, bool), void*, bool, char const*)
-INLINE 0 223 15 128 3ffe 47
-INLINE 1 1945 13 57 3ffe 47
-INLINE 2 1949 13 58 3ffe 47
-INLINE 0 223 15 128 4090 16
-INLINE 1 92 16 129 4090 16
-INLINE 0 242 15 128 40a6 20
-INLINE 1 126 17 130 40ab f
-INLINE 2 1631 13 131 40ab f
-INLINE 3 1633 13 132 40ab f
-INLINE 4 1791 13 133 40ab 5
-INLINE 4 1791 13 133 40b0 6
-INLINE 4 1791 13 133 40b6 4
-INLINE 0 246 15 128 40e2 b
-INLINE 1 40 18 134 40e2 b
-INLINE 0 246 15 128 40ed 1d
-INLINE 0 223 15 128 412f 7
-INLINE 1 92 16 129 412f 7
-INLINE 0 249 15 128 4136 11
-INLINE 1 96 16 135 4136 11
-INLINE 0 249 15 128 414f e
-INLINE 1 96 16 136 414f e
+INLINE 0 223 15 65 3ffe 47
+INLINE 1 1945 13 66 3ffe 47
+INLINE 2 1949 13 67 3ffe 47
+INLINE 0 223 15 161 4090 16 412f 7
+INLINE 1 92 16 162 4090 16 412f 7
+INLINE 0 242 15 163 40a6 20
+INLINE 1 126 17 164 40ab f
+INLINE 2 1631 13 165 40ab f
+INLINE 3 1633 13 166 40ab f
+INLINE 4 1791 13 71 40ab 5
+INLINE 4 1791 13 167 40b0 6
+INLINE 4 1791 13 168 40b6 4
+INLINE 0 246 15 169 40e2 b
+INLINE 1 40 18 170 40e2 b
+INLINE 0 246 15 171 40ed 1d
+INLINE 0 249 15 172 4136 11
+INLINE 1 96 16 173 4136 11
+INLINE 0 249 15 174 414f e
+INLINE 1 96 16 175 414f e
 3ff0 e 240 15
 3ffe 47 1798 13
 4045 4 230 15
@@ -2944,27 +2488,25 @@ FUNC 4180 111 0 google_breakpad::ExceptionHandler::Setup(bool)
 4266 17 765 15
 427d 14 766 15
 FUNC 42a0 e 0 google_breakpad::scoped_ptr<google_breakpad::CrashGenerationClient>::~scoped_ptr()
-INLINE 0 96 16 135 42a0 d
+INLINE 0 96 16 173 42a0 d
 42a0 d 98 16
 42ad 1 99 16
 FUNC 42b0 e 0 google_breakpad::scoped_ptr<sigaction>::~scoped_ptr()
-INLINE 0 96 16 136 42b0 d
+INLINE 0 96 16 175 42b0 d
 42b0 d 98 16
 42bd 1 99 16
 FUNC 42c0 9 0 google_breakpad::ExceptionHandler::ExceptionHandler(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool (*)(void*), bool (*)(char const*, char const*, void*, bool), void*, bool, char const*)
 42c0 9 240 15
 FUNC 42d0 124 0 google_breakpad::ExceptionHandler::ExceptionHandler(bool (*)(void*, int, int, int, unsigned int), void*, bool)
-INLINE 0 253 15 137 42e5 47
-INLINE 1 1945 13 57 42e5 47
-INLINE 2 1949 13 58 42e5 47
-INLINE 0 253 15 137 4360 7
-INLINE 1 92 16 129 4360 7
-INLINE 0 253 15 137 4382 16
-INLINE 1 92 16 129 4382 16
-INLINE 0 270 15 137 43b5 11
-INLINE 1 96 16 135 43b5 11
-INLINE 0 270 15 137 43c6 e
-INLINE 1 96 16 136 43c6 e
+INLINE 0 253 15 65 42e5 47
+INLINE 1 1945 13 66 42e5 47
+INLINE 2 1949 13 67 42e5 47
+INLINE 0 253 15 161 4360 7 4382 16
+INLINE 1 92 16 162 4360 7 4382 16
+INLINE 0 270 15 172 43b5 11
+INLINE 1 96 16 173 43b5 11
+INLINE 0 270 15 174 43c6 e
+INLINE 1 96 16 175 43c6 e
 42d0 d 267 15
 42dd 8 253 15
 42e5 47 1798 13
@@ -2986,14 +2528,12 @@ INLINE 1 96 16 136 43c6 e
 FUNC 4400 8 0 google_breakpad::ExceptionHandler::ExceptionHandler(bool (*)(void*, int, int, int, unsigned int), void*, bool)
 4400 8 267 15
 FUNC 4410 163 0 google_breakpad::ExceptionHandler::~ExceptionHandler()
-INLINE 0 273 15 138 442f 16
-INLINE 0 273 15 138 444a 67
-INLINE 1 776 15 139 444a 4f
-INLINE 0 273 15 138 44b5 21
-INLINE 0 274 15 138 44d6 11
-INLINE 1 96 16 135 44d6 11
-INLINE 0 274 15 138 44e7 11
-INLINE 1 96 16 136 44e7 11
+INLINE 0 273 15 176 442f 16 444a 67 44b5 21
+INLINE 1 776 15 177 444a 4f
+INLINE 0 274 15 172 44d6 11
+INLINE 1 96 16 173 44d6 11
+INLINE 0 274 15 174 44e7 11
+INLINE 1 96 16 175 44e7 11
 4410 1f 272 15
 442f 7 770 15
 4436 f 772 15
@@ -3015,7 +2555,7 @@ INLINE 1 96 16 136 44e7 11
 44e7 11 98 16
 44f8 7b 274 15
 FUNC 4580 f8 0 google_breakpad::ExceptionHandler::Teardown()
-INLINE 0 776 15 139 45bb 51
+INLINE 0 776 15 177 45bb 51
 4580 1e 768 15
 459e 7 770 15
 45a5 16 772 15
@@ -3036,8 +2576,7 @@ PUBLIC 4680 0 __clang_call_terminate
 FUNC 4690 5 0 google_breakpad::ExceptionHandler::~ExceptionHandler()
 4690 5 272 15
 FUNC 46a0 112 0 google_breakpad::ExceptionHandler::WriteMinidump(bool)
-INLINE 0 288 15 140 4736 5c
-INLINE 0 288 15 140 4795 2
+INLINE 0 288 15 177 4736 5c 4795 2
 46a0 22 276 15
 46c2 d 278 15
 46cf 7 281 15
@@ -3074,31 +2613,23 @@ FUNC 47c0 b1 0 google_breakpad::ExceptionHandler::SendMessageToHandlerThread(goo
 4826 23 808 15
 4849 28 813 15
 FUNC 4880 b4 0 google_breakpad::ExceptionHandler::UpdateNextID()
-INLINE 0 817 15 141 48a3 54
-INLINE 1 2476 13 59 48a3 54
-INLINE 2 2462 13 60 48a3 1d
-INLINE 3 3163 13 61 48a3 7
-INLINE 3 3171 13 61 48aa 7
-INLINE 3 3165 13 61 48b1 4
-INLINE 3 3165 13 61 48b5 3
-INLINE 3 3166 13 61 48b8 8
-INLINE 2 2463 13 60 48c0 a
-INLINE 2 2466 13 60 48e3 14
-INLINE 0 820 15 141 48fc e
-INLINE 1 1631 13 131 48fc e
-INLINE 2 1633 13 132 48fc e
-INLINE 3 1791 13 133 48fc 5
-INLINE 3 1791 13 133 4901 5
-INLINE 3 1791 13 133 4906 4
-INLINE 0 821 15 141 490e 10
-INLINE 1 1631 13 131 490e 10
-INLINE 2 1633 13 132 490e 10
-INLINE 3 1791 13 133 490e 7
-INLINE 3 1791 13 133 4915 5
-INLINE 3 1791 13 133 491a 4
-INLINE 0 817 15 141 492c 8
-INLINE 1 2476 13 59 492c 8
-INLINE 2 2463 13 60 492c 8
+INLINE 0 817 15 68 48a3 54 492c 8
+INLINE 1 2476 13 69 48a3 54 492c 8
+INLINE 2 2462 13 70 48a3 1d
+INLINE 3 3163 13 71 48a3 7
+INLINE 3 3171 13 72 48aa 7
+INLINE 3 3165 13 73 48b1 4
+INLINE 3 3165 13 74 48b5 3
+INLINE 3 3166 13 75 48b8 8
+INLINE 2 2463 13 76 48c0 a 492c 8
+INLINE 2 2466 13 67 48e3 14
+INLINE 0 820 15 164 48fc e
+INLINE 1 1631 13 165 48fc e 490e 10
+INLINE 2 1633 13 166 48fc e 490e 10
+INLINE 3 1791 13 71 48fc 5 490e 7
+INLINE 3 1791 13 167 4901 5 4915 5
+INLINE 3 1791 13 168 4906 4 491a 4
+INLINE 0 821 15 164 490e 10
 4880 c 816 15
 488c 4 817 15
 4890 13 818 15
@@ -3122,9 +2653,8 @@ INLINE 2 2463 13 60 492c 8
 4922 a 822 15
 492c 8 1471 13
 FUNC 4940 96 0 google_breakpad::ExceptionHandler::WriteMinidump(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, bool (*)(char const*, char const*, void*, bool), void*)
-INLINE 0 311 15 142 4961 23
-INLINE 0 314 15 142 4996 19
-INLINE 0 314 15 142 49c9 d
+INLINE 0 311 15 178 4961 23
+INLINE 0 314 15 179 4996 19 49c9 d
 4940 21 310 15
 4961 23 240 15
 4984 12 313 15
@@ -3132,33 +2662,20 @@ INLINE 0 314 15 142 49c9 d
 49af 1a 314 15
 49c9 d 272 15
 FUNC 49e0 139 0 google_breakpad::ExceptionHandler::WriteMinidumpForChild(unsigned int, unsigned int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool (*)(char const*, char const*, void*, bool), void*)
-INLINE 0 322 15 143 49fd 5
-INLINE 1 42 19 144 49fd 5
-INLINE 0 325 15 143 4a11 10
-INLINE 1 1945 13 57 4a11 10
-INLINE 2 1949 13 58 4a11 10
-INLINE 0 328 15 143 4a32 1c
-INLINE 0 340 15 143 4a4e 10
-INLINE 1 1631 13 131 4a4e 10
-INLINE 2 1633 13 132 4a4e 10
-INLINE 3 1791 13 133 4a4e 5
-INLINE 3 1791 13 133 4a53 5
-INLINE 0 343 15 143 4a6f d
-INLINE 1 1631 13 131 4a6f d
-INLINE 2 1633 13 132 4a6f d
-INLINE 3 1791 13 133 4a6f 4
-INLINE 3 1791 13 133 4a73 4
-INLINE 0 343 15 143 4a7c f
-INLINE 1 1631 13 131 4a7c f
-INLINE 2 1633 13 132 4a7c f
-INLINE 3 1791 13 133 4a7c 4
-INLINE 3 1791 13 133 4a80 5
-INLINE 0 347 15 143 4ab3 8
-INLINE 1 46 19 145 4ab3 8
-INLINE 0 347 15 143 4acf 8
-INLINE 1 46 19 145 4acf 8
-INLINE 0 347 15 143 4b01 18
-INLINE 1 46 19 145 4b01 18
+INLINE 0 322 15 180 49fd 5
+INLINE 1 42 19 181 49fd 5
+INLINE 0 325 15 65 4a11 10
+INLINE 1 1945 13 66 4a11 10
+INLINE 2 1949 13 67 4a11 10
+INLINE 0 328 15 182 4a32 1c
+INLINE 0 340 15 164 4a4e 10
+INLINE 1 1631 13 165 4a4e 10 4a6f d 4a7c f
+INLINE 2 1633 13 166 4a4e 10 4a6f d 4a7c f
+INLINE 3 1791 13 71 4a4e 5 4a73 4 4a7c 4
+INLINE 3 1791 13 167 4a53 5 4a6f 4 4a80 5
+INLINE 0 343 15 164 4a6f d 4a7c f
+INLINE 0 347 15 183 4ab3 8 4acf 8 4b01 18
+INLINE 1 46 19 184 4ab3 8 4acf 8 4b01 18
 49e0 1d 321 15
 49fd 5 43 19
 4a02 f 324 15
@@ -3187,20 +2704,18 @@ INLINE 1 46 19 145 4b01 18
 4adf 22 347 15
 4b01 18 47 19
 FUNC 4b20 252 0 google_breakpad::ExceptionHandler::WriteMinidumpWithException(int, int, int, __darwin_ucontext*, unsigned int, bool, bool)
-INLINE 0 374 15 146 4b7e a
-INLINE 1 163 17 147 4b7e 7
-INLINE 0 380 15 146 4bb7 10
-INLINE 0 391 15 146 4bfa 11
-INLINE 1 1945 13 57 4bfa 11
-INLINE 2 1949 13 58 4bfa 11
-INLINE 0 395 15 146 4c0b 1f
-INLINE 1 1474 13 148 4c0b 14
-INLINE 2 1460 13 149 4c0b 3
-INLINE 2 1460 13 149 4c0e 2
-INLINE 2 1460 13 149 4c16 5
-INLINE 2 1460 13 149 4c1b 4
-INLINE 0 406 15 146 4c8e 13
-INLINE 0 380 15 146 4d2f 1f
+INLINE 0 374 15 185 4b7e a
+INLINE 1 163 17 186 4b7e 7
+INLINE 0 380 15 187 4bb7 10 4d2f 1f
+INLINE 0 391 15 65 4bfa 11
+INLINE 1 1945 13 66 4bfa 11
+INLINE 2 1949 13 67 4bfa 11
+INLINE 0 395 15 188 4c0b 1f
+INLINE 1 1474 13 189 4c0b 14
+INLINE 2 1460 13 190 4c0b 3 4c16 5
+INLINE 2 1460 13 71 4c0e 2
+INLINE 2 1460 13 191 4c1b 4
+INLINE 0 406 15 182 4c8e 13
 4b20 27 356 15
 4b47 c 364 15
 4b53 24 365 15
@@ -3246,14 +2761,10 @@ INLINE 0 380 15 146 4d2f 1f
 4d56 f 411 15
 4d65 d 424 15
 FUNC 4d80 2d2 0 google_breakpad::ExceptionHandler::WaitForMessage(void*)
-INLINE 0 517 15 150 4db7 e
-INLINE 0 566 15 150 4e42 19
-INLINE 0 566 15 150 4e5d 31
-INLINE 0 601 15 150 4ee5 b
-INLINE 0 517 15 150 4f0b 1d
-INLINE 0 517 15 150 4f2a 36
-INLINE 0 552 15 150 4fad 1d
-INLINE 0 552 15 150 4fcc 32
+INLINE 0 517 15 192 4db7 e 4f0b 1d 4f2a 36
+INLINE 0 566 15 192 4e42 19 4e5d 31
+INLINE 0 601 15 193 4ee5 b
+INLINE 0 552 15 194 4fad 1d 4fcc 32
 4d80 26 483 15
 4da6 11 555 15
 4db7 19 828 15
@@ -3312,8 +2823,8 @@ FUNC 50d0 70 0 google_breakpad::ExceptionHandler::ResumeThreads()
 5121 11 852 15
 5132 e 850 15
 FUNC 5140 e6 0 google_breakpad::ExceptionHandler::UninstallHandler(bool)
-INLINE 0 697 15 151 514e 8
-INLINE 0 703 15 151 5167 1e
+INLINE 0 697 15 195 514e 8
+INLINE 0 703 15 196 5167 1e
 5140 e 694 15
 514e 8 122 16
 5156 5 697 15
@@ -3343,15 +2854,11 @@ FUNC 5230 47 0 google_breakpad::ExceptionHandler::SignalHandler(int, __siginfo*,
 5246 29 621 15
 526f 8 633 15
 FUNC 5280 161 0 google_breakpad::ExceptionHandler::InstallHandler()
-INLINE 0 652 15 152 535d e
-INLINE 0 658 15 152 5372 13
-INLINE 1 96 16 136 5372 13
-INLINE 0 658 15 152 5385 d
-INLINE 1 96 16 136 5385 d
-INLINE 0 658 15 152 5395 8
-INLINE 1 96 16 136 5395 8
-INLINE 0 668 15 152 53b5 10
-INLINE 1 82 11 153 53b5 10
+INLINE 0 652 15 197 535d e
+INLINE 0 658 15 174 5372 13 5385 d 5395 8
+INLINE 1 96 16 175 5372 13 5385 d 5395 8
+INLINE 0 668 15 198 53b5 10
+INLINE 1 82 11 199 53b5 10
 5280 9 635 15
 5289 e 637 15
 5297 a 640 15
@@ -3382,75 +2889,44 @@ INLINE 1 82 11 153 53b5 10
 5385 10 98 16
 5395 13 98 16
 53a8 d 667 15
-53b5 10 82 10
+53b5 10 82 11
 53c5 d 667 15
 53d2 f 670 15
 FUNC 53f0 316 0 google_breakpad::MinidumpGenerator::MinidumpGenerator()
-INLINE 0 83 21 154 5441 4
-INLINE 1 219 22 155 5441 4
-INLINE 2 220 22 156 5441 4
-INLINE 3 1538 9 157 5441 4
-INLINE 4 310 12 158 5441 4
-INLINE 5 311 12 159 5441 4
-INLINE 6 1500 10 160 5441 4
-INLINE 0 72 21 154 5445 5
-INLINE 1 67 22 161 5445 5
-INLINE 0 83 21 154 544a 3
-INLINE 1 219 22 155 544a 3
-INLINE 2 220 22 156 544a 3
-INLINE 3 1538 9 157 544a 3
-INLINE 4 310 12 158 544a 3
-INLINE 5 311 12 159 544a 3
-INLINE 6 1500 10 160 544a 3
-INLINE 7 190 22 162 544a 3
-INLINE 0 72 21 154 545d 4
-INLINE 1 67 22 161 545d 4
-INLINE 0 83 21 154 5461 217
-INLINE 1 219 22 155 5461 217
-INLINE 2 219 22 156 5461 5b
-INLINE 3 496 9 163 5461 5b
-INLINE 4 443 9 164 5461 5b
-INLINE 5 2427 10 165 5461 5b
-INLINE 6 2427 10 166 5461 5b
-INLINE 2 220 22 156 54bc 1bc
-INLINE 3 1538 9 157 54bc 8b
-INLINE 4 310 12 158 54bc 8b
-INLINE 5 311 12 159 54bc 8b
-INLINE 6 1500 10 160 54bc 8b
-INLINE 7 190 22 162 54bc 8b
-INLINE 8 91 22 167 54cb 3d
-INLINE 3 1539 9 157 554a b
-INLINE 3 1538 9 157 5555 7
-INLINE 4 310 12 158 5555 7
-INLINE 3 1539 9 157 555c 11c
-INLINE 4 893 9 168 555c 3
-INLINE 4 894 9 168 555f 9
-INLINE 4 893 9 168 5568 fe
-INLINE 5 1630 10 169 5583 15
-INLINE 6 1514 10 170 5583 15
-INLINE 7 1668 10 171 5583 15
-INLINE 5 1630 10 169 559c 8
-INLINE 6 1514 10 170 559c 8
-INLINE 7 1668 10 171 559c 8
-INLINE 5 1630 10 169 55c3 8c
-INLINE 6 1514 10 170 55c3 8c
-INLINE 7 1668 10 171 55c3 8c
-INLINE 4 894 9 168 5666 4
-INLINE 4 895 9 168 566a 7
-INLINE 4 896 9 168 5671 7
-INLINE 0 85 21 154 568c 2d
-INLINE 1 216 22 172 568c 2d
-INLINE 2 216 22 173 568c 2d
-INLINE 3 458 9 174 568c 2d
-INLINE 4 452 9 175 5695 24
-INLINE 5 369 9 176 5695 24
-INLINE 6 425 9 177 56a1 11
-INLINE 0 72 21 154 56b9 4
-INLINE 1 67 22 161 56b9 4
-INLINE 0 85 21 154 56bd 36
-INLINE 1 70 22 178 56bd 36
-INLINE 2 71 22 179 56bd 18
-INLINE 2 71 22 179 56d8 13
+INLINE 0 83 21 200 5441 4 544a 3 5461 217
+INLINE 1 219 22 201 5441 4 544a 3 5461 217
+INLINE 2 220 22 202 5441 4 544a 3 54bc 1bc
+INLINE 3 1538 9 203 5441 4 544a 3 54bc 8b 5555 7
+INLINE 4 310 12 204 5441 4 544a 3 54bc 8b 5555 7
+INLINE 5 311 12 205 5441 4 544a 3 54bc 8b
+INLINE 6 1500 10 206 5441 4 544a 3 54bc 8b
+INLINE 0 72 21 207 5445 5 545d 4 56b9 4
+INLINE 1 67 22 208 5445 5 545d 4 56b9 4
+INLINE 7 190 22 209 544a 3 54bc 8b
+INLINE 2 219 22 210 5461 5b
+INLINE 3 496 9 211 5461 5b
+INLINE 4 443 9 212 5461 5b
+INLINE 5 2427 10 213 5461 5b
+INLINE 6 2427 10 214 5461 5b
+INLINE 8 91 22 215 54cb 3d
+INLINE 3 1539 9 216 554a b 555c 11c
+INLINE 4 893 9 217 555c 3 5568 fe
+INLINE 4 894 9 218 555f 9 5666 4
+INLINE 5 1630 10 219 5583 15 559c 8 55c3 8c
+INLINE 6 1514 10 220 5583 15 559c 8 55c3 8c
+INLINE 7 1668 10 221 5583 15 559c 8 55c3 8c
+INLINE 4 895 9 218 566a 7
+INLINE 4 896 9 218 5671 7
+INLINE 0 85 21 222 568c 2d
+INLINE 1 216 22 223 568c 2d
+INLINE 2 216 22 224 568c 2d
+INLINE 3 458 9 225 568c 2d
+INLINE 4 452 9 226 5695 24
+INLINE 5 369 9 227 5695 24
+INLINE 6 425 9 228 56a1 11
+INLINE 0 85 21 229 56bd 36
+INLINE 1 70 22 230 56bd 36
+INLINE 2 71 22 231 56bd 18 56d8 13
 53f0 17 83 21
 5407 c 73 21
 5413 10 75 21
@@ -3462,7 +2938,7 @@ INLINE 2 71 22 179 56d8 13
 544a 3 90 22
 544d 10 82 21
 545d 4 63 22
-5461 5b 2065 12
+5461 5b 2065 10
 54bc f 90 22
 54cb 24 119 22
 54ef 6 121 22
@@ -3477,19 +2953,19 @@ INLINE 2 71 22 179 56d8 13
 552c 15 98 22
 5541 9 100 22
 554a b 893 9
-5555 7 313 11
-555c 3 1628 12
+5555 7 313 12
+555c 3 1628 10
 555f 9 3618 7
-5568 28 1630 12
-5590 8 1752 12
-5598 4 1630 12
-559c 8 1752 12
-55a4 4 1631 12
-55a8 a 1628 12
-55b2 1e 1630 12
-55d0 7f 1752 12
-564f 4 1630 12
-5653 13 1628 12
+5568 28 1630 10
+5590 8 1752 10
+5598 4 1630 10
+559c 8 1752 10
+55a4 4 1631 10
+55a8 a 1628 10
+55b2 1e 1630 10
+55d0 7f 1752 10
+564f 4 1630 10
+5653 13 1628 10
 5666 4 3618 7
 566a 7 3618 7
 5671 7 3618 7
@@ -3507,11 +2983,11 @@ INLINE 2 71 22 179 56d8 13
 56eb b 71 22
 56f6 10 85 21
 FUNC 5710 259 0 google_breakpad::MinidumpGenerator::GatherSystemInformation()
-INLINE 0 186 21 180 58a0 10
-INLINE 1 1631 13 131 58a0 10
-INLINE 2 1633 13 132 58a0 10
-INLINE 3 1791 13 133 58a0 5
-INLINE 3 1791 13 133 58a5 5
+INLINE 0 186 21 164 58a0 10
+INLINE 1 1631 13 165 58a0 10
+INLINE 2 1633 13 166 58a0 10
+INLINE 3 1791 13 71 58a0 5
+INLINE 3 1791 13 167 58a5 5
 5710 20 123 21
 5730 21 125 21
 5751 f 192 21
@@ -3554,74 +3030,41 @@ INLINE 3 1791 13 133 58a5 5
 FUNC 5970 5 0 google_breakpad::MinidumpGenerator::MinidumpGenerator()
 5970 5 83 21
 FUNC 5980 343 0 google_breakpad::MinidumpGenerator::MinidumpGenerator(unsigned int, unsigned int)
-INLINE 0 101 21 181 59c4 4
-INLINE 1 219 22 155 59c4 4
-INLINE 2 220 22 156 59c4 4
-INLINE 3 1538 9 157 59c4 4
-INLINE 4 310 12 158 59c4 4
-INLINE 5 311 12 159 59c4 4
-INLINE 6 1500 10 160 59c4 4
-INLINE 0 89 21 181 59c8 5
-INLINE 1 67 22 161 59c8 5
-INLINE 0 101 21 181 59cd 3
-INLINE 1 219 22 155 59cd 3
-INLINE 2 220 22 156 59cd 3
-INLINE 3 1538 9 157 59cd 3
-INLINE 4 310 12 158 59cd 3
-INLINE 5 311 12 159 59cd 3
-INLINE 6 1500 10 160 59cd 3
-INLINE 7 190 22 162 59cd 3
-INLINE 0 89 21 181 59e0 4
-INLINE 1 67 22 161 59e0 4
-INLINE 0 101 21 181 59e4 214
-INLINE 1 219 22 155 59e4 214
-INLINE 2 219 22 156 59e4 5b
-INLINE 3 496 9 163 59e4 5b
-INLINE 4 443 9 164 59e4 5b
-INLINE 5 2427 10 165 59e4 5b
-INLINE 6 2427 10 166 59e4 5b
-INLINE 2 220 22 156 5a3f 1b9
-INLINE 3 1538 9 157 5a3f 8b
-INLINE 4 310 12 158 5a3f 8b
-INLINE 5 311 12 159 5a3f 8b
-INLINE 6 1500 10 160 5a3f 8b
-INLINE 7 190 22 162 5a3f 8b
-INLINE 8 91 22 167 5a4e 3d
-INLINE 3 1539 9 157 5acd b
-INLINE 3 1538 9 157 5ad8 7
-INLINE 4 310 12 158 5ad8 7
-INLINE 3 1539 9 157 5adf 119
-INLINE 4 893 9 168 5adf 3
-INLINE 4 894 9 168 5ae2 9
-INLINE 4 893 9 168 5aeb fb
-INLINE 5 1630 10 169 5b06 12
-INLINE 6 1514 10 170 5b06 12
-INLINE 7 1668 10 171 5b06 12
-INLINE 5 1630 10 169 5b1c 8
-INLINE 6 1514 10 170 5b1c 8
-INLINE 7 1668 10 171 5b1c 8
-INLINE 5 1630 10 169 5b43 8c
-INLINE 6 1514 10 170 5b43 8c
-INLINE 7 1668 10 171 5b43 8c
-INLINE 4 894 9 168 5be6 4
-INLINE 4 895 9 168 5bea 7
-INLINE 4 896 9 168 5bf1 7
-INLINE 0 104 21 181 5c2f 3
-INLINE 0 111 21 181 5c55 2d
-INLINE 1 216 22 172 5c55 2d
-INLINE 2 216 22 173 5c55 2d
-INLINE 3 458 9 174 5c55 2d
-INLINE 4 452 9 175 5c5e 24
-INLINE 5 369 9 176 5c5e 24
-INLINE 6 425 9 177 5c6a 11
-INLINE 0 89 21 181 5c82 4
-INLINE 1 67 22 161 5c82 4
-INLINE 0 111 21 181 5c86 25
-INLINE 1 70 22 178 5c86 25
-INLINE 2 71 22 179 5c86 f
-INLINE 2 71 22 179 5c98 13
-INLINE 0 111 21 181 5cbb 8
-INLINE 1 70 22 178 5cbb 8
+INLINE 0 101 21 200 59c4 4 59cd 3 59e4 214
+INLINE 1 219 22 201 59c4 4 59cd 3 59e4 214
+INLINE 2 220 22 202 59c4 4 59cd 3 5a3f 1b9
+INLINE 3 1538 9 203 59c4 4 59cd 3 5a3f 8b 5ad8 7
+INLINE 4 310 12 204 59c4 4 59cd 3 5a3f 8b 5ad8 7
+INLINE 5 311 12 205 59c4 4 59cd 3 5a3f 8b
+INLINE 6 1500 10 206 59c4 4 59cd 3 5a3f 8b
+INLINE 0 89 21 207 59c8 5 59e0 4 5c82 4
+INLINE 1 67 22 208 59c8 5 59e0 4 5c82 4
+INLINE 7 190 22 209 59cd 3 5a3f 8b
+INLINE 2 219 22 210 59e4 5b
+INLINE 3 496 9 211 59e4 5b
+INLINE 4 443 9 212 59e4 5b
+INLINE 5 2427 10 213 59e4 5b
+INLINE 6 2427 10 214 59e4 5b
+INLINE 8 91 22 215 5a4e 3d
+INLINE 3 1539 9 216 5acd b 5adf 119
+INLINE 4 893 9 217 5adf 3 5aeb fb
+INLINE 4 894 9 218 5ae2 9 5be6 4
+INLINE 5 1630 10 219 5b06 12 5b1c 8 5b43 8c
+INLINE 6 1514 10 220 5b06 12 5b1c 8 5b43 8c
+INLINE 7 1668 10 221 5b06 12 5b1c 8 5b43 8c
+INLINE 4 895 9 218 5bea 7
+INLINE 4 896 9 218 5bf1 7
+INLINE 0 104 21 232 5c2f 3
+INLINE 0 111 21 222 5c55 2d
+INLINE 1 216 22 223 5c55 2d
+INLINE 2 216 22 224 5c55 2d
+INLINE 3 458 9 225 5c55 2d
+INLINE 4 452 9 226 5c5e 24
+INLINE 5 369 9 227 5c5e 24
+INLINE 6 425 9 228 5c6a 11
+INLINE 0 111 21 229 5c86 25 5cbb 8
+INLINE 1 70 22 230 5c86 25 5cbb 8
+INLINE 2 71 22 231 5c86 f 5c98 13
 5980 1a 101 21
 599a c 91 21
 59a6 10 93 21
@@ -3633,7 +3076,7 @@ INLINE 1 70 22 178 5cbb 8
 59cd 3 90 22
 59d0 10 100 21
 59e0 4 63 22
-59e4 5b 2065 12
+59e4 5b 2065 10
 5a3f f 90 22
 5a4e 24 119 22
 5a72 6 121 22
@@ -3648,19 +3091,19 @@ INLINE 1 70 22 178 5cbb 8
 5aaf 15 98 22
 5ac4 9 100 22
 5acd b 893 9
-5ad8 7 313 11
-5adf 3 1628 12
+5ad8 7 313 12
+5adf 3 1628 10
 5ae2 9 3618 7
-5aeb 25 1630 12
-5b10 8 1752 12
-5b18 4 1630 12
-5b1c 8 1752 12
-5b24 4 1631 12
-5b28 a 1628 12
-5b32 1e 1630 12
-5b50 7f 1752 12
-5bcf 4 1630 12
-5bd3 13 1628 12
+5aeb 25 1630 10
+5b10 8 1752 10
+5b18 4 1630 10
+5b1c 8 1752 10
+5b24 4 1631 10
+5b28 a 1628 10
+5b32 1e 1630 10
+5b50 7f 1752 10
+5bcf 4 1630 10
+5bd3 13 1628 10
 5be6 4 3618 7
 5bea 7 3618 7
 5bf1 7 3618 7
@@ -3686,20 +3129,17 @@ INLINE 1 70 22 178 5cbb 8
 FUNC 5cd0 5 0 google_breakpad::MinidumpGenerator::MinidumpGenerator(unsigned int, unsigned int)
 5cd0 5 101 21
 FUNC 5ce0 94 0 google_breakpad::MinidumpGenerator::~MinidumpGenerator()
-INLINE 0 114 21 182 5cfb 8
-INLINE 0 115 21 182 5d0b 2d
-INLINE 1 216 22 172 5d0b 2d
-INLINE 2 216 22 173 5d0b 2d
-INLINE 3 458 9 174 5d0b 2d
-INLINE 4 452 9 175 5d14 24
-INLINE 5 369 9 176 5d14 24
-INLINE 6 425 9 177 5d20 11
-INLINE 0 115 21 182 5d38 23
-INLINE 1 70 22 178 5d38 23
-INLINE 2 71 22 179 5d38 d
-INLINE 2 71 22 179 5d48 13
-INLINE 0 115 21 182 5d6c 8
-INLINE 1 70 22 178 5d6c 8
+INLINE 0 114 21 233 5cfb 8
+INLINE 0 115 21 222 5d0b 2d
+INLINE 1 216 22 223 5d0b 2d
+INLINE 2 216 22 224 5d0b 2d
+INLINE 3 458 9 225 5d0b 2d
+INLINE 4 452 9 226 5d14 24
+INLINE 5 369 9 227 5d14 24
+INLINE 6 425 9 228 5d20 11
+INLINE 0 115 21 229 5d38 23 5d6c 8
+INLINE 1 70 22 230 5d38 23 5d6c 8
+INLINE 2 71 22 231 5d38 d 5d48 13
 5ce0 12 113 21
 5cf2 9 114 21
 5cfb 8 243 6
@@ -3717,7 +3157,7 @@ INLINE 1 70 22 178 5d6c 8
 FUNC 5d80 5 0 google_breakpad::MinidumpGenerator::~MinidumpGenerator()
 5d80 5 113 21
 FUNC 5d90 12 0 google_breakpad::MinidumpGenerator::~MinidumpGenerator()
-INLINE 0 113 21 183 5d94 5
+INLINE 0 113 21 234 5d94 5
 5d90 4 113 21
 5d94 5 113 21
 5d99 9 113 21
@@ -3725,23 +3165,16 @@ FUNC 5db0 5 0 google_breakpad::MinidumpGenerator::SetTaskContext(__darwin_uconte
 5db0 4 195 21
 5db4 1 196 21
 FUNC 5dc0 114 0 google_breakpad::MinidumpGenerator::UniqueNameInDirectory(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*)
-INLINE 0 209 21 184 5e15 18
-INLINE 1 1474 13 148 5e15 13
-INLINE 2 1460 13 149 5e15 b
-INLINE 2 1460 13 149 5e20 2
-INLINE 0 214 21 184 5e4f 27
-INLINE 1 2677 13 185 5e4f 5
-INLINE 2 1460 13 149 5e4f 5
-INLINE 1 2677 13 185 5e54 f
-INLINE 2 1633 13 132 5e54 f
-INLINE 3 1791 13 133 5e54 4
-INLINE 3 1791 13 133 5e58 5
-INLINE 1 2677 13 185 5e63 3
-INLINE 2 1460 13 149 5e63 3
-INLINE 1 2677 13 185 5e66 2
-INLINE 2 1633 13 132 5e66 2
-INLINE 3 1791 13 133 5e66 2
-INLINE 1 2677 13 185 5e68 6
+INLINE 0 209 21 188 5e15 18
+INLINE 1 1474 13 189 5e15 13
+INLINE 2 1460 13 190 5e15 b 5e4f 5 5e63 3
+INLINE 2 1460 13 71 5e20 2
+INLINE 0 214 21 235 5e4f 27
+INLINE 1 2677 13 189 5e4f 5 5e63 3 5e68 6
+INLINE 1 2677 13 165 5e54 f 5e66 2
+INLINE 2 1633 13 166 5e54 f 5e66 2
+INLINE 3 1791 13 71 5e54 4 5e66 2
+INLINE 3 1791 13 167 5e58 5
 5dc0 16 199 21
 5dd6 a 200 21
 5de0 d 201 21
@@ -3768,38 +3201,22 @@ INLINE 1 2677 13 185 5e68 6
 5e8a 12 218 21
 5e9c 38 221 21
 FUNC 5ee0 2b3 0 google_breakpad::MinidumpGenerator::Write(char const*)
-INLINE 0 242 21 186 5f08 3a
-INLINE 1 212 2 187 5f08 3a
-INLINE 2 210 2 188 5f08 d
-INLINE 3 160 2 9 5f0d 4
-INLINE 0 243 21 186 5f42 23
-INLINE 1 212 2 189 5f42 23
-INLINE 2 210 2 190 5f42 8
-INLINE 0 245 21 186 5f65 17
-INLINE 0 256 21 186 5fa0 27
-INLINE 0 264 21 186 5ff1 4
-INLINE 0 272 21 186 6035 23
-INLINE 0 274 21 186 6084 2b
-INLINE 1 214 2 191 6084 2b
-INLINE 2 217 2 192 6098 17
-INLINE 0 274 21 186 60af 1f
-INLINE 1 214 2 193 60af 1f
-INLINE 2 217 2 194 60b6 18
-INLINE 0 272 21 186 60ef 1f
-INLINE 0 274 21 186 6112 8
-INLINE 1 214 2 193 6112 8
-INLINE 0 274 21 186 611a 8
-INLINE 1 214 2 191 611a 8
-INLINE 0 274 21 186 612c 5
-INLINE 1 214 2 191 612c 5
-INLINE 0 274 21 186 613b 21
-INLINE 1 214 2 191 613b 21
-INLINE 2 217 2 192 6145 17
-INLINE 0 274 21 186 615c 2f
-INLINE 1 214 2 193 615c 2f
-INLINE 2 217 2 194 6163 18
-INLINE 0 274 21 186 618b 8
-INLINE 1 214 2 191 618b 8
+INLINE 0 242 21 236 5f08 3a
+INLINE 1 212 2 237 5f08 3a
+INLINE 2 210 2 7 5f08 d 5f42 8
+INLINE 3 160 2 8 5f0d 4
+INLINE 0 243 21 238 5f42 23
+INLINE 1 212 2 239 5f42 23
+INLINE 0 245 21 240 5f65 17
+INLINE 0 256 21 241 5fa0 27
+INLINE 0 264 21 242 5ff1 4
+INLINE 0 272 21 243 6035 23 60ef 1f
+INLINE 0 274 21 244 6084 2b 611a 8 612c 5 613b 21 618b 8
+INLINE 1 214 2 245 6084 2b 611a 8 612c 5 613b 21 618b 8
+INLINE 2 217 2 246 6098 17 6145 17
+INLINE 0 274 21 247 60af 1f 6112 8 615c 2f
+INLINE 1 214 2 248 60af 1f 6112 8 615c 2f
+INLINE 2 217 2 249 60b6 18 6163 18
 5ee0 14 223 21
 5ef4 14 241 21
 5f08 5 159 2
@@ -3845,26 +3262,16 @@ INLINE 1 214 2 191 618b 8
 6183 8 217 2
 618b 8 217 2
 FUNC 61a0 246 0 google_breakpad::MinidumpGenerator::WriteThreadListStream(MDRawDirectory*)
-INLINE 0 990 21 195 61bb 5c
-INLINE 1 212 2 196 61bb 5c
-INLINE 2 210 2 197 61bb c
-INLINE 3 160 2 9 61c0 3
-INLINE 0 1027 21 195 622d a
-INLINE 1 214 2 198 622d a
-INLINE 0 1003 21 195 6244 8
-INLINE 0 1003 21 195 624f 23
-INLINE 0 1008 21 195 6281 f
-INLINE 0 1022 21 195 62f5 29
-INLINE 0 1027 21 195 6337 1e
-INLINE 1 214 2 198 6337 1e
-INLINE 2 217 2 199 633d 18
-INLINE 0 1022 21 195 636a 1f
-INLINE 0 1003 21 195 6389 1f
-INLINE 0 1027 21 195 63aa 8
-INLINE 1 214 2 198 63aa 8
-INLINE 0 1027 21 195 63b7 2f
-INLINE 1 214 2 198 63b7 2f
-INLINE 2 217 2 199 63be 18
+INLINE 0 990 21 250 61bb 5c
+INLINE 1 212 2 251 61bb 5c
+INLINE 2 210 2 7 61bb c
+INLINE 3 160 2 8 61c0 3
+INLINE 0 1027 21 252 622d a 6337 1e 63aa 8 63b7 2f
+INLINE 1 214 2 253 622d a 6337 1e 63aa 8 63b7 2f
+INLINE 0 1003 21 254 6244 8 624f 23 6389 1f
+INLINE 0 1008 21 10 6281 f
+INLINE 0 1022 21 255 62f5 29 636a 1f
+INLINE 2 217 2 256 633d 18 63be 18
 61a0 17 989 21
 61b7 4 990 21
 61bb 5 159 2
@@ -3911,73 +3318,54 @@ INLINE 2 217 2 199 63be 18
 63be 20 92 1
 63de 8 217 2
 FUNC 63f0 51f 0 google_breakpad::MinidumpGenerator::WriteMemoryListStream(MDRawDirectory*)
-INLINE 0 1031 21 200 641d 39
-INLINE 1 212 2 201 641d 39
-INLINE 2 210 2 202 641d d
-INLINE 3 160 2 9 6422 4
-INLINE 0 1043 21 200 646d ab
-INLINE 1 921 21 203 64bf 3
-INLINE 2 2591 5 204 64bf 3
-INLINE 3 2583 5 205 64bf 3
-INLINE 0 1044 21 200 6527 28
-INLINE 1 460 21 206 653e 9
-INLINE 1 462 21 206 6547 8
-INLINE 0 1067 21 200 65b6 3
-INLINE 1 2656 5 109 65b6 3
-INLINE 2 2648 5 110 65b6 3
-INLINE 0 1070 21 200 65c8 3
-INLINE 1 2591 5 204 65c8 3
-INLINE 2 2583 5 205 65c8 3
-INLINE 0 1080 21 200 65d4 2e
-INLINE 1 1590 9 207 65e4 11
-INLINE 2 1514 10 208 65e4 11
-INLINE 3 1668 10 209 65e4 11
-INLINE 0 1080 21 200 660e a
-INLINE 0 1086 21 200 661e 18
-INLINE 0 1087 21 200 6636 16
-INLINE 0 1092 21 200 665a f
-INLINE 0 1098 21 200 667e d
-INLINE 0 1098 21 200 668b 8
-INLINE 0 1098 21 200 6693 17
-INLINE 0 1104 21 200 66c2 1f
-INLINE 1 161 2 15 66c2 1f
-INLINE 2 160 2 9 66ca 4
-INLINE 0 1110 21 200 6705 14
+INLINE 0 1031 21 257 641d 39
+INLINE 1 212 2 258 641d 39
+INLINE 2 210 2 7 641d d
+INLINE 3 160 2 8 6422 4
+INLINE 0 1043 21 259 646d ab
+INLINE 1 921 21 260 64bf 3
+INLINE 2 2591 5 261 64bf 3
+INLINE 3 2583 5 140 64bf 3
+INLINE 0 1044 21 262 6527 28 686b 1f
+INLINE 1 460 21 263 653e 9
+INLINE 1 462 21 264 6547 8
+INLINE 0 1067 21 138 65b6 3
+INLINE 1 2656 5 139 65b6 3
+INLINE 2 2648 5 140 65b6 3
+INLINE 0 1070 21 260 65c8 3
+INLINE 1 2591 5 261 65c8 3
+INLINE 2 2583 5 140 65c8 3
+INLINE 0 1080 21 265 65d4 2e 660e a
+INLINE 1 1590 9 266 65e4 11
+INLINE 2 1514 10 267 65e4 11
+INLINE 3 1668 10 268 65e4 11
+INLINE 0 1086 21 269 661e 18
+INLINE 0 1087 21 270 6636 16 6847 1f
+INLINE 0 1092 21 10 665a f
+INLINE 0 1098 21 271 667e d 6693 17 6828 1f
+INLINE 0 1098 21 272 668b 8
+INLINE 0 1104 21 14 66c2 1f
+INLINE 1 161 2 7 66c2 1f
+INLINE 2 160 2 8 66ca 4
+INLINE 0 1110 21 33 6705 14
 INLINE 1 485 9 34 6705 14
 INLINE 2 484 9 35 6705 14
-INLINE 0 1118 21 200 673a 5
-INLINE 0 1118 21 200 6746 14
-INLINE 0 1119 21 200 675a 1b
-INLINE 1 458 9 36 675a 1b
-INLINE 2 458 9 37 675a 1b
-INLINE 3 452 9 38 6764 c
-INLINE 4 369 9 39 6764 c
-INLINE 3 453 9 38 6770 5
-INLINE 4 1508 10 40 6770 5
-INLINE 5 1743 10 41 6770 5
-INLINE 0 1133 21 200 677c 1f
-INLINE 1 214 2 210 677c 1f
-INLINE 2 217 2 211 6783 18
-INLINE 0 1121 21 200 67d0 14
-INLINE 0 1126 21 200 67e4 15
-INLINE 0 1128 21 200 67fe 2a
-INLINE 0 1098 21 200 6828 1f
-INLINE 0 1087 21 200 6847 1f
-INLINE 0 1044 21 200 686b 1f
-INLINE 0 1128 21 200 688a 1f
-INLINE 0 1119 21 200 68b0 1d
-INLINE 1 458 9 36 68b0 1d
-INLINE 2 458 9 37 68b0 1d
-INLINE 3 452 9 38 68ba c
-INLINE 4 369 9 39 68ba c
-INLINE 3 453 9 38 68c6 7
-INLINE 4 1508 10 40 68c6 7
-INLINE 5 1743 10 41 68c6 7
-INLINE 0 1133 21 200 68d3 8
-INLINE 1 214 2 210 68d3 8
-INLINE 0 1133 21 200 68e0 2f
-INLINE 1 214 2 210 68e0 2f
-INLINE 2 217 2 211 68e7 18
+INLINE 0 1118 21 36 673a 5
+INLINE 0 1118 21 15 6746 14
+INLINE 0 1119 21 37 675a 1b 68b0 1d
+INLINE 1 458 9 38 675a 1b 68b0 1d
+INLINE 2 458 9 39 675a 1b 68b0 1d
+INLINE 3 452 9 40 6764 c 68ba c
+INLINE 4 369 9 41 6764 c 68ba c
+INLINE 3 453 9 42 6770 5 68c6 7
+INLINE 4 1508 10 43 6770 5 68c6 7
+INLINE 5 1743 10 44 6770 5 68c6 7
+INLINE 0 1133 21 273 677c 1f 68d3 8 68e0 2f
+INLINE 1 214 2 274 677c 1f 68d3 8 68e0 2f
+INLINE 2 217 2 275 6783 18 68e7 18
+INLINE 0 1121 21 15 67d0 14
+INLINE 0 1126 21 10 67e4 15
+INLINE 0 1128 21 271 67fe 2a 688a 1f
 63f0 29 1030 21
 6419 4 1031 21
 641d 5 159 2
@@ -4023,7 +3411,7 @@ INLINE 2 217 2 211 68e7 18
 65cb 5 1072 21
 65d0 4 1074 21
 65d4 10 1587 9
-65e4 11 1752 12
+65e4 11 1752 10
 65f5 12 1593 9
 6607 7 1080 21
 660e 10 1596 9
@@ -4063,7 +3451,7 @@ INLINE 2 217 2 211 68e7 18
 675f 5 450 9
 6764 7 424 9
 676b 5 425 9
-6770 c 177 10
+6770 c 177 11
 677c 7 216 2
 6783 30 92 1
 67b3 14 1133 21
@@ -4084,26 +3472,21 @@ INLINE 2 217 2 211 68e7 18
 68b5 5 450 9
 68ba 7 424 9
 68c1 5 425 9
-68c6 d 177 10
+68c6 d 177 11
 68d3 d 217 2
 68e0 7 216 2
 68e7 20 92 1
 6907 8 217 2
 FUNC 6910 25d 0 google_breakpad::MinidumpGenerator::WriteSystemInfoStream(MDRawDirectory*)
-INLINE 0 1172 21 212 6935 54
-INLINE 1 212 2 213 6935 54
-INLINE 2 210 2 214 6935 c
-INLINE 3 160 2 9 693a 3
-INLINE 0 1174 21 212 6989 17
-INLINE 0 1178 21 212 69af f
-INLINE 0 1292 21 212 6aeb 1f
-INLINE 1 214 2 215 6aeb 1f
-INLINE 2 217 2 216 6af2 18
-INLINE 0 1292 21 212 6b2f 8
-INLINE 1 214 2 215 6b2f 8
-INLINE 0 1292 21 212 6b3e 2f
-INLINE 1 214 2 215 6b3e 2f
-INLINE 2 217 2 216 6b45 18
+INLINE 0 1172 21 276 6935 54
+INLINE 1 212 2 277 6935 54
+INLINE 2 210 2 7 6935 c
+INLINE 3 160 2 8 693a 3
+INLINE 0 1174 21 278 6989 17
+INLINE 0 1178 21 10 69af f
+INLINE 0 1292 21 279 6aeb 1f 6b2f 8 6b3e 2f
+INLINE 1 214 2 280 6aeb 1f 6b2f 8 6b3e 2f
+INLINE 2 217 2 281 6af2 18 6b45 18
 6910 21 1171 21
 6931 4 1172 21
 6935 5 159 2
@@ -4156,29 +3539,20 @@ INLINE 2 217 2 216 6b45 18
 6b45 20 92 1
 6b65 8 217 2
 FUNC 6b70 28d 0 google_breakpad::MinidumpGenerator::WriteModuleListStream(MDRawDirectory*)
-INLINE 0 1491 21 217 6b8b 20
-INLINE 1 212 2 218 6b8b 20
-INLINE 2 210 2 219 6b8b 11
-INLINE 3 160 2 9 6b90 3
-INLINE 0 1494 21 217 6bb4 e
-INLINE 1 250 6 105 6bb4 e
-INLINE 0 1497 21 217 6bca 9
-INLINE 0 1497 21 217 6bd6 1d
-INLINE 0 1501 21 217 6c02 f
-INLINE 0 1506 21 217 6c1a 4c
-INLINE 0 1512 21 217 6c86 2c
-INLINE 0 1521 21 217 6ce8 28
-INLINE 0 1526 21 217 6d21 22
-INLINE 1 214 2 220 6d21 22
-INLINE 2 217 2 221 6d2b 18
-INLINE 0 1521 21 217 6d57 1f
-INLINE 0 1497 21 217 6d76 1f
-INLINE 0 1512 21 217 6d95 1f
-INLINE 0 1526 21 217 6db8 8
-INLINE 1 214 2 220 6db8 8
-INLINE 0 1526 21 217 6dcb 32
-INLINE 1 214 2 220 6dcb 32
-INLINE 2 217 2 221 6dd5 18
+INLINE 0 1491 21 282 6b8b 20
+INLINE 1 212 2 283 6b8b 20
+INLINE 2 210 2 7 6b8b 11
+INLINE 3 160 2 8 6b90 3
+INLINE 0 1494 21 133 6bb4 e
+INLINE 1 250 6 48 6bb4 e
+INLINE 0 1497 21 284 6bca 9 6bd6 1d 6d76 1f
+INLINE 0 1501 21 10 6c02 f
+INLINE 0 1506 21 285 6c1a 4c
+INLINE 0 1512 21 286 6c86 2c 6d95 1f
+INLINE 0 1521 21 286 6ce8 28 6d57 1f
+INLINE 0 1526 21 287 6d21 22 6db8 8 6dcb 32
+INLINE 1 214 2 288 6d21 22 6db8 8 6dcb 32
+INLINE 2 217 2 289 6d2b 18 6dd5 18
 6b70 17 1490 21
 6b87 4 1491 21
 6b8b 5 159 2
@@ -4234,20 +3608,15 @@ INLINE 2 217 2 221 6dd5 18
 6dd5 20 92 1
 6df5 8 217 2
 FUNC 6e00 259 0 google_breakpad::MinidumpGenerator::WriteMiscInfoStream(MDRawDirectory*)
-INLINE 0 1529 21 222 6e21 24
-INLINE 1 212 2 223 6e21 24
-INLINE 2 210 2 224 6e21 1a
-INLINE 3 160 2 9 6e29 3
-INLINE 0 1531 21 222 6e45 1d
-INLINE 0 1535 21 222 6e70 15
-INLINE 0 1577 21 222 6fbc 2b
-INLINE 1 214 2 225 6fbc 2b
-INLINE 2 217 2 226 6fc6 21
-INLINE 0 1577 21 222 700b 8
-INLINE 1 214 2 225 700b 8
-INLINE 0 1577 21 222 701e 3b
-INLINE 1 214 2 225 701e 3b
-INLINE 2 217 2 226 7028 21
+INLINE 0 1529 21 290 6e21 24
+INLINE 1 212 2 291 6e21 24
+INLINE 2 210 2 7 6e21 1a
+INLINE 3 160 2 8 6e29 3
+INLINE 0 1531 21 292 6e45 1d
+INLINE 0 1535 21 10 6e70 15
+INLINE 0 1577 21 293 6fbc 2b 700b 8 701e 3b
+INLINE 1 214 2 294 6fbc 2b 700b 8 701e 3b
+INLINE 2 217 2 295 6fc6 21 7028 21
 6e00 1d 1528 21
 6e1d 4 1529 21
 6e21 8 159 2
@@ -4292,20 +3661,15 @@ INLINE 2 217 2 226 7028 21
 7028 29 92 1
 7051 8 217 2
 FUNC 7060 10b 0 google_breakpad::MinidumpGenerator::WriteBreakpadInfoStream(MDRawDirectory*)
-INLINE 0 1581 21 227 7071 26
-INLINE 1 212 2 228 7071 26
-INLINE 2 210 2 229 7071 b
-INLINE 3 160 2 9 7075 3
-INLINE 0 1583 21 227 7097 16
-INLINE 0 1587 21 227 70b8 f
-INLINE 0 1602 21 227 710a 1e
-INLINE 1 214 2 230 710a 1e
-INLINE 2 217 2 231 7111 17
-INLINE 0 1602 21 227 7132 8
-INLINE 1 214 2 230 7132 8
-INLINE 0 1602 21 227 713d 2e
-INLINE 1 214 2 230 713d 2e
-INLINE 2 217 2 231 7144 17
+INLINE 0 1581 21 296 7071 26
+INLINE 1 212 2 297 7071 26
+INLINE 2 210 2 7 7071 b
+INLINE 3 160 2 8 7075 3
+INLINE 0 1583 21 298 7097 16
+INLINE 0 1587 21 10 70b8 f
+INLINE 0 1602 21 299 710a 1e 7132 8 713d 2e
+INLINE 1 214 2 300 710a 1e 7132 8 713d 2e
+INLINE 2 217 2 301 7111 17 7144 17
 7060 d 1580 21
 706d 4 1581 21
 7071 4 159 2
@@ -4355,33 +3719,25 @@ FUNC 7170 113 0 google_breakpad::MinidumpGenerator::CalculateStackSize(unsigned 
 7260 14 333 21
 7274 f 334 21
 FUNC 7290 176 0 google_breakpad::MinidumpGenerator::WriteStackFromStartAddress(unsigned long long, MDMemoryDescriptor*)
-INLINE 0 339 21 232 72a9 15
-INLINE 1 161 2 15 72a9 15
-INLINE 2 160 2 9 72ae 3
-INLINE 0 365 21 232 72ef 11
+INLINE 0 339 21 14 72a9 15
+INLINE 1 161 2 7 72a9 15
+INLINE 2 160 2 8 72ae 3
+INLINE 0 365 21 33 72ef 11
 INLINE 1 485 9 34 72ef 11
 INLINE 2 484 9 35 72ef 11
-INLINE 0 373 21 232 731f 5
-INLINE 0 373 21 232 7324 14
-INLINE 0 374 21 232 733b 1b
-INLINE 1 458 9 36 733b 1b
-INLINE 2 458 9 37 733b 1b
-INLINE 3 452 9 38 7345 c
-INLINE 4 369 9 39 7345 c
-INLINE 3 453 9 38 7351 5
-INLINE 4 1508 10 40 7351 5
-INLINE 5 1743 10 41 7351 5
-INLINE 0 358 21 232 7379 23
-INLINE 0 375 21 232 73a0 17
-INLINE 0 380 21 232 73ba f
-INLINE 0 374 21 232 73e3 1b
-INLINE 1 458 9 36 73e3 1b
-INLINE 2 458 9 37 73e3 1b
-INLINE 3 452 9 38 73ed c
-INLINE 4 369 9 39 73ed c
-INLINE 3 453 9 38 73f9 5
-INLINE 4 1508 10 40 73f9 5
-INLINE 5 1743 10 41 73f9 5
+INLINE 0 373 21 36 731f 5
+INLINE 0 373 21 15 7324 14
+INLINE 0 374 21 37 733b 1b 73e3 1b
+INLINE 1 458 9 38 733b 1b 73e3 1b
+INLINE 2 458 9 39 733b 1b 73e3 1b
+INLINE 3 452 9 40 7345 c 73ed c
+INLINE 4 369 9 41 7345 c 73ed c
+INLINE 3 453 9 42 7351 5 73f9 5
+INLINE 4 1508 10 43 7351 5 73f9 5
+INLINE 5 1743 10 44 7351 5 73f9 5
+INLINE 0 358 21 15 7379 23
+INLINE 0 375 21 15 73a0 17
+INLINE 0 380 21 10 73ba f
 7290 15 338 21
 72a5 4 339 21
 72a9 5 159 2
@@ -4401,7 +3757,7 @@ INLINE 5 1743 10 41 73f9 5
 7340 5 450 9
 7345 7 424 9
 734c 5 425 9
-7351 e 177 10
+7351 e 177 11
 735f e 350 21
 736d c 355 21
 7379 27 186 2
@@ -4417,10 +3773,10 @@ INLINE 5 1743 10 41 73f9 5
 73e8 5 450 9
 73ed 7 424 9
 73f4 5 425 9
-73f9 d 177 10
+73f9 d 177 11
 FUNC 7410 24 0 google_breakpad::MinidumpGenerator::WriteStack(unsigned int*, MDMemoryDescriptor*)
-INLINE 0 404 21 233 7420 5
-INLINE 0 406 21 233 7425 b
+INLINE 0 404 21 302 7420 5
+INLINE 0 406 21 303 7425 b
 7410 10 387 21
 7420 5 775 21
 7425 4 785 21
@@ -4438,20 +3794,15 @@ FUNC 7460 22 0 google_breakpad::MinidumpGenerator::WriteContext(unsigned int*, M
 7477 9 434 21
 7480 2 439 21
 FUNC 7490 1a7 0 google_breakpad::MinidumpGenerator::WriteContextX86(unsigned int*, MDLocationDescriptor*)
-INLINE 0 808 21 234 74b6 1b
-INLINE 1 212 2 235 74b6 1b
-INLINE 2 210 2 236 74b6 11
-INLINE 3 160 2 9 74bb 3
-INLINE 0 812 21 234 74d1 1a
-INLINE 0 815 21 234 74f3 f
-INLINE 0 843 21 234 75b2 22
-INLINE 1 214 2 237 75b2 22
-INLINE 2 217 2 238 75bc 18
-INLINE 0 843 21 234 75fa 8
-INLINE 1 214 2 237 75fa 8
-INLINE 0 843 21 234 7605 32
-INLINE 1 214 2 237 7605 32
-INLINE 2 217 2 238 760f 18
+INLINE 0 808 21 304 74b6 1b
+INLINE 1 212 2 305 74b6 1b
+INLINE 2 210 2 7 74b6 11
+INLINE 3 160 2 8 74bb 3
+INLINE 0 812 21 306 74d1 1a
+INLINE 0 815 21 10 74f3 f
+INLINE 0 843 21 307 75b2 22 75fa 8 7605 32
+INLINE 1 214 2 308 75b2 22 75fa 8 7605 32
+INLINE 2 217 2 309 75bc 18 760f 18
 7490 22 807 21
 74b2 4 808 21
 74b6 5 159 2
@@ -4491,20 +3842,15 @@ INLINE 2 217 2 238 760f 18
 760f 20 92 1
 762f 8 217 2
 FUNC 7640 1c1 0 google_breakpad::MinidumpGenerator::WriteContextX86_64(unsigned int*, MDLocationDescriptor*)
-INLINE 0 848 21 239 7666 1a
-INLINE 1 212 2 240 7666 1a
-INLINE 2 210 2 241 7666 10
-INLINE 3 160 2 9 766a 3
-INLINE 0 852 21 239 7680 19
-INLINE 0 855 21 239 76a1 f
-INLINE 0 890 21 239 777e 21
-INLINE 1 214 2 242 777e 21
-INLINE 2 217 2 243 7788 17
-INLINE 0 890 21 239 77c5 8
-INLINE 1 214 2 242 77c5 8
-INLINE 0 890 21 239 77d0 31
-INLINE 1 214 2 242 77d0 31
-INLINE 2 217 2 243 77da 17
+INLINE 0 848 21 310 7666 1a
+INLINE 1 212 2 311 7666 1a
+INLINE 2 210 2 7 7666 10
+INLINE 3 160 2 8 766a 3
+INLINE 0 852 21 312 7680 19
+INLINE 0 855 21 10 76a1 f
+INLINE 0 890 21 313 777e 21 77c5 8 77d0 31
+INLINE 1 214 2 314 777e 21 77c5 8 77d0 31
+INLINE 2 217 2 315 7788 17 77da 17
 7640 22 847 21
 7662 4 848 21
 7666 4 159 2
@@ -4544,8 +3890,8 @@ INLINE 2 217 2 243 77da 17
 77da 1f 92 1
 77f9 8 217 2
 FUNC 7810 3d 0 google_breakpad::MinidumpGenerator::CurrentPCForStack(unsigned int*)
-INLINE 0 460 21 206 7820 3
-INLINE 0 462 21 206 7825 7
+INLINE 0 460 21 263 7820 3
+INLINE 0 462 21 264 7825 7
 7810 10 443 21
 7820 3 794 21
 7823 2 468 21
@@ -4557,9 +3903,9 @@ FUNC 7850 4 0 google_breakpad::MinidumpGenerator::CurrentPCForStackX86(unsigned 
 FUNC 7860 8 0 google_breakpad::MinidumpGenerator::CurrentPCForStackX86_64(unsigned int*)
 7860 8 802 21
 FUNC 7870 b5 0 google_breakpad::MinidumpGenerator::GetThreadState(unsigned int, unsigned int*, unsigned int*)
-INLINE 0 921 21 203 78d2 3
-INLINE 1 2591 5 204 78d2 3
-INLINE 2 2583 5 205 78d2 3
+INLINE 0 921 21 260 78d2 3
+INLINE 1 2591 5 261 78d2 3
+INLINE 2 2583 5 140 78d2 3
 7870 12 895 21
 7882 10 896 21
 7892 3 918 21
@@ -4579,20 +3925,15 @@ INLINE 2 2583 5 205 78d2 3
 7911 9 962 21
 791a b 963 21
 FUNC 7930 1a6 0 google_breakpad::MinidumpGenerator::WriteThreadStream(unsigned int, MDRawThread*)
-INLINE 0 971 21 244 7964 92
-INLINE 0 971 21 244 79fe 4
-INLINE 0 972 21 244 7a02 4
-INLINE 0 972 21 244 7a0a 27
-INLINE 1 406 21 233 7a1b 7
-INLINE 1 404 21 233 7a22 4
-INLINE 1 406 21 233 7a26 b
-INLINE 0 975 21 244 7a35 29
-INLINE 1 1590 9 207 7a45 f
-INLINE 2 1514 10 208 7a45 f
-INLINE 3 1668 10 209 7a45 f
-INLINE 0 975 21 244 7a62 8
-INLINE 0 977 21 244 7a6e 1d
-INLINE 0 977 21 244 7a96 8
+INLINE 0 971 21 259 7964 92 79fe 4
+INLINE 0 972 21 316 7a02 4 7a0a 27
+INLINE 1 406 21 303 7a1b 7 7a26 b
+INLINE 1 404 21 302 7a22 4
+INLINE 0 975 21 265 7a35 29 7a62 8
+INLINE 1 1590 9 266 7a45 f
+INLINE 2 1514 10 267 7a45 f
+INLINE 3 1668 10 268 7a45 f
+INLINE 0 977 21 317 7a6e 1d 7a96 8
 7930 2c 966 21
 795c 8 968 21
 7964 11 896 21
@@ -4615,7 +3956,7 @@ INLINE 0 977 21 244 7a96 8
 7a26 b 786 21
 7a31 4 972 21
 7a35 10 1587 9
-7a45 f 1752 12
+7a45 f 1752 10
 7a54 a 1593 9
 7a5e 4 975 21
 7a62 8 1596 9
@@ -4628,31 +3969,23 @@ INLINE 0 977 21 244 7a96 8
 7aa2 1d 980 21
 7abf 17 986 21
 FUNC 7ae0 272 0 google_breakpad::MinidumpGenerator::WriteExceptionStream(MDRawDirectory*)
-INLINE 0 1137 21 245 7b09 1b
-INLINE 1 212 2 246 7b09 1b
-INLINE 2 210 2 247 7b09 11
-INLINE 3 160 2 9 7b0e 3
-INLINE 0 1139 21 245 7b24 1a
-INLINE 0 1143 21 245 7b4d f
-INLINE 0 1156 21 245 7b7f a7
-INLINE 1 921 21 203 7bd5 3
-INLINE 2 2591 5 204 7bd5 3
-INLINE 3 2583 5 205 7bd5 3
-INLINE 0 1156 21 245 7c2e 4
-INLINE 0 1159 21 245 7c32 3
-INLINE 0 1159 21 245 7c3d 31
-INLINE 0 1165 21 245 7c82 20
-INLINE 1 460 21 206 7c91 9
-INLINE 1 462 21 206 7c9a 8
-INLINE 0 1168 21 245 7ca9 22
-INLINE 1 214 2 248 7ca9 22
-INLINE 2 217 2 249 7cb3 18
-INLINE 0 1165 21 245 7cf4 1f
-INLINE 0 1168 21 245 7d13 8
-INLINE 1 214 2 248 7d13 8
-INLINE 0 1168 21 245 7d20 32
-INLINE 1 214 2 248 7d20 32
-INLINE 2 217 2 249 7d2a 18
+INLINE 0 1137 21 318 7b09 1b
+INLINE 1 212 2 319 7b09 1b
+INLINE 2 210 2 7 7b09 11
+INLINE 3 160 2 8 7b0e 3
+INLINE 0 1139 21 320 7b24 1a
+INLINE 0 1143 21 10 7b4d f
+INLINE 0 1156 21 259 7b7f a7 7c2e 4
+INLINE 1 921 21 260 7bd5 3
+INLINE 2 2591 5 261 7bd5 3
+INLINE 3 2583 5 140 7bd5 3
+INLINE 0 1159 21 317 7c32 3 7c3d 31
+INLINE 0 1165 21 262 7c82 20 7cf4 1f
+INLINE 1 460 21 263 7c91 9
+INLINE 1 462 21 264 7c9a 8
+INLINE 0 1168 21 321 7ca9 22 7d13 8 7d20 32
+INLINE 1 214 2 322 7ca9 22 7d13 8 7d20 32
+INLINE 2 217 2 323 7cb3 18 7d2a 18
 7ae0 25 1136 21
 7b05 4 1137 21
 7b09 5 159 2
@@ -4710,28 +4043,21 @@ INLINE 2 217 2 249 7d2a 18
 7d2a 20 92 1
 7d4a 8 217 2
 FUNC 7d60 399 0 google_breakpad::MinidumpGenerator::WriteModuleStream(unsigned int, MDRawModule*)
-INLINE 0 1298 21 250 7d84 1f
-INLINE 1 254 6 103 7d84 f
-INLINE 1 255 6 103 7d9f 4
-INLINE 0 1307 21 250 7e29 d
-INLINE 0 1308 21 250 7e36 4
-INLINE 1 1631 13 131 7e36 4
-INLINE 2 1633 13 132 7e36 4
-INLINE 3 1791 13 133 7e36 4
-INLINE 0 1308 21 250 7e3e e
-INLINE 1 1631 13 131 7e3e e
-INLINE 2 1633 13 132 7e3e e
-INLINE 3 1791 13 133 7e3e a
-INLINE 0 1311 21 250 7e60 4
-INLINE 0 1312 21 250 7e6c 4
-INLINE 0 1318 21 250 7e7e 21
-INLINE 0 1318 21 250 801a 29
-INLINE 0 1328 21 250 8059 4
-INLINE 0 1335 21 250 807a 4
-INLINE 0 1335 21 250 807e f
-INLINE 1 1631 13 131 807e f
-INLINE 2 1633 13 132 807e f
-INLINE 3 1791 13 133 807e 9
+INLINE 0 1298 21 131 7d84 1f
+INLINE 1 254 6 48 7d84 f
+INLINE 1 255 6 97 7d9f 4
+INLINE 0 1307 21 324 7e29 d
+INLINE 0 1308 21 164 7e36 4 7e3e e
+INLINE 1 1631 13 165 7e36 4 7e3e e 807e f
+INLINE 2 1633 13 166 7e36 4 7e3e e 807e f
+INLINE 3 1791 13 71 7e36 4 807e 9
+INLINE 3 1791 13 167 7e3e a
+INLINE 0 1311 21 325 7e60 4
+INLINE 0 1312 21 326 7e6c 4
+INLINE 0 1318 21 285 7e7e 21 801a 29
+INLINE 0 1328 21 327 8059 4
+INLINE 0 1335 21 328 807a 4
+INLINE 0 1335 21 164 807e f
 7d60 17 1295 21
 7d77 d 1296 21
 7d84 f 642 9
@@ -4808,23 +4134,16 @@ FUNC 8100 4e 0 google_breakpad::MinidumpGenerator::FindExecutableModule()
 813d 8 1410 21
 8145 9 1420 21
 FUNC 8150 3a2 0 google_breakpad::MinidumpGenerator::WriteCVRecord(MDRawModule*, int, char const*, bool)
-INLINE 0 1424 21 251 8183 4e
-INLINE 1 212 2 252 8183 4e
-INLINE 2 210 2 253 8183 12
-INLINE 3 160 2 9 818b 3
-INLINE 0 1437 21 251 81fb 26
-INLINE 0 1440 21 251 8229 2b
-INLINE 0 1443 21 251 825c 15
-INLINE 0 1487 21 251 8400 2b
-INLINE 1 214 2 254 8400 2b
-INLINE 2 217 2 255 840a 21
-INLINE 0 1437 21 251 8453 1f
-INLINE 0 1440 21 251 8477 1f
-INLINE 0 1487 21 251 84ac 8
-INLINE 1 214 2 254 84ac 8
-INLINE 0 1487 21 251 84b7 3b
-INLINE 1 214 2 254 84b7 3b
-INLINE 2 217 2 255 84c1 21
+INLINE 0 1424 21 329 8183 4e
+INLINE 1 212 2 330 8183 4e
+INLINE 2 210 2 7 8183 12
+INLINE 3 160 2 8 818b 3
+INLINE 0 1437 21 331 81fb 26 8453 1f
+INLINE 0 1440 21 332 8229 2b 8477 1f
+INLINE 0 1443 21 10 825c 15
+INLINE 0 1487 21 333 8400 2b 84ac 8 84b7 3b
+INLINE 1 214 2 334 8400 2b 84ac 8 84b7 3b
+INLINE 2 217 2 335 840a 21 84c1 21
 8150 2f 1423 21
 817f 4 1424 21
 8183 8 159 2
@@ -4894,32 +4213,28 @@ INLINE 2 217 2 255 84c1 21
 84c1 29 92 1
 84ea 8 217 2
 FUNC 8500 ad 0 google_breakpad::DynamicImages::~DynamicImages()
-INLINE 0 244 6 256 8508 12
-INLINE 1 250 6 105 8508 12
-INLINE 0 245 6 256 8521 13
-INLINE 0 245 6 256 8539 20
-INLINE 1 109 6 67 8539 20
-INLINE 2 109 6 68 8542 17
-INLINE 3 458 9 36 8542 17
-INLINE 4 458 9 37 8542 17
-INLINE 5 452 9 38 854a a
-INLINE 6 369 9 39 854a a
-INLINE 5 453 9 38 8554 5
-INLINE 6 1508 10 40 8554 5
-INLINE 7 1743 10 41 8554 5
-INLINE 0 244 6 256 8561 8
-INLINE 1 250 6 105 8561 8
-INLINE 0 244 6 256 856c 6
-INLINE 1 250 6 105 856c 6
-INLINE 0 247 6 256 857e 29
-INLINE 1 458 9 98 857e 29
-INLINE 2 458 9 99 857e 29
-INLINE 3 452 9 100 8583 1a
-INLINE 4 369 9 101 8583 1a
-INLINE 5 425 9 79 8588 11
-INLINE 3 453 9 100 859d a
-INLINE 4 1508 10 55 859d a
-INLINE 5 1743 10 56 859d a
+INLINE 0 244 6 133 8508 12 8561 8 856c 6
+INLINE 1 250 6 48 8508 12 8561 8 856c 6
+INLINE 0 245 6 97 8521 13
+INLINE 0 245 6 84 8539 20
+INLINE 1 109 6 85 8539 20
+INLINE 2 109 6 37 8542 17
+INLINE 3 458 9 38 8542 17
+INLINE 4 458 9 39 8542 17
+INLINE 5 452 9 40 854a a
+INLINE 6 369 9 41 854a a
+INLINE 5 453 9 42 8554 5
+INLINE 6 1508 10 43 8554 5
+INLINE 7 1743 10 44 8554 5
+INLINE 0 247 6 127 857e 29
+INLINE 1 458 9 128 857e 29
+INLINE 2 458 9 129 857e 29
+INLINE 3 452 9 130 8583 1a
+INLINE 4 369 9 104 8583 1a
+INLINE 5 425 9 105 8588 11
+INLINE 3 453 9 62 859d a
+INLINE 4 1508 10 63 859d a
+INLINE 5 1743 10 44 859d a
 8500 8 243 6
 8508 12 642 9
 851a 16 244 6
@@ -4930,7 +4245,7 @@ INLINE 5 1743 10 56 859d a
 8545 5 450 9
 854a 6 424 9
 8550 4 425 9
-8554 5 177 10
+8554 5 177 11
 8559 8 245 6
 8561 8 642 9
 8569 3 244 6
@@ -4940,22 +4255,19 @@ INLINE 5 1743 10 56 859d a
 8583 5 424 9
 8588 11 0 9
 8599 4 425 9
-859d a 177 10
+859d a 177 11
 85a7 6 247 6
 FUNC 85b0 158 0 std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::__split_buffer(unsigned long, unsigned long, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&)
-INLINE 0 309 12 159 85c4 c
-INLINE 1 2427 10 257 85c4 c
-INLINE 2 2427 10 258 85c4 c
-INLINE 0 311 12 159 85d9 db
-INLINE 1 1500 10 160 85d9 db
-INLINE 2 190 22 162 85ed ba
-INLINE 3 91 22 167 8622 43
-INLINE 0 311 12 159 86e0 24
-INLINE 1 1500 10 160 86e0 24
-INLINE 2 190 22 162 86e0 24
-85b0 14 310 11
-85c4 c 2065 12
-85d0 9 311 11
+INLINE 0 309 12 336 85c4 c
+INLINE 1 2427 10 337 85c4 c
+INLINE 2 2427 10 338 85c4 c
+INLINE 0 311 12 205 85d9 db 86e0 24
+INLINE 1 1500 10 206 85d9 db 86e0 24
+INLINE 2 190 22 209 85ed ba 86e0 24
+INLINE 3 91 22 215 8622 43
+85b0 14 310 12
+85c4 c 2065 10
+85d0 9 311 12
 85d9 7 186 22
 85e0 a 187 22
 85ea 3 190 22
@@ -4977,120 +4289,87 @@ INLINE 2 190 22 162 86e0 24
 86a3 4 100 22
 86a7 9 190 22
 86b0 4 188 22
-86b4 3 311 11
-86b7 f 312 11
-86c6 b 313 11
-86d1 f 314 11
+86b4 3 311 12
+86b7 f 312 12
+86c6 b 313 12
+86d1 f 314 12
 86e0 3 79 22
 86e3 7 80 22
 86ea 5 81 22
 86ef 4 78 22
 86f3 15 83 22
 FUNC 8710 272 0 void std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__push_back_slow_path<MDMemoryDescriptor const&>(MDMemoryDescriptor const&)
-INLINE 0 1575 9 259 871f e
-INLINE 0 1575 9 259 8730 14
-INLINE 1 965 9 260 8741 3
-INLINE 2 645 9 261 8741 3
-INLINE 0 1574 9 259 8744 4
-INLINE 1 351 9 262 8744 4
-INLINE 2 2479 10 263 8744 4
-INLINE 0 1575 9 259 8748 2a
-INLINE 1 965 9 260 8748 e
-INLINE 2 645 9 261 8748 e
-INLINE 1 968 9 260 8769 3
-INLINE 2 2656 5 109 8769 3
-INLINE 3 2648 5 110 8769 3
-INLINE 0 1575 9 259 877c 10
-INLINE 0 1575 9 259 878c 5
-INLINE 0 1577 9 259 8796 e
-INLINE 1 1514 10 208 8796 e
-INLINE 2 1668 10 209 8796 e
-INLINE 0 1579 9 259 87b2 1ab
-INLINE 1 893 9 168 87b9 169
-INLINE 2 1630 10 169 87df 9
-INLINE 3 1514 10 170 87df 9
-INLINE 4 1668 10 171 87df 9
-INLINE 2 1630 10 169 87ec 8
-INLINE 3 1514 10 170 87ec 8
-INLINE 4 1668 10 171 87ec 8
-INLINE 2 1630 10 169 8818 18
-INLINE 3 1514 10 170 8818 18
-INLINE 4 1668 10 171 8818 18
-INLINE 2 1630 10 169 883e 10
-INLINE 3 1514 10 170 883e 10
-INLINE 4 1668 10 171 883e 10
-INLINE 2 1630 10 169 885c 10
-INLINE 3 1514 10 170 885c 10
-INLINE 4 1668 10 171 885c 10
-INLINE 2 1630 10 169 887a 10
-INLINE 3 1514 10 170 887a 10
-INLINE 4 1668 10 171 887a 10
-INLINE 2 1630 10 169 8898 10
-INLINE 3 1514 10 170 8898 10
-INLINE 4 1668 10 171 8898 10
-INLINE 2 1630 10 169 88b6 10
-INLINE 3 1514 10 170 88b6 10
-INLINE 4 1668 10 171 88b6 10
-INLINE 2 1630 10 169 88d4 10
-INLINE 3 1514 10 170 88d4 10
-INLINE 4 1668 10 171 88d4 10
-INLINE 2 1630 10 169 88f2 f
-INLINE 3 1514 10 170 88f2 f
-INLINE 4 1668 10 171 88f2 f
-INLINE 1 894 9 168 8922 3
-INLINE 1 895 9 168 8925 b
-INLINE 1 894 9 168 8930 d
-INLINE 1 895 9 168 893d 9
-INLINE 1 896 9 168 8946 12
-INLINE 0 1580 9 259 895d 1b
-INLINE 1 340 12 264 895d 1b
-INLINE 2 341 12 265 895d 1b
-INLINE 3 86 12 266 895d 1b
-INLINE 4 141 12 267 895d 1b
-INLINE 5 296 12 268 8962 11
+INLINE 0 1575 9 269 871f e 877c 10
+INLINE 0 1575 9 339 8730 14 8748 2a
+INLINE 1 965 9 340 8741 3 8748 e
+INLINE 2 645 9 341 8741 3 8748 e
+INLINE 0 1574 9 228 8744 4
+INLINE 1 351 9 342 8744 4
+INLINE 2 2479 10 343 8744 4
+INLINE 1 968 9 138 8769 3
+INLINE 2 2656 5 139 8769 3
+INLINE 3 2648 5 140 8769 3
+INLINE 0 1575 9 203 878c 5
+INLINE 0 1577 9 266 8796 e
+INLINE 1 1514 10 267 8796 e
+INLINE 2 1668 10 268 8796 e
+INLINE 0 1579 9 216 87b2 1ab
+INLINE 1 893 9 217 87b9 169
+INLINE 2 1630 10 219 87df 9 87ec 8 8818 18 883e 10 885c 10 887a 10 8898 10 88b6 10 88d4 10 88f2 f
+INLINE 3 1514 10 220 87df 9 87ec 8 8818 18 883e 10 885c 10 887a 10 8898 10 88b6 10 88d4 10 88f2 f
+INLINE 4 1668 10 221 87df 9 87ec 8 8818 18 883e 10 885c 10 887a 10 8898 10 88b6 10 88d4 10 88f2 f
+INLINE 1 894 9 218 8922 3 8930 d
+INLINE 1 895 9 218 8925 b 893d 9
+INLINE 1 896 9 218 8946 12
+INLINE 0 1580 9 344 895d 1b
+INLINE 1 340 12 345 895d 1b
+INLINE 2 341 12 346 895d 1b
+INLINE 3 86 12 347 895d 1b
+INLINE 4 141 12 348 895d 1b
+INLINE 5 296 12 349 8962 11
 8710 f 1573 9
 871f e 642 9
 872d 3 1575 9
 8730 9 963 9
 8739 8 964 9
 8741 3 372 9
-8744 4 2123 12
+8744 4 2123 10
 8748 e 372 9
 8756 f 966 9
 8765 4 968 9
 8769 3 702 5
 876c 10 968 9
 877c 10 642 9
-878c 5 310 11
+878c 5 310 12
 8791 5 1577 9
-8796 e 1752 12
+8796 e 1752 10
 87a4 e 1578 9
 87b2 7 893 9
-87b9 9 1628 12
-87c2 1e 1630 12
-87e0 8 1752 12
-87e8 4 1630 12
-87ec 8 1752 12
-87f4 e 1631 12
-8802 5 1628 12
-8807 19 1630 12
-8820 10 1752 12
-8830 e 1631 12
-883e 10 1752 12
-884e e 1631 12
-885c 10 1752 12
-886c e 1631 12
-887a 10 1752 12
-888a e 1631 12
-8898 10 1752 12
-88a8 e 1631 12
-88b6 10 1752 12
-88c6 e 1631 12
-88d4 10 1752 12
-88e4 e 1631 12
-88f2 f 1752 12
-8901 e 1631 12
-890f 13 1628 12
+87b9 9 1628 10
+87c2 1e 1630 10
+87e0 8 1752 10
+87e8 4 1630 10
+87ec 8 1752 10
+87f4 e 1631 10
+8802 5 1628 10
+8807 19 1630 10
+8820 10 1752 10
+8830 e 1631 10
+883e 10 1752 10
+884e e 1631 10
+885c 10 1752 10
+886c e 1631 10
+887a 10 1752 10
+888a e 1631 10
+8898 10 1752 10
+88a8 e 1631 10
+88b6 10 1752 10
+88c6 e 1631 10
+88d4 10 1752 10
+88e4 e 1631 10
+88f2 f 1752 10
+8901 e 1631 10
+890f 13 1628 10
 8922 3 3617 7
 8925 4 3617 7
 8929 7 3618 7
@@ -5102,9 +4381,9 @@ INLINE 5 296 12 268 8962 11
 894a 9 3618 7
 8953 5 3619 7
 8958 5 897 9
-895d 5 295 11
-8962 11 0 11
-8973 5 296 11
+895d 5 295 12
+8962 11 0 12
+8973 5 296 12
 8978 a 1580 9
 FUNC 8990 1a3 0 ConvertUTF32toUTF16
 8990 9 85 23
@@ -5235,14 +4514,7 @@ FUNC 8c60 2e7 0 ConvertUTF16toUTF8
 8f3a 3 296 23
 8f3d a 297 23
 FUNC 8f70 fa 0 isLegalUTF8Sequence
-INLINE 0 349 23 269 8f91 1f
-INLINE 0 349 23 269 8fc4 38
-INLINE 0 349 23 269 9002 24
-INLINE 0 349 23 269 902e 5
-INLINE 0 349 23 269 903b 5
-INLINE 0 349 23 269 9046 8
-INLINE 0 349 23 269 9056 5
-INLINE 0 349 23 269 9061 5
+INLINE 0 349 23 350 8f91 1f 8fc4 38 9002 24 902e 5 903b 5 9046 8 9056 5 9061 5
 8f70 e 345 23
 8f7e f 346 23
 8f8d 4 350 23
@@ -5267,7 +4539,7 @@ INLINE 0 349 23 269 9061 5
 9061 5 334 23
 9066 4 350 23
 FUNC 90d0 26d 0 ConvertUTF8toUTF16
-INLINE 0 366 23 270 912e ce
+INLINE 0 366 23 350 912e ce
 90d0 f 355 23
 90df 8 357 23
 90e7 5 358 23
@@ -5369,8 +4641,7 @@ FUNC 93c0 24b 0 ConvertUTF32toUTF8
 95fd 3 472 23
 9600 b 473 23
 FUNC 9630 3f9 0 ConvertUTF8toUTF32
-INLINE 0 490 23 271 9695 c5
-INLINE 0 490 23 271 9838 cd
+INLINE 0 490 23 350 9695 c5 9838 cd
 9630 d 481 23
 963d 5 482 23
 9642 15 483 23
@@ -5595,24 +4866,19 @@ a408 e 146 24
 a416 57 147 24
 a46d b 148 24
 FUNC a480 ed 0 google_breakpad::UTF8ToUTF16(char const*, std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >*)
-INLINE 0 47 25 272 a49a 3
-INLINE 0 46 25 272 a49d 1e
-INLINE 1 741 9 273 a49d 1e
-INLINE 2 369 9 274 a49d 1e
-INLINE 3 425 9 275 a4a6 11
-INLINE 0 48 25 272 a4d2 3
-INLINE 0 49 25 272 a4da 7
-INLINE 1 645 9 276 a4da 7
-INLINE 0 55 25 272 a4fe 14
-INLINE 1 1996 9 277 a4fe 14
-INLINE 0 55 25 272 a517 3
-INLINE 0 55 25 272 a51a 4
-INLINE 1 1996 9 277 a51a 4
-INLINE 0 55 25 272 a527 3e
-INLINE 1 1996 9 277 a527 9
-INLINE 1 2000 9 277 a54b 1a
-INLINE 2 814 9 278 a54b 1a
-INLINE 3 425 9 275 a550 11
+INLINE 0 47 25 351 a49a 3
+INLINE 0 46 25 352 a49d 1e
+INLINE 1 741 9 353 a49d 1e
+INLINE 2 369 9 354 a49d 1e
+INLINE 3 425 9 355 a4a6 11 a550 11
+INLINE 0 48 25 356 a4d2 3
+INLINE 0 49 25 357 a4da 7
+INLINE 1 645 9 358 a4da 7
+INLINE 0 55 25 359 a4fe 14 a51a 4 a527 3e
+INLINE 1 1996 9 360 a4fe 14 a51a 4 a527 9
+INLINE 0 55 25 356 a517 3
+INLINE 1 2000 9 361 a54b 1a
+INLINE 2 814 9 354 a54b 1a
 a480 d 41 25
 a48d 5 42 25
 a492 5 43 25
@@ -5643,82 +4909,43 @@ a550 11 0 9
 a561 4 425 9
 a565 8 56 25
 FUNC a570 685 0 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::insert(std::__1::__wrap_iter<unsigned short const*>, unsigned long, unsigned short const&)
-INLINE 0 1872 9 283 a5ad a
-INLINE 0 1872 9 283 a5b7 45
-INLINE 1 965 9 284 a5c4 16
-INLINE 2 645 9 276 a5c4 16
-INLINE 1 968 9 284 a5da 3
-INLINE 2 2656 5 109 a5da 3
-INLINE 3 2648 5 110 a5da 3
-INLINE 0 1872 9 283 a60d 24
-INLINE 1 310 12 285 a60d 24
-INLINE 2 311 12 286 a620 11
-INLINE 3 1500 10 287 a620 11
-INLINE 4 1741 10 288 a624 d
-INLINE 0 1861 9 283 a63d c
-INLINE 0 1855 9 283 a652 fa
-INLINE 1 1006 9 289 a68b 11
-INLINE 2 1514 10 290 a68b 11
-INLINE 3 1668 10 291 a68b 11
-INLINE 1 1006 9 289 a6a3 16
-INLINE 2 1514 10 290 a6a3 16
-INLINE 3 1668 10 291 a6a3 16
-INLINE 1 1006 9 289 a6d8 e
-INLINE 2 1514 10 290 a6d8 e
-INLINE 3 1668 10 291 a6d8 e
-INLINE 1 1006 9 289 a6f8 3f
-INLINE 2 1514 10 290 a6f8 3f
-INLINE 3 1668 10 291 a6f8 3f
-INLINE 0 1861 9 283 a761 12b
-INLINE 1 1708 9 292 a7cd 39
-INLINE 2 1514 10 293 a7f1 15
-INLINE 3 1668 10 294 a7f1 15
-INLINE 1 1708 9 292 a813 4b
-INLINE 2 1514 10 293 a819 45
-INLINE 3 1668 10 294 a819 45
-INLINE 1 1711 9 292 a879 13
-INLINE 2 1953 5 295 a879 13
-INLINE 0 1866 9 283 a89d a9
-INLINE 1 2072 5 296 a89d a9
-INLINE 0 1872 9 283 a949 4
-INLINE 1 310 12 285 a949 4
-INLINE 0 1873 9 283 a94d f4
-INLINE 1 222 12 297 a98c 11
-INLINE 2 1514 10 290 a98c 11
-INLINE 3 1668 10 291 a98c 11
-INLINE 1 222 12 297 a9a5 14
-INLINE 2 1514 10 290 a9a5 14
-INLINE 3 1668 10 291 a9a5 14
-INLINE 1 222 12 297 a9d8 e
-INLINE 2 1514 10 290 a9d8 e
-INLINE 3 1668 10 291 a9d8 e
-INLINE 1 222 12 297 a9f8 3f
-INLINE 2 1514 10 290 a9f8 3f
-INLINE 3 1668 10 291 a9f8 3f
-INLINE 0 1874 9 283 aa41 21
-INLINE 1 908 9 298 aa41 21
-INLINE 0 1872 9 283 aa62 9
-INLINE 1 310 12 285 aa62 9
-INLINE 0 1873 9 283 aa6b 5
-INLINE 0 1874 9 283 aa70 39
-INLINE 1 909 9 298 aa7e 16
-INLINE 1 910 9 298 aa99 3
-INLINE 1 911 9 298 aa9c 4
-INLINE 1 912 9 298 aaa0 9
-INLINE 0 1875 9 283 aaa9 a
-INLINE 1 340 12 299 aaa9 a
-INLINE 2 343 12 300 aaae 5
-INLINE 3 1508 10 301 aaae 5
-INLINE 4 1743 10 302 aaae 5
-INLINE 0 1866 9 283 aac5 42
-INLINE 1 2072 5 296 aac5 42
-INLINE 0 1861 9 283 ab17 de
-INLINE 1 1708 9 292 ab38 1c
-INLINE 2 1514 10 293 ab38 1c
-INLINE 3 1668 10 294 ab38 1c
-INLINE 1 1708 9 292 ab81 50
-INLINE 2 1514 10 293 ab81 50
-INLINE 3 1668 10 294 ab81 50
+INLINE 0 1872 9 360 a5ad a
+INLINE 0 1872 9 368 a5b7 45
+INLINE 1 965 9 357 a5c4 16
+INLINE 2 645 9 358 a5c4 16
+INLINE 1 968 9 138 a5da 3
+INLINE 2 2656 5 139 a5da 3
+INLINE 3 2648 5 140 a5da 3
+INLINE 0 1872 9 369 a60d 24 a949 4 aa62 9
+INLINE 1 310 12 370 a60d 24 a949 4 aa62 9
+INLINE 2 311 12 371 a620 11
+INLINE 3 1500 10 372 a620 11
+INLINE 4 1741 10 53 a624 d
+INLINE 0 1861 9 373 a63d c a761 12b ab17 de
+INLINE 0 1855 9 374 a652 fa
+INLINE 1 1006 9 375 a68b 11 a6a3 16 a6d8 e a6f8 3f
+INLINE 2 1514 10 376 a68b 11 a6a3 16 a6d8 e a6f8 3f a98c 11 a9a5 14 a9d8 e a9f8 3f
+INLINE 3 1668 10 377 a68b 11 a6a3 16 a6d8 e a6f8 3f a98c 11 a9a5 14 a9d8 e a9f8 3f
+INLINE 1 1708 9 378 a7cd 39 a813 4b ab38 1c ab81 50
+INLINE 2 1514 10 379 a7f1 15 a819 45 ab38 1c ab81 50
+INLINE 3 1668 10 380 a7f1 15 a819 45 ab38 1c ab81 50
+INLINE 1 1711 9 381 a879 13
+INLINE 2 1953 5 382 a879 13
+INLINE 0 1866 9 383 a89d a9 aac5 42
+INLINE 1 2072 5 384 a89d a9 aac5 42
+INLINE 0 1873 9 385 a94d f4 aa6b 5
+INLINE 1 222 12 375 a98c 11 a9a5 14 a9d8 e a9f8 3f
+INLINE 0 1874 9 386 aa41 21 aa70 39
+INLINE 1 908 9 387 aa41 21
+INLINE 1 909 9 388 aa7e 16
+INLINE 1 910 9 389 aa99 3
+INLINE 1 911 9 389 aa9c 4
+INLINE 1 912 9 389 aaa0 9
+INLINE 0 1875 9 390 aaa9 a
+INLINE 1 340 12 391 aaa9 a
+INLINE 2 343 12 392 aaae 5
+INLINE 3 1508 10 393 aaae 5
+INLINE 4 1743 10 44 aaae 5
 a570 1a 1839 9
 a58a 9 1846 9
 a593 1a 1848 9
@@ -5730,24 +4957,24 @@ a5da 3 702 5
 a5dd 4 968 9
 a5e1 1b 966 9
 a5fc 11 1872 9
-a60d 13 311 11
-a620 4 1741 12
-a624 d 169 10
+a60d 13 311 12
+a620 4 1741 10
+a624 d 169 11
 a631 c 1852 9
 a63d f 1709 9
 a64c 6 1854 9
 a652 39 1003 9
-a68b 11 1752 12
+a68b 11 1752 10
 a69c 14 775 9
-a6b0 9 1752 12
+a6b0 9 1752 10
 a6b9 f 1003 9
 a6c8 18 775 9
-a6e0 6 1752 12
+a6e0 6 1752 10
 a6e6 4 1007 9
 a6ea 3 1008 9
 a6ed 5 1010 9
 a6f2 e 775 9
-a700 37 1752 12
+a700 37 1752 10
 a737 a 1010 9
 a741 7 1003 9
 a748 4 1006 9
@@ -5755,11 +4982,11 @@ a74c c 1858 9
 a758 9 1861 9
 a761 c 1706 9
 a76d 60 1707 9
-a7cd 33 1513 12
-a800 6 1752 12
+a7cd 33 1513 10
+a800 6 1752 10
 a806 d 1707 9
-a813 d 1513 12
-a820 3e 1752 12
+a813 d 1513 10
+a820 3e 1752 10
 a85e 17 1707 9
 a875 4 1709 9
 a879 5 1939 5
@@ -5773,44 +5000,44 @@ a8c9 1d 2047 5
 a8e6 c 2046 5
 a8f2 45 2047 5
 a937 12 2046 5
-a949 4 312 11
-a94d 3f 220 11
-a98c 11 1752 12
-a99d 13 115 11
-a9b0 9 1752 12
-a9b9 f 220 11
-a9c8 18 115 11
-a9e0 6 1752 12
-a9e6 4 223 11
-a9ea 3 224 11
-a9ed 5 225 11
-a9f2 e 115 11
-aa00 37 1752 12
-aa37 a 225 11
-aa41 6 1648 12
-aa47 5 1649 12
-aa4c 16 1650 12
-aa62 9 313 11
-aa6b 5 220 11
+a949 4 312 12
+a94d 3f 220 12
+a98c 11 1752 10
+a99d 13 115 12
+a9b0 9 1752 10
+a9b9 f 220 12
+a9c8 18 115 12
+a9e0 6 1752 10
+a9e6 4 223 12
+a9ea 3 224 12
+a9ed 5 225 12
+a9f2 e 115 12
+aa00 37 1752 10
+aa37 a 225 12
+aa41 6 1648 10
+aa47 5 1649 10
+aa4c 16 1650 10
+aa62 9 313 12
+aa6b 5 220 12
 aa70 e 909 9
-aa7e 3 1583 12
-aa81 5 1584 12
-aa86 b 1586 12
-aa91 8 1587 12
+aa7e 3 1583 10
+aa81 5 1584 10
+aa86 b 1586 10
+aa91 8 1587 10
 aa99 3 3618 7
 aa9c 4 3618 7
 aaa0 9 3618 7
-aaa9 5 342 11
-aaae 5 177 10
+aaa9 5 342 12
+aaae 5 177 11
 aab3 12 1878 9
 aac5 b 2046 5
 aad0 2e 2047 5
 aafe 19 2046 5
 ab17 29 1709 9
-ab40 14 1752 12
+ab40 14 1752 10
 ab54 d 1707 9
 ab61 2f 1709 9
-ab90 41 1752 12
+ab90 41 1752 10
 abd1 24 1707 9
 FUNC ac00 7f 0 google_breakpad::UTF8ToUTF16Char(char const*, int, unsigned short*)
 ac00 14 58 25
@@ -5827,24 +5054,19 @@ ac5d c 76 25
 ac69 7 72 25
 ac70 f 83 25
 FUNC ac80 ed 0 google_breakpad::UTF32ToUTF16(wchar_t const*, std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >*)
-INLINE 0 91 25 279 ac9d 3
-INLINE 0 90 25 279 aca0 1e
-INLINE 1 741 9 273 aca0 1e
-INLINE 2 369 9 274 aca0 1e
-INLINE 3 425 9 275 aca9 11
-INLINE 0 92 25 279 acd3 3
-INLINE 0 93 25 279 acda 7
-INLINE 1 645 9 276 acda 7
-INLINE 0 99 25 279 acfd 14
-INLINE 1 1996 9 277 acfd 14
-INLINE 0 99 25 279 ad15 3
-INLINE 0 99 25 279 ad18 4
-INLINE 1 1996 9 277 ad18 4
-INLINE 0 99 25 279 ad25 3e
-INLINE 1 1996 9 277 ad25 9
-INLINE 1 2000 9 277 ad49 1a
-INLINE 2 814 9 278 ad49 1a
-INLINE 3 425 9 275 ad4e 11
+INLINE 0 91 25 351 ac9d 3
+INLINE 0 90 25 352 aca0 1e
+INLINE 1 741 9 353 aca0 1e
+INLINE 2 369 9 354 aca0 1e
+INLINE 3 425 9 355 aca9 11 ad4e 11
+INLINE 0 92 25 356 acd3 3
+INLINE 0 93 25 357 acda 7
+INLINE 1 645 9 358 acda 7
+INLINE 0 99 25 359 acfd 14 ad18 4 ad25 3e
+INLINE 1 1996 9 360 acfd 14 ad18 4 ad25 9
+INLINE 0 99 25 356 ad15 3
+INLINE 1 2000 9 361 ad49 1a
+INLINE 2 814 9 354 ad49 1a
 ac80 f 85 25
 ac8f 5 86 25
 ac94 5 87 25
@@ -5886,31 +5108,21 @@ adac 4 112 25
 adb0 6 113 25
 adb6 6 115 25
 FUNC adc0 2be 0 google_breakpad::UTF16ToUTF8(std::__1::vector<unsigned short, std::__1::allocator<unsigned short> > const&, bool)
-INLINE 0 138 25 280 add1 3
-INLINE 0 128 25 280 add9 4
-INLINE 0 128 25 280 ade8 c
-INLINE 0 131 25 280 ae0a 9
-INLINE 0 131 25 280 ae7c 4
-INLINE 0 131 25 280 aece d
-INLINE 0 138 25 280 aeee 3
-INLINE 0 149 25 280 af23 18
-INLINE 1 2019 13 85 af23 18
-INLINE 2 1364 13 86 af23 18
-INLINE 3 2421 10 87 af23 18
-INLINE 4 2421 10 88 af23 18
-INLINE 0 152 25 280 af3f 13
-INLINE 1 2019 13 85 af3f 13
-INLINE 0 149 25 280 af52 16
-INLINE 1 2019 13 85 af52 16
-INLINE 2 2021 13 86 af52 8
-INLINE 0 153 25 280 af68 8
-INLINE 1 201 16 281 af68 8
-INLINE 0 153 25 280 af70 d
-INLINE 1 201 16 282 af70 d
-INLINE 0 153 25 280 b05c a
-INLINE 1 201 16 281 b05c a
-INLINE 0 153 25 280 b069 d
-INLINE 1 201 16 282 b069 d
+INLINE 0 138 25 360 add1 3 aeee 3
+INLINE 0 128 25 360 add9 4 ade8 c
+INLINE 0 131 25 362 ae0a 9 aece d
+INLINE 0 131 25 363 ae7c 4
+INLINE 0 149 25 110 af23 18 af52 16
+INLINE 1 2019 13 111 af23 18 af3f 13 af52 16
+INLINE 2 1364 13 112 af23 18
+INLINE 3 2421 10 113 af23 18
+INLINE 4 2421 10 114 af23 18
+INLINE 0 152 25 110 af3f 13
+INLINE 2 2021 13 115 af52 8
+INLINE 0 153 25 364 af68 8 b05c a
+INLINE 1 201 16 365 af68 8 b05c a
+INLINE 0 153 25 366 af70 d b069 d
+INLINE 1 201 16 367 af70 d b069 d
 adc0 11 121 25
 add1 3 642 9
 add4 5 122 25
@@ -5934,7 +5146,7 @@ af00 3 138 25
 af03 5 141 25
 af08 3 142 25
 af0b 18 143 25
-af23 18 2242 12
+af23 18 2242 10
 af3b 4 147 25
 af3f 13 2021 13
 af52 8 644 13
@@ -5947,43 +5159,34 @@ b02a 32 130 25
 b05c d 203 16
 b069 15 203 16
 FUNC b080 114 0 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__append(unsigned long)
-INLINE 0 1041 9 303 b0a7 c
-INLINE 0 1041 9 303 b0b3 14
-INLINE 1 965 9 284 b0c0 7
-INLINE 2 645 9 276 b0c0 7
-INLINE 0 1041 9 303 b0c7 4
-INLINE 0 1041 9 303 b0cb 2b
-INLINE 1 965 9 284 b0cb 9
-INLINE 2 645 9 276 b0cb 9
-INLINE 1 968 9 284 b0d4 3
-INLINE 2 2656 5 109 b0d4 3
-INLINE 3 2648 5 110 b0d4 3
-INLINE 0 1041 9 303 b0f6 9
-INLINE 0 1041 9 303 b0ff 11
-INLINE 1 310 12 285 b0ff 11
-INLINE 2 311 12 286 b104 c
-INLINE 3 1500 10 287 b104 c
-INLINE 4 1741 10 288 b109 7
-INLINE 0 1037 9 303 b110 17
-INLINE 1 984 9 304 b114 8
-INLINE 2 1514 10 305 b114 8
-INLINE 3 1668 10 306 b114 8
-INLINE 0 1041 9 303 b129 8
-INLINE 1 310 12 285 b129 8
-INLINE 0 1042 9 303 b131 14
-INLINE 1 203 12 307 b139 8
-INLINE 2 1514 10 305 b139 8
-INLINE 3 1668 10 306 b139 8
-INLINE 0 1043 9 303 b145 25
-INLINE 1 893 9 308 b145 16
-INLINE 1 894 9 308 b15b 3
-INLINE 1 895 9 308 b15e 4
-INLINE 1 896 9 308 b162 8
-INLINE 0 1044 9 303 b16a 1b
-INLINE 1 340 12 299 b16a 1b
-INLINE 2 343 12 300 b16f 16
-INLINE 3 1508 10 301 b16f 16
-INLINE 4 1743 10 302 b16f 16
+INLINE 0 1041 9 360 b0a7 c b0c7 4 b0f6 9
+INLINE 0 1041 9 368 b0b3 14 b0cb 2b
+INLINE 1 965 9 357 b0c0 7 b0cb 9
+INLINE 2 645 9 358 b0c0 7 b0cb 9
+INLINE 1 968 9 138 b0d4 3
+INLINE 2 2656 5 139 b0d4 3
+INLINE 3 2648 5 140 b0d4 3
+INLINE 0 1041 9 369 b0ff 11 b129 8
+INLINE 1 310 12 370 b0ff 11 b129 8
+INLINE 2 311 12 371 b104 c
+INLINE 3 1500 10 372 b104 c
+INLINE 4 1741 10 53 b109 7
+INLINE 0 1037 9 394 b110 17
+INLINE 1 984 9 395 b114 8
+INLINE 2 1514 10 396 b114 8 b139 8
+INLINE 3 1668 10 397 b114 8 b139 8
+INLINE 0 1042 9 398 b131 14
+INLINE 1 203 12 395 b139 8
+INLINE 0 1043 9 399 b145 25
+INLINE 1 893 9 387 b145 16
+INLINE 1 894 9 389 b15b 3
+INLINE 1 895 9 389 b15e 4
+INLINE 1 896 9 389 b162 8
+INLINE 0 1044 9 390 b16a 1b
+INLINE 1 340 12 391 b16a 1b
+INLINE 2 343 12 392 b16f 16
+INLINE 3 1508 10 393 b16f 16
+INLINE 4 1743 10 44 b16f 16
 b080 11 1035 9
 b091 16 1036 9
 b0a7 c 642 9
@@ -5996,26 +5199,26 @@ b0d4 3 702 5
 b0d7 4 968 9
 b0db 1b 966 9
 b0f6 9 642 9
-b0ff 5 311 11
-b104 5 1741 12
-b109 7 169 10
+b0ff 5 311 12
+b104 5 1741 10
+b109 7 169 11
 b110 4 981 9
-b114 8 1752 12
+b114 8 1752 10
 b11c 5 981 9
 b121 8 984 9
-b129 4 312 11
-b12d 4 313 11
-b131 8 201 11
-b139 8 1752 12
-b141 4 201 11
-b145 3 1648 12
-b148 5 1649 12
-b14d e 1650 12
+b129 4 312 12
+b12d 4 313 12
+b131 8 201 12
+b139 8 1752 10
+b141 4 201 12
+b145 3 1648 10
+b148 5 1649 10
+b14d e 1650 10
 b15b 3 3618 7
 b15e 4 3618 7
 b162 8 3618 7
-b16a 5 342 11
-b16f 16 177 10
+b16a 5 342 12
+b16f 16 177 11
 b185 f 1045 9
 FUNC b1a0 5 0 breakpad::BootstrapRegister(unsigned int, char*, unsigned int)
 b1a0 5 38 26
@@ -6023,7 +5226,7 @@ FUNC b1b0 16 0 google_breakpad::FileID::FileID(char const*)
 b1b0 3 48 27
 b1b3 13 49 27
 FUNC b1d0 16 0 google_breakpad::FileID::FileID(char const*)
-INLINE 0 48 27 309 b1d3 13
+INLINE 0 48 27 400 b1d3 13
 b1d0 3 48 27
 b1d3 13 49 27
 FUNC b1f0 d6 0 google_breakpad::FileID::FileIdentifier(unsigned char*)
@@ -6063,7 +5266,7 @@ b413 99 58 28
 b4ac 16 61 28
 b4c2 13 62 28
 FUNC b4e0 c5 0 MacFileUtilities::MachoID::MachoID(char const*)
-INLINE 0 61 28 310 b4e3 c2
+INLINE 0 61 28 401 b4e3 c2
 b4e0 3 61 28
 b4e3 99 58 28
 b57c 16 61 28
@@ -6076,7 +5279,7 @@ b5c1 83 69 28
 b644 16 70 28
 b65a 16 71 28
 FUNC b670 c0 0 MacFileUtilities::MachoID::MachoID(char const*, void*, unsigned long)
-INLINE 0 70 28 311 b673 bd
+INLINE 0 70 28 402 b673 bd
 b670 3 70 28
 b673 7 66 28
 b67a 7 67 28
@@ -6192,14 +5395,8 @@ bd61 17 219 28
 bd78 6 222 28
 bd7e 2 223 28
 FUNC bd80 598 0 MacFileUtilities::MachoID::WalkerCB(MacFileUtilities::MachoWalker*, load_command*, long long, bool, void*)
-INLINE 0 284 28 312 be95 10
-INLINE 0 284 28 312 beaa 7f
-INLINE 0 317 28 312 c017 19
-INLINE 0 317 28 312 c035 84
-INLINE 0 317 28 312 c11a 19
-INLINE 0 317 28 312 c138 81
-INLINE 0 284 28 312 c232 10
-INLINE 0 284 28 312 c247 82
+INLINE 0 284 28 403 be95 10 beaa 7f c232 10 c247 82
+INLINE 0 317 28 403 c017 19 c035 84 c11a 19 c138 81
 bd80 30 252 28
 bdb0 1e 255 28
 bdce 19 258 28
@@ -6287,90 +5484,82 @@ c356 1c 230 28
 c372 11 233 28
 c383 9 235 28
 FUNC c390 f 0 breakpad_swap_uuid_command(breakpad_uuid_command*)
-INLINE 0 41 29 313 c392 2
-INLINE 1 43 30 314 c392 2
-INLINE 0 42 29 313 c399 2
-INLINE 1 43 30 314 c399 2
+INLINE 0 41 29 404 c392 2
+INLINE 1 43 30 405 c392 2 c399 2
+INLINE 0 42 29 404 c399 2
 c390 2 41 29
-c392 2 60 30
+c392 2 60 31
 c394 2 41 29
 c396 3 42 29
-c399 2 60 30
+c399 2 60 31
 c39b 3 42 29
 c39e 1 43 29
 FUNC c3a0 f 0 breakpad_swap_load_command(load_command*)
-INLINE 0 46 29 315 c3a2 2
-INLINE 1 43 30 314 c3a2 2
-INLINE 0 47 29 315 c3a9 2
-INLINE 1 43 30 314 c3a9 2
+INLINE 0 46 29 404 c3a2 2
+INLINE 1 43 30 405 c3a2 2 c3a9 2
+INLINE 0 47 29 404 c3a9 2
 c3a0 2 46 29
-c3a2 2 60 30
+c3a2 2 60 31
 c3a4 2 46 29
 c3a6 3 47 29
-c3a9 2 60 30
+c3a9 2 60 31
 c3ab 3 47 29
 c3ae 1 48 29
 FUNC c3b0 22 0 breakpad_swap_dylib_command(dylib_command*)
-INLINE 0 51 29 316 c3b4 9
-INLINE 1 43 30 314 c3b4 9
-INLINE 0 56 29 316 c3c4 2
-INLINE 1 43 30 314 c3c4 2
-INLINE 0 57 29 316 c3cc 2
-INLINE 1 43 30 314 c3cc 2
+INLINE 0 51 29 404 c3b4 9
+INLINE 1 43 30 405 c3b4 9 c3c4 2 c3cc 2
+INLINE 0 56 29 404 c3c4 2
+INLINE 0 57 29 404 c3cc 2
 c3b0 4 51 29
-c3b4 9 60 30
+c3b4 9 60 31
 c3bd 4 51 29
 c3c1 3 56 29
-c3c4 2 60 30
+c3c4 2 60 31
 c3c6 3 56 29
 c3c9 3 57 29
-c3cc 2 60 30
+c3cc 2 60 31
 c3ce 3 57 29
 c3d1 1 58 29
 FUNC c3e0 35 0 breakpad_swap_segment_command(segment_command*)
-INLINE 0 61 29 317 c3e2 2
-INLINE 1 43 30 314 c3e2 2
-INLINE 0 62 29 317 c3e9 2
-INLINE 1 43 30 314 c3e9 2
-INLINE 0 64 29 317 c3f3 d
-INLINE 1 43 30 314 c3f3 d
-INLINE 0 68 29 317 c40a 5
-INLINE 1 46 30 318 c40a 5
+INLINE 0 61 29 404 c3e2 2
+INLINE 1 43 30 405 c3e2 2 c3e9 2 c3f3 d
+INLINE 0 62 29 404 c3e9 2
+INLINE 0 64 29 404 c3f3 d
+INLINE 0 68 29 406 c40a 5
+INLINE 1 46 30 405 c40a 5
 c3e0 2 61 29
-c3e2 2 60 30
+c3e2 2 60 31
 c3e4 2 61 29
 c3e6 3 62 29
-c3e9 2 60 30
+c3e9 2 60 31
 c3eb 3 62 29
 c3ee 5 64 29
-c3f3 d 60 30
+c3f3 d 60 31
 c400 5 64 29
 c405 5 68 29
-c40a 5 60 30
+c40a 5 60 31
 c40f 5 68 29
 c414 1 72 29
 FUNC c420 6d 0 breakpad_swap_segment_command_64(segment_command_64*)
-INLINE 0 75 29 319 c423 4
-INLINE 1 43 30 314 c423 4
-INLINE 0 76 29 319 c42d 2
-INLINE 1 43 30 314 c42d 2
-INLINE 0 78 29 319 c437 d
-INLINE 1 44 30 320 c437 d
-INLINE 0 80 29 319 c44e 5
-INLINE 1 44 30 320 c44e 5
-INLINE 0 83 29 319 c47e 9
-INLINE 1 46 30 318 c47e 9
+INLINE 0 75 29 404 c423 4
+INLINE 1 43 30 405 c423 4 c42d 2
+INLINE 0 76 29 404 c42d 2
+INLINE 0 78 29 407 c437 d
+INLINE 1 44 30 408 c437 d c44e 5
+INLINE 0 80 29 407 c44e 5
+INLINE 0 83 29 406 c47e 9
+INLINE 1 46 30 405 c47e 9
 c420 3 75 29
-c423 4 60 30
+c423 4 60 31
 c427 2 75 29
 c429 4 76 29
-c42d 2 60 30
+c42d 2 60 31
 c42f 3 76 29
 c432 5 78 29
-c437 d 74 30
+c437 d 74 31
 c444 5 78 29
 c449 5 80 29
-c44e 5 74 30
+c44e 5 74 31
 c453 5 80 29
 c458 4 83 29
 c45c 4 85 29
@@ -6379,550 +5568,444 @@ c464 4 84 29
 c468 c 83 29
 c474 4 86 29
 c478 6 83 29
-c47e 9 60 30
+c47e 9 60 31
 c487 5 83 29
 c48c 1 87 29
 FUNC c490 f 0 breakpad_swap_fat_header(fat_header*)
-INLINE 0 90 29 321 c492 2
-INLINE 1 43 30 314 c492 2
-INLINE 0 91 29 321 c499 2
-INLINE 1 43 30 314 c499 2
+INLINE 0 90 29 404 c492 2
+INLINE 1 43 30 405 c492 2 c499 2
+INLINE 0 91 29 404 c499 2
 c490 2 90 29
-c492 2 60 30
+c492 2 60 31
 c494 2 90 29
 c496 3 91 29
-c499 2 60 30
+c499 2 60 31
 c49b 3 91 29
 c49e 1 92 29
 FUNC c4a0 87 0 breakpad_swap_fat_arch(fat_arch*, unsigned int)
-INLINE 0 96 29 322 c4b6 9
-INLINE 1 46 30 318 c4b6 9
-INLINE 0 100 29 322 c4c6 2
-INLINE 1 43 30 314 c4c6 2
-INLINE 0 96 29 322 c4e1 8
-INLINE 1 46 30 318 c4e1 8
-INLINE 0 96 29 322 c4f5 5
-INLINE 1 46 30 318 c4f5 5
-INLINE 0 100 29 322 c502 2
-INLINE 1 43 30 314 c502 2
-INLINE 0 96 29 322 c50c 5
-INLINE 1 46 30 318 c50c 5
-INLINE 0 100 29 322 c518 2
-INLINE 1 43 30 314 c518 2
+INLINE 0 96 29 406 c4b6 9 c4e1 8 c4f5 5 c50c 5
+INLINE 1 46 30 405 c4b6 9 c4e1 8 c4f5 5 c50c 5
+INLINE 0 100 29 404 c4c6 2 c502 2 c518 2
+INLINE 1 43 30 405 c4c6 2 c502 2 c518 2
 c4a0 a 95 29
 c4aa c 96 29
-c4b6 9 60 30
+c4b6 9 60 31
 c4bf 4 96 29
 c4c3 3 100 29
-c4c6 2 60 30
+c4c6 2 60 31
 c4c8 8 100 29
 c4d0 11 96 29
-c4e1 f 60 30
+c4e1 f 60 31
 c4f0 5 96 29
-c4f5 5 60 30
+c4f5 5 60 31
 c4fa 5 96 29
 c4ff 3 100 29
-c502 2 60 30
+c502 2 60 31
 c504 3 100 29
 c507 5 96 29
-c50c 5 60 30
+c50c 5 60 31
 c511 5 96 29
 c516 2 100 29
-c518 2 60 30
+c518 2 60 31
 c51a 2 100 29
 c51c a 95 29
 c526 1 102 29
 FUNC c530 2a 0 breakpad_swap_mach_header(mach_header*)
-INLINE 0 105 29 323 c534 9
-INLINE 1 43 30 314 c534 9
-INLINE 0 109 29 323 c544 2
-INLINE 1 43 30 314 c544 2
-INLINE 0 110 29 323 c54c 2
-INLINE 1 43 30 314 c54c 2
-INLINE 0 111 29 323 c554 2
-INLINE 1 43 30 314 c554 2
+INLINE 0 105 29 404 c534 9
+INLINE 1 43 30 405 c534 9 c544 2 c54c 2 c554 2
+INLINE 0 109 29 404 c544 2
+INLINE 0 110 29 404 c54c 2
+INLINE 0 111 29 404 c554 2
 c530 4 105 29
-c534 9 60 30
+c534 9 60 31
 c53d 4 105 29
 c541 3 109 29
-c544 2 60 30
+c544 2 60 31
 c546 3 109 29
 c549 3 110 29
-c54c 2 60 30
+c54c 2 60 31
 c54e 3 110 29
 c551 3 111 29
-c554 2 60 30
+c554 2 60 31
 c556 3 111 29
 c559 1 112 29
 FUNC c560 25 0 breakpad_swap_mach_header_64(mach_header_64*)
-INLINE 0 115 29 324 c564 d
-INLINE 1 43 30 314 c564 d
-INLINE 0 119 29 324 c57a 5
-INLINE 1 43 30 314 c57a 5
+INLINE 0 115 29 404 c564 d
+INLINE 1 43 30 405 c564 d c57a 5
+INLINE 0 119 29 404 c57a 5
 c560 4 115 29
-c564 d 60 30
+c564 d 60 31
 c571 4 115 29
 c575 5 119 29
-c57a 5 60 30
+c57a 5 60 31
 c57f 5 119 29
 c584 1 123 29
 FUNC c590 c8 0 breakpad_swap_section(section*, unsigned int)
-INLINE 0 128 29 325 c5a7 d
-INLINE 1 43 30 314 c5a7 d
-INLINE 0 133 29 325 c5be 5
-INLINE 1 43 30 314 c5be 5
-INLINE 0 137 29 325 c5cb 2
-INLINE 1 43 30 314 c5cb 2
-INLINE 0 128 29 325 c5e9 8
-INLINE 1 43 30 314 c5e9 8
-INLINE 0 128 29 325 c605 5
-INLINE 1 43 30 314 c605 5
-INLINE 0 133 29 325 c614 5
-INLINE 1 43 30 314 c614 5
-INLINE 0 137 29 325 c621 2
-INLINE 1 43 30 314 c621 2
-INLINE 0 128 29 325 c62b 5
-INLINE 1 43 30 314 c62b 5
-INLINE 0 133 29 325 c63a 5
-INLINE 1 43 30 314 c63a 5
-INLINE 0 137 29 325 c646 2
-INLINE 1 43 30 314 c646 2
+INLINE 0 128 29 404 c5a7 d c5e9 8 c605 5 c62b 5
+INLINE 1 43 30 405 c5a7 d c5be 5 c5cb 2 c5e9 8 c605 5 c614 5 c621 2 c62b 5 c63a 5 c646 2
+INLINE 0 133 29 404 c5be 5 c614 5 c63a 5
+INLINE 0 137 29 404 c5cb 2 c621 2 c646 2
 c590 a 127 29
 c59a d 128 29
-c5a7 d 60 30
+c5a7 d 60 31
 c5b4 5 128 29
 c5b9 5 133 29
-c5be 5 60 30
+c5be 5 60 31
 c5c3 5 133 29
 c5c8 3 137 29
-c5cb 2 60 30
+c5cb 2 60 31
 c5cd 8 137 29
 c5d5 14 128 29
-c5e9 17 60 30
+c5e9 17 60 31
 c600 5 128 29
-c605 5 60 30
+c605 5 60 31
 c60a 5 128 29
 c60f 5 133 29
-c614 5 60 30
+c614 5 60 31
 c619 5 133 29
 c61e 3 137 29
-c621 2 60 30
+c621 2 60 31
 c623 3 137 29
 c626 5 128 29
-c62b 5 60 30
+c62b 5 60 31
 c630 5 128 29
 c635 5 133 29
-c63a 5 60 30
+c63a 5 60 31
 c63f 5 133 29
 c644 2 137 29
-c646 2 60 30
+c646 2 60 31
 c648 2 137 29
 c64a d 127 29
 c657 1 139 29
 FUNC c660 5e 0 breakpad_swap_section_64(section_64*, unsigned int)
-INLINE 0 144 29 326 c685 5
-INLINE 1 44 30 320 c685 5
-INLINE 0 147 29 326 c694 5
-INLINE 1 43 30 314 c694 5
-INLINE 0 151 29 326 c6a1 2
-INLINE 1 43 30 314 c6a1 2
-INLINE 0 152 29 326 c6a9 2
-INLINE 1 43 30 314 c6a9 2
-INLINE 0 153 29 326 c6b0 2
-INLINE 1 43 30 314 c6b0 2
+INLINE 0 144 29 407 c685 5
+INLINE 1 44 30 408 c685 5
+INLINE 0 147 29 404 c694 5
+INLINE 1 43 30 405 c694 5 c6a1 2 c6a9 2 c6b0 2
+INLINE 0 151 29 404 c6a1 2
+INLINE 0 152 29 404 c6a9 2
+INLINE 0 153 29 404 c6b0 2
 c660 6 143 29
 c666 1f 144 29
-c685 5 74 30
+c685 5 74 31
 c68a 5 144 29
 c68f 5 147 29
-c694 5 60 30
+c694 5 60 31
 c699 5 147 29
 c69e 3 151 29
-c6a1 2 60 30
+c6a1 2 60 31
 c6a3 3 151 29
 c6a6 3 152 29
-c6a9 2 60 30
+c6a9 2 60 31
 c6ab 3 152 29
 c6ae 2 153 29
-c6b0 2 60 30
+c6b0 2 60 31
 c6b2 2 153 29
 c6b4 9 143 29
 c6bd 1 155 29
 FUNC c6c0 4d 0 MacFileUtilities::MachoWalker::MachoWalker(char const*, bool (*)(MacFileUtilities::MachoWalker*, load_command*, long long, bool, void*), void*)
-c6c0 7 59 31
-c6c7 6 52 31
-c6cd 10 54 31
-c6dd 4 55 31
-c6e1 4 56 31
-c6e5 18 58 31
-c6fd e 60 31
-c70b 2 61 31
+c6c0 7 59 32
+c6c7 6 52 32
+c6cd 10 54 32
+c6dd 4 55 32
+c6e1 4 56 32
+c6e5 18 58 32
+c6fd e 60 32
+c70b 2 61 32
 FUNC c710 4d 0 MacFileUtilities::MachoWalker::MachoWalker(char const*, bool (*)(MacFileUtilities::MachoWalker*, load_command*, long long, bool, void*), void*)
-INLINE 0 59 32 327 c717 44
-c710 7 59 31
-c717 6 52 31
-c71d 10 54 31
-c72d 4 55 31
-c731 4 56 31
-c735 18 58 31
-c74d e 60 31
-c75b 2 61 31
+INLINE 0 59 32 409 c717 44
+c710 7 59 32
+c717 6 52 32
+c71d 10 54 32
+c72d 4 55 32
+c731 4 56 32
+c735 18 58 32
+c74d e 60 32
+c75b 2 61 32
 FUNC c760 2f 0 MacFileUtilities::MachoWalker::MachoWalker(void*, unsigned long, bool (*)(MacFileUtilities::MachoWalker*, load_command*, long long, bool, void*), void*)
-c760 6 65 31
-c766 4 66 31
-c76a 4 67 31
-c76e 4 68 31
-c772 4 69 31
-c776 18 71 31
-c78e 1 73 31
+c760 6 65 32
+c766 4 66 32
+c76a 4 67 32
+c76e 4 68 32
+c772 4 69 32
+c776 18 71 32
+c78e 1 73 32
 FUNC c790 2f 0 MacFileUtilities::MachoWalker::MachoWalker(void*, unsigned long, bool (*)(MacFileUtilities::MachoWalker*, load_command*, long long, bool, void*), void*)
-INLINE 0 72 32 328 c790 2e
-c790 6 65 31
-c796 4 66 31
-c79a 4 67 31
-c79e 4 68 31
-c7a2 4 69 31
-c7a6 18 71 31
-c7be 1 73 31
+INLINE 0 72 32 410 c790 2e
+c790 6 65 32
+c796 4 66 32
+c79a 4 67 32
+c79e 4 68 32
+c7a2 4 69 32
+c7a6 18 71 32
+c7be 1 73 32
 FUNC c7c0 17 0 MacFileUtilities::MachoWalker::~MachoWalker()
-c7c0 8 76 31
-c7c8 5 77 31
-c7cd 2 78 31
-c7cf 8 77 31
+c7c0 8 76 32
+c7c8 5 77 32
+c7cd 2 78 32
+c7cf 8 77 32
 FUNC c7e0 17 0 MacFileUtilities::MachoWalker::~MachoWalker()
-INLINE 0 75 32 329 c7e0 d
-INLINE 0 75 32 329 c7ef 8
-c7e0 8 76 31
-c7e8 5 77 31
-c7ed 2 78 31
-c7ef 8 77 31
+INLINE 0 75 32 411 c7e0 d c7ef 8
+c7e0 8 76 32
+c7e8 5 77 32
+c7ed 2 78 32
+c7ef 8 77 32
 FUNC c800 152 0 MacFileUtilities::MachoWalker::WalkHeader(int, int)
-INLINE 0 93 32 330 c852 49
-INLINE 1 230 32 331 c852 49
-INLINE 0 93 32 330 c8a6 8d
-INLINE 1 230 32 331 c8a6 27
-c800 d 80 31
-c80d 4 84 31
-c811 5 85 31
-c816 9 86 31
-c81f d 87 31
-c82c c 91 31
-c838 6 92 31
-c83e 7 93 31
-c845 d 95 31
-c852 4 112 31
-c856 5 102 31
-c85b 5 103 31
-c860 d 106 31
-c86d 5 107 31
-c872 f 112 31
-c881 1c 115 31
-c89d 9 99 31
-c8a6 27 112 31
-c8cd 4 233 31
-c8d1 d 234 31
-c8de 15 235 31
-c8f3 4 237 31
-c8f7 8 238 31
-c8ff 4 239 31
-c903 4 240 31
-c907 f 241 31
-c916 1d 243 31
-c933 1f 86 31
+INLINE 0 93 32 412 c852 49 c8a6 8d
+INLINE 1 230 32 413 c852 49 c8a6 27
+c800 d 80 32
+c80d 4 84 32
+c811 5 85 32
+c816 9 86 32
+c81f d 87 32
+c82c c 91 32
+c838 6 92 32
+c83e 7 93 32
+c845 d 95 32
+c852 4 112 32
+c856 5 102 32
+c85b 5 103 32
+c860 d 106 32
+c86d 5 107 32
+c872 f 112 32
+c881 1c 115 32
+c89d 9 99 32
+c8a6 27 112 32
+c8cd 4 233 32
+c8d1 d 234 32
+c8de 15 235 32
+c8f3 4 237 32
+c8f7 8 238 32
+c8ff 4 239 32
+c903 4 240 32
+c907 f 241 32
+c916 1d 243 32
+c933 1f 86 32
 FUNC c960 392 0 MacFileUtilities::MachoWalker::FindHeader(int, int, long long&)
-INLINE 0 134 32 332 c979 3c
-INLINE 0 134 32 332 c9c5 6
-INLINE 0 153 32 332 ca0c 20
-INLINE 0 134 32 332 ca31 d
-INLINE 0 171 32 332 ca45 2a
-INLINE 0 153 32 332 ca82 16
-INLINE 0 153 32 332 caa8 21
-INLINE 0 171 32 332 cb10 2f
-INLINE 0 182 32 332 cb76 68
-INLINE 0 182 32 332 cc32 4f
-INLINE 0 182 32 332 ccdc 16
-c960 19 131 31
-c979 4 112 31
-c97d 5 102 31
-c982 a 106 31
-c98c 13 107 31
-c99f 16 115 31
-c9b5 a 134 31
-c9bf 6 141 31
-c9c5 6 112 31
-c9cb a 137 31
-c9d5 37 141 31
-ca0c 4 112 31
-ca10 5 102 31
-ca15 e 106 31
-ca23 e 107 31
-ca31 d 112 31
-ca3e 7 169 31
-ca45 4 112 31
-ca49 9 102 31
-ca52 e 106 31
-ca60 a 107 31
-ca6a 18 112 31
-ca82 16 115 31
-ca98 a 153 31
-caa2 6 156 31
-caa8 21 112 31
-cac9 11 156 31
-cada 5 157 31
-cadf 7 159 31
-cae6 5 160 31
-caeb 6 159 31
-caf1 1f 165 31
-cb10 27 115 31
-cb37 d 112 31
-cb44 5 175 31
-cb49 d 177 31
-cb56 b 181 31
-cb61 1f 189 31
-cb80 4 112 31
-cb84 5 102 31
-cb89 9 103 31
-cb92 11 106 31
-cba3 1d 112 31
-cbc0 1e 115 31
-cbde 10 186 31
-cbee 15 188 31
-cc03 a 195 31
-cc0d 25 181 31
-cc32 4 112 31
-cc36 5 102 31
-cc3b 9 103 31
-cc44 11 106 31
-cc55 1d 112 31
-cc72 f 115 31
-cc81 a 182 31
-cc8b d 186 31
-cc98 7 188 31
-cc9f a 195 31
-cca9 12 181 31
-ccbb 12 200 31
-cccd f 191 31
-ccdc 9 107 31
-cce5 d 112 31
+INLINE 0 134 32 413 c979 3c c9c5 6 ca31 d
+INLINE 0 153 32 413 ca0c 20 ca82 16 caa8 21
+INLINE 0 171 32 413 ca45 2a cb10 2f
+INLINE 0 182 32 413 cb76 68 cc32 4f ccdc 16
+c960 19 131 32
+c979 4 112 32
+c97d 5 102 32
+c982 a 106 32
+c98c 13 107 32
+c99f 16 115 32
+c9b5 a 134 32
+c9bf 6 141 32
+c9c5 6 112 32
+c9cb a 137 32
+c9d5 37 141 32
+ca0c 4 112 32
+ca10 5 102 32
+ca15 e 106 32
+ca23 e 107 32
+ca31 d 112 32
+ca3e 7 169 32
+ca45 4 112 32
+ca49 9 102 32
+ca52 e 106 32
+ca60 a 107 32
+ca6a 18 112 32
+ca82 16 115 32
+ca98 a 153 32
+caa2 6 156 32
+caa8 21 112 32
+cac9 11 156 32
+cada 5 157 32
+cadf 7 159 32
+cae6 5 160 32
+caeb 6 159 32
+caf1 1f 165 32
+cb10 27 115 32
+cb37 d 112 32
+cb44 5 175 32
+cb49 d 177 32
+cb56 b 181 32
+cb61 1f 189 32
+cb80 4 112 32
+cb84 5 102 32
+cb89 9 103 32
+cb92 11 106 32
+cba3 1d 112 32
+cbc0 1e 115 32
+cbde 10 186 32
+cbee 15 188 32
+cc03 a 195 32
+cc0d 25 181 32
+cc32 4 112 32
+cc36 5 102 32
+cc3b 9 103 32
+cc44 11 106 32
+cc55 1d 112 32
+cc72 f 115 32
+cc81 a 182 32
+cc8b d 186 32
+cc98 7 188 32
+cc9f a 195 32
+cca9 12 181 32
+ccbb 12 200 32
+cccd f 191 32
+ccdc 9 107 32
+cce5 d 112 32
 FUNC cd00 e9 0 MacFileUtilities::MachoWalker::WalkHeader64AtOffset(long long)
-INLINE 0 230 32 331 cd0e 74
-cd00 e 228 31
-cd0e 4 112 31
-cd12 5 102 31
-cd17 5 103 31
-cd1c d 106 31
-cd29 5 107 31
-cd2e e 112 31
-cd3c 20 115 31
-cd5c 26 112 31
-cd82 3 233 31
-cd85 c 234 31
-cd91 14 235 31
-cda5 4 237 31
-cda9 8 238 31
-cdb1 4 239 31
-cdb5 4 240 31
-cdb9 f 241 31
-cdc8 18 243 31
-cde0 9 246 31
+INLINE 0 230 32 413 cd0e 74
+cd00 e 228 32
+cd0e 4 112 32
+cd12 5 102 32
+cd17 5 103 32
+cd1c d 106 32
+cd29 5 107 32
+cd2e e 112 32
+cd3c 20 115 32
+cd5c 26 112 32
+cd82 3 233 32
+cd85 c 234 32
+cd91 14 235 32
+cda5 4 237 32
+cda9 8 238 32
+cdb1 4 239 32
+cdb5 4 240 32
+cdb9 f 241 32
+cdc8 18 243 32
+cde0 9 246 32
 FUNC cdf0 116 0 MacFileUtilities::MachoWalker::WalkHeaderAtOffset(long long)
-INLINE 0 204 32 333 cdfe 73
-cdf0 e 202 31
-cdfe 4 112 31
-ce02 5 102 31
-ce07 5 103 31
-ce0c d 106 31
-ce19 5 107 31
-ce1e e 112 31
-ce2c 20 115 31
-ce4c 25 112 31
-ce71 3 207 31
-ce74 c 208 31
-ce80 10 209 31
-ce90 25 214 31
-ceb5 d 215 31
-cec2 4 217 31
-cec6 8 218 31
-cece 4 219 31
-ced2 4 220 31
-ced6 f 221 31
-cee5 18 223 31
-cefd 9 226 31
+INLINE 0 204 32 413 cdfe 73
+cdf0 e 202 32
+cdfe 4 112 32
+ce02 5 102 32
+ce07 5 103 32
+ce0c d 106 32
+ce19 5 107 32
+ce1e e 112 32
+ce2c 20 115 32
+ce4c 25 112 32
+ce71 3 207 32
+ce74 c 208 32
+ce80 10 209 32
+ce90 25 214 32
+ceb5 d 215 32
+cec2 4 217 32
+cec6 8 218 32
+cece 4 219 32
+ced2 4 220 32
+ced6 f 221 32
+cee5 18 223 32
+cefd 9 226 32
 FUNC cf10 5f 0 MacFileUtilities::MachoWalker::ReadBytes(void*, unsigned long, long long)
-cf10 6 101 31
-cf16 4 112 31
-cf1a 5 102 31
-cf1f 5 103 31
-cf24 12 106 31
-cf36 8 107 31
-cf3e 13 112 31
-cf51 15 115 31
-cf66 9 117 31
+cf10 6 101 32
+cf16 4 112 32
+cf1a 5 102 32
+cf1f 5 103 32
+cf24 12 106 32
+cf36 8 107 32
+cf3e 13 112 32
+cf51 15 115 32
+cf66 9 117 32
 FUNC cf70 34 0 MacFileUtilities::MachoWalker::CurrentHeader(mach_header_64*, long long*)
-cf70 9 120 31
-cf79 1e 121 31
-cf97 9 122 31
-cfa0 4 127 31
+cf70 9 120 32
+cf79 1e 121 32
+cf97 9 122 32
+cfa0 4 127 32
 FUNC cfb0 1ab 0 MacFileUtilities::MachoWalker::WalkHeaderCore(long long, unsigned int, bool)
-INLINE 0 252 32 334 cfe1 69
-INLINE 0 252 32 334 d09e 52
-INLINE 0 252 32 334 d134 11
-cfb0 1a 249 31
-cfca f 250 31
-cfd9 17 255 31
-cff0 4 112 31
-cff4 b 102 31
-cfff 9 103 31
-d008 11 106 31
-d019 17 112 31
-d030 1a 115 31
-d04a a 252 31
-d054 8 256 31
-d05c 2b 259 31
-d087 7 262 31
-d08e 12 250 31
-d0a0 4 112 31
-d0a4 b 102 31
-d0af 9 103 31
-d0b8 d 106 31
-d0c5 b 112 31
-d0d0 20 115 31
-d0f0 24 259 31
-d114 7 262 31
-d11b 19 250 31
-d134 5 107 31
-d139 13 112 31
-d14c f 266 31
+INLINE 0 252 32 413 cfe1 69 d09e 52 d134 11
+cfb0 1a 249 32
+cfca f 250 32
+cfd9 17 255 32
+cff0 4 112 32
+cff4 b 102 32
+cfff 9 103 32
+d008 11 106 32
+d019 17 112 32
+d030 1a 115 32
+d04a a 252 32
+d054 8 256 32
+d05c 2b 259 32
+d087 7 262 32
+d08e 12 250 32
+d0a0 4 112 32
+d0a4 b 102 32
+d0af 9 103 32
+d0b8 d 106 32
+d0c5 b 112 32
+d0d0 20 115 32
+d0f0 24 259 32
+d114 7 262 32
+d11b 19 250 32
+d134 5 107 32
+d139 13 112 32
+d14c f 266 32
 FUNC d160 107 0 MacStringUtils::ConvertToString(__CFString const*)
-INLINE 0 39 33 335 d17e 1a
-INLINE 1 1945 13 57 d17e 1a
-INLINE 2 1949 13 58 d17e 1a
-INLINE 0 50 33 335 d1f8 5
-INLINE 0 54 33 335 d20d 8
-INLINE 1 201 16 281 d20d 8
-INLINE 0 50 33 335 d226 1f
-INLINE 0 54 33 335 d24f 8
-INLINE 1 201 16 281 d24f 8
-d160 13 37 32
-d173 b 38 32
+INLINE 0 39 33 65 d17e 1a
+INLINE 1 1945 13 66 d17e 1a
+INLINE 2 1949 13 67 d17e 1a
+INLINE 0 50 33 414 d1f8 5 d226 1f
+INLINE 0 54 33 364 d20d 8 d24f 8
+INLINE 1 201 16 365 d20d 8 d24f 8
+d160 13 37 33
+d173 b 38 33
 d17e 1a 1798 13
-d198 5 41 32
-d19d 10 45 32
-d1ad 1b 46 32
-d1c8 2b 48 32
-d1f3 5 50 32
+d198 5 41 33
+d19d 10 45 33
+d1ad 1b 46 33
+d1c8 2b 48 33
+d1f3 5 50 33
 d1f8 5 220 16
-d1fd 5 50 32
-d202 b 51 32
+d1fd 5 50 33
+d202 b 51 33
 d20d 8 203 16
-d215 11 54 32
+d215 11 54 33
 d226 29 220 16
 d24f 8 203 16
-d257 10 54 32
+d257 10 54 33
 FUNC d270 31d 0 MacStringUtils::IntegerValueAtIndex(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, unsigned int)
-INLINE 0 57 33 336 d286 27
-INLINE 1 2019 13 85 d286 27
-INLINE 2 1364 13 86 d286 11
-INLINE 3 2421 10 87 d286 11
-INLINE 4 2421 10 88 d286 11
-INLINE 0 57 33 336 d2ad 10
-INLINE 1 1945 13 57 d2ad 10
-INLINE 2 1949 13 58 d2ad 10
-INLINE 0 64 33 336 d2c0 d6
-INLINE 1 3595 13 337 d2c0 4
-INLINE 2 1633 13 132 d2c0 4
-INLINE 3 1791 13 133 d2c0 4
-INLINE 1 3595 13 337 d2c4 5
-INLINE 2 1633 13 132 d2c4 5
-INLINE 3 1791 13 133 d2c4 5
-INLINE 1 3595 13 337 d2c9 3
-INLINE 2 1460 13 149 d2c9 3
-INLINE 1 3595 13 337 d2cc 4
-INLINE 2 1633 13 132 d2cc 4
-INLINE 3 1791 13 133 d2cc 4
-INLINE 1 3595 13 337 d2d0 4
-INLINE 2 1460 13 149 d2d0 4
-INLINE 1 3595 13 337 d2d4 11
-INLINE 2 1633 13 132 d2d4 11
-INLINE 3 1791 13 133 d2d4 a
-INLINE 3 1791 13 133 d2de 7
-INLINE 1 3595 13 337 d2e5 23
-INLINE 2 1460 13 149 d2e5 23
-INLINE 1 3595 13 337 d308 12
-INLINE 2 1460 13 149 d308 12
-INLINE 1 3595 13 337 d31a 1e
-INLINE 2 1633 13 132 d31a 1e
-INLINE 3 1791 13 133 d31a a
-INLINE 1 3595 13 337 d338 4
-INLINE 2 1460 13 149 d338 4
-INLINE 1 3595 13 337 d33c d
-INLINE 2 1633 13 132 d33c d
-INLINE 3 1791 13 133 d33c 4
-INLINE 1 3595 13 337 d349 3
-INLINE 2 1460 13 149 d349 3
-INLINE 1 3595 13 337 d34c 3
-INLINE 2 1633 13 132 d34c 3
-INLINE 3 1791 13 133 d34c 3
-INLINE 1 3595 13 337 d34f 4
-INLINE 1 3594 13 337 d353 43
-INLINE 2 1080 13 338 d361 1e
-INLINE 3 646 13 339 d366 e
-INLINE 0 67 33 336 d3af 4
-INLINE 0 69 33 336 d3b9 1b
-INLINE 0 69 33 336 d3d4 66
-INLINE 1 2476 13 59 d3d4 66
-INLINE 2 2462 13 60 d3d4 2d
-INLINE 3 3163 13 61 d3d4 e
-INLINE 3 3171 13 61 d3e2 8
-INLINE 3 3165 13 61 d3ea b
-INLINE 3 3165 13 61 d3f5 3
-INLINE 3 3166 13 61 d3f8 9
-INLINE 2 2463 13 60 d401 b
-INLINE 2 2466 13 60 d429 11
-INLINE 0 72 33 336 d44b 12
-INLINE 1 1631 13 131 d44b 12
-INLINE 2 1633 13 132 d44b 12
-INLINE 3 1791 13 133 d44b 9
-INLINE 0 75 33 336 d46a b7
-INLINE 1 3509 13 340 d46a a
-INLINE 2 1460 13 149 d46a a
-INLINE 1 3509 13 340 d474 5
-INLINE 2 1633 13 132 d474 5
-INLINE 3 1791 13 133 d474 5
-INLINE 1 3509 13 340 d479 4
-INLINE 2 1460 13 149 d479 4
-INLINE 1 3509 13 340 d47d 18
-INLINE 2 1633 13 132 d47d 18
-INLINE 3 1791 13 133 d47d 9
-INLINE 3 1791 13 133 d48a 2
-INLINE 1 3509 13 340 d495 6
-INLINE 2 1460 13 149 d495 6
-INLINE 1 3509 13 340 d49b 5
-INLINE 2 1633 13 132 d49b 5
-INLINE 3 1791 13 133 d49b 5
-INLINE 1 3509 13 340 d4a0 5
-INLINE 2 1460 13 149 d4a0 5
-INLINE 1 3509 13 340 d4a5 11
-INLINE 2 1633 13 132 d4a5 11
-INLINE 3 1791 13 133 d4a5 5
-INLINE 1 3509 13 340 d4b6 6
-INLINE 2 1460 13 149 d4b6 6
-INLINE 1 3509 13 340 d4bc 2
-INLINE 2 1633 13 132 d4bc 2
-INLINE 3 1791 13 133 d4bc 2
-INLINE 1 3509 13 340 d4be 4
-INLINE 1 3508 13 340 d4c2 5f
-INLINE 2 1039 13 341 d4d4 b
-INLINE 2 1039 13 341 d4e5 24
-INLINE 3 1052 5 342 d4e5 f
-INLINE 0 69 33 336 d567 8
-INLINE 1 2476 13 59 d567 8
-INLINE 2 2463 13 60 d567 8
-d270 16 56 32
-d286 11 2242 12
+INLINE 0 57 33 110 d286 27
+INLINE 1 2019 13 111 d286 27
+INLINE 2 1364 13 112 d286 11
+INLINE 3 2421 10 113 d286 11
+INLINE 4 2421 10 114 d286 11
+INLINE 0 57 33 65 d2ad 10
+INLINE 1 1945 13 66 d2ad 10
+INLINE 2 1949 13 67 d2ad 10
+INLINE 0 64 33 415 d2c0 d6
+INLINE 1 3595 13 165 d2c0 4 d2c4 5 d2cc 4 d2d4 11 d31a 1e d33c d d34c 3
+INLINE 2 1633 13 166 d2c0 4 d2c4 5 d2cc 4 d2d4 11 d31a 1e d33c d d34c 3 d44b 12 d474 5 d47d 18 d49b 5 d4a5 11 d4bc 2
+INLINE 3 1791 13 167 d2c0 4 d2c4 5
+INLINE 1 3595 13 189 d2c9 3 d2d0 4 d2e5 23 d308 12 d338 4 d349 3 d34f 4
+INLINE 2 1460 13 71 d2c9 3
+INLINE 3 1791 13 168 d2cc 4 d2de 7 d47d 9 d4a5 5
+INLINE 2 1460 13 191 d2d0 4 d2e5 23 d479 4 d4a0 5
+INLINE 3 1791 13 71 d2d4 a d31a a d33c 4 d34c 3 d44b 9 d474 5 d48a 2 d49b 5 d4bc 2
+INLINE 2 1460 13 190 d308 12 d338 4 d349 3 d46a a d495 6 d4b6 6
+INLINE 1 3594 13 416 d353 43
+INLINE 2 1080 13 417 d361 1e
+INLINE 3 646 13 418 d366 e
+INLINE 0 67 33 189 d3af 4
+INLINE 0 69 33 419 d3b9 1b
+INLINE 0 69 33 68 d3d4 66 d567 8
+INLINE 1 2476 13 69 d3d4 66 d567 8
+INLINE 2 2462 13 70 d3d4 2d
+INLINE 3 3163 13 71 d3d4 e
+INLINE 3 3171 13 72 d3e2 8
+INLINE 3 3165 13 73 d3ea b
+INLINE 3 3165 13 74 d3f5 3
+INLINE 3 3166 13 75 d3f8 9
+INLINE 2 2463 13 76 d401 b d567 8
+INLINE 2 2466 13 67 d429 11
+INLINE 0 72 33 164 d44b 12
+INLINE 1 1631 13 165 d44b 12
+INLINE 0 75 33 420 d46a b7
+INLINE 1 3509 13 189 d46a a d479 4 d495 6 d4a0 5 d4b6 6 d4be 4
+INLINE 1 3509 13 165 d474 5 d47d 18 d49b 5 d4a5 11 d4bc 2
+INLINE 1 3508 13 421 d4c2 5f
+INLINE 2 1039 13 422 d4d4 b d4e5 24
+INLINE 3 1052 5 423 d4e5 f
+d270 16 56 33
+d286 11 2242 10
 d297 16 2021 13
 d2ad 10 1798 13
-d2bd 3 63 32
+d2bd 3 63 33
 d2c0 4 1785 13
 d2c4 5 1785 13
 d2c9 3 1697 13
@@ -6948,9 +6031,9 @@ d374 b 646 13
 d37f 5 1080 13
 d384 f 1079 13
 d393 3 1081 13
-d396 19 66 32
+d396 19 66 33
 d3af 4 1460 13
-d3b3 6 69 32
+d3b3 6 69 33
 d3b9 1b 3369 13
 d3d4 e 1697 13
 d3e2 e 1741 13
@@ -6960,13 +6043,13 @@ d3f8 9 1756 13
 d401 b 1471 13
 d40c 1d 2464 13
 d429 11 1798 13
-d43a a 69 32
-d444 7 71 32
+d43a a 69 33
+d444 7 71 33
 d44b 9 1697 13
 d454 9 1791 13
-d45d 5 72 32
-d462 5 73 32
-d467 3 75 32
+d45d 5 72 33
+d462 5 73 33
+d467 3 75 33
 d46a a 1749 13
 d474 5 1697 13
 d479 4 1759 13
@@ -6992,281 +6075,267 @@ d4f4 8 1051 5
 d4fc 17 1050 5
 d513 5 1041 13
 d518 11 1043 13
-d529 18 63 32
-d541 26 82 32
+d529 18 63 33
+d541 26 82 33
 d567 f 1471 13
-d576 17 82 32
+d576 17 82 33
 FUNC d590 44 0 google_breakpad::MachSendMessage::MachSendMessage(int)
-INLINE 0 39 34 343 d59c a
-INLINE 0 47 34 343 d5b6 6
-INLINE 0 49 34 343 d5bc 3
-INLINE 0 50 34 343 d5bf e
-INLINE 1 68 34 344 d5c6 7
-d590 c 39 33
+INLINE 0 39 34 424 d59c a
+INLINE 0 47 34 425 d5b6 6
+INLINE 0 49 34 426 d5bc 3
+INLINE 0 50 34 427 d5bf e
+INLINE 1 68 34 428 d5c6 7
+d590 c 39 34
 d59c a 203 4
-d5a6 10 44 33
-d5b6 6 138 33
+d5a6 10 44 34
+d5b6 6 138 34
 d5bc 3 177 4
-d5bf 7 65 33
-d5c6 7 87 33
-d5cd 7 51 33
+d5bf 7 65 34
+d5c6 7 87 34
+d5cd 7 51 34
 FUNC d5e0 1a 0 google_breakpad::MachMessage::SetDescriptorCount(int)
-d5e0 3 135 33
-d5e3 2 138 33
-d5e5 8 140 33
-d5ed 5 138 33
-d5f2 5 137 33
-d5f7 2 138 33
-d5f9 1 142 33
+d5e0 3 135 34
+d5e3 2 138 34
+d5e5 8 140 34
+d5ed 5 138 34
+d5f2 5 137 34
+d5f7 2 138 34
+d5f9 1 142 34
 FUNC d600 73 0 google_breakpad::MachMessage::SetData(void*, int)
-INLINE 0 58 34 344 d604 1f
-INLINE 1 81 34 345 d604 4
-INLINE 2 172 4 346 d604 4
-INLINE 1 81 34 345 d60b c
-INLINE 2 172 4 346 d60b 8
-INLINE 0 66 34 344 d63f 8
-INLINE 0 68 34 344 d654 1d
-INLINE 1 81 34 345 d654 c
-INLINE 2 172 4 346 d654 8
-d600 4 56 33
-d604 4 94 33
-d608 3 85 33
-d60b 8 94 33
+INLINE 0 58 34 428 d604 1f
+INLINE 1 81 34 429 d604 4 d60b c d654 c
+INLINE 2 172 4 430 d604 4 d60b 8 d654 8
+INLINE 0 66 34 430 d63f 8
+INLINE 0 68 34 428 d654 1d
+d600 4 56 34
+d604 4 94 34
+d608 3 85 34
+d60b 8 94 34
 d613 4 172 4
-d617 6 82 33
-d61d 3 85 33
-d620 3 87 33
-d623 6 59 33
-d629 d 61 33
-d636 4 65 33
-d63a 5 66 33
-d63f 8 94 33
-d647 d 66 33
-d654 8 94 33
+d617 6 82 34
+d61d 3 85 34
+d620 3 87 34
+d623 6 59 34
+d629 d 61 34
+d636 4 65 34
+d63a 5 66 34
+d63f 8 94 34
+d647 d 66 34
+d654 8 94 34
 d65c 4 172 4
-d660 6 82 33
-d666 6 85 33
-d66c 5 87 33
-d671 2 71 33
+d660 6 82 34
+d666 6 85 34
+d66c 5 87 34
+d671 2 71 34
 FUNC d680 34 0 google_breakpad::MachSendMessage::MachSendMessage(int)
-INLINE 0 39 34 347 d68c 21
-INLINE 1 47 34 343 d696 6
-INLINE 1 49 34 343 d69c 3
-INLINE 1 50 34 343 d69f e
-INLINE 2 68 34 344 d6a6 7
-d680 c 39 33
-d68c a 44 33
-d696 6 138 33
+INLINE 0 39 34 431 d68c 21
+INLINE 1 47 34 425 d696 6
+INLINE 1 49 34 426 d69c 3
+INLINE 1 50 34 427 d69f e
+INLINE 2 68 34 428 d6a6 7
+d680 c 39 34
+d68c a 44 34
+d696 6 138 34
 d69c 3 177 4
-d69f 7 65 33
-d6a6 7 87 33
-d6ad 7 51 33
+d69f 7 65 34
+d6a6 7 87 34
+d6ad 7 51 34
 FUNC d6c0 1c 0 google_breakpad::MachMessage::CalculateSize()
-INLINE 0 81 34 345 d6c0 c
-INLINE 1 172 4 346 d6c0 8
-d6c0 8 94 33
+INLINE 0 81 34 429 d6c0 c
+INLINE 1 172 4 430 d6c0 8
+d6c0 8 94 34
 d6c8 4 172 4
-d6cc 6 82 33
-d6d2 6 85 33
-d6d8 3 87 33
-d6db 1 89 33
+d6cc 6 82 34
+d6d2 6 85 34
+d6d8 3 87 34
+d6db 1 89 34
 FUNC d6e0 e 0 google_breakpad::MachMessage::GetDataPacket()
-d6e0 8 94 33
-d6e8 5 96 33
-d6ed 1 98 33
+d6e0 8 94 34
+d6e8 5 96 34
+d6ed 1 98 34
 FUNC d6f0 17 0 google_breakpad::MachMessage::SetDescriptor(int, google_breakpad::MachMsgPortDescriptor const&)
-d6f0 16 106 33
-d706 1 107 33
+d6f0 16 106 34
+d706 1 107 34
 FUNC d710 aa 0 google_breakpad::MachMessage::AddDescriptor(google_breakpad::MachMsgPortDescriptor const&)
-INLINE 0 113 34 348 d71a 1b
-INLINE 1 81 34 345 d71a c
-INLINE 2 172 4 346 d71a 8
-INLINE 0 113 34 348 d749 5
-INLINE 1 81 34 345 d749 5
-INLINE 2 172 4 346 d749 5
-INLINE 0 125 34 348 d75e 18
-INLINE 0 128 34 348 d776 4
-INLINE 1 81 34 345 d776 4
-INLINE 2 172 4 346 d776 4
-INLINE 0 126 34 348 d77e 13
-INLINE 0 126 34 348 d791 3
-INLINE 0 126 34 348 d794 5
-INLINE 0 128 34 348 d799 19
-INLINE 1 81 34 345 d799 8
-INLINE 2 172 4 346 d799 4
-d710 a 111 33
-d71a 8 94 33
+INLINE 0 113 34 428 d71a 1b d749 5
+INLINE 1 81 34 429 d71a c d749 5 d776 4 d799 8
+INLINE 2 172 4 430 d71a 8 d749 5 d776 4 d799 4
+INLINE 0 125 34 432 d75e 18
+INLINE 0 128 34 428 d776 4 d799 19
+INLINE 0 126 34 425 d77e 13 d794 5
+INLINE 0 126 34 433 d791 3
+d710 a 111 34
+d71a 8 94 34
 d722 4 172 4
-d726 6 82 33
-d72c 6 85 33
-d732 3 87 33
-d735 7 114 33
-d73c d 116 33
-d749 5 96 33
-d74e 10 123 33
-d75e 18 106 33
-d776 4 94 33
-d77a 4 126 33
-d77e 3 135 33
-d781 2 138 33
-d783 8 140 33
-d78b 6 138 33
+d726 6 82 34
+d72c 6 85 34
+d732 3 87 34
+d735 7 114 34
+d73c d 116 34
+d749 5 96 34
+d74e 10 123 34
+d75e 18 106 34
+d776 4 94 34
+d77a 4 126 34
+d77e 3 135 34
+d781 2 138 34
+d783 8 140 34
+d78b 6 138 34
 d791 3 186 4
-d794 3 137 33
-d797 2 138 33
-d799 4 94 33
+d794 3 137 34
+d797 2 138 34
+d799 4 94 34
 d79d 4 172 4
-d7a1 6 82 33
-d7a7 6 85 33
-d7ad 5 87 33
-d7b2 8 131 33
+d7a1 6 82 34
+d7a7 6 85 34
+d7ad 5 87 34
+d7b2 8 131 34
 FUNC d7c0 16 0 google_breakpad::MachMessage::GetDescriptor(int)
-d7c0 2 145 33
-d7c2 3 146 33
-d7c5 c 149 33
-d7d1 4 146 33
-d7d5 1 153 33
+d7c0 2 145 34
+d7c2 3 146 34
+d7c5 c 149 34
+d7d1 4 146 34
+d7d5 1 153 34
 FUNC d7e0 13 0 google_breakpad::MachMessage::GetTranslatedPort(int)
-INLINE 0 158 34 349 d7e7 3
-INLINE 0 158 34 349 d7ea 8
-d7e0 2 156 33
-d7e2 5 157 33
-d7e7 3 149 33
+INLINE 0 158 34 434 d7e7 3
+INLINE 0 158 34 435 d7ea 8
+d7e0 2 156 34
+d7e2 5 157 34
+d7e7 3 149 34
 d7ea 8 135 4
-d7f2 1 161 33
+d7f2 1 161 34
 FUNC d800 83 0 google_breakpad::ReceivePort::ReceivePort(char const*)
-d800 e 167 33
-d80e 9 168 33
-d817 12 170 33
-d829 4 174 33
-d82d 2 178 33
-d82f 11 177 33
-d840 4 182 33
-d844 d 185 33
-d851 f 186 33
-d860 4 188 33
-d864 9 192 33
-d86d 2 194 33
-d86f b 191 33
-d87a 9 195 33
+d800 e 167 34
+d80e 9 168 34
+d817 12 170 34
+d829 4 174 34
+d82d 2 178 34
+d82f 11 177 34
+d840 4 182 34
+d844 d 185 34
+d851 f 186 34
+d860 4 188 34
+d864 9 192 34
+d86d 2 194 34
+d86f b 191 34
+d87a 9 195 34
 FUNC d890 83 0 google_breakpad::ReceivePort::ReceivePort(char const*)
-INLINE 0 167 34 350 d89e 6c
-d890 e 167 33
-d89e 9 168 33
-d8a7 12 170 33
-d8b9 4 174 33
-d8bd 2 178 33
-d8bf 11 177 33
-d8d0 4 182 33
-d8d4 d 185 33
-d8e1 f 186 33
-d8f0 4 188 33
-d8f4 9 192 33
-d8fd 2 194 33
-d8ff b 191 33
-d90a 9 195 33
+INLINE 0 167 34 436 d89e 6c
+d890 e 167 34
+d89e 9 168 34
+d8a7 12 170 34
+d8b9 4 174 34
+d8bd 2 178 34
+d8bf 11 177 34
+d8d0 4 182 34
+d8d4 d 185 34
+d8e1 f 186 34
+d8f0 4 188 34
+d8f4 9 192 34
+d8fd 2 194 34
+d8ff b 191 34
+d90a 9 195 34
 FUNC d920 3f 0 google_breakpad::ReceivePort::ReceivePort()
-d920 6 199 33
-d926 9 200 33
-d92f 12 202 33
-d941 4 206 33
-d945 2 210 33
-d947 11 209 33
-d958 7 213 33
+d920 6 199 34
+d926 9 200 34
+d92f 12 202 34
+d941 4 206 34
+d945 2 210 34
+d947 11 209 34
+d958 7 213 34
 FUNC d960 3f 0 google_breakpad::ReceivePort::ReceivePort()
-INLINE 0 199 34 351 d966 32
-d960 6 199 33
-d966 9 200 33
-d96f 12 202 33
-d981 4 206 33
-d985 2 210 33
-d987 11 209 33
-d998 7 213 33
+INLINE 0 199 34 437 d966 32
+d960 6 199 34
+d966 9 200 34
+d96f 12 202 34
+d981 4 206 34
+d985 2 210 34
+d987 11 209 34
+d998 7 213 34
 FUNC d9a0 a 0 google_breakpad::ReceivePort::ReceivePort(unsigned int)
-d9a0 2 219 33
-d9a2 7 220 33
-d9a9 1 221 33
+d9a0 2 219 34
+d9a2 7 220 34
+d9a9 1 221 34
 FUNC d9b0 a 0 google_breakpad::ReceivePort::ReceivePort(unsigned int)
-INLINE 0 220 34 352 d9b0 9
-d9b0 2 219 33
-d9b2 7 220 33
-d9b9 1 221 33
+INLINE 0 220 34 438 d9b0 9
+d9b0 2 219 34
+d9b2 7 220 34
+d9b9 1 221 34
 FUNC d9c0 23 0 google_breakpad::ReceivePort::~ReceivePort()
-d9c0 7 225 33
-d9c7 12 226 33
-d9d9 2 227 33
-d9db 8 226 33
+d9c0 7 225 34
+d9c7 12 226 34
+d9d9 2 227 34
+d9db 8 226 34
 FUNC d9f0 23 0 google_breakpad::ReceivePort::~ReceivePort()
-INLINE 0 224 34 353 d9f0 19
-INLINE 0 224 34 353 da0b 8
-d9f0 7 225 33
-d9f7 12 226 33
-da09 2 227 33
-da0b 8 226 33
+INLINE 0 224 34 439 d9f0 19 da0b 8
+d9f0 7 225 34
+d9f7 12 226 34
+da09 2 227 34
+da0b 8 226 34
 FUNC da20 66 0 google_breakpad::ReceivePort::WaitForMessage(google_breakpad::MachReceiveMessage*, unsigned int)
-da20 9 231 33
-da29 5 232 33
-da2e 7 237 33
-da35 2 258 33
-da37 6 240 33
-da3d 7 241 33
-da44 7 242 33
-da4b 7 243 33
-da52 7 244 33
-da59 10 247 33
-da69 18 249 33
-da81 5 258 33
+da20 9 231 34
+da29 5 232 34
+da2e 7 237 34
+da35 2 258 34
+da37 6 240 34
+da3d 7 241 34
+da44 7 242 34
+da4b 7 243 34
+da52 7 244 34
+da59 10 247 34
+da69 18 249 34
+da81 5 258 34
 FUNC da90 4b 0 google_breakpad::MachPortSender::MachPortSender(char const*)
-da90 a 264 33
-da9a 8 265 33
-daa2 1b 266 33
-dabd 4 269 33
-dac1 12 272 33
-dad3 8 275 33
+da90 a 264 34
+da9a 8 265 34
+daa2 1b 266 34
+dabd 4 269 34
+dac1 12 272 34
+dad3 8 275 34
 FUNC dae0 4b 0 google_breakpad::MachPortSender::MachPortSender(char const*)
-INLINE 0 264 34 354 daea 39
-dae0 a 264 33
-daea 8 265 33
-daf2 1b 266 33
-db0d 4 269 33
-db11 12 272 33
-db23 8 275 33
+INLINE 0 264 34 440 daea 39
+dae0 a 264 34
+daea 8 265 34
+daf2 1b 266 34
+db0d 4 269 34
+db11 12 272 34
+db23 8 275 34
 FUNC db30 a 0 google_breakpad::MachPortSender::MachPortSender(unsigned int)
-db30 2 279 33
-db32 7 280 33
-db39 1 281 33
+db30 2 279 34
+db32 7 280 34
+db39 1 281 34
 FUNC db40 a 0 google_breakpad::MachPortSender::MachPortSender(unsigned int)
-INLINE 0 280 34 355 db40 9
-db40 2 279 33
-db42 7 280 33
-db49 1 281 33
+INLINE 0 280 34 441 db40 9
+db40 2 279 34
+db42 7 280 34
+db49 1 281 34
 FUNC db50 41 0 google_breakpad::MachPortSender::SendMessage(google_breakpad::MachSendMessage&, unsigned int)
-db50 7 285 33
-db57 9 297 33
-db60 4 286 33
-db64 7 290 33
-db6b 2 304 33
-db6d 6 293 33
-db73 19 295 33
-db8c 5 304 33
+db50 7 285 34
+db57 9 297 34
+db60 4 286 34
+db64 7 290 34
+db6b 2 304 34
+db6d 6 293 34
+db73 19 295 34
+db8c 5 304 34
 FUNC dba0 c3 0 main
-INLINE 0 31 35 356 dbba 2a
-INLINE 1 2019 13 85 dbba 2a
-INLINE 2 1364 13 86 dbba 11
-INLINE 3 2421 10 87 dbba 11
-INLINE 4 2421 10 88 dbba 11
-INLINE 0 32 35 356 dc15 10
-INLINE 1 25 35 357 dc15 10
-dba0 1a 30 34
-dbba 11 2242 12
+INLINE 0 31 35 110 dbba 2a
+INLINE 1 2019 13 111 dbba 2a
+INLINE 2 1364 13 112 dbba 11
+INLINE 3 2421 10 113 dbba 11
+INLINE 4 2421 10 114 dbba 11
+INLINE 0 32 35 442 dc15 10
+INLINE 1 25 35 443 dc15 10
+dba0 1a 30 35
+dbba 11 2242 10
 dbcb 19 2021 13
-dbe4 31 31 34
-dc15 10 21 34
-dc25 31 34 34
-dc56 d 31 34
+dbe4 31 31 35
+dc15 10 21 35
+dc25 31 34 35
+dc56 d 31 35
 FUNC dc70 33 0 (anonymous namespace)::callback(char const*, char const*, void*, bool)
-dc70 9 9 34
-dc79 4 10 34
-dc7d 16 11 34
-dc93 c 13 34
-dc9f 4 16 34
+dc70 9 9 35
+dc79 4 10 35
+dc7d 16 11 35
+dc93 c 13 35
+dc9f 4 16 35


### PR DESCRIPTION
The previous test file was generated before I had ironed out all the bugs in dump_syms.
Now that the bugs are fixed, re-generate the test fixture and update the snapshot.

The specific bugs were wrong function names (every inlinee had its parent function's name
instead of its own name) and sometimes wrong file names (I was missing a call to
source.get_true_id).

With the fixed sym file, these snapshots now match even more closely:
test_objects__breakpad_functions_mac_with_inlines.snap
test_objects__mach_functions.snap

Because one file has mangled names and the other one does not, the incorrect
function names can be easy to miss.