### PR TITLE
Remove one unused lifetime

### DIFF
--- a/symbolic-common/src/types.rs
+++ b/symbolic-common/src/types.rs
@@ -797,6 +797,7 @@ impl fmt::Display for Name<'_> {
 
 macro_rules! impl_eq {
     ($lhs:ty, $rhs: ty) => {
+        #[allow(clippy::extra_unused_lifetimes)]
         impl<'a, 'b> PartialEq<$rhs> for $lhs {
             #[inline]
             fn eq(&self, other: &$rhs) -> bool {
@@ -804,6 +805,7 @@ macro_rules! impl_eq {
             }
         }
 
+        #[allow(clippy::extra_unused_lifetimes)]
         impl<'a, 'b> PartialEq<$lhs> for $rhs {
             #[inline]
             fn eq(&self, other: &$lhs) -> bool {

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -242,7 +242,7 @@ struct DwarfLineProgram<'d> {
     sequences: Vec<DwarfSequence>,
 }
 
-impl<'d, 'a> DwarfLineProgram<'d> {
+impl<'d> DwarfLineProgram<'d> {
     fn prepare(program: IncompleteLineNumberProgram<'d>) -> Self {
         let mut sequences = Vec::new();
         let mut sequence_rows = Vec::<DwarfRow>::new();


### PR DESCRIPTION
New Rust stable, new clippy warnings in CI. The lint job is currently failing because of unused lifetimes.

This PR fixes one of the three.

There are two more clippy warnings of the same type, but those are in macros and I'm not sure what to do about them.