### PR TITLE
Revert "feat: Use pdb_addr2line::TypeFormatter (#426)"

### DIFF
--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -48,13 +48,12 @@ macho = [
 ]
 # PDB/PE processing
 ms = [
-    "elsa",
     "goblin/pe32",
     "goblin/pe64",
     "goblin/std",
     "lazycell",
     "parking_lot",
-    "pdb-addr2line",
+    "pdb",
     "scroll",
     "smallvec",
 ]
@@ -74,7 +73,6 @@ wasm = ["bitvec", "dwarf", "wasmparser"]
 bitvec = { version = "1.0.0", optional = true, features = ["alloc"] }
 dmsort = "1.0.1"
 elementtree = { version = "0.7.0", optional = true }
-elsa = { version = "1.4.0", optional = true }
 fallible-iterator = "0.2.0"
 flate2 = { version = "1.0.13", optional = true, default-features = false, features = [
     "rust_backend",
@@ -89,7 +87,7 @@ lazycell = { version = "1.2.1", optional = true }
 nom = { version = "7.0.0", optional = true }
 nom-supreme = { version = "0.8.0", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
-pdb-addr2line = { version = "0.10.0", optional = true }
+pdb = { version = "0.8.0", optional = true }
 regex = { version = "1.3.5", optional = true }
 # keep this in sync with whatever version `goblin` uses
 scroll = { version = "0.11", optional = true }

--- a/symbolic-debuginfo/src/pdb.rs
+++ b/symbolic-debuginfo/src/pdb.rs
@@ -1,20 +1,21 @@
 //! Support for Program Database, the debug companion format on Windows.
 
 use std::borrow::Cow;
-use std::collections::btree_map::BTreeMap;
+use std::cell::{RefCell, RefMut};
+use std::cmp::Ordering;
+use std::collections::btree_map::{BTreeMap, Entry};
 use std::error::Error;
 use std::fmt;
 use std::io::Cursor;
 use std::sync::Arc;
 
-use elsa::FrozenMap;
+use lazycell::LazyCell;
 use parking_lot::RwLock;
-use pdb_addr2line::pdb::{
-    AddressMap, FallibleIterator, InlineSiteSymbol, LineProgram, MachineType, Module, ModuleInfo,
-    PdbInternalSectionOffset, ProcedureSymbol, RawString, SeparatedCodeSymbol, SymbolData,
-    TypeIndex,
+use pdb::{
+    AddressMap, FallibleIterator, InlineSiteSymbol, ItemIndex, LineProgram, MachineType, Module,
+    ModuleInfo, PdbInternalSectionOffset, ProcedureSymbol, RawString, SeparatedCodeSymbol,
+    SymbolData, TypeIndex,
 };
-use pdb_addr2line::ModuleProvider;
 use smallvec::SmallVec;
 use thiserror::Error;
 
@@ -32,7 +33,7 @@ const MAGIC_BIG: &[u8] = b"Microsoft C/C++ MSF 7.00\r\n\x1a\x44\x53\x00\x00\x00"
 
 // Used for CFI, remove once abstraction is complete
 #[doc(hidden)]
-pub use pdb_addr2line::pdb;
+pub use pdb;
 
 /// The error type for [`PdbError`].
 #[non_exhaustive]
@@ -99,16 +100,6 @@ impl From<pdb::Error> for PdbError {
 impl From<fmt::Error> for PdbError {
     fn from(e: fmt::Error) -> Self {
         Self::new(PdbErrorKind::FormattingFailed, e)
-    }
-}
-
-impl From<pdb_addr2line::Error> for PdbError {
-    fn from(e: pdb_addr2line::Error) -> Self {
-        match e {
-            pdb_addr2line::Error::PdbError(e) => Self::new(PdbErrorKind::BadObject, e),
-            pdb_addr2line::Error::FormatError(e) => Self::new(PdbErrorKind::FormattingFailed, e),
-            e => Self::new(PdbErrorKind::FormattingFailed, e),
-        }
     }
 }
 
@@ -430,25 +421,99 @@ impl<'data, 'object> Iterator for PdbSymbolIterator<'data, 'object> {
     }
 }
 
+struct ItemMap<'s, I: ItemIndex> {
+    iter: pdb::ItemIter<'s, I>,
+    finder: pdb::ItemFinder<'s, I>,
+}
+
+impl<'s, I> ItemMap<'s, I>
+where
+    I: ItemIndex,
+{
+    pub fn try_get(&mut self, index: I) -> Result<pdb::Item<'s, I>, PdbError> {
+        if index <= self.finder.max_index() {
+            return Ok(self.finder.find(index)?);
+        }
+
+        while let Some(item) = self.iter.next()? {
+            self.finder.update(&self.iter);
+            match item.index().partial_cmp(&index) {
+                Some(Ordering::Equal) => return Ok(item),
+                Some(Ordering::Greater) => break,
+                _ => continue,
+            }
+        }
+
+        Err(pdb::Error::TypeNotFound(index.into()).into())
+    }
+}
+
+type TypeMap<'d> = ItemMap<'d, pdb::TypeIndex>;
+type IdMap<'d> = ItemMap<'d, pdb::IdIndex>;
+
 struct PdbStreams<'d> {
     debug_info: Arc<pdb::DebugInformation<'d>>,
     type_info: pdb::TypeInformation<'d>,
     id_info: pdb::IdInformation<'d>,
-    string_table: Option<pdb::StringTable<'d>>,
-
-    pdb: Arc<RwLock<Pdb<'d>>>,
-
-    /// ModuleInfo objects are stored on this object (outside PdbDebugInfo) so that the
-    /// PdbDebugInfo can store a TypeFormatter, which has a lifetime dependency on its
-    /// ModuleProvider, which is this PdbStreams. This is so that TypeFormatter can cache
-    /// CrossModuleImports inside itself, and those have a lifetime dependency on the
-    /// ModuleInfo.
-    module_infos: FrozenMap<usize, Box<ModuleInfo<'d>>>,
 }
 
 impl<'d> PdbStreams<'d> {
     fn from_pdb(pdb: &PdbObject<'d>) -> Result<Self, PdbError> {
         let mut p = pdb.pdb.write();
+
+        Ok(Self {
+            debug_info: pdb.debug_info.clone(),
+            type_info: p.type_information()?,
+            id_info: p.id_information()?,
+        })
+    }
+
+    fn type_map(&self) -> TypeMap<'_> {
+        ItemMap {
+            iter: self.type_info.iter(),
+            finder: self.type_info.finder(),
+        }
+    }
+
+    fn id_map(&self) -> IdMap<'_> {
+        ItemMap {
+            iter: self.id_info.iter(),
+            finder: self.id_info.finder(),
+        }
+    }
+}
+
+struct PdbDebugInfo<'d> {
+    /// The original PDB to load module streams on demand.
+    pdb: Arc<RwLock<Pdb<'d>>>,
+    /// All module headers for repeated iteration.
+    modules: Vec<Module<'d>>,
+    /// Lazy loaded module streams in the same order as headers.
+    module_infos: Vec<LazyCell<Option<ModuleInfo<'d>>>>,
+    /// Cache for module by name lookup for cross module imports.
+    module_exports: RefCell<BTreeMap<pdb::ModuleRef, Option<pdb::CrossModuleExports>>>,
+    /// OMAP structure to map reordered sections to RVAs.
+    address_map: pdb::AddressMap<'d>,
+    /// String table for name lookups.
+    string_table: Option<pdb::StringTable<'d>>,
+    /// Lazy loaded map of the TPI stream.
+    type_map: RefCell<TypeMap<'d>>,
+    /// Lazy loaded map of the IPI stream.
+    id_map: RefCell<IdMap<'d>>,
+}
+
+impl<'d> PdbDebugInfo<'d> {
+    fn build(pdb: &PdbObject<'d>, streams: &'d PdbStreams<'d>) -> Result<Self, PdbError> {
+        let modules = streams.debug_info.modules()?.collect::<Vec<_>>()?;
+        let module_infos = modules.iter().map(|_| LazyCell::new()).collect();
+        let module_exports = RefCell::new(BTreeMap::new());
+        let type_map = RefCell::new(streams.type_map());
+        let id_map = RefCell::new(streams.id_map());
+
+        // Avoid deadlocks by only covering the two access to the address map and string table. For
+        // instance, `pdb.symbol_map()` requires a mutable borrow of the PDB as well.
+        let mut p = pdb.pdb.write();
+        let address_map = p.address_map()?;
 
         // PDB::string_table errors if the named stream for the string table is not present.
         // However, this occurs in certain PDBs and does not automatically indicate an error.
@@ -458,70 +523,17 @@ impl<'d> PdbStreams<'d> {
             Err(e) => return Err(e.into()),
         };
 
-        Ok(Self {
-            string_table,
-            debug_info: pdb.debug_info.clone(),
-            type_info: p.type_information()?,
-            id_info: p.id_information()?,
-            pdb: pdb.pdb.clone(),
-            module_infos: FrozenMap::new(),
-        })
-    }
-}
-
-impl<'d> pdb_addr2line::ModuleProvider<'d> for PdbStreams<'d> {
-    fn get_module_info(
-        &self,
-        module_index: usize,
-        module: &Module,
-    ) -> Result<Option<&ModuleInfo<'d>>, pdb::Error> {
-        if let Some(module_info) = self.module_infos.get(&module_index) {
-            return Ok(Some(module_info));
-        }
-
-        let mut pdb = self.pdb.write();
-        Ok(pdb.module_info(module)?.map(|module_info| {
-            self.module_infos
-                .insert(module_index, Box::new(module_info))
-        }))
-    }
-}
-
-struct PdbDebugInfo<'d> {
-    /// The streams, to load module streams on demand.
-    streams: &'d PdbStreams<'d>,
-    /// OMAP structure to map reordered sections to RVAs.
-    address_map: pdb::AddressMap<'d>,
-    /// String table for name lookups.
-    string_table: Option<&'d pdb::StringTable<'d>>,
-    /// Type formatter for function name strings.
-    type_formatter: pdb_addr2line::TypeFormatter<'d, 'd>,
-}
-
-impl<'d> PdbDebugInfo<'d> {
-    fn build(pdb: &PdbObject<'d>, streams: &'d PdbStreams<'d>) -> Result<Self, PdbError> {
-        let modules = streams.debug_info.modules()?.collect::<Vec<_>>()?;
-
-        // Avoid deadlocks by only covering the two access to the address map. For
-        // instance, `pdb.symbol_map()` requires a mutable borrow of the PDB as well.
-        let mut p = pdb.pdb.write();
-        let address_map = p.address_map()?;
-
         drop(p);
 
         Ok(PdbDebugInfo {
+            pdb: pdb.pdb.clone(),
+            modules,
+            module_infos,
+            module_exports,
             address_map,
-            streams,
-            string_table: streams.string_table.as_ref(),
-            type_formatter: pdb_addr2line::TypeFormatter::new_from_parts(
-                streams,
-                modules,
-                &streams.debug_info,
-                &streams.type_info,
-                &streams.id_info,
-                streams.string_table.as_ref(),
-                Default::default(),
-            )?,
+            string_table,
+            type_map,
+            id_map,
         })
     }
 
@@ -533,27 +545,72 @@ impl<'d> PdbDebugInfo<'d> {
         }
     }
 
-    fn modules(&self) -> &[Module<'d>] {
-        self.type_formatter.modules()
-    }
-
     fn get_module(&'d self, index: usize) -> Result<Option<&ModuleInfo<'_>>, PdbError> {
         // Silently ignore module references out-of-bound
-        let module = match self.modules().get(index) {
-            Some(module) => module,
+        let cell = match self.module_infos.get(index) {
+            Some(cell) => cell,
             None => return Ok(None),
         };
 
-        Ok(self.streams.get_module_info(index, module)?)
+        let module_opt = cell.try_borrow_with(|| {
+            let module = &self.modules[index];
+            self.pdb.write().module_info(module)
+        })?;
+
+        Ok(module_opt.as_ref())
     }
 
     fn file_info(&self, file_info: pdb::FileInfo<'d>) -> Result<FileInfo<'_>, PdbError> {
         let file_path = match self.string_table {
-            Some(string_table) => file_info.name.to_raw_string(string_table)?,
+            Some(ref string_table) => file_info.name.to_raw_string(string_table)?,
             None => "".into(),
         };
 
         Ok(FileInfo::from_path(file_path.as_bytes()))
+    }
+
+    fn get_exports(
+        &'d self,
+        module_ref: pdb::ModuleRef,
+    ) -> Result<Option<pdb::CrossModuleExports>, PdbError> {
+        let name = match self.string_table {
+            Some(ref string_table) => module_ref.0.to_string_lossy(string_table)?,
+            None => return Ok(None),
+        };
+
+        let module_index = self
+            .modules
+            .iter()
+            .position(|m| m.module_name().eq_ignore_ascii_case(&name));
+
+        let module = match module_index {
+            Some(index) => self.get_module(index)?,
+            None => None,
+        };
+
+        Ok(match module {
+            Some(module) => Some(module.exports()?),
+            None => None,
+        })
+    }
+
+    fn resolve_import<I: ItemIndex>(
+        &'d self,
+        cross_ref: pdb::CrossModuleRef<I>,
+    ) -> Result<Option<I>, PdbError> {
+        let pdb::CrossModuleRef(module_ref, local_index) = cross_ref;
+
+        let mut module_exports = self.module_exports.borrow_mut();
+        let exports = match module_exports.entry(module_ref) {
+            Entry::Vacant(vacant) => vacant.insert(self.get_exports(module_ref)?),
+            Entry::Occupied(occupied) => occupied.into_mut(),
+        };
+
+        Ok(if let Some(ref exports) = *exports {
+            exports.resolve_import(local_index)?
+        } else {
+            None
+        })
     }
 }
 
@@ -625,23 +682,278 @@ impl<'session> DebugSession<'session> for PdbDebugSession<'_> {
     }
 }
 
+/// Checks whether the given name declares an anonymous namespace.
+///
+/// ID records specify the mangled format for anonymous namespaces: `?A0x<id>`, where `id` is a hex
+/// identifier of the namespace. Demanglers usually resolve this as "anonymous namespace".
+fn is_anonymous_namespace(name: &str) -> bool {
+    name.strip_prefix("?A0x")
+        .map_or(false, |rest| u32::from_str_radix(rest, 16).is_ok())
+}
+
+/// Formatter for function types.
+///
+/// This formatter currently only contains the minimum implementation requried to format inline
+/// function names without parameters.
+struct TypeFormatter<'u, 'd> {
+    unit: &'u Unit<'d>,
+    type_map: RefMut<'u, TypeMap<'d>>,
+    id_map: RefMut<'u, IdMap<'d>>,
+}
+
+impl<'u, 'd> TypeFormatter<'u, 'd> {
+    /// Creates a new `TypeFormatter`.
+    pub fn new(unit: &'u Unit<'d>) -> Self {
+        Self {
+            unit,
+            type_map: unit.debug_info.type_map.borrow_mut(),
+            id_map: unit.debug_info.id_map.borrow_mut(),
+        }
+    }
+
+    /// Writes the `Id` with the given index.
+    pub fn write_id<W: fmt::Write>(
+        &mut self,
+        target: &mut W,
+        index: pdb::IdIndex,
+    ) -> Result<(), PdbError> {
+        let index = match self.unit.resolve_index(index)? {
+            Some(index) => index,
+            None => return Ok(write!(target, "<redacted>")?),
+        };
+
+        let id = self.id_map.try_get(index)?;
+        match id.parse() {
+            Ok(pdb::IdData::Function(data)) => {
+                if let Some(scope) = data.scope {
+                    self.write_id(target, scope)?;
+                    write!(target, "::")?;
+                }
+
+                write!(target, "{}", data.name.to_string())?;
+            }
+            Ok(pdb::IdData::MemberFunction(data)) => {
+                self.write_type(target, data.parent)?;
+                write!(target, "::{}", data.name.to_string())?;
+            }
+            Ok(pdb::IdData::BuildInfo(_)) => {
+                // nothing to do
+            }
+            Ok(pdb::IdData::StringList(data)) => {
+                write!(target, "\"")?;
+                for (i, string_index) in data.substrings.iter().enumerate() {
+                    if i > 0 {
+                        write!(target, "\" \"")?;
+                    }
+                    self.write_type(target, *string_index)?;
+                }
+                write!(target, "\"")?;
+            }
+            Ok(pdb::IdData::String(data)) => {
+                let mut string = data.name.to_string();
+
+                if is_anonymous_namespace(&string) {
+                    string = Cow::Borrowed("`anonymous namespace'");
+                }
+
+                write!(target, "{}", string)?;
+            }
+            Ok(pdb::IdData::UserDefinedTypeSource(_)) => {
+                // nothing to do.
+            }
+            Ok(_) => {
+                // non_exhaustive match
+            }
+            Err(pdb::Error::UnimplementedTypeKind(_)) => {
+                write!(target, "<unknown>")?;
+            }
+            Err(e) => return Err(e.into()),
+        }
+
+        Ok(())
+    }
+
+    /// Writes the `Type` with the given index.
+    pub fn write_type<W: fmt::Write>(
+        &mut self,
+        target: &mut W,
+        index: pdb::TypeIndex,
+    ) -> Result<(), PdbError> {
+        let index = match self.unit.resolve_index(index)? {
+            Some(index) => index,
+            None => return Ok(write!(target, "<redacted>")?),
+        };
+
+        let ty = self.type_map.try_get(index)?;
+        match ty.parse() {
+            Ok(pdb::TypeData::Primitive(_)) => {
+                // nothing to do
+            }
+            Ok(pdb::TypeData::Class(data)) => {
+                write!(target, "{}", data.name.to_string())?;
+            }
+            Ok(pdb::TypeData::Member(_)) => {
+                // nothing to do
+            }
+            Ok(pdb::TypeData::MemberFunction(data)) => {
+                self.write_type(target, data.return_type)?;
+                write!(target, " ")?;
+                self.write_type(target, data.class_type)?;
+                write!(target, "::")?;
+                self.write_type(target, data.argument_list)?;
+            }
+            Ok(pdb::TypeData::OverloadedMethod(_)) => {
+                // nothing to do
+            }
+            Ok(pdb::TypeData::Method(_)) => {
+                // nothing to do
+            }
+            Ok(pdb::TypeData::StaticMember(_)) => {
+                // nothing to do
+            }
+            Ok(pdb::TypeData::Nested(_)) => {
+                // nothing to do
+            }
+            Ok(pdb::TypeData::BaseClass(_)) => {
+                // nothing to do
+            }
+            Ok(pdb::TypeData::VirtualBaseClass(_)) => {
+                // nothing to do
+            }
+            Ok(pdb::TypeData::VirtualFunctionTablePointer(_)) => {
+                // nothing to do
+            }
+            Ok(pdb::TypeData::Procedure(data)) => {
+                match data.return_type {
+                    Some(return_type) => self.write_type(target, return_type)?,
+                    None => write!(target, "void")?,
+                }
+
+                write!(target, " ")?;
+                self.write_type(target, data.argument_list)?;
+            }
+            Ok(pdb::TypeData::Pointer(data)) => {
+                self.write_type(target, data.underlying_type)?;
+
+                if let Some(containing_class) = data.containing_class {
+                    write!(target, " ")?;
+                    self.write_type(target, containing_class)?;
+                } else {
+                    match data.attributes.pointer_mode() {
+                        pdb::PointerMode::Pointer => write!(target, "*")?,
+                        pdb::PointerMode::LValueReference => write!(target, "&")?,
+                        pdb::PointerMode::RValueReference => write!(target, "&&")?,
+                        _ => (),
+                    }
+
+                    if data.attributes.is_const() {
+                        write!(target, " const")?;
+                    }
+                    if data.attributes.is_volatile() {
+                        write!(target, " volatile")?;
+                    }
+                    if data.attributes.is_unaligned() {
+                        write!(target, " __unaligned")?;
+                    }
+                    if data.attributes.is_restrict() {
+                        write!(target, " __restrict")?;
+                    }
+                }
+            }
+            Ok(pdb::TypeData::Modifier(data)) => {
+                if data.constant {
+                    write!(target, "const ")?;
+                }
+                if data.volatile {
+                    write!(target, "volatile ")?;
+                }
+                if data.unaligned {
+                    write!(target, "__unaligned ")?;
+                }
+
+                self.write_type(target, data.underlying_type)?;
+            }
+            Ok(pdb::TypeData::Enumeration(data)) => {
+                write!(target, "{}", data.name.to_string())?;
+            }
+            Ok(pdb::TypeData::Enumerate(data)) => {
+                write!(target, "{}", data.name.to_string())?;
+            }
+            Ok(pdb::TypeData::Array(_)) => {
+                // nothing to do
+            }
+            Ok(pdb::TypeData::Union(data)) => {
+                write!(target, "{}", data.name.to_string())?;
+            }
+            Ok(pdb::TypeData::Bitfield(_)) => {
+                // nothing to do
+            }
+            Ok(pdb::TypeData::FieldList(_)) => {
+                write!(target, "<field list>")?;
+            }
+            Ok(pdb::TypeData::ArgumentList(data)) => {
+                write!(target, "(")?;
+                for (i, arg_index) in data.arguments.iter().enumerate() {
+                    if i > 0 {
+                        write!(target, ", ")?;
+                    }
+                    self.write_type(target, *arg_index)?;
+                }
+                write!(target, ")")?;
+            }
+            Ok(pdb::TypeData::MethodList(_)) => {
+                // nothing to do
+            }
+            Ok(_) => {
+                // non_exhaustive match
+            }
+            Err(pdb::Error::UnimplementedTypeKind(_)) => {
+                write!(target, "<unknown>")?;
+            }
+            Err(e) => return Err(e.into()),
+        }
+
+        Ok(())
+    }
+
+    /// Formats the `Id` with the given index to a string.
+    pub fn format_id(&mut self, index: pdb::IdIndex) -> Result<String, PdbError> {
+        let mut string = String::new();
+        self.write_id(&mut string, index)?;
+        Ok(string)
+    }
+}
+
 struct Unit<'s> {
     debug_info: &'s PdbDebugInfo<'s>,
-    module_index: usize,
     module: &'s pdb::ModuleInfo<'s>,
+    imports: pdb::CrossModuleImports<'s>,
 }
 
 impl<'s> Unit<'s> {
     fn load(
         debug_info: &'s PdbDebugInfo<'s>,
-        module_index: usize,
         module: &'s pdb::ModuleInfo<'s>,
     ) -> Result<Self, PdbError> {
+        let imports = module.imports()?;
+
         Ok(Self {
             debug_info,
-            module_index,
             module,
+            imports,
         })
+    }
+
+    fn resolve_index<I>(&self, index: I) -> Result<Option<I>, PdbError>
+    where
+        I: ItemIndex,
+    {
+        if index.is_cross_module() {
+            let cross_ref = self.imports.resolve_import(index)?;
+            self.debug_info.resolve_import(cross_ref)
+        } else {
+            Ok(Some(index))
+        }
     }
 
     fn collect_lines<I>(
@@ -681,7 +993,7 @@ impl<'s> Unit<'s> {
         offset: PdbInternalSectionOffset,
         len: u32,
         name: RawString<'s>,
-        type_index: TypeIndex,
+        _type_index: TypeIndex,
         program: &LineProgram<'s>,
     ) -> Result<Option<Function<'s>>, PdbError> {
         let address_map = &self.debug_info.address_map;
@@ -694,14 +1006,9 @@ impl<'s> Unit<'s> {
         };
 
         // Names from the private symbol table are generally demangled. They contain the path of the
-        // scope and name of the function itself, including type parameters, and the parameter lists
-        // are contained in the type info. We do not emit a return type.
-        let formatter = &self.debug_info.type_formatter;
-        let name = Name::new(
-            formatter.format_function(&name.to_string(), self.module_index, type_index)?,
-            NameMangling::Unmangled,
-            Language::Unknown,
-        );
+        // scope and name of the function itself, including type parameters, but do not contain
+        // parameter lists or return types. This is good enough for us at the moment.
+        let name = Name::new(name.to_string(), NameMangling::Unmangled, Language::Unknown);
 
         let line_iter = program.lines_for_symbol(offset);
         let lines = self.collect_lines(line_iter, program)?;
@@ -766,9 +1073,9 @@ impl<'s> Unit<'s> {
             None => return Ok(None),
         };
 
-        let formatter = &self.debug_info.type_formatter;
+        let mut formatter = TypeFormatter::new(self);
         let name = Name::new(
-            formatter.format_id(self.module_index, inline_site.inlinee)?,
+            formatter.format_id(inline_site.inlinee)?,
             NameMangling::Unmangled,
             Language::Unknown,
         );
@@ -901,9 +1208,8 @@ impl<'s> Iterator for PdbUnitIterator<'s> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let debug_info = self.debug_info;
-        while self.index < debug_info.modules().len() {
-            let module_index = self.index;
-            let result = debug_info.get_module(module_index);
+        while self.index < debug_info.modules.len() {
+            let result = debug_info.get_module(self.index);
             self.index += 1;
 
             let module = match result {
@@ -912,7 +1218,7 @@ impl<'s> Iterator for PdbUnitIterator<'s> {
                 Err(error) => return Some(Err(error)),
             };
 
-            return Some(Unit::load(debug_info, module_index, module));
+            return Some(Unit::load(debug_info, module));
         }
 
         None

--- a/symbolic-debuginfo/tests/snapshots/test_objects__pdb_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__pdb_functions.snap
@@ -1,16 +1,15 @@
 ---
-source: symbolic-debuginfo/tests/test_objects.rs
+source: debuginfo/tests/test_objects.rs
 expression: "FunctionsDebug(&functions[..10], 0)"
-
 ---
 
-> 0x1120: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::~basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >() (0x54)
+> 0x1120: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::~basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> > (0x54)
   0x1120: xstring:2424 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x1123: xstring:2425 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x116c: xstring:2426 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x116d: xstring:2425 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x1123: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Tidy_deallocate() (0x50)
+  > 0x1123: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Tidy_deallocate (0x50)
     0x1123: xstring:3902 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x112b: xstring:3907 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x1158: xstring:3910 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
@@ -19,31 +18,31 @@ expression: "FunctionsDebug(&functions[..10], 0)"
     0x1168: xstring:3914 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x116d: xstring:3907 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x1123: std::_String_val<std::_Simple_types<wchar_t> >::_Large_string_engaged() const (0x6)
+    > 0x1123: std::_String_val<std::_Simple_types<wchar_t> >::_Large_string_engaged (0x6)
       0x1123: xstring:1802 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x115f: std::_WChar_traits<wchar_t>::assign(wchar_t&, wchar_t const&) (0xc)
+    > 0x115f: std::_WChar_traits<wchar_t>::assign (0xc)
       0x115f: iosfwd:341 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x1168: iosfwd:341 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x112b: std::allocator<wchar_t>::deallocate(wchar_t* const, const unsigned int) (0x48)
+    > 0x112b: std::allocator<wchar_t>::deallocate (0x48)
       0x112b: xmemory0:1030 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x116d: xmemory0:1030 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-      > 0x1134: std::_Deallocate(void*, unsigned int) (0x3f)
+      > 0x1134: std::_Deallocate (0x3f)
         0x1134: xmemory0:211 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x113c: xmemory0:213 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x114e: xmemory0:217 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x116d: xmemory0:213 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-        > 0x113c: std::_Adjust_manually_vector_aligned(void*&, unsigned int&) (0x37)
+        > 0x113c: std::_Adjust_manually_vector_aligned (0x37)
           0x113c: xmemory0:119 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x1142: xmemory0:137 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x1144: xmemory0:138 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x114c: xmemory0:143 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x116d: xmemory0:140 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-> 0x1000: google_breakpad::CrashGenerationClient::RequestDump(_EXCEPTION_POINTERS*, MDRawAssertionInfo*) (0x114)
+> 0x1000: google_breakpad::CrashGenerationClient::RequestDump (0x114)
   0x1000: crash_generation_client.cc:323 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\crash_generation)
   0x1011: crash_generation_client.cc:324 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\crash_generation)
   0x1017: crash_generation_client.cc:325 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\crash_generation)
@@ -59,10 +58,10 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x1101: crash_generation_client.cc:337 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\crash_generation)
   0x1107: crash_generation_client.cc:338 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\crash_generation)
 
-  > 0x1011: google_breakpad::CrashGenerationClient::IsRegistered() const (0x4)
+  > 0x1011: google_breakpad::CrashGenerationClient::IsRegistered (0x4)
     0x1011: crash_generation_client.cc:319 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\crash_generation)
 
-  > 0x1064: google_breakpad::CrashGenerationClient::SignalCrashEventAndWait() (0xa3)
+  > 0x1064: google_breakpad::CrashGenerationClient::SignalCrashEventAndWait (0xa3)
     0x1064: crash_generation_client.cc:349 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\crash_generation)
     0x1084: crash_generation_client.cc:350 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\crash_generation)
     0x109e: crash_generation_client.cc:351 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\crash_generation)
@@ -73,11 +72,11 @@ expression: "FunctionsDebug(&functions[..10], 0)"
     0x1101: crash_generation_client.cc:373 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\crash_generation)
     0x1104: crash_generation_client.cc:373 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\crash_generation)
 
-> 0x12d0: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Xlen() (0xc)
+> 0x12d0: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Xlen (0xc)
   0x12d0: xstring:3918 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x12d0: xstring:3919 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-> 0x1180: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::assign(wchar_t const* const, const unsigned int) (0x150)
+> 0x1180: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::assign (0x150)
   0x1180: xstring:2612 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x1195: xstring:2614 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x11a0: xstring:2616 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
@@ -91,7 +90,7 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x12c1: xstring:2627 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x12ca: xstring:2623 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x11d1: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Reallocate_for(const unsigned int, std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::assign::__l2::<lambda_03628ca18370b1f44a99b655e704819b>, wchar_t const*) (0xfe)
+  > 0x11d1: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Reallocate_for (0xfe)
     0x11d1: xstring:3804 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x11dd: xstring:3811 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x120f: xstring:3813 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
@@ -103,38 +102,38 @@ expression: "FunctionsDebug(&functions[..10], 0)"
     0x128f: xstring:3820 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x12ca: xstring:3806 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x1268: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::assign::__l2::<lambda_03628ca18370b1f44a99b655e704819b>::operator()(wchar_t* const, const unsigned int, wchar_t const* const) const (0x1e)
+    > 0x1268: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::assign::__l2::<lambda_03628ca18370b1f44a99b655e704819b>::operator() (0x1e)
       0x1268: xstring:2624 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x1277: xstring:2624 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x127d: xstring:2625 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x127f: xstring:2624 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x1282: xstring:2625 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-      > 0x127d: std::_WChar_traits<wchar_t>::assign(wchar_t&, wchar_t const&) (0x9)
+      > 0x127d: std::_WChar_traits<wchar_t>::assign (0x9)
         0x127d: iosfwd:341 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x1282: iosfwd:341 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-      > 0x1268: std::_WChar_traits<wchar_t>::copy(wchar_t* const, wchar_t const* const, const unsigned int) (0x1a)
+      > 0x1268: std::_WChar_traits<wchar_t>::copy (0x1a)
         0x1268: iosfwd:295 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x1277: iosfwd:295 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x127f: iosfwd:295 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-        > 0x1268: wmemcpy(wchar_t*, wchar_t const*, unsigned int) (0x1a)
+        > 0x1268: wmemcpy (0x1a)
           0x1268: wchar.h:232 (c:\program files (x86)\windows kits\10\include\10.0.16299.0\ucrt)
           0x1277: wchar.h:232 (c:\program files (x86)\windows kits\10\include\10.0.16299.0\ucrt)
           0x127f: wchar.h:232 (c:\program files (x86)\windows kits\10\include\10.0.16299.0\ucrt)
 
-    > 0x1212: std::allocator<wchar_t>::allocate(const unsigned int) (0x53)
+    > 0x1212: std::allocator<wchar_t>::allocate (0x53)
       0x1212: xmemory0:1035 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-      > 0x121f: std::_Allocate(const unsigned int) (0x46)
+      > 0x121f: std::_Allocate (0x46)
         0x121f: xmemory0:192 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x1229: xmemory0:194 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x1252: xmemory0:198 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x1256: xmemory0:200 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x1263: xmemory0:203 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-        > 0x1229: std::_Allocate_manually_vector_aligned(const unsigned int) (0x27)
+        > 0x1229: std::_Allocate_manually_vector_aligned (0x27)
           0x1229: xmemory0:94 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x122c: xmemory0:95 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x1234: xmemory0:101 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
@@ -142,18 +141,18 @@ expression: "FunctionsDebug(&functions[..10], 0)"
           0x1247: xmemory0:104 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x124d: xmemory0:105 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-          > 0x1234: std::_Default_allocate_traits::_Allocate(const unsigned int) (0x9)
+          > 0x1234: std::_Default_allocate_traits::_Allocate (0x9)
             0x1234: xmemory0:51 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-        > 0x1256: std::_Default_allocate_traits::_Allocate(const unsigned int) (0x9)
+        > 0x1256: std::_Default_allocate_traits::_Allocate (0x9)
           0x1256: xmemory0:51 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-      > 0x1212: std::_Get_size_of_n(const unsigned int) (0xd)
+      > 0x1212: std::_Get_size_of_n (0xd)
         0x1212: xmemory0:24 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x1215: xmemory0:25 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x121c: xmemory0:28 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x11dd: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Calculate_growth(const unsigned int) const (0x32)
+    > 0x11dd: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Calculate_growth (0x32)
       0x11dd: xstring:3784 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x11e8: xstring:3785 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x11ea: xstring:3787 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
@@ -161,46 +160,46 @@ expression: "FunctionsDebug(&functions[..10], 0)"
       0x1200: xstring:3793 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x1207: xstring:3796 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-      > 0x120a: std::_Max_value(unsigned int const&, unsigned int const&) (0x5)
+      > 0x120a: std::_Max_value (0x5)
         0x120a: utility:32 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x128f: std::allocator<wchar_t>::deallocate(wchar_t* const, const unsigned int) (0x2d)
+    > 0x128f: std::allocator<wchar_t>::deallocate (0x2d)
       0x128f: xmemory0:1030 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-      > 0x1298: std::_Deallocate(void*, unsigned int) (0x24)
+      > 0x1298: std::_Deallocate (0x24)
         0x1298: xmemory0:211 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x12a0: xmemory0:213 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x12b2: xmemory0:217 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-        > 0x12a0: std::_Adjust_manually_vector_aligned(void*&, unsigned int&) (0x12)
+        > 0x12a0: std::_Adjust_manually_vector_aligned (0x12)
           0x12a0: xmemory0:119 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x12a6: xmemory0:137 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x12a8: xmemory0:138 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x12b0: xmemory0:143 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x11bf: std::_WChar_traits<wchar_t>::assign(wchar_t&, wchar_t const&) (0x6)
+  > 0x11bf: std::_WChar_traits<wchar_t>::assign (0x6)
     0x11bf: iosfwd:341 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x11a9: std::_WChar_traits<wchar_t>::move(wchar_t* const, wchar_t const* const, const unsigned int) (0x16)
+  > 0x11a9: std::_WChar_traits<wchar_t>::move (0x16)
     0x11a9: iosfwd:329 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x11b3: iosfwd:329 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x11a9: wmemmove(wchar_t*, wchar_t const*, unsigned int) (0x16)
+    > 0x11a9: wmemmove (0x16)
       0x11a9: wchar.h:245 (c:\program files (x86)\windows kits\10\include\10.0.16299.0\ucrt)
       0x11b3: wchar.h:245 (c:\program files (x86)\windows kits\10\include\10.0.16299.0\ucrt)
 
-  > 0x11a0: std::_String_val<std::_Simple_types<wchar_t> >::_Myptr() (0x9)
+  > 0x11a0: std::_String_val<std::_Simple_types<wchar_t> >::_Myptr (0x9)
     0x11a0: xstring:1780 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x11a2: xstring:1781 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x11a7: xstring:1783 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x11a2: std::_String_val<std::_Simple_types<wchar_t> >::_Large_string_engaged() const (0x3)
+    > 0x11a2: std::_String_val<std::_Simple_types<wchar_t> >::_Large_string_engaged (0x3)
       0x11a2: xstring:1802 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x11a7: std::_Unfancy(wchar_t*) (0x2)
+    > 0x11a7: std::_Unfancy (0x2)
       0x11a7: xstddef:265 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-> 0x12e0: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::operator=(std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >&&) (0x7f)
+> 0x12e0: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::operator= (0x7f)
   0x12e0: xstring:2267 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x12e8: xstring:2268 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x12ec: xstring:2270 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
@@ -209,22 +208,22 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x1354: xstring:2278 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x1358: xstring:2270 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x1334: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Assign_rv_contents(std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >&&, std::integral_constant<bool,1>) (0x1d)
+  > 0x1334: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Assign_rv_contents (0x1d)
     0x1334: xstring:2291 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x1334: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Assign_rv_contents_with_alloc_always_equal(std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >&&, std::integral_constant<bool,1>) (0x1d)
+    > 0x1334: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Assign_rv_contents_with_alloc_always_equal (0x1d)
       0x1334: xstring:2331 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x1344: xstring:2332 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-      > 0x1344: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Tidy_init() (0xd)
+      > 0x1344: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Tidy_init (0xd)
         0x1344: xstring:3891 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x1347: xstring:3892 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x134e: xstring:3895 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-        > 0x134e: std::_WChar_traits<wchar_t>::assign(wchar_t&, wchar_t const&) (0x3)
+        > 0x134e: std::_WChar_traits<wchar_t>::assign (0x3)
           0x134e: iosfwd:341 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x12ec: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Tidy_deallocate() (0x72)
+  > 0x12ec: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Tidy_deallocate (0x72)
     0x12ec: xstring:3902 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x12f4: xstring:3907 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x1321: xstring:3910 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
@@ -233,40 +232,40 @@ expression: "FunctionsDebug(&functions[..10], 0)"
     0x1331: xstring:3914 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x1358: xstring:3907 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x12ec: std::_String_val<std::_Simple_types<wchar_t> >::_Large_string_engaged() const (0x6)
+    > 0x12ec: std::_String_val<std::_Simple_types<wchar_t> >::_Large_string_engaged (0x6)
       0x12ec: xstring:1802 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x1328: std::_WChar_traits<wchar_t>::assign(wchar_t&, wchar_t const&) (0xc)
+    > 0x1328: std::_WChar_traits<wchar_t>::assign (0xc)
       0x1328: iosfwd:341 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x1331: iosfwd:341 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x12f4: std::allocator<wchar_t>::deallocate(wchar_t* const, const unsigned int) (0x6a)
+    > 0x12f4: std::allocator<wchar_t>::deallocate (0x6a)
       0x12f4: xmemory0:1030 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x1358: xmemory0:1030 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-      > 0x12fd: std::_Deallocate(void*, unsigned int) (0x61)
+      > 0x12fd: std::_Deallocate (0x61)
         0x12fd: xmemory0:211 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x1305: xmemory0:213 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x1317: xmemory0:217 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x1358: xmemory0:213 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-        > 0x1305: std::_Adjust_manually_vector_aligned(void*&, unsigned int&) (0x59)
+        > 0x1305: std::_Adjust_manually_vector_aligned (0x59)
           0x1305: xmemory0:119 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x130b: xmemory0:137 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x130d: xmemory0:138 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x1315: xmemory0:143 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x1358: xmemory0:140 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-> 0x27d0: std::_List_buy<google_breakpad::AppMemory,std::allocator<google_breakpad::AppMemory> >::_Buynode<google_breakpad::AppMemory const &>(std::_List_node<google_breakpad::AppMemory,void *>*, std::_List_node<google_breakpad::AppMemory,void *>*, google_breakpad::AppMemory const&) (0x1b)
+> 0x27d0: std::_List_buy<google_breakpad::AppMemory,std::allocator<google_breakpad::AppMemory> >::_Buynode<google_breakpad::AppMemory const &> (0x1b)
   0x27d0: list:761 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x27d0: list:762 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x27dd: list:766 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x27e8: list:775 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x27dd: std::_Default_allocator_traits<std::allocator<std::_List_node<google_breakpad::AppMemory,void *> > >::construct(std::allocator<std::_List_node<google_breakpad::AppMemory,void *> >&, google_breakpad::AppMemory* const, google_breakpad::AppMemory const&) (0xb)
+  > 0x27dd: std::_Default_allocator_traits<std::allocator<std::_List_node<google_breakpad::AppMemory,void *> > >::construct (0xb)
     0x27dd: xmemory0:917 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-> 0x2560: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::emplace_back<google_breakpad::ExceptionHandler *>(google_breakpad::ExceptionHandler*&&) (0x121)
+> 0x2560: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::emplace_back<google_breakpad::ExceptionHandler *> (0x121)
   0x2560: vector:947 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x2565: vector:948 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x256f: vector:950 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
@@ -285,31 +284,31 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x2676: vector:987 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x267b: vector:958 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x2565: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::_Has_unused_capacity() const (0x8)
+  > 0x2565: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::_Has_unused_capacity (0x8)
     0x2565: vector:1797 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x256f: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::_Emplace_back_with_unused_capacity(google_breakpad::ExceptionHandler*&&) (0xc)
+  > 0x256f: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::_Emplace_back_with_unused_capacity (0xc)
     0x256f: vector:939 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x2577: vector:941 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x256f: std::_Default_allocator_traits<std::allocator<google_breakpad::ExceptionHandler *> >::construct(std::allocator<google_breakpad::ExceptionHandler *>&, google_breakpad::ExceptionHandler** const, google_breakpad::ExceptionHandler*&&) (0x8)
+    > 0x256f: std::_Default_allocator_traits<std::allocator<google_breakpad::ExceptionHandler *> >::construct (0x8)
       0x256f: xmemory0:917 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x2581: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::size() const (0x7)
+  > 0x2581: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::size (0x7)
     0x2581: vector:1775 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x25b8: std::allocator<google_breakpad::ExceptionHandler *>::allocate(const unsigned int) (0x5c)
+  > 0x25b8: std::allocator<google_breakpad::ExceptionHandler *>::allocate (0x5c)
     0x25b8: xmemory0:1035 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x25c4: xmemory0:1035 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x25ce: std::_Allocate(const unsigned int) (0x46)
+    > 0x25ce: std::_Allocate (0x46)
       0x25ce: xmemory0:192 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x25d8: xmemory0:194 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x2601: xmemory0:198 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x2605: xmemory0:200 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x2612: xmemory0:203 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-      > 0x25d8: std::_Allocate_manually_vector_aligned(const unsigned int) (0x27)
+      > 0x25d8: std::_Allocate_manually_vector_aligned (0x27)
         0x25d8: xmemory0:94 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x25db: xmemory0:95 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x25e3: xmemory0:101 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
@@ -317,18 +316,18 @@ expression: "FunctionsDebug(&functions[..10], 0)"
         0x25f6: xmemory0:104 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x25fc: xmemory0:105 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-        > 0x25e3: std::_Default_allocate_traits::_Allocate(const unsigned int) (0x9)
+        > 0x25e3: std::_Default_allocate_traits::_Allocate (0x9)
           0x25e3: xmemory0:51 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-      > 0x2605: std::_Default_allocate_traits::_Allocate(const unsigned int) (0x9)
+      > 0x2605: std::_Default_allocate_traits::_Allocate (0x9)
         0x2605: xmemory0:51 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x25b8: std::_Get_size_of_n(const unsigned int) (0x16)
+    > 0x25b8: std::_Get_size_of_n (0x16)
       0x25b8: xmemory0:24 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x25c4: xmemory0:25 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x25cb: xmemory0:28 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x2594: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::_Calculate_growth(const unsigned int) const (0x24)
+  > 0x2594: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::_Calculate_growth (0x24)
     0x2594: vector:1955 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x2596: vector:1957 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x259b: vector:1955 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
@@ -338,36 +337,36 @@ expression: "FunctionsDebug(&functions[..10], 0)"
     0x25b0: vector:1962 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x25b3: vector:1964 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x2594: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::capacity() const (0xa)
+    > 0x2594: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::capacity (0xa)
       0x2594: vector:1786 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x259b: vector:1786 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x261d: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::_Umove_if_noexcept(google_breakpad::ExceptionHandler**, google_breakpad::ExceptionHandler**, google_breakpad::ExceptionHandler**) (0x15)
+  > 0x261d: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::_Umove_if_noexcept (0x15)
     0x261d: vector:1944 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x262f: vector:1944 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x261d: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::_Umove_if_noexcept1(google_breakpad::ExceptionHandler**, google_breakpad::ExceptionHandler**, google_breakpad::ExceptionHandler**, std::integral_constant<bool,1>) (0x15)
+    > 0x261d: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::_Umove_if_noexcept1 (0x15)
       0x261d: vector:1934 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x262f: vector:1934 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-      > 0x261d: std::_Uninitialized_move(google_breakpad::ExceptionHandler**, google_breakpad::ExceptionHandler**, google_breakpad::ExceptionHandler**, std::allocator<google_breakpad::ExceptionHandler *>&) (0x15)
+      > 0x261d: std::_Uninitialized_move (0x15)
         0x261d: xmemory:198 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x262f: xmemory:198 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-        > 0x261d: std::_Uninitialized_move_al_unchecked(google_breakpad::ExceptionHandler**, google_breakpad::ExceptionHandler**, google_breakpad::ExceptionHandler**, std::allocator<google_breakpad::ExceptionHandler *>&, std::_Really_trivial_ptr_iterator_tag, std::integral_constant<bool,1>) (0x15)
+        > 0x261d: std::_Uninitialized_move_al_unchecked (0x15)
           0x261d: xmemory:185 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x262f: xmemory:185 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-          > 0x261d: std::_Copy_memmove(google_breakpad::ExceptionHandler**, google_breakpad::ExceptionHandler**, google_breakpad::ExceptionHandler**) (0x15)
+          > 0x261d: std::_Copy_memmove (0x15)
             0x261d: xutility:2386 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
             0x261f: xutility:2389 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
             0x2624: xutility:2390 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
             0x262f: xutility:2390 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x2614: std::_Default_allocator_traits<std::allocator<google_breakpad::ExceptionHandler *> >::construct(std::allocator<google_breakpad::ExceptionHandler *>&, google_breakpad::ExceptionHandler** const, google_breakpad::ExceptionHandler*&&) (0x9)
+  > 0x2614: std::_Default_allocator_traits<std::allocator<google_breakpad::ExceptionHandler *> >::construct (0x9)
     0x2614: xmemory0:917 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x262d: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::_Change_array(google_breakpad::ExceptionHandler** const, const unsigned int, const unsigned int) (0x48)
+  > 0x262d: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::_Change_array (0x48)
     0x262d: vector:1999 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x2632: vector:1999 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x2636: vector:2002 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
@@ -375,24 +374,24 @@ expression: "FunctionsDebug(&functions[..10], 0)"
     0x266a: vector:2007 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x2672: vector:2007 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x263b: std::allocator<google_breakpad::ExceptionHandler *>::deallocate(google_breakpad::ExceptionHandler** const, const unsigned int) (0x27)
+    > 0x263b: std::allocator<google_breakpad::ExceptionHandler *>::deallocate (0x27)
       0x263b: xmemory0:1030 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-      > 0x263e: std::_Deallocate(void*, unsigned int) (0x24)
+      > 0x263e: std::_Deallocate (0x24)
         0x263e: xmemory0:211 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x2646: xmemory0:213 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x2658: xmemory0:217 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-        > 0x2646: std::_Adjust_manually_vector_aligned(void*&, unsigned int&) (0x12)
+        > 0x2646: std::_Adjust_manually_vector_aligned (0x12)
           0x2646: xmemory0:119 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x264c: xmemory0:137 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x264e: xmemory0:138 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x2656: xmemory0:143 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x2636: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::capacity() const (0x5)
+    > 0x2636: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::capacity (0x5)
       0x2636: vector:1786 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-> 0x1b90: google_breakpad::AutoExceptionHandler::AutoExceptionHandler() (0x70)
+> 0x1b90: google_breakpad::AutoExceptionHandler::AutoExceptionHandler (0x70)
   0x1b90: exception_handler.cc:422 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\handler)
   0x1b92: exception_handler.cc:439 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\handler)
   0x1b9f: exception_handler.cc:440 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\handler)
@@ -402,45 +401,45 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x1bf5: exception_handler.cc:451 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\handler)
   0x1bfa: exception_handler.cc:440 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\handler)
 
-  > 0x1bb5: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::at(const unsigned int) (0x4a)
+  > 0x1bb5: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::at (0x4a)
     0x1bb5: vector:1831 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x1bbc: vector:1831 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x1bfa: vector:1833 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x1bb5: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::size() const (0xf)
+    > 0x1bb5: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::size (0xf)
       0x1bb5: vector:1775 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x1bbc: vector:1775 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x1b9f: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::size() const (0x1b)
+  > 0x1b9f: std::vector<google_breakpad::ExceptionHandler *,std::allocator<google_breakpad::ExceptionHandler *> >::size (0x1b)
     0x1b9f: vector:1775 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x1bb0: vector:1775 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x1bb7: vector:1775 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-> 0x26a0: std::list<google_breakpad::AppMemory,std::allocator<google_breakpad::AppMemory> >::~list<google_breakpad::AppMemory,std::allocator<google_breakpad::AppMemory> >() (0x43)
+> 0x26a0: std::list<google_breakpad::AppMemory,std::allocator<google_breakpad::AppMemory> >::~list<google_breakpad::AppMemory,std::allocator<google_breakpad::AppMemory> > (0x43)
   0x26a0: list:1034 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x26a3: list:1035 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x26d6: list:1036 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x26d6: std::_List_alloc<std::_List_base_types<google_breakpad::AppMemory,std::allocator<google_breakpad::AppMemory> > >::{dtor}() (0xc)
+  > 0x26d6: std::_List_alloc<std::_List_base_types<google_breakpad::AppMemory,std::allocator<google_breakpad::AppMemory> > >::{dtor} (0xc)
     0x26d6: list:530 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x26d6: std::_List_alloc<std::_List_base_types<google_breakpad::AppMemory,std::allocator<google_breakpad::AppMemory> > >::_Freeheadnode(std::_List_node<google_breakpad::AppMemory,void *>*) (0xc)
+    > 0x26d6: std::_List_alloc<std::_List_base_types<google_breakpad::AppMemory,std::allocator<google_breakpad::AppMemory> > >::_Freeheadnode (0xc)
       0x26d6: list:655 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-      > 0x26d6: std::_List_node<google_breakpad::AppMemory,void *>::_Freenode0(std::allocator<std::_List_node<google_breakpad::AppMemory,void *> >&, std::_List_node<google_breakpad::AppMemory,void *>*) (0xc)
+      > 0x26d6: std::_List_node<google_breakpad::AppMemory,void *>::_Freenode0 (0xc)
         0x26d6: list:424 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-        > 0x26d6: std::_Default_allocator_traits<std::allocator<std::_List_node<google_breakpad::AppMemory,void *> > >::deallocate(std::allocator<std::_List_node<google_breakpad::AppMemory,void *> >&, std::_List_node<google_breakpad::AppMemory,void *>* const, const unsigned int) (0xc)
+        > 0x26d6: std::_Default_allocator_traits<std::allocator<std::_List_node<google_breakpad::AppMemory,void *> > >::deallocate (0xc)
           0x26d6: xmemory0:911 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-          > 0x26d6: std::_Deallocate(void*, unsigned int) (0xc)
+          > 0x26d6: std::_Deallocate (0xc)
             0x26d6: xmemory0:217 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-  > 0x26a3: std::list<google_breakpad::AppMemory,std::allocator<google_breakpad::AppMemory> >::_Tidy() (0x32)
+  > 0x26a3: std::list<google_breakpad::AppMemory,std::allocator<google_breakpad::AppMemory> >::_Tidy (0x32)
     0x26a3: list:1836 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
     0x26c0: list:1836 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-    > 0x26a3: std::list<google_breakpad::AppMemory,std::allocator<google_breakpad::AppMemory> >::clear() (0x32)
+    > 0x26a3: std::list<google_breakpad::AppMemory,std::allocator<google_breakpad::AppMemory> >::clear (0x32)
       0x26a3: list:1448 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x26a7: list:1449 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x26a9: list:1450 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
@@ -452,23 +451,23 @@ expression: "FunctionsDebug(&functions[..10], 0)"
       0x26cc: list:1456 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
       0x26cf: list:1453 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-      > 0x26c2: std::_List_buy<google_breakpad::AppMemory,std::allocator<google_breakpad::AppMemory> >::_Freenode(std::_List_node<google_breakpad::AppMemory,void *>*) (0xd)
+      > 0x26c2: std::_List_buy<google_breakpad::AppMemory,std::allocator<google_breakpad::AppMemory> >::_Freenode (0xd)
         0x26c2: list:781 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
         0x26cc: list:781 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-        > 0x26c2: std::_List_node<google_breakpad::AppMemory,void *>::_Freenode0(std::allocator<std::_List_node<google_breakpad::AppMemory,void *> >&, std::_List_node<google_breakpad::AppMemory,void *>*) (0xd)
+        > 0x26c2: std::_List_node<google_breakpad::AppMemory,void *>::_Freenode0 (0xd)
           0x26c2: list:424 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
           0x26cc: list:424 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-          > 0x26c2: std::_Default_allocator_traits<std::allocator<std::_List_node<google_breakpad::AppMemory,void *> > >::deallocate(std::allocator<std::_List_node<google_breakpad::AppMemory,void *> >&, std::_List_node<google_breakpad::AppMemory,void *>* const, const unsigned int) (0xd)
+          > 0x26c2: std::_Default_allocator_traits<std::allocator<std::_List_node<google_breakpad::AppMemory,void *> > >::deallocate (0xd)
             0x26c2: xmemory0:911 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
             0x26cc: xmemory0:911 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-            > 0x26c2: std::_Deallocate(void*, unsigned int) (0xd)
+            > 0x26c2: std::_Deallocate (0xd)
               0x26c2: xmemory0:217 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
               0x26cc: xmemory0:217 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
 
-> 0x2690: google_breakpad::scoped_ptr<google_breakpad::CrashGenerationClient>::~scoped_ptr<google_breakpad::CrashGenerationClient>() (0xd)
+> 0x2690: google_breakpad::scoped_ptr<google_breakpad::CrashGenerationClient>::~scoped_ptr<google_breakpad::CrashGenerationClient> (0xd)
   0x2690: scoped_ptr.h:96 (c:\projects\breakpad-tools\deps\breakpad\src\common)
   0x2690: scoped_ptr.h:98 (c:\projects\breakpad-tools\deps\breakpad\src\common)
   0x269c: scoped_ptr.h:99 (c:\projects\breakpad-tools\deps\breakpad\src\common)

--- a/symbolic-debuginfo/tests/test_objects.rs
+++ b/symbolic-debuginfo/tests/test_objects.rs
@@ -547,7 +547,7 @@ fn test_pdb_anonymous_namespace() -> Result<(), Error> {
         .expect("start function at 0x2a3d");
 
     // was: "?A0xc3a0617d::start"
-    assert_eq!(start_function.name, "`anonymous namespace'::start()");
+    assert_eq!(start_function.name, "`anonymous namespace'::start");
 
     Ok(())
 }


### PR DESCRIPTION
This reverts commit ca9c64bc355cb0f4c508b7c3cf94f89ec92ec756.

The reason for the revert is that the new code throws errors when processing the `electron.exe.pdb` from this archive:
https://github.com/electron/electron/releases/download/v20.0.0-beta.11/electron-v20.0.0-beta.11-win32-x64-pdb.zip

It might be possible to safely skip over this error instead, but I rather revert for now and figure out a more error tolerant way later.

CC @mstange you probably know your way around that code better to figure out a proper solution for this.

My example errors out with: `Type 1660 not found`.
I was invoking the `symcache_debug` util like so:

> cargo run -p symcache_debug --release -- -d testcases/electron20/electron.exe.pdb -w --report