### PR TITLE
ref: Split DWARF line records according to inlinees

### DIFF
--- a/symbolic-debuginfo/src/base.rs
+++ b/symbolic-debuginfo/src/base.rs
@@ -526,7 +526,7 @@ impl<'data> Deref for FileEntry<'data> {
 }
 
 /// File and line number mapping for an instruction address.
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct LineInfo<'data> {
     /// The instruction address relative to the image base (load address).
     pub address: u64,
@@ -536,6 +536,21 @@ pub struct LineInfo<'data> {
     pub file: FileInfo<'data>,
     /// Absolute line number starting at 1. Zero means no line number.
     pub line: u64,
+}
+
+#[cfg(test)]
+impl LineInfo<'static> {
+    pub(crate) fn new(address: u64, size: u64, file: &[u8], line: u64) -> LineInfo {
+        LineInfo {
+            address,
+            size: Some(size),
+            file: FileInfo {
+                name: file,
+                dir: &[],
+            },
+            line,
+        }
+    }
 }
 
 impl fmt::Debug for LineInfo<'_> {

--- a/symbolic-debuginfo/tests/snapshots/test_objects__breakpad_functions_mac_with_inlines.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__breakpad_functions_mac_with_inlines.snap
@@ -1,5 +1,6 @@
 ---
 source: symbolic-debuginfo/tests/test_objects.rs
+assertion_line: 150
 expression: "FunctionsDebug(&functions[..10], 0)"
 ---
 
@@ -83,6 +84,7 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0xefa: minidump_file_writer.cc:174 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
   0xf1f: minidump_file_writer.cc:173 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
   0xf23: minidump_file_writer.cc:174 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
+  0xf67: minidump_file_writer.cc:328 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
   0xf6b: minidump_file_writer.cc:166 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
   0xf72: minidump_file_writer.cc:167 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
   0xf76: minidump_file_writer.cc:175 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
@@ -125,6 +127,7 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x1049: minidump_file_writer.cc:201 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
   0x1067: minidump_file_writer.cc:200 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
   0x106b: minidump_file_writer.cc:201 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
+  0x10b3: minidump_file_writer.cc:328 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
   0x10b7: minidump_file_writer.cc:195 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
   0x10ba: minidump_file_writer.cc:196 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
   0x10c0: minidump_file_writer.cc:202 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)

--- a/symbolic-debuginfo/tests/snapshots/test_objects__elf_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__elf_functions.snap
@@ -1,5 +1,6 @@
 ---
 source: symbolic-debuginfo/tests/test_objects.rs
+assertion_line: 247
 expression: "FunctionsDebug(&functions[..10], 0)"
 ---
 
@@ -166,6 +167,7 @@ expression: "FunctionsDebug(&functions[..10], 0)"
       0x1cdc: basic_string.h:383 (/usr/include/c++/5/bits)
 
       > 0x1cdc: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_Alloc_hiderC4EPcRKS3_ (0x4)
+        0x1cdc: basic_string.h:109 (/usr/include/c++/5/bits)
 
     > 0x1ce0: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC4ERKS4_ (0x7)
       0x1ce0: basic_string.h:400 (/usr/include/c++/5/bits)
@@ -259,6 +261,7 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x20c6: exception_handler.cc:318 (../deps/breakpad/src/client/linux/handler)
   0x20cd: exception_handler.cc:319 (../deps/breakpad/src/client/linux/handler)
   0x20e0: exception_handler.cc:315 (../deps/breakpad/src/client/linux/handler)
+  0x20ec: exception_handler.cc:199 (../deps/breakpad/src/client/linux/handler)
 
   > 0x20e0: InstallDefaultHandler (0xc)
     0x20e0: exception_handler.cc:199 (../deps/breakpad/src/client/linux/handler)
@@ -314,6 +317,7 @@ expression: "FunctionsDebug(&functions[..10], 0)"
     0x2122: stl_vector.h:548 (/usr/include/c++/5/bits)
 
     > 0x2122: _ZN9__gnu_cxx17__normal_iteratorIPPN15google_breakpad16ExceptionHandlerESt6vectorIS3_SaIS3_EEEC4ERKS4_ (0x4)
+      0x2122: stl_iterator.h:741 (/usr/include/c++/5/bits)
 
   > 0x2126: _ZSt4findIN9__gnu_cxx17__normal_iteratorIPPN15google_breakpad16ExceptionHandlerESt6vectorIS4_SaIS4_EEEES4_ET_SA_SA_RKT0_ (0xaa)
     0x2126: stl_algo.h:3791 (/usr/include/c++/5/bits)
@@ -555,8 +559,10 @@ expression: "FunctionsDebug(&functions[..10], 0)"
           0x2350: stl_iterator.h:763 (/usr/include/c++/5/bits)
 
         > 0x2360: _ZN9__gnu_cxx17__normal_iteratorIPPN15google_breakpad16ExceptionHandlerESt6vectorIS3_SaIS3_EEEppEv (0x10)
+          0x2360: stl_iterator.h:763 (/usr/include/c++/5/bits)
 
         > 0x2370: _ZN9__gnu_cxx17__normal_iteratorIPPN15google_breakpad16ExceptionHandlerESt6vectorIS3_SaIS3_EEEppEv (0x9)
+          0x2370: stl_iterator.h:763 (/usr/include/c++/5/bits)
 
         > 0x2382: _ZN9__gnu_cxx17__normal_iteratorIPPN15google_breakpad16ExceptionHandlerESt6vectorIS3_SaIS3_EEEppEv (0x4)
           0x2382: stl_iterator.h:763 (/usr/include/c++/5/bits)
@@ -610,8 +616,10 @@ expression: "FunctionsDebug(&functions[..10], 0)"
           0x23ed: stl_iterator.h:763 (/usr/include/c++/5/bits)
 
         > 0x23f6: _ZN9__gnu_cxx17__normal_iteratorIPPN15google_breakpad16ExceptionHandlerESt6vectorIS3_SaIS3_EEEppEv (0x9)
+          0x23f6: stl_iterator.h:763 (/usr/include/c++/5/bits)
 
         > 0x23ff: _ZN9__gnu_cxx17__normal_iteratorIPPN15google_breakpad16ExceptionHandlerESt6vectorIS3_SaIS3_EEEppEv (0x9)
+          0x23ff: stl_iterator.h:763 (/usr/include/c++/5/bits)
 
   > 0x2408: RestoreAlternateStackLocked (0x24)
     0x2408: exception_handler.cc:176 (../deps/breakpad/src/client/linux/handler)
@@ -716,6 +724,7 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x2996: exception_handler.cc:508 (../deps/breakpad/src/client/linux/handler)
   0x299d: exception_handler.cc:568 (../deps/breakpad/src/client/linux/handler)
   0x29a5: exception_handler.cc:505 (../deps/breakpad/src/client/linux/handler)
+  0x29e6: memory_allocator.h:143 (../deps/breakpad/src/common)
 
   > 0x2534: _ZNK15google_breakpad16ExceptionHandler14IsOutOfProcessEv (0x4)
     0x2534: exception_handler.h:205 (../deps/breakpad/src/client/linux/handler)
@@ -794,6 +803,7 @@ expression: "FunctionsDebug(&functions[..10], 0)"
     0x2738: linux_syscall_support.h:3357 (../deps/third_party/lss)
 
   > 0x275c: sys_close (0x10)
+    0x275c: linux_syscall_support.h:3357 (../deps/third_party/lss)
 
   > 0x276e: sys_close (0x1a)
     0x276e: linux_syscall_support.h:3357 (../deps/third_party/lss)

--- a/symbolic-debuginfo/tests/snapshots/test_objects__mach_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__mach_functions.snap
@@ -1,5 +1,6 @@
 ---
 source: symbolic-debuginfo/tests/test_objects.rs
+assertion_line: 396
 expression: "FunctionsDebug(&functions[..10], 0)"
 ---
 
@@ -100,6 +101,7 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0xefa: minidump_file_writer.cc:174 (../deps/breakpad/src/client)
   0xf1f: minidump_file_writer.cc:173 (../deps/breakpad/src/client)
   0xf23: minidump_file_writer.cc:174 (../deps/breakpad/src/client)
+  0xf67: minidump_file_writer.cc:328 (../deps/breakpad/src/client)
   0xf6b: minidump_file_writer.cc:166 (../deps/breakpad/src/client)
   0xf72: minidump_file_writer.cc:167 (../deps/breakpad/src/client)
   0xf76: minidump_file_writer.cc:175 (../deps/breakpad/src/client)
@@ -146,6 +148,7 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x1049: minidump_file_writer.cc:201 (../deps/breakpad/src/client)
   0x1067: minidump_file_writer.cc:200 (../deps/breakpad/src/client)
   0x106b: minidump_file_writer.cc:201 (../deps/breakpad/src/client)
+  0x10b3: minidump_file_writer.cc:328 (../deps/breakpad/src/client)
   0x10b7: minidump_file_writer.cc:195 (../deps/breakpad/src/client)
   0x10ba: minidump_file_writer.cc:196 (../deps/breakpad/src/client)
   0x10c0: minidump_file_writer.cc:202 (../deps/breakpad/src/client)

--- a/symbolic-symcache/tests/test_writer.rs
+++ b/symbolic-symcache/tests/test_writer.rs
@@ -36,8 +36,8 @@ fn test_write_header_linux() -> Result<(), Error> {
         arch: Amd64,
         files: 55,
         functions: 697,
-        source_locations: 8164,
-        ranges: 6795,
+        source_locations: 8220,
+        ranges: 6818,
         string_bytes: 52180,
     }
     "###);
@@ -80,8 +80,8 @@ fn test_write_header_macos() -> Result<(), Error> {
         arch: Amd64,
         files: 36,
         functions: 639,
-        source_locations: 6749,
-        ranges: 5662,
+        source_locations: 6871,
+        ranges: 5783,
         string_bytes: 42829,
     }
     "###);


### PR DESCRIPTION
Consider the following code:

```
  | fn parent() {
1 |   child1();
2 |   child2();
  | }
1 | fn child1() { child2() }
1 | fn child2() {}
```

we assume here that we transitively inline `child2` all the way into `parent`.
but we only have a single line record for that whole chunk of code,
even though the inlining hierarchy specifies two different call sites

```
addr:    0x10 0x20 0x30 0x40 0x50
         v    v    v    v    v
# DWARF hierarchy
parent:  |-------------------|
child1:       |----|           (called from parent.c line 1)
child2:       |----|           (called from child1.c line 1)
                   |----|      (called from parent.c line 2)
# line records
         |----|         |----| (parent.c line 1)
              |---------|      (child2.c line 1)
```