### PR TITLE
fix: Update pdb-addr2line TypeFormatter

### DIFF
--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -89,7 +89,7 @@ lazycell = { version = "1.2.1", optional = true }
 nom = { version = "7.0.0", optional = true }
 nom-supreme = { version = "0.8.0", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
-pdb-addr2line = { version = "0.10.0", optional = true }
+pdb-addr2line = { version = "0.10.2", optional = true }
 regex = { version = "1.3.5", optional = true }
 # keep this in sync with whatever version `goblin` uses
 scroll = { version = "0.11", optional = true }

--- a/symbolic-debuginfo/src/pdb.rs
+++ b/symbolic-debuginfo/src/pdb.rs
@@ -697,8 +697,12 @@ impl<'s> Unit<'s> {
         // scope and name of the function itself, including type parameters, and the parameter lists
         // are contained in the type info. We do not emit a return type.
         let formatter = &self.debug_info.type_formatter;
+        let name = name.to_string();
         let name = Name::new(
-            formatter.format_function(&name.to_string(), self.module_index, type_index)?,
+            formatter
+                .format_function(&name, self.module_index, type_index)
+                .map(Cow::Owned)
+                .unwrap_or(name),
             NameMangling::Unmangled,
             Language::Unknown,
         );


### PR DESCRIPTION
- The updated crate can correctly deal with missing type references
- We now swallow errors, falling back to the mangled names

This is rolling forward and a better alternative to #631 