### PR TITLE
fix(demangle): tweak MSVC demangling flags

### DIFF
--- a/symbolic-demangle/src/lib.rs
+++ b/symbolic-demangle/src/lib.rs
@@ -165,7 +165,11 @@ fn try_demangle_msvc(ident: &str, opts: DemangleOptions) -> Option<String> {
     use msvc_demangler::DemangleFlags as MsvcFlags;
 
     // the flags are bitflags
-    let mut flags = MsvcFlags::COMPLETE;
+    let mut flags = MsvcFlags::COMPLETE
+        | MsvcFlags::SPACE_AFTER_COMMA
+        | MsvcFlags::HUG_TYPE
+        | MsvcFlags::NO_MS_KEYWORDS
+        | MsvcFlags::NO_CLASS_TYPE;
     if !opts.return_type {
         flags |= MsvcFlags::NO_FUNCTION_RETURNS;
     }

--- a/symbolic-demangle/tests/test_msvc.rs
+++ b/symbolic-demangle/tests/test_msvc.rs
@@ -27,9 +27,9 @@ fn test_msvc_demangle_full() {
     assert_demangle!(Language::Cpp, DemangleOptions::name_only().parameters(true), {
         // These symbols were extracted from electron.exe.pdb
         // https://github.com/electron/electron/releases/download/v2.0.11/electron-v2.0.11-win32-x64-pdb.zip
-        "??3@YAXPEAX@Z" => "operator delete(void *)",
+        "??3@YAXPEAX@Z" => "operator delete(void*)",
         "?LoadV8Snapshot@V8Initializer@gin@@SAXXZ" => "gin::V8Initializer::LoadV8Snapshot(void)",
-        "??9@YA_NAEBVGURL@@0@Z" => "operator!=(class GURL const &,class GURL const &)",
+        "??9@YA_NAEBVGURL@@0@Z" => "operator!=(GURL const&, GURL const&)",
         "??_GAtomSandboxedRenderFrameObserver@?A0x77c58568@atom@@UEAAPEAXI@Z" => "atom::`anonymous namespace'::AtomSandboxedRenderFrameObserver::`scalar deleting destructor'(unsigned int)",
     })
 }


### PR DESCRIPTION
These flags create more visually pleasing results for function names
which are demangled from the MSVC mangling scheme.

Here are two examples from oleaut32.pdb A128178EA85DAE837E96C39303FF06381:

Before: `SafeGetLocaleInfoPooled(struct tagDATEINFO *,unsigned long,unsigned short * *,int *)`
After: `SafeGetLocaleInfoPooled(tagDATEINFO*, unsigned long, unsigned short**, int*)`

Before: `CTypeInfo2::Invoke(void *,long,unsigned short,struct tagDISPPARAMS *,struct tagVARIANT *,struct tagEXCEPINFO *,unsigned int *)`
After: `CTypeInfo2::Invoke(void*, long, unsigned short, tagDISPPARAMS*, tagVARIANT*, tagEXCEPINFO*, unsigned int*)`

The flags in detail:

 * `SPACE_AFTER_COMMA`: Adds a space after each comma.
 * `HUG_TYPE`: Removes the space in front of "*" and "&".
 * `NO_CLASS_TYPE`: Removes "struct" / "class" / "enum" / "union" keywords from argument types.
 * `NO_MS_KEYWORDS`: Removes `__cdecl` and similar distracting keywords.

The new output is more consistent with the output that we produce for
functions which were mangled with the Itanium C++ ABI scheme, i.e. which
are going down the `cpp_demangle` path.
For comparison, here are two demangled functions from a macOS mozglue.dylib;
you can see that these already follow the same "space after comma", "no class/struct keyword",
"no space before *" rules:

`mozilla::baseprofiler::ParseFeaturesFromStringArray(char const**, unsigned int, bool)`
`double_conversion::RoundUp(double_conversion::Vector<char>, int*, int*)`