### PR TITLE
fix: Allow Windows CFI to underflow

### DIFF
--- a/symbolic-cfi/tests/snapshots/test_cfi__cfi_pe_windows.snap
+++ b/symbolic-cfi/tests/snapshots/test_cfi__cfi_pe_windows.snap
@@ -1,8 +1,7 @@
 ---
-source: symbolic-minidump/tests/test_cfi.rs
+source: symbolic-cfi/tests/test_cfi.rs
 assertion_line: 105
 expression: cfi
-
 ---
 STACK CFI INIT 1010 55 .cfa: $rsp 80 + $rbx: .cfa 16 - ^ $rsi: .cfa 24 - ^ $rdi: .cfa 32 - ^ .ra: .cfa 8 - ^
 STACK CFI INIT 10b0 43 .cfa: $rsp 48 + $rdi: .cfa 16 - ^ $rbx: .cfa 0 - ^ .ra: .cfa 8 - ^
@@ -15,7 +14,7 @@ STACK CFI INIT 11f8 2b .cfa: $rsp 48 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
 STACK CFI INIT 1224 b7 .cfa: $rsp 48 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
 STACK CFI INIT 12dc 10 .cfa: $rsp 48 + .ra: .cfa 8 - ^
 STACK CFI INIT 12ec 19 .cfa: $rsp 48 + .ra: .cfa 8 - ^
-STACK CFI INIT 1308 17c .cfa: $rsp 64 + $rdi: .cfa 16 - ^ $rbx: .cfa 0 - ^ $rsi: .cfa 0 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 1308 17c .cfa: $rsp 64 + $rdi: .cfa 16 - ^ $rbx: .cfa 0 - ^ $rsi: .cfa -8 - ^ .ra: .cfa 8 - ^
 STACK CFI INIT 1484 12 .cfa: $rsp 48 + .ra: .cfa 8 - ^
 STACK CFI INIT 1498 34 .cfa: $rsp 48 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
 STACK CFI INIT 14cc d1 .cfa: $rsp 64 + .ra: .cfa 8 - ^
@@ -34,14 +33,14 @@ STACK CFI INIT 19a8 24 .cfa: $rsp 48 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
 STACK CFI INIT 19cc 2b .cfa: $rsp 48 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
 STACK CFI INIT 19f8 4f .cfa: $rsp 48 + $rbx: .cfa 16 - ^ .ra: .cfa 8 - ^
 STACK CFI INIT 1a48 17 .cfa: $rsp 48 + .ra: .cfa 8 - ^
-STACK CFI INIT 1a60 ac .cfa: $rsp 48 + $rbp: .cfa 16 - ^ $rbx: .cfa 0 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 1a60 ac .cfa: $rsp 48 + $rbp: .cfa 16 - ^ $rbx: .cfa -24 - ^ .ra: .cfa 8 - ^
 STACK CFI INIT 1b40 1b .cfa: $rsp 48 + .ra: .cfa 8 - ^
 STACK CFI INIT 1b80 14a .cfa: $rsp 1488 + $rbp: .cfa 16 - ^ $rbx: .cfa 0 - ^ .ra: .cfa 8 - ^
 STACK CFI INIT 1cd4 52 .cfa: $rsp 48 + .ra: .cfa 8 - ^
 STACK CFI INIT 1d38 38 .cfa: $rsp 48 + .ra: .cfa 8 - ^
 STACK CFI INIT 1d70 3c .cfa: $rsp 48 + $rdi: .cfa 16 - ^ $rbx: .cfa 0 - ^ .ra: .cfa 8 - ^
 STACK CFI INIT 1dac 3c .cfa: $rsp 48 + $rdi: .cfa 16 - ^ $rbx: .cfa 0 - ^ .ra: .cfa 8 - ^
-STACK CFI INIT 1de8 1b9 .cfa: $rsp 48 + $rsi: .cfa 16 - ^ $rdi: .cfa 24 - ^ $r14: .cfa 32 - ^ $rbx: .cfa 0 - ^ $rbp: .cfa 0 - ^ .ra: .cfa 8 - ^
+STACK CFI INIT 1de8 1b9 .cfa: $rsp 48 + $rsi: .cfa 16 - ^ $rdi: .cfa 24 - ^ $r14: .cfa 32 - ^ $rbx: .cfa -8 - ^ $rbp: .cfa -16 - ^ .ra: .cfa 8 - ^
 STACK CFI INIT 2090 2 .cfa: $rsp 8 + .ra: .cfa 8 - ^
 STACK CFI INIT 20ac 1e .cfa: $rsp 48 + $rbp: .cfa 16 - ^ .ra: .cfa 8 - ^
 STACK CFI INIT 20ca 18 .cfa: $rsp 16 + $rbp: .cfa 16 - ^ .ra: .cfa 8 - ^


### PR DESCRIPTION
We have seen some SaveNonVolatile unwind operations underflow the current stack frame, so they are saving/loading registers into the callers stack frame.
For example `VCRUNTIME140.dll!__C_specific_handler` can do this.

Its full Unwind Operations look like this:

```
Function Table:
  Start Address: 0xbff0
  End Address: 0xc1eb
  Unwind Info Address: 0x10138
    Version: 1
    Flags: 0
    Size of prolog: 28
    Number of Codes: 12
    No frame pointer used
    Unwind Codes:
      0x1c: UOP_SaveNonVol RSI [0x0080]
      0x1c: UOP_SaveNonVol RBP [0x0078]
      0x1c: UOP_SaveNonVol RBX [0x0070]
      0x1c: UOP_AllocSmall 64
      0x18: UOP_PushNonVol R15
      0x16: UOP_PushNonVol R14
      0x14: UOP_PushNonVol R13
      0x12: UOP_PushNonVol R12
      0x10: UOP_PushNonVol RDI
```

We previously used saturating_sub to clamp these offsets to 0, meaning things are loaded from the current stack frame instead of from the callers frame. Now we correctly generate ASCII CFI for these Unwind Codes.

This fixes one pre-condition of #638, namely that it depends on `$rbp` which is loaded from the above unwind codes, thus outside its own stack frame.