### PR TITLE
fix: Correctly use DWARF5 .debug_addr section

### DIFF
--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -1066,6 +1066,8 @@ where
 /// All DWARF sections that are needed by `DwarfDebugSession`.
 struct DwarfSections<'data> {
     debug_abbrev: DwarfSectionData<'data, gimli::read::DebugAbbrev<Slice<'data>>>,
+    debug_addr: DwarfSectionData<'data, gimli::read::DebugAddr<Slice<'data>>>,
+    debug_aranges: DwarfSectionData<'data, gimli::read::DebugAranges<Slice<'data>>>,
     debug_info: DwarfSectionData<'data, gimli::read::DebugInfo<Slice<'data>>>,
     debug_line: DwarfSectionData<'data, gimli::read::DebugLine<Slice<'data>>>,
     debug_line_str: DwarfSectionData<'data, gimli::read::DebugLineStr<Slice<'data>>>,
@@ -1083,6 +1085,8 @@ impl<'data> DwarfSections<'data> {
     {
         DwarfSections {
             debug_abbrev: DwarfSectionData::load(dwarf),
+            debug_addr: DwarfSectionData::load(dwarf),
+            debug_aranges: DwarfSectionData::load(dwarf),
             debug_info: DwarfSectionData::load(dwarf),
             debug_line: DwarfSectionData::load(dwarf),
             debug_line_str: DwarfSectionData::load(dwarf),
@@ -1121,8 +1125,8 @@ impl<'d> DwarfInfo<'d> {
     ) -> Result<Self, DwarfError> {
         let inner = gimli::read::Dwarf {
             debug_abbrev: sections.debug_abbrev.to_gimli(),
-            debug_addr: Default::default(),
-            debug_aranges: Default::default(),
+            debug_addr: sections.debug_addr.to_gimli(),
+            debug_aranges: sections.debug_aranges.to_gimli(),
             debug_info: sections.debug_info.to_gimli(),
             debug_line: sections.debug_line.to_gimli(),
             debug_line_str: sections.debug_line_str.to_gimli(),


### PR DESCRIPTION
We were correctly handling `DebugAddrIndex` attributes, but never provided the `.debug_addr` section they are based on, so resolving those indices always failed.

Fixes https://github.com/getsentry/symbolicator/issues/855
Fixes https://getsentry.atlassian.net/browse/ISSUE-1563