### PR TITLE
ref: Use CFI for modules that only have a CodeId

### DIFF
--- a/examples/minidump_stackwalk/Cargo.toml
+++ b/examples/minidump_stackwalk/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 [dependencies]
 async-trait = "0.1.53"
 clap = "3.1.0"
-minidump = "0.12.0"
-minidump-processor = "0.12.0"
+minidump = "0.13.0"
+minidump-processor = "0.13.0"
 symbolic = { path = "../../symbolic", features = ["symcache", "demangle", "cfi"] }
 thiserror = "1.0.31"
 tokio = {version = "1.18.1", features = ["macros", "rt"] }


### PR DESCRIPTION
We are dealing with a PE file that does not have a CodeView record / DebugId,
in which case we should still be able to use it based on its CodeId.