### PR TITLE
deps: Update insta to 1.18.0 and enable its yaml feature

### DIFF
--- a/symbolic-cfi/Cargo.toml
+++ b/symbolic-cfi/Cargo.toml
@@ -20,6 +20,6 @@ symbolic-debuginfo = { version = "9.0.0", path = "../symbolic-debuginfo" }
 thiserror = "1.0.20"
 
 [dev-dependencies]
-insta = "1.3.0"
+insta = { version = "1.18.0", features = ["yaml"] }
 symbolic-testutils = { path = "../symbolic-testutils" }
 similar-asserts = "1.0.0"

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -103,7 +103,7 @@ zip = { version = "0.6.2", optional = true, default-features = false, features =
 
 [dev-dependencies]
 criterion = { version = "0.3.4", features = ["html_reports"] }
-insta = "1.3.0"
+insta = { version = "1.18.0", features = ["yaml"] }
 tempfile = "3.1.0"
 similar-asserts = "1.0.0"
 symbolic-testutils = { path = "../symbolic-testutils" }

--- a/symbolic-symcache/Cargo.toml
+++ b/symbolic-symcache/Cargo.toml
@@ -32,7 +32,7 @@ thiserror = "1.0.20"
 indexmap = "1.7.0"
 
 [dev-dependencies]
-insta = "1.3.0"
+insta = { version = "1.18.0", features = ["yaml"] }
 criterion = "0.3.4"
 symbolic-testutils = { path = "../symbolic-testutils" }
 similar-asserts = "1.0.0"

--- a/symbolic-unreal/Cargo.toml
+++ b/symbolic-unreal/Cargo.toml
@@ -40,6 +40,6 @@ thiserror = "1.0.20"
 time = { version = "0.3.5", features = ["formatting"] }
 
 [dev-dependencies]
-insta = "1.3.0"
+insta = { version = "1.18.0", features = ["yaml"] }
 symbolic-testutils = { path = "../symbolic-testutils" }
 similar-asserts = "1.0.0"


### PR DESCRIPTION
`1.18.0` added a warning for future `yaml` and `json` assertions deprecation, which makes our builds fail, as we use `-Dwarnings` flag in the CI.