### PR TITLE
fix: Speed up the SmCache SourceContext

### DIFF
--- a/examples/smcache_debug/src/main.rs
+++ b/examples/smcache_debug/src/main.rs
@@ -15,8 +15,13 @@ fn execute(matches: &ArgMatches) -> Result<()> {
     // Tracing subscriber controlled by `RUST_LOG`
     fmt()
         .with_env_filter(EnvFilter::from_default_env())
-        .with_span_events(fmt::format::FmtSpan::NEW | fmt::format::FmtSpan::CLOSE)
-        .event_format(tracing_subscriber::fmt::format().compact().without_time())
+        .with_span_events(fmt::format::FmtSpan::CLOSE)
+        .event_format(
+            tracing_subscriber::fmt::format()
+                .compact()
+                .with_target(false)
+                .without_time(),
+        )
         .init();
 
     // Actual behavior

--- a/symbolic-smcache/src/smcache/writer.rs
+++ b/symbolic-smcache/src/smcache/writer.rs
@@ -11,8 +11,8 @@ use crate::{extract_scope_names, NameResolver, SourcePosition};
 use super::raw;
 use raw::{ANONYMOUS_SCOPE_SENTINEL, GLOBAL_SCOPE_SENTINEL, NO_FILE_SENTINEL};
 
-/// A structure that allows quick resolution of minified [`raw::MinifiedSourcePosition`]s
-/// to the original [`raw::OriginalSourceLocation`] it maps to.
+/// A structure that allows quick resolution of minified source position
+/// to the original source position it maps to.
 pub struct SmCacheWriter {
     string_bytes: Vec<u8>,
     files: Vec<raw::File>,

--- a/symbolic-smcache/src/smcache/writer.rs
+++ b/symbolic-smcache/src/smcache/writer.rs
@@ -65,7 +65,7 @@ impl SmCacheWriter {
 
         // convert our offset index to a source position index
         let scope_index = ScopeIndex::new(scopes).map_err(SmCacheErrorInner::ScopeIndex)?;
-        let scope_index: Vec<_> = tracing::trace_span!("scope index").in_scope(|| {
+        let scope_index: Vec<_> = tracing::trace_span!("convert scope index").in_scope(|| {
             scope_index
                 .iter()
                 .filter_map(|(offset, result)| {


### PR DESCRIPTION
The SourceContext is responsible to offer fast byte offset <-> line/column
conversion. Previously it was based on saving the offset of each line
and doing a byte/utf16-offset counting loop. Turns out this is not a
good idea if you never have line breaks like in the case of minified js.

Instead, this now creates an index every X chars and rather goes from there.

This cuts total "create/write SmCache" more than in half, and the
previous "resolve original names" and "convert scope index" spans that
do a lot of conversions down by 1-2 orders of magnitude.