### PR TITLE
ref: Skip parsing Minified Source when dealing with Metro/Hermes

### DIFF
--- a/symbolic-sourcemapcache/Cargo.toml
+++ b/symbolic-sourcemapcache/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 thiserror = "1.0.31"
 rslint_parser = "0.3.1"
-sourcemap = { git = "https://github.com/getsentry/rust-sourcemap.git", branch = "master" }
+sourcemap = "6.1.0"
 zerocopy = "0.6.1"
 leb128 = "0.2.5"
 indexmap = "1.9.1"

--- a/symbolic-sourcemapcache/Cargo.toml
+++ b/symbolic-sourcemapcache/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 thiserror = "1.0.31"
 rslint_parser = "0.3.1"
-sourcemap = "6.0.2"
+sourcemap = { git = "https://github.com/getsentry/rust-sourcemap.git", branch = "master" }
 zerocopy = "0.6.1"
 leb128 = "0.2.5"
 indexmap = "1.9.1"

--- a/symbolic-sourcemapcache/src/sourcemapcache/mod.rs
+++ b/symbolic-sourcemapcache/src/sourcemapcache/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::derive_partial_eq_without_eq)]
+
 mod lookup;
 mod raw;
 mod writer;

--- a/symbolic-sourcemapcache/tests/integration.rs
+++ b/symbolic-sourcemapcache/tests/integration.rs
@@ -345,16 +345,11 @@ fn metro_scope_lookup() {
 
     let cache = SourceMapCache::parse(&buf).unwrap();
 
-    // TODO: The scope names come from parsing the minified source right now,
-    // and not directly from the hermes/metro sourcemap extension.
-    // Once the sourcemap crate allows directly looking up the scope of tokens,
-    // we will get the same scope names as above.
-
     // e.foo (react-native-metro.js:7:101)
     let sl = cache.lookup(SourcePosition::new(6, 100)).unwrap();
     assert_eq!(sl.file_name(), Some("module.js"));
     assert_eq!(sl.line(), 1);
-    assert_eq!(sl.scope(), ScopeLookupResult::NamedScope("foo.foo"));
+    assert_eq!(sl.scope(), ScopeLookupResult::NamedScope("foo"));
     assert_eq!(
         sl.line_contents().unwrap(),
         "    throw new Error(\"lets throw!\");\n"
@@ -364,6 +359,7 @@ fn metro_scope_lookup() {
     let sl = cache.lookup(SourcePosition::new(5, 43)).unwrap();
     assert_eq!(sl.file_name(), Some("input.js"));
     assert_eq!(sl.line(), 2);
-    assert_eq!(sl.scope(), ScopeLookupResult::AnonymousScope);
+    // NOTE: metro has a special `<global>` scope
+    assert_eq!(sl.scope(), ScopeLookupResult::NamedScope("<global>"));
     assert_eq!(sl.line_contents().unwrap(), "foo();\n");
 }


### PR DESCRIPTION
The Metro/Hermes SourceMaps have scopes embedded in them which we now prefer.
In that case, we can completely skip parsing and extracting scopes from the minified JS.

This depends on having https://github.com/getsentry/rust-sourcemap/pull/48 in a published release.