### PR TITLE
feat: Add column getter to SourceLocation lookup struct

### DIFF
--- a/symbolic-sourcemapcache/src/sourcemapcache/lookup.rs
+++ b/symbolic-sourcemapcache/src/sourcemapcache/lookup.rs
@@ -4,13 +4,15 @@ use crate::{ScopeLookupResult, SourcePosition};
 
 use super::raw;
 
-/// A resolved Source Location  with file, line and scope information.
+/// A resolved Source Location with file, line, column and scope information.
 #[derive(Debug, PartialEq)]
 pub struct SourceLocation<'data> {
     /// The source file this location belongs to.
     file: Option<File<'data>>,
     /// The source line.
     line: u32,
+    /// The source column.
+    column: u32,
     /// The scope containing this source location.
     scope: ScopeLookupResult<'data>,
 }
@@ -24,6 +26,11 @@ impl<'data> SourceLocation<'data> {
     /// The number of the source line.
     pub fn line(&self) -> u32 {
         self.line
+    }
+
+    /// The number of the source column.
+    pub fn column(&self) -> u32 {
+        self.column
     }
 
     /// The contents of the source line.
@@ -160,6 +167,7 @@ impl<'data> SourceMapCache<'data> {
         let sl = self.orig_source_locations.get(idx)?;
 
         let line = sl.line;
+        let column = sl.column;
 
         let file = self
             .files
@@ -174,7 +182,12 @@ impl<'data> SourceMapCache<'data> {
                 .map_or(ScopeLookupResult::Unknown, ScopeLookupResult::NamedScope),
         };
 
-        Some(SourceLocation { file, line, scope })
+        Some(SourceLocation {
+            file,
+            line,
+            column,
+            scope,
+        })
     }
 
     /// Returns an iterator over all files in the cache.

--- a/symbolic-sourcemapcache/src/sourcemapcache/raw.rs
+++ b/symbolic-sourcemapcache/src/sourcemapcache/raw.rs
@@ -63,7 +63,7 @@ pub const GLOBAL_SCOPE_SENTINEL: u32 = u32::MAX;
 /// Sentinel value used to denote anonymous function scope.
 pub const ANONYMOUS_SCOPE_SENTINEL: u32 = u32::MAX - 1;
 
-/// The original source location, file line and scope.
+/// The original source location, line, column and scope.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, FromBytes, AsBytes)]
 #[repr(C)]
 pub struct OriginalSourceLocation {
@@ -71,6 +71,8 @@ pub struct OriginalSourceLocation {
     pub file_idx: u32,
     /// The original line number.
     pub line: u32,
+    /// The original column number.
+    pub column: u32,
     /// The optional scope name (offset into string table).
     pub scope_idx: u32,
 }
@@ -119,7 +121,7 @@ mod tests {
         assert_eq!(mem::size_of::<MinifiedSourcePosition>(), 8);
         assert_eq!(mem::align_of::<MinifiedSourcePosition>(), 4);
 
-        assert_eq!(mem::size_of::<OriginalSourceLocation>(), 12);
+        assert_eq!(mem::size_of::<OriginalSourceLocation>(), 16);
         assert_eq!(mem::align_of::<OriginalSourceLocation>(), 4);
     }
 }

--- a/symbolic-sourcemapcache/src/sourcemapcache/writer.rs
+++ b/symbolic-sourcemapcache/src/sourcemapcache/writer.rs
@@ -151,6 +151,7 @@ impl SourceMapCacheWriter {
                 let sp = SourcePosition::new(min_line, min_col);
                 let file = token.get_source();
                 let line = token.get_src_line();
+                let column = token.get_src_col();
                 let scope = lookup_scope(&sp);
 
                 let file_idx = match file {
@@ -173,6 +174,7 @@ impl SourceMapCacheWriter {
                 let sl = raw::OriginalSourceLocation {
                     file_idx,
                     line,
+                    column,
                     scope_idx,
                 };
 

--- a/symbolic-sourcemapcache/tests/integration.rs
+++ b/symbolic-sourcemapcache/tests/integration.rs
@@ -175,16 +175,19 @@ fn resolves_inlined_function() {
     let sl = cache.lookup(SourcePosition::new(0, 62)).unwrap();
     assert_eq!(sl.file_name(), Some("../src/app.js"));
     assert_eq!(sl.line(), 2);
+    assert_eq!(sl.column(), 29);
     assert_eq!(sl.scope(), ScopeLookupResult::NamedScope("buttonCallback"));
 
     let sl = cache.lookup(SourcePosition::new(0, 46)).unwrap();
     assert_eq!(sl.file_name(), Some("../src/bar.js"));
     assert_eq!(sl.line(), 3);
+    assert_eq!(sl.column(), 2);
     assert_eq!(sl.scope(), ScopeLookupResult::NamedScope("bar"));
 
     let sl = cache.lookup(SourcePosition::new(0, 33)).unwrap();
     assert_eq!(sl.file_name(), Some("../src/foo.js"));
     assert_eq!(sl.line(), 1);
+    assert_eq!(sl.column(), 8);
     assert_eq!(sl.scope(), ScopeLookupResult::NamedScope("foo"));
 }
 
@@ -204,6 +207,7 @@ fn writes_simple_cache() {
 
     assert_eq!(sl.file_name(), Some("tests/fixtures/simple/original.js"));
     assert_eq!(sl.line(), 1);
+    assert_eq!(sl.column(), 9);
     assert_eq!(sl.scope(), ScopeLookupResult::NamedScope("abcd"));
     assert_eq!(sl.line_contents().unwrap(), "function abcd() {}\n");
 }
@@ -230,26 +234,31 @@ fn resolves_location_from_cache() {
     let sl = lookup(1, 50).unwrap();
     assert_eq!(sl.file_name(), Some("../src/constants.js"));
     assert_eq!(sl.line(), 2);
+    assert_eq!(sl.column(), 34);
     assert_eq!(sl.scope(), Unknown);
 
     let sl = lookup(1, 133).unwrap();
     assert_eq!(sl.file_name(), Some("../src/util.js"));
     assert_eq!(sl.line(), 11);
+    assert_eq!(sl.column(), 22);
     assert_eq!(sl.scope(), NamedScope("assign"));
 
     let sl = lookup(1, 482).unwrap();
     assert_eq!(sl.file_name(), Some("../src/create-element.js"));
     assert_eq!(sl.line(), 39);
+    assert_eq!(sl.column(), 8);
     assert_eq!(sl.scope(), NamedScope("createElement"));
 
     let sl = lookup(1, 9780).unwrap();
     assert_eq!(sl.file_name(), Some("../src/component.js"));
     assert_eq!(sl.line(), 181);
+    assert_eq!(sl.column(), 4);
     assert_eq!(sl.scope(), Unknown);
 
     let sl = lookup(1, 9795).unwrap();
     assert_eq!(sl.file_name(), Some("../src/create-context.js"));
     assert_eq!(sl.line(), 2);
+    assert_eq!(sl.column(), 11);
     assert_eq!(sl.scope(), Unknown);
 }
 
@@ -312,6 +321,7 @@ fn hermes_scope_lookup() {
     let sl = cache.lookup(SourcePosition::new(0, 11939)).unwrap();
     assert_eq!(sl.file_name(), Some("module.js"));
     assert_eq!(sl.line(), 1);
+    assert_eq!(sl.column(), 10);
     assert_eq!(sl.scope(), ScopeLookupResult::NamedScope("foo"));
     assert_eq!(
         sl.line_contents().unwrap(),
@@ -322,6 +332,7 @@ fn hermes_scope_lookup() {
     let sl = cache.lookup(SourcePosition::new(0, 11857)).unwrap();
     assert_eq!(sl.file_name(), Some("input.js"));
     assert_eq!(sl.line(), 2);
+    assert_eq!(sl.column(), 0);
     assert_eq!(sl.scope(), ScopeLookupResult::NamedScope("<global>"));
     assert_eq!(sl.line_contents().unwrap(), "foo();\n");
 }
@@ -349,6 +360,7 @@ fn metro_scope_lookup() {
     let sl = cache.lookup(SourcePosition::new(6, 100)).unwrap();
     assert_eq!(sl.file_name(), Some("module.js"));
     assert_eq!(sl.line(), 1);
+    assert_eq!(sl.column(), 10);
     assert_eq!(sl.scope(), ScopeLookupResult::NamedScope("foo"));
     assert_eq!(
         sl.line_contents().unwrap(),
@@ -359,6 +371,7 @@ fn metro_scope_lookup() {
     let sl = cache.lookup(SourcePosition::new(5, 43)).unwrap();
     assert_eq!(sl.file_name(), Some("input.js"));
     assert_eq!(sl.line(), 2);
+    assert_eq!(sl.column(), 0);
     // NOTE: metro has a special `<global>` scope
     assert_eq!(sl.scope(), ScopeLookupResult::NamedScope("<global>"));
     assert_eq!(sl.line_contents().unwrap(), "foo();\n");


### PR DESCRIPTION
This addition will give us the original column line number, which we need to preserve current functionality.