### PR TITLE
Bump wasmparser to 0.89.1

### DIFF
--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -98,7 +98,7 @@ serde_json = { version = "1.0.40", optional = true }
 smallvec = { version = "1.2.0", optional = true }
 symbolic-common = { version = "9.1.1", path = "../symbolic-common" }
 thiserror = "1.0.20"
-wasmparser = { version = "0.85.0", optional = true }
+wasmparser = { version = "0.89.1", optional = true }
 zip = { version = "0.6.2", optional = true, default-features = false, features = [
     "deflate",
 ] }

--- a/symbolic-debuginfo/src/wasm/parser.rs
+++ b/symbolic-debuginfo/src/wasm/parser.rs
@@ -48,7 +48,7 @@ impl<'data> super::WasmObject<'data> {
                     let fs = func_sigs.as_mut_bitslice();
 
                     for (i, ty) in tsr.into_iter().enumerate() {
-                        if matches!(ty?, wasmparser::TypeDef::Func(_)) {
+                        if matches!(ty?, wasmparser::Type::Func(_)) {
                             fs.set(i, true);
                         }
                     }
@@ -206,7 +206,7 @@ fn get_function_info(
         for _ in 0..body.read_var_u32()? {
             let pos = body.original_position();
             let count = body.read_var_u32()?;
-            let ty = body.read_type()?;
+            let ty = body.read_val_type()?;
             validator.define_locals(pos, count, ty)?;
         }
     }


### PR DESCRIPTION
Unfortunately there doesn't seem to be any changelog file for wasmparser, but API changes are quite limited here.