### PR TITLE
fix(sourcemapcache): Correct line offsets

### DIFF
--- a/symbolic-sourcemapcache/src/sourcemapcache/lookup.rs
+++ b/symbolic-sourcemapcache/src/sourcemapcache/lookup.rs
@@ -286,7 +286,8 @@ mod tests {
     #[test]
     fn lines_empty_file() {
         let source = "";
-        let line_offsets = SourceMapCacheWriter::line_offsets(source).collect::<Vec<_>>();
+        let mut line_offsets = Vec::new();
+        SourceMapCacheWriter::append_line_offsets(source, &mut line_offsets);
 
         let file = File {
             name: "empty",
@@ -301,7 +302,8 @@ mod tests {
     #[test]
     fn lines_almost_empty_file() {
         let source = "\n";
-        let line_offsets = SourceMapCacheWriter::line_offsets(source).collect::<Vec<_>>();
+        let mut line_offsets = Vec::new();
+        SourceMapCacheWriter::append_line_offsets(source, &mut line_offsets);
 
         let file = File {
             name: "almost_empty",
@@ -317,8 +319,8 @@ mod tests {
     #[test]
     fn lines_several_lines() {
         let source = "a\n\nb\nc";
-
-        let line_offsets = SourceMapCacheWriter::line_offsets(source).collect::<Vec<_>>();
+        let mut line_offsets = Vec::new();
+        SourceMapCacheWriter::append_line_offsets(source, &mut line_offsets);
 
         let file = File {
             name: "several_lines",
@@ -335,8 +337,8 @@ mod tests {
     #[test]
     fn lines_several_lines_trailing_newline() {
         let source = "a\n\nb\nc\n";
-
-        let line_offsets = SourceMapCacheWriter::line_offsets(source).collect::<Vec<_>>();
+        let mut line_offsets = Vec::new();
+        SourceMapCacheWriter::append_line_offsets(source, &mut line_offsets);
 
         let file = File {
             name: "several_lines_trailing_newline",

--- a/symbolic-sourcemapcache/src/sourcemapcache/lookup.rs
+++ b/symbolic-sourcemapcache/src/sourcemapcache/lookup.rs
@@ -238,9 +238,13 @@ impl<'data> File<'data> {
 
     /// Returns the requested source line if possible.
     pub fn line(&self, line_no: usize) -> Option<&'data str> {
+        let source = self.source?;
         let from = self.line_offsets.get(line_no).copied()?.0 as usize;
-        let to = self.line_offsets.get(line_no.checked_add(1)?).copied()?.0 as usize;
-        self.source.and_then(|source| source.get(from..to))
+        let next_line_no = line_no.checked_add(1);
+        let to = next_line_no
+            .and_then(|next_line_no| self.line_offsets.get(next_line_no))
+            .map_or(source.len(), |lo| lo.0 as usize);
+        source.get(from..to)
     }
 }
 
@@ -272,4 +276,78 @@ impl<'data> Iterator for Files<'data> {
 fn align_buf(buf: &[u8]) -> &[u8] {
     let offset = buf.as_ptr().align_offset(8);
     buf.get(offset..).unwrap_or(&[])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SourceMapCacheWriter;
+
+    #[test]
+    fn lines_empty_file() {
+        let source = "";
+        let line_offsets = SourceMapCacheWriter::line_offsets(source).collect::<Vec<_>>();
+
+        let file = File {
+            name: "empty",
+            source: Some(source),
+            line_offsets: &line_offsets,
+        };
+
+        assert_eq!(file.line(0), Some(""));
+        assert_eq!(file.line(1), None);
+    }
+
+    #[test]
+    fn lines_almost_empty_file() {
+        let source = "\n";
+        let line_offsets = SourceMapCacheWriter::line_offsets(source).collect::<Vec<_>>();
+
+        let file = File {
+            name: "almost_empty",
+            source: Some(source),
+            line_offsets: &line_offsets,
+        };
+
+        assert_eq!(file.line(0), Some("\n"));
+        assert_eq!(file.line(1), Some(""));
+        assert_eq!(file.line(2), None);
+    }
+
+    #[test]
+    fn lines_several_lines() {
+        let source = "a\n\nb\nc";
+
+        let line_offsets = SourceMapCacheWriter::line_offsets(source).collect::<Vec<_>>();
+
+        let file = File {
+            name: "several_lines",
+            source: Some(source),
+            line_offsets: &line_offsets,
+        };
+
+        assert_eq!(file.line(0), Some("a\n"));
+        assert_eq!(file.line(1), Some("\n"));
+        assert_eq!(file.line(2), Some("b\n"));
+        assert_eq!(file.line(3), Some("c"));
+    }
+
+    #[test]
+    fn lines_several_lines_trailing_newline() {
+        let source = "a\n\nb\nc\n";
+
+        let line_offsets = SourceMapCacheWriter::line_offsets(source).collect::<Vec<_>>();
+
+        let file = File {
+            name: "several_lines_trailing_newline",
+            source: Some(source),
+            line_offsets: &line_offsets,
+        };
+
+        assert_eq!(file.line(0), Some("a\n"));
+        assert_eq!(file.line(1), Some("\n"));
+        assert_eq!(file.line(2), Some("b\n"));
+        assert_eq!(file.line(3), Some("c\n"));
+        assert_eq!(file.line(4), Some(""));
+    }
 }

--- a/symbolic-sourcemapcache/src/sourcemapcache/writer.rs
+++ b/symbolic-sourcemapcache/src/sourcemapcache/writer.rs
@@ -123,7 +123,7 @@ impl SourceMapCacheWriter {
                 let name_offset = Self::insert_string(&mut string_bytes, &mut strings, name);
                 let source_offset = Self::insert_string(&mut string_bytes, &mut strings, source);
                 let line_offsets_start = line_offsets.len() as u32;
-                line_offsets.extend(Self::line_offsets(source));
+                Self::append_line_offsets(source, &mut line_offsets);
                 let line_offsets_end = line_offsets.len() as u32;
 
                 files.push((
@@ -264,26 +264,27 @@ impl SourceMapCacheWriter {
         Ok(())
     }
 
-    /// Compute line offsets for a source file.
+    /// Compute line offsets for a source file and append them to the given  vector.
     ///
     /// There is always one line offset at the start of the file (even if the file is empty)
     /// and then another one after every newline (even if the file ends on a newline).
-    pub(crate) fn line_offsets(source: &str) -> impl Iterator<Item = raw::LineOffset> + '_ {
+    pub(crate) fn append_line_offsets(source: &str, out: &mut Vec<raw::LineOffset>) {
+        // The empty file has only one line offset for the start.
+        if source.is_empty() {
+            out.push(raw::LineOffset(0));
+            return;
+        }
+
         let buf_ptr = source.as_ptr();
-        source
-            .is_empty()
-            .then(|| raw::LineOffset(0))
-            .into_iter()
-            .chain(source.lines().map(move |line| {
-                raw::LineOffset(unsafe { line.as_ptr().offset_from(buf_ptr) as usize } as u32)
-            }))
-            .chain(
-                // If the file ends with a line break, add another line offset for the empty last line
-                // (the lines iterator skips it).
-                source
-                    .ends_with('\n')
-                    .then(|| raw::LineOffset(source.len() as u32)),
-            )
+        out.extend(source.lines().map(move |line| {
+            raw::LineOffset(unsafe { line.as_ptr().offset_from(buf_ptr) as usize } as u32)
+        }));
+
+        // If the file ends with a line break, add another line offset for the empty last line
+        // (the lines iterator skips it).
+        if source.ends_with('\n') {
+            out.push(raw::LineOffset(source.len() as u32));
+        }
     }
 }
 
@@ -351,8 +352,8 @@ mod tests {
     #[test]
     fn line_offsets_empty_file() {
         let source = "";
-
-        let line_offsets = SourceMapCacheWriter::line_offsets(source).collect::<Vec<_>>();
+        let mut line_offsets = Vec::new();
+        SourceMapCacheWriter::append_line_offsets(source, &mut line_offsets);
 
         assert_eq!(line_offsets, [LineOffset(0)]);
     }
@@ -360,8 +361,8 @@ mod tests {
     #[test]
     fn line_offsets_almost_empty_file() {
         let source = "\n";
-
-        let line_offsets = SourceMapCacheWriter::line_offsets(source).collect::<Vec<_>>();
+        let mut line_offsets = Vec::new();
+        SourceMapCacheWriter::append_line_offsets(source, &mut line_offsets);
 
         assert_eq!(line_offsets, [LineOffset(0), LineOffset(1)]);
     }
@@ -369,8 +370,8 @@ mod tests {
     #[test]
     fn line_offsets_several_lines() {
         let source = "a\n\nb\nc";
-
-        let line_offsets = SourceMapCacheWriter::line_offsets(source).collect::<Vec<_>>();
+        let mut line_offsets = Vec::new();
+        SourceMapCacheWriter::append_line_offsets(source, &mut line_offsets);
 
         assert_eq!(
             line_offsets,
@@ -381,8 +382,8 @@ mod tests {
     #[test]
     fn line_offsets_several_lines_trailing_newline() {
         let source = "a\n\nb\nc\n";
-
-        let line_offsets = SourceMapCacheWriter::line_offsets(source).collect::<Vec<_>>();
+        let mut line_offsets = Vec::new();
+        SourceMapCacheWriter::append_line_offsets(source, &mut line_offsets);
 
         assert_eq!(
             line_offsets,


### PR DESCRIPTION
This changes the logic of line offsets as follows: each file has one line offset at the start and then one after every line, no exceptions. In particular, this means that an empty file has one line offset and a file ending with on a newline has a line offset for the final empty line. The tests should illustrate fairly clearly how it works.

Since files don't have a line offset for the end of the file anymore, the logic of `File::line` changes as well, but this is straightforward: if there is a next line offset, we slice until that offset, and if there isn't, we just slice until the end of the file.

I've gotta say I don't love the implementation of `SourceMapCacheWriter::line_offsets`, I think this madcap chaining of iterators is hard to read. But I can't really think of a better way to do it.