### PR TITLE
fix: Be more strict when demangling C++ names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 **Fixes**:
 
-- Correctly resolve the `DW_AT_producer` attribute of DWARF files ([#676](https://github.com/getsentry/symbolic/pull/676))
+- Be stricter about demangling only `_Z` prefixed C++ names. ([#681](https://github.com/getsentry/symbolic/pull/681))
+- Correctly resolve the `DW_AT_producer` attribute of DWARF files. ([#676](https://github.com/getsentry/symbolic/pull/676))
 
 ## 9.1.1
 

--- a/symbolic-demangle/src/lib.rs
+++ b/symbolic-demangle/src/lib.rs
@@ -240,6 +240,13 @@ fn try_demangle_cpp(ident: &str, opts: DemangleOptions) -> Option<String> {
         return try_demangle_msvc(ident, opts);
     }
 
+    // C++ *symbols* will always start with a `_Z` prefix, but `cpp_demangle` is a bit more lenient
+    // and will also demangle bare types, turning `a` into `signed char` for example. So lets be
+    // a bit stricter and make sure we always have a `_Z` prefix.
+    if !is_maybe_cpp(ident) {
+        return None;
+    }
+
     #[cfg(feature = "cpp")]
     {
         use cpp_demangle::{DemangleOptions as CppOptions, ParseOptions, Symbol as CppSymbol};

--- a/symbolic-demangle/tests/test_cpp.rs
+++ b/symbolic-demangle/tests/test_cpp.rs
@@ -8,7 +8,7 @@
 mod utils;
 
 use symbolic_common::Language;
-use symbolic_demangle::DemangleOptions;
+use symbolic_demangle::{Demangle, DemangleOptions};
 
 #[test]
 fn test_demangle_cpp() {
@@ -45,6 +45,18 @@ fn test_demangle_cpp_hash_suffix() {
     "__ZZN3xxx12xxxxxxxxxxxx9xxxxxxxxxILNS0_16xxxxxxxxxxxxxxxxE0EZNKS_6xxxxxx16xxxxxxxxxxxxxxxxEPjbbE4$_76EEvRKT0_PS3_PNS_7xxxxxxxENS0_13xxxxxxxxxxxxxEbbEN18xxxxxxxxxxxxxxxxxx10xxxxxxxxxxEv$57c34bde3fedbd1a4bf6fbbe5453ff24" =>
     "void xxx::xxxxxxxxxxxx::xxxxxxxxx<(xxx::xxxxxxxxxxxx::xxxxxxxxxxxxxxxx)0, xxx::xxxxxx::xxxxxxxxxxxxxxxx(unsigned int*, bool, bool) const::$_76>(xxx::xxxxxx::xxxxxxxxxxxxxxxx(unsigned int*, bool, bool) const::$_76 const&, xxx::xxxxxx*, xxx::xxxxxxx*, xxx::xxxxxxxxxxxx::xxxxxxxxxxxxx, bool, bool)::xxxxxxxxxxxxxxxxxx::xxxxxxxxxx()"
     });
+}
+
+#[test]
+fn test_demangle_cpp_bare_type() {
+    let names = ["a", "b", "c", "d", "e", "f", "g"];
+    for name in names {
+        let name =
+            symbolic_common::Name::new(name, symbolic_common::NameMangling::Mangled, Language::Cpp);
+        let demangled = name.try_demangle(DemangleOptions::complete());
+
+        assert_eq!(name.as_str(), &demangled);
+    }
 }
 
 #[test]


### PR DESCRIPTION
The underlying `cpp_demangle` crate is a bit too lenient and accepts bare types, turning `a` into `signed char` for example. We want to be more strict and instead only accept `_Z` prefixed mangled names.