### PR TITLE
ref: Update deps and switch to Rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "symbolic*",
     "examples/*",

--- a/examples/addr2line/Cargo.toml
+++ b/examples/addr2line/Cargo.toml
@@ -2,7 +2,7 @@
 name = "addr2line"
 version = "9.1.2"
 authors = ["Jan Michael Auer <mail@jauer.org>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/dump_cfi/Cargo.toml
+++ b/examples/dump_cfi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dump_cfi"
 version = "9.1.2"
 authors = ["Jan Michael Auer <mail@jauer.org>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/dump_sources/Cargo.toml
+++ b/examples/dump_sources/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dump_sources"
 version = "9.1.2"
 authors = ["Jan Michael Auer <mail@jauer.org>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/minidump_stackwalk/Cargo.toml
+++ b/examples/minidump_stackwalk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "minidump_stackwalk"
 version = "9.1.2"
 authors = ["Jan Michael Auer <mail@jauer.org>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,8 +10,8 @@ publish = false
 [dependencies]
 async-trait = "0.1.53"
 clap = "3.1.0"
-minidump = "0.13.0"
-minidump-processor = "0.13.0"
+minidump = "0.14.0"
+minidump-processor = "0.14.0"
 symbolic = { path = "../../symbolic", features = ["symcache", "demangle", "cfi"] }
 thiserror = "1.0.31"
 tokio = {version = "1.18.1", features = ["macros", "rt"] }

--- a/examples/object_debug/Cargo.toml
+++ b/examples/object_debug/Cargo.toml
@@ -2,7 +2,7 @@
 name = "object_debug"
 version = "9.1.2"
 authors = ["Jan Michael Auer <mail@jauer.org>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/symcache_debug/Cargo.toml
+++ b/examples/symcache_debug/Cargo.toml
@@ -2,7 +2,7 @@
 name = "symcache_debug"
 version = "9.1.2"
 authors = ["Jan Michael Auer <mail@jauer.org>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/unreal_engine_crash/Cargo.toml
+++ b/examples/unreal_engine_crash/Cargo.toml
@@ -2,7 +2,7 @@
 name = "unreal_engine_crash"
 version = "9.1.2"
 authors = ["Jan Michael Auer <mail@jauer.org>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/symbolic-cabi/Cargo.toml
+++ b/symbolic-cabi/Cargo.toml
@@ -13,7 +13,7 @@ C interface wrapper for symbolic, a library to symbolicate and process stack
 traces from native applications, minidumps, minified JavaScripts or ProGuard
 optimized Android apps.
 """
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/symbolic-cfi/Cargo.toml
+++ b/symbolic-cfi/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/getsentry/symbolic"
 description = """
 A library to process call frame information
 """
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 symbolic-common = { version = "9.1.2", path = "../symbolic-common" }

--- a/symbolic-common/Cargo.toml
+++ b/symbolic-common/Cargo.toml
@@ -15,7 +15,7 @@ Common types and utilities for symbolic, a library to symbolicate and process
 stack traces from native applications, minidumps, minified JavaScripts or
 ProGuard optimized Android apps.
 """
-edition = "2018"
+edition = "2021"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -13,7 +13,7 @@ description = """
 A library to inspect and load DWARF debugging information from binaries, such
 as Mach-O or ELF.
 """
-edition = "2018"
+edition = "2021"
 
 exclude = ["tests/**/*"]
 
@@ -73,7 +73,7 @@ wasm = ["bitvec", "dwarf", "wasmparser"]
 [dependencies]
 bitvec = { version = "1.0.0", optional = true, features = ["alloc"] }
 dmsort = "1.0.1"
-elementtree = { version = "0.7.0", optional = true }
+elementtree = { version = "1.2.2", optional = true }
 elsa = { version = "1.4.0", optional = true }
 fallible-iterator = "0.2.0"
 flate2 = { version = "1.0.13", optional = true, default-features = false, features = [
@@ -98,13 +98,13 @@ serde_json = { version = "1.0.40", optional = true }
 smallvec = { version = "1.2.0", optional = true }
 symbolic-common = { version = "9.1.2", path = "../symbolic-common" }
 thiserror = "1.0.20"
-wasmparser = { version = "0.89.1", optional = true }
+wasmparser = { version = "0.90.0", optional = true }
 zip = { version = "0.6.2", optional = true, default-features = false, features = [
     "deflate",
 ] }
 
 [dev-dependencies]
-criterion = { version = "0.3.4", features = ["html_reports"] }
+criterion = { version = "0.4.0", features = ["html_reports"] }
 insta = { version = "1.18.0", features = ["yaml"] }
 tempfile = "3.1.0"
 similar-asserts = "1.0.0"

--- a/symbolic-debuginfo/fuzz/Cargo.toml
+++ b/symbolic-debuginfo/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "symbolic-debuginfo-fuzz"
 version = "9.1.2"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/symbolic-demangle/Cargo.toml
+++ b/symbolic-demangle/Cargo.toml
@@ -14,7 +14,7 @@ description = """
 A library to demangle symbols from various languages and compilers.
 """
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 exclude = [
     "tests/**/*",

--- a/symbolic-symcache/Cargo.toml
+++ b/symbolic-symcache/Cargo.toml
@@ -13,7 +13,7 @@ description = """
 An optimized cache file for fast and memory efficient lookup of symbols and
 stack frames in debugging information.
 """
-edition = "2018"
+edition = "2021"
 
 exclude = [
     "tests/**/*",
@@ -32,7 +32,7 @@ tracing = "0.1.35"
 
 [dev-dependencies]
 insta = { version = "1.18.0", features = ["yaml"] }
-criterion = "0.3.4"
+criterion = "0.4.0"
 symbolic-testutils = { path = "../symbolic-testutils" }
 similar-asserts = "1.0.0"
 

--- a/symbolic-symcache/src/lookup.rs
+++ b/symbolic-symcache/src/lookup.rs
@@ -8,7 +8,6 @@ impl<'data> SymCache<'data> {
     /// Looks up an instruction address in the SymCache, yielding an iterator of [`SourceLocation`]s
     /// representing a hierarchy of inlined function calls.
     pub fn lookup(&self, addr: u64) -> SourceLocations<'data, '_> {
-        use std::convert::TryFrom;
         let addr = match u32::try_from(addr) {
             Ok(addr) => addr,
             Err(_) => {

--- a/symbolic-testutils/Cargo.toml
+++ b/symbolic-testutils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "symbolic-testutils"
 version = "9.1.2"
 license = "MIT"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [package.metadata.docs.rs]

--- a/symbolic-unreal/Cargo.toml
+++ b/symbolic-unreal/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/getsentry/symbolic"
 description = """
 Parsing and processing utilities for Unreal Engine 4 crash files.
 """
-edition = "2018"
+edition = "2021"
 
 exclude = [
     "tests/**/*",
@@ -30,7 +30,7 @@ anylog = "0.6.1"
 bytes = "1.1.0"
 # this is still used for compatibility with `anylog`
 chrono = "0.4.7"
-elementtree = "0.7.0"
+elementtree = "1.2.2"
 flate2 = { version = "1.0.13", features = ["rust_backend"], default-features = false }
 lazy_static = "1.4.0"
 regex = "1.3.5"

--- a/symbolic/Cargo.toml
+++ b/symbolic/Cargo.toml
@@ -14,7 +14,7 @@ description = """
 A library to symbolicate and process stack traces from native applications,
 minidumps, Unreal Engine 4, minified JavaScripts or ProGuard optimized Android apps.
 """
-edition = "2018"
+edition = "2021"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
I was actually surprised that we were still on Rust 2018 here.