### PR TITLE
fix: Be more lenient parsing Abbreviations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Be more lenient when eagerly parsing DWARF `Abbreviations`. ([#685](https://github.com/getsentry/symbolic/pull/685))
+
 ## 9.1.3
 
 **Fixes**:
 
 - Be stricter about demangling only `_Z` prefixed C++ names. ([#681](https://github.com/getsentry/symbolic/pull/681))
-- Work around a pathological case in DWARF processing that could lead to slowness and high memory usage ([#683](https://github.com/getsentry/symbolic/pull/683))
+- Work around a pathological case in DWARF processing that could lead to slowness and high memory usage. ([#683](https://github.com/getsentry/symbolic/pull/683))
 
 ## 9.1.2
 

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -1159,7 +1159,7 @@ impl<'d> DwarfInfo<'d> {
     ) -> Result<Self, DwarfError> {
         let debug_abbrev = sections.debug_abbrev.to_gimli();
         let offset_0 = DebugAbbrevOffset(0);
-        let abbrevs_at_0 = debug_abbrev.abbreviations(offset_0)?;
+        let abbrevs_at_0 = debug_abbrev.abbreviations(offset_0).unwrap_or_default();
 
         let inner = gimli::read::Dwarf {
             debug_abbrev,


### PR DESCRIPTION
The recent fix for Abbreviations parsing might have been too overeager and may cause EOF errors in case there are no Abbreviations (at offset 0) at all.