### PR TITLE
feat(cabi): Add function to load SourceMapCache from disk

### DIFF
--- a/py/symbolic/sourcemapcache.py
+++ b/py/symbolic/sourcemapcache.py
@@ -43,6 +43,11 @@ class SourceMapCache(RustObject):
     __dealloc_func__ = lib.symbolic_sourcemapcache_free
 
     @classmethod
+    def open(cls, path):
+        """Loads a sourcemapcache from a file via mmap."""
+        return cls._from_objptr(rustcall(lib.symbolic_sourcemapcache_open, encode_path(path)))
+
+    @classmethod
     def from_bytes(cls, source_content, sourcemap_content):
         """Constructs a sourcemapcache from bytes."""
         return cls._from_objptr(

--- a/py/symbolic/sourcemapcache.py
+++ b/py/symbolic/sourcemapcache.py
@@ -1,5 +1,5 @@
 from symbolic._lowlevel import lib, ffi
-from symbolic.utils import RustObject, rustcall, decode_str
+from symbolic.utils import RustObject, rustcall, decode_str, encode_path
 
 
 __all__ = ["SourceMapCache", "SourceMapCacheToken"]

--- a/py/symbolic/sourcemapcache.py
+++ b/py/symbolic/sourcemapcache.py
@@ -45,7 +45,9 @@ class SourceMapCache(RustObject):
     @classmethod
     def open(cls, path):
         """Loads a sourcemapcache from a file via mmap."""
-        return cls._from_objptr(rustcall(lib.symbolic_sourcemapcache_open, encode_path(path)))
+        return cls._from_objptr(
+            rustcall(lib.symbolic_sourcemapcache_open, encode_path(path))
+        )
 
     @classmethod
     def from_bytes(cls, source_content, sourcemap_content):

--- a/symbolic-sourcemapcache/Cargo.toml
+++ b/symbolic-sourcemapcache/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2021"
 js-source-scopes = "0.1.0"
 thiserror = "1.0.31"
 sourcemap = "6.1.0"
+symbolic-common = { version = "9.1.4", path = "../symbolic-common" }
 tracing = "0.1.36"
 watto = { version = "0.1.0", features = ["writer", "strings"] }
 itertools = "0.10.3"

--- a/symbolic-sourcemapcache/src/lookup.rs
+++ b/symbolic-sourcemapcache/src/lookup.rs
@@ -1,3 +1,4 @@
+use symbolic_common::AsSelf;
 use watto::{align_to, Pod, StringTable};
 
 use crate::{ScopeLookupResult, SourcePosition};
@@ -275,6 +276,14 @@ impl<'data> Iterator for Files<'data> {
         self.raw_files
             .next()
             .and_then(|raw_file| self.cache.resolve_file(raw_file))
+    }
+}
+
+impl<'slf, 'd: 'slf> AsSelf<'slf> for SourceMapCache<'d> {
+    type Ref = SourceMapCache<'slf>;
+
+    fn as_self(&'slf self) -> &Self::Ref {
+        self
     }
 }
 


### PR DESCRIPTION
This also implements `AsSelf` for `SourceMapCache` and consequently removes the `Inner` and `OwnedSourceMapCache` types from CABI.