### PR TITLE
ci: Bump docker builds to manylinux2014

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "release/**"
-      - "manylinux2014"
 
 jobs:
   python-wheel-mac:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "release/**"
+      - "manylinux2014"
 
 jobs:
   python-wheel-mac:
@@ -52,8 +53,8 @@ jobs:
       fail-fast: false
       matrix:
         build-arch:
-          - manylinux2010_i686
-          - manylinux2010_x86_64
+          - manylinux2014_i686
+          - manylinux2014_x86_64
           - manylinux2014_aarch64
 
     name: Python Linux ${{ matrix.build-arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,9 +52,9 @@ jobs:
       fail-fast: false
       matrix:
         build-arch:
-          - manylinux_2_28_i686
-          - manylinux_2_28_x86_64
-          - manylinux_2_28_aarch64
+          - manylinux2014_i686
+          - manylinux2014_x86_64
+          - manylinux2014_aarch64
 
     name: Python Linux ${{ matrix.build-arch }}
     runs-on: ubuntu-latest
@@ -64,7 +64,7 @@ jobs:
         with:
           submodules: recursive
 
-      - if: matrix.build-arch == 'manylinux_2_28_aarch64'
+      - if: matrix.build-arch == 'manylinux2014_aarch64'
         uses: docker/setup-qemu-action@v1
         with:
           platforms: arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,9 +53,9 @@ jobs:
       fail-fast: false
       matrix:
         build-arch:
-          - manylinux2014_i686
-          - manylinux2014_x86_64
-          - manylinux2014_aarch64
+          - manylinux_2_28_i686
+          - manylinux_2_28_x86_64
+          - manylinux_2_28_aarch64
 
     name: Python Linux ${{ matrix.build-arch }}
     runs-on: ubuntu-latest
@@ -65,7 +65,7 @@ jobs:
         with:
           submodules: recursive
 
-      - if: matrix.build-arch == 'manylinux2014_aarch64'
+      - if: matrix.build-arch == 'manylinux_2_28_aarch64'
         uses: docker/setup-qemu-action@v1
         with:
           platforms: arm64


### PR DESCRIPTION
NOTE: Move to `manylinux_2_28` and drop `manylinux_2_28_i686` in the next major.