### PR TITLE
deps(unreal): Update anylog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+- Fixed a bug in Unreal Engine log parsing by updating the `anylog` dependency.
+
 ## 9.2.0
 
 **Features**:

--- a/symbolic-unreal/Cargo.toml
+++ b/symbolic-unreal/Cargo.toml
@@ -26,7 +26,7 @@ all-features = true
 serde = ["serde_", "chrono/serde"]
 
 [dependencies]
-anylog = "0.6.1"
+anylog = "0.6.2"
 bytes = "1.1.0"
 # this is still used for compatibility with `anylog`
 chrono = "0.4.7"


### PR DESCRIPTION
This updates `anylog` to use a recent parsing fix (see https://github.com/mitsuhiko/rust-anylog/pull/6). Should hopefully fix #694.