### PR TITLE
ref: Persist SourceMap `name` in the cache.

### DIFF
--- a/symbolic-sourcemapcache/Cargo.toml
+++ b/symbolic-sourcemapcache/Cargo.toml
@@ -12,7 +12,7 @@ A fast lookup cache for JavaScript Source Maps.
 edition = "2021"
 
 [dependencies]
-js-source-scopes = "0.1.0"
+js-source-scopes = { path = "../../js-source-scopes" }
 thiserror = "1.0.31"
 sourcemap = "6.1.0"
 tracing = "0.1.36"

--- a/symbolic-sourcemapcache/src/lookup.rs
+++ b/symbolic-sourcemapcache/src/lookup.rs
@@ -13,6 +13,8 @@ pub struct SourceLocation<'data> {
     line: u32,
     /// The source column.
     column: u32,
+    /// The `name` of the source location.
+    name: Option<&'data str>,
     /// The scope containing this source location.
     scope: ScopeLookupResult<'data>,
 }
@@ -31,6 +33,11 @@ impl<'data> SourceLocation<'data> {
     /// The number of the source column.
     pub fn column(&self) -> u32 {
         self.column
+    }
+
+    /// The `name` of this source location.
+    pub fn name(&self) -> Option<&'data str> {
+        self.name
     }
 
     /// The contents of the source line.
@@ -169,6 +176,11 @@ impl<'data> SourceMapCache<'data> {
             .get(sl.file_idx as usize)
             .and_then(|raw_file| self.resolve_file(raw_file));
 
+        let name = match sl.name_idx {
+            raw::NO_NAME_SENTINEL => None,
+            idx => self.get_string(idx),
+        };
+
         let scope = match sl.scope_idx {
             raw::GLOBAL_SCOPE_SENTINEL => ScopeLookupResult::Unknown,
             raw::ANONYMOUS_SCOPE_SENTINEL => ScopeLookupResult::AnonymousScope,
@@ -181,6 +193,7 @@ impl<'data> SourceMapCache<'data> {
             file,
             line,
             column,
+            name,
             scope,
         })
     }

--- a/symbolic-sourcemapcache/src/raw.rs
+++ b/symbolic-sourcemapcache/src/raw.rs
@@ -12,7 +12,12 @@ pub const SOURCEMAPCACHE_MAGIC: u32 = u32::from_le_bytes(SOURCEMAPCACHE_MAGIC_BY
 pub const SOURCEMAPCACHE_MAGIC_FLIPPED: u32 = SOURCEMAPCACHE_MAGIC.swap_bytes();
 
 /// The current Format version
-pub const SOURCEMAPCACHE_VERSION: u32 = 1;
+///
+/// # Version History
+///
+/// - 2: Added `name` reference
+/// - 1: Initial version
+pub const SOURCEMAPCACHE_VERSION: u32 = 2;
 
 /// The SourceMapCache binary Header.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -59,6 +64,8 @@ impl From<SourcePosition> for MinifiedSourcePosition {
 
 /// Sentinel value used to denote unknown file.
 pub const NO_FILE_SENTINEL: u32 = u32::MAX;
+/// Sentinel value used to denote no `name`.
+pub const NO_NAME_SENTINEL: u32 = u32::MAX;
 /// Sentinel value used to denote unknown/global scope.
 pub const GLOBAL_SCOPE_SENTINEL: u32 = u32::MAX;
 /// Sentinel value used to denote anonymous function scope.
@@ -74,6 +81,8 @@ pub struct OriginalSourceLocation {
     pub line: u32,
     /// The original column number.
     pub column: u32,
+    /// The optional `name` of this token (offset into string table).
+    pub name_idx: u32,
     /// The optional scope name (offset into string table).
     pub scope_idx: u32,
 }
@@ -117,7 +126,7 @@ mod tests {
         assert_eq!(mem::size_of::<MinifiedSourcePosition>(), 8);
         assert_eq!(mem::align_of::<MinifiedSourcePosition>(), 4);
 
-        assert_eq!(mem::size_of::<OriginalSourceLocation>(), 16);
+        assert_eq!(mem::size_of::<OriginalSourceLocation>(), 20);
         assert_eq!(mem::align_of::<OriginalSourceLocation>(), 4);
     }
 }

--- a/symbolic-sourcemapcache/src/writer.rs
+++ b/symbolic-sourcemapcache/src/writer.rs
@@ -8,7 +8,7 @@ use js_source_scopes::{
 use sourcemap::DecodedMap;
 use watto::{Pod, StringTable, Writer};
 
-use super::raw::{self, ANONYMOUS_SCOPE_SENTINEL, GLOBAL_SCOPE_SENTINEL, NO_FILE_SENTINEL};
+use super::raw;
 use super::{ScopeLookupResult, SourcePosition};
 
 /// A structure that allows quick resolution of minified source position
@@ -153,21 +153,28 @@ impl SourceMapCacheWriter {
                 let mut file_idx = token.get_src_id();
 
                 if file_idx >= files.len() as u32 {
-                    file_idx = NO_FILE_SENTINEL;
+                    file_idx = raw::NO_FILE_SENTINEL;
                 }
 
                 let scope_idx = match scope {
                     ScopeLookupResult::NamedScope(name) => {
-                        std::cmp::min(string_table.insert(name) as u32, GLOBAL_SCOPE_SENTINEL)
+                        std::cmp::min(string_table.insert(name) as u32, raw::GLOBAL_SCOPE_SENTINEL)
                     }
-                    ScopeLookupResult::AnonymousScope => ANONYMOUS_SCOPE_SENTINEL,
-                    ScopeLookupResult::Unknown => GLOBAL_SCOPE_SENTINEL,
+                    ScopeLookupResult::AnonymousScope => raw::ANONYMOUS_SCOPE_SENTINEL,
+                    ScopeLookupResult::Unknown => raw::GLOBAL_SCOPE_SENTINEL,
+                };
+
+                let name = token.get_name();
+                let name_idx = match name {
+                    Some(name) => string_table.insert(name) as u32,
+                    None => raw::NO_NAME_SENTINEL,
                 };
 
                 let sl = raw::OriginalSourceLocation {
                     file_idx,
                     line,
                     column,
+                    name_idx,
                     scope_idx,
                 };
 

--- a/symbolic-sourcemapcache/tests/integration.rs
+++ b/symbolic-sourcemapcache/tests/integration.rs
@@ -29,11 +29,15 @@ fn resolves_inlined_function() {
     assert_eq!(sl.column(), 2);
     assert_eq!(sl.scope(), ScopeLookupResult::NamedScope("bar"));
 
+    // NOTE: The last source position itself does not have a named scope, it truely is an
+    // anonymous function. However, the *call* itself has a `name` which we use in its place.
+    assert_eq!(sl.name(), Some("foo"));
+
     let sl = cache.lookup(SourcePosition::new(0, 33)).unwrap();
     assert_eq!(sl.file_name(), Some("../src/foo.js"));
     assert_eq!(sl.line(), 1);
     assert_eq!(sl.column(), 8);
-    assert_eq!(sl.scope(), ScopeLookupResult::NamedScope("foo"));
+    assert_eq!(sl.scope(), ScopeLookupResult::AnonymousScope);
 }
 
 #[test]


### PR DESCRIPTION
Anonymous functions are most of the time being called through a variable binding, which when minified gets a `name` mapping. This information from the parent/caller frame can be used as a good heuristic as fallback for a scope name.