### PR TITLE
feat(smcache): Expose token name via Python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Add `name` to `SourceMapCacheToken` Python bindings ([#703](https://github.com/getsentry/symbolic/pull/703))
+
 ## 10.0.0
 
 **Features**:

--- a/py/symbolic/sourcemapcache.py
+++ b/py/symbolic/sourcemapcache.py
@@ -14,6 +14,7 @@ class SourceMapCacheToken(object):
         rv.line = tm.line
         rv.col = tm.col
         rv.src = decode_str(tm.src, free=False) or None
+        rv.name = decode_str(tm.name, free=False) or None
         rv.function_name = decode_str(tm.function_name, free=False) or None
 
         rv.context_line = decode_str(tm.context_line, free=False) or None

--- a/symbolic-cabi/src/sourcemapcache.rs
+++ b/symbolic-cabi/src/sourcemapcache.rs
@@ -65,6 +65,8 @@ pub struct SymbolicSmTokenMatch {
     pub col: u32,
     /// The path to the original source.
     pub src: SymbolicStr,
+    /// The name of the source location as it is defined in the SourceMap.
+    pub name: SymbolicStr,
     /// The name of the function containing the token.
     pub function_name: SymbolicStr,
 
@@ -156,6 +158,7 @@ fn make_token_match(token: SourceLocation, context_lines: u32) -> *mut SymbolicS
         line: token.line() + 1,
         col: token.column() + 1,
         src: SymbolicStr::new(token.file_name().unwrap_or_default()),
+        name: SymbolicStr::new(token.name().unwrap_or_default()),
         function_name: SymbolicStr::new(function_name),
 
         pre_context,


### PR DESCRIPTION
Followup to https://github.com/getsentry/symbolic/pull/698