### PR TITLE
Bump goblin to 0.6

### DIFF
--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-debuginfo"
-version = "10.1.1"
+version = "10.1.2"
 license = "MIT"
 authors = [
     "Armin Ronacher <armin.ronacher@active-4.com>",
@@ -58,9 +58,7 @@ ms = [
     "scroll",
     "smallvec",
 ]
-ppdb = [
-    "symbolic-ppdb"
-]
+ppdb = ["symbolic-ppdb"]
 # Source bundle creation
 sourcebundle = [
     "lazy_static",
@@ -86,7 +84,7 @@ gimli = { version = "0.26.1", optional = true, default-features = false, feature
     "read",
     "std",
 ] }
-goblin = { version = "0.5.1", optional = true, default-features = false }
+goblin = { version = "0.6", optional = true, default-features = false }
 lazy_static = { version = "1.4.0", optional = true }
 lazycell = { version = "1.2.1", optional = true }
 nom = { version = "7.0.0", optional = true }


### PR DESCRIPTION
Bump `goblin` dependency across breaking version 0.5→0.6. There are [several bug fixes](https://github.com/m4b/goblin/blob/master/CHANGELOG.md#060---2022-10-23) included.

The version number update is tentative; it’s possible there are breaking changes exposed (in particular [the MachO types changed](https://github.com/m4b/goblin/compare/0.5.4...0.6.0#diff-a22eb400c0763d872ba8fd4c9e1a563d0e0cf957c36fb3bf6796318ac2278827)), in which case this should be a major version bump?