### PR TITLE
chore: Update anylog to 0.6.3

### DIFF
--- a/examples/symcache_debug/src/main.rs
+++ b/examples/symcache_debug/src/main.rs
@@ -56,7 +56,7 @@ fn execute(matches: &ArgMatches) -> Result<()> {
 
         let bcsymbolmap_buffer = matches
             .get_one::<PathBuf>("bcsymbolmap_file")
-            .map(|path| ByteView::open(&path))
+            .map(ByteView::open)
             .transpose()?;
         let bcsymbolmap_transformer = bcsymbolmap_buffer
             .as_ref()
@@ -65,7 +65,7 @@ fn execute(matches: &ArgMatches) -> Result<()> {
 
         let linemapping_buffer = matches
             .get_one::<PathBuf>("linemapping_file")
-            .map(|path| ByteView::open(&path))
+            .map(ByteView::open)
             .transpose()?;
         let linemapping_transformer = linemapping_buffer
             .as_ref()

--- a/symbolic-cfi/src/lib.rs
+++ b/symbolic-cfi/src/lib.rs
@@ -1028,7 +1028,7 @@ impl<W: Write> AsciiCfiWriter<W> {
             frame.saved_regs_size,
             frame.locals_size,
             frame.max_stack_size.unwrap_or(0),
-            if has_program { 1 } else { 0 },
+            i32::from(has_program)
         )?;
 
         match frame.program {
@@ -1043,11 +1043,7 @@ impl<W: Write> AsciiCfiWriter<W> {
                 writeln!(self.inner, "{}", program_string.trim())?;
             }
             None => {
-                writeln!(
-                    self.inner,
-                    "{}",
-                    if frame.uses_base_pointer { 1 } else { 0 }
-                )?;
+                writeln!(self.inner, "{}", i32::from(frame.uses_base_pointer))?;
             }
         }
 

--- a/symbolic-common/src/byteview.rs
+++ b/symbolic-common/src/byteview.rs
@@ -266,7 +266,7 @@ mod tests {
     fn test_open_empty_file() -> Result<(), std::io::Error> {
         let tmp = NamedTempFile::new()?;
 
-        let view = ByteView::open(&tmp.path())?;
+        let view = ByteView::open(tmp.path())?;
         assert_eq!(&*view, b"");
 
         Ok(())
@@ -278,7 +278,7 @@ mod tests {
 
         tmp.write_all(b"1234")?;
 
-        let view = ByteView::open(&tmp.path())?;
+        let view = ByteView::open(tmp.path())?;
         assert_eq!(&*view, b"1234");
 
         Ok(())

--- a/symbolic-symcache/src/writer.rs
+++ b/symbolic-symcache/src/writer.rs
@@ -521,7 +521,7 @@ impl<'a> SymCacheConverter<'a> {
 /// This code is adapted from `dump_syms`:
 /// See https://github.com/mozilla/dump_syms/blob/325cf2c61b2cacc55a7f1af74081b57237c7f9de/src/symbol.rs#L169-L216
 fn undecorate_win_symbol(name: &str) -> &str {
-    if name.starts_with('?') || name.contains(&[':', '(', '<']) {
+    if name.starts_with('?') || name.contains([':', '(', '<']) {
         return name;
     }
 

--- a/symbolic-unreal/Cargo.toml
+++ b/symbolic-unreal/Cargo.toml
@@ -26,7 +26,7 @@ all-features = true
 serde = ["serde_", "chrono/serde"]
 
 [dependencies]
-anylog = "0.6.2"
+anylog = "0.6.3"
 bytes = "1.1.0"
 # this is still used for compatibility with `anylog`
 chrono = "0.4.7"


### PR DESCRIPTION
Update the `anylog` crate to 0.6.3 with fix from https://github.com/getsentry/rust-anylog/pull/7 which caused panic in some cases of parsing and creating the dates. 