### PR TITLE
ref: Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**
+
+- Updated `goblin`, `cpp_demangle` and `wasmparser` dependencies. ([#709](https://github.com/getsentry/symbolic/pull/709))
+
 ## 10.1.1
 
 **Fixed**:

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -86,7 +86,7 @@ gimli = { version = "0.26.1", optional = true, default-features = false, feature
     "read",
     "std",
 ] }
-goblin = { version = "0.5.1", optional = true, default-features = false }
+goblin = { version = "0.6.0", optional = true, default-features = false }
 lazy_static = { version = "1.4.0", optional = true }
 lazycell = { version = "1.2.1", optional = true }
 nom = { version = "7.0.0", optional = true }
@@ -102,7 +102,7 @@ smallvec = { version = "1.2.0", optional = true }
 symbolic-common = { version = "10.1.1", path = "../symbolic-common" }
 symbolic-ppdb = { version = "10.1.1", path = "../symbolic-ppdb", optional = true }
 thiserror = "1.0.20"
-wasmparser = { version = "0.90.0", optional = true }
+wasmparser = { version = "0.94.0", optional = true }
 zip = { version = "0.6.2", optional = true, default-features = false, features = [
     "deflate",
 ] }

--- a/symbolic-demangle/Cargo.toml
+++ b/symbolic-demangle/Cargo.toml
@@ -31,7 +31,7 @@ rust = ["rustc-demangle"]
 swift = ["cc"]
 
 [dependencies]
-cpp_demangle = { version = "0.3.2", optional = true }
+cpp_demangle = { version = "0.4.0", optional = true }
 msvc-demangler = { version = "0.9.0", optional = true }
 rustc-demangle = { version = "0.1.16", optional = true }
 symbolic-common = { version = "10.1.1", path = "../symbolic-common" }


### PR DESCRIPTION
This pulls in new versions of goblin, cpp_demangle and wasmparser. The first two did not need any code changes, just `wasmparser` had the usual amount of churn.

Supercedes #707