### PR TITLE
Fix rust-analyzer extension ID.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,18 +1,18 @@
 {
-  // See http://go.microsoft.com/fwlink/?LinkId=827846
-  // for the documentation about the extensions.json format
-  "recommendations": [
-    // C++ language support
-    "ms-vscode.cpptools",
-    // TOML language support
-    "bungcip.better-toml",
-    // Rust language server
-    "matklad.rust-analyzer",
-    // Crates.io dependency versions
-    "serayuzgur.crates",
-    // Debugger support for Rust and native
-    "vadimcn.vscode-lldb",
-    // PEST syntax support
-    "xoronic.pestfile"
-  ]
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        // C++ language support
+        "ms-vscode.cpptools",
+        // TOML language support
+        "bungcip.better-toml",
+        // Rust language server
+        "rust-lang.rust-analyzer",
+        // Crates.io dependency versions
+        "serayuzgur.crates",
+        // Debugger support for Rust and native
+        "vadimcn.vscode-lldb",
+        // PEST syntax support
+        "xoronic.pestfile"
+    ]
 }


### PR DESCRIPTION
The old rust-analyzer extension has been removed from the VS Code market place, so VS Code now displays a warning when the symbolic repo is opened in the editor. This fixes that warning.

The file indentation has changed because it seems that this is the first time anybody has touched this file since editor.formatOnSave was turned on.