### PR TITLE
fix: Write SourceMapCache to disk in cabi

### DIFF
--- a/symbolic-cabi/Cargo.toml
+++ b/symbolic-cabi/Cargo.toml
@@ -23,3 +23,4 @@ crate-type = ["cdylib"]
 proguard = { version = "5.0.0", features = ["uuid"] }
 sourcemap = "6.0.2"
 symbolic = { version = "10.1.2", path = "../symbolic", features = ["cfi", "debuginfo", "demangle", "sourcemapcache", "symcache"] }
+tempfile = "3.1.0"


### PR DESCRIPTION
Instead of holding the SourceMapCache buffer in memory when it is being used via the cabi/python bindings, write it to a tempfile which is automatically cleaned up when the SourceMapCache is dropped.

This should reduce memory pressure and allow the OS to page that out.