### PR TITLE
fix(debuginfo): Split lines in more cases.

### DIFF
--- a/symbolic-debuginfo/tests/snapshots/test_objects__elf_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__elf_functions.snap
@@ -1,6 +1,5 @@
 ---
 source: symbolic-debuginfo/tests/test_objects.rs
-assertion_line: 247
 expression: "FunctionsDebug(&functions[..10], 0)"
 ---
 
@@ -261,7 +260,6 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x20c6: exception_handler.cc:318 (../deps/breakpad/src/client/linux/handler)
   0x20cd: exception_handler.cc:319 (../deps/breakpad/src/client/linux/handler)
   0x20e0: exception_handler.cc:315 (../deps/breakpad/src/client/linux/handler)
-  0x20ec: exception_handler.cc:199 (../deps/breakpad/src/client/linux/handler)
 
   > 0x20e0: InstallDefaultHandler (0xc)
     0x20e0: exception_handler.cc:199 (../deps/breakpad/src/client/linux/handler)
@@ -724,7 +722,6 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x2996: exception_handler.cc:508 (../deps/breakpad/src/client/linux/handler)
   0x299d: exception_handler.cc:568 (../deps/breakpad/src/client/linux/handler)
   0x29a5: exception_handler.cc:505 (../deps/breakpad/src/client/linux/handler)
-  0x29e6: memory_allocator.h:143 (../deps/breakpad/src/common)
 
   > 0x2534: _ZNK15google_breakpad16ExceptionHandler14IsOutOfProcessEv (0x4)
     0x2534: exception_handler.h:205 (../deps/breakpad/src/client/linux/handler)

--- a/symbolic-symcache/tests/test_writer.rs
+++ b/symbolic-symcache/tests/test_writer.rs
@@ -33,8 +33,8 @@ fn test_write_header_linux() -> Result<(), Error> {
         arch: Amd64,
         files: 55,
         functions: 697,
-        source_locations: 8305,
-        ranges: 6843,
+        source_locations: 8284,
+        ranges: 6828,
         string_bytes: 49877,
     }
     "###);
@@ -77,8 +77,8 @@ fn test_write_header_macos() -> Result<(), Error> {
         arch: Amd64,
         files: 36,
         functions: 639,
-        source_locations: 7204,
-        ranges: 5759,
+        source_locations: 7199,
+        ranges: 5782,
         string_bytes: 40958,
     }
     "###);

--- a/symbolic-testutils/fixtures/macos/crash.inlines.sym
+++ b/symbolic-testutils/fixtures/macos/crash.inlines.sym
@@ -1,18 +1,19 @@
 MODULE Mac x86_64 67E9247C814E392BA027DBDE6748FCBF0 crash
 INFO CODE_ID 67E9247C814E392BA027DBDE6748FCBF
+INFO GENERATOR mozilla/dump_syms 2.1.0
 FILE 0 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/minidump_file_writer.cc
 FILE 1 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/minidump_file_writer-inl.h
 FILE 2 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/minidump_file_writer.h
-FILE 3 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/mac/crash_generation/crash_generation_client.cc
-FILE 4 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/MachIPC.h
-FILE 5 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/algorithm
-FILE 6 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/mac/handler/dynamic_images.h
+FILE 3 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/MachIPC.h
+FILE 4 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/mac/crash_generation/crash_generation_client.cc
+FILE 5 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/mac/handler/dynamic_images.h
+FILE 6 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/algorithm
 FILE 7 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits
-FILE 8 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/mac/handler/dynamic_images.cc
-FILE 9 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/vector
+FILE 8 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/vector
+FILE 9 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/new
 FILE 10 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory
-FILE 11 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/new
-FILE 12 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__split_buffer
+FILE 11 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__split_buffer
+FILE 12 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/mac/handler/dynamic_images.cc
 FILE 13 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/string
 FILE 14 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/iterator
 FILE 15 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/mac/handler/exception_handler.cc
@@ -21,17 +22,17 @@ FILE 17 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/ma
 FILE 18 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/mac/crash_generation/crash_generation_client.h
 FILE 19 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/scoped_task_suspend-inl.h
 FILE 20 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/mac/handler/minidump_generator.h
-FILE 21 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/mac/handler/minidump_generator.cc
-FILE 22 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/memory_allocator.h
+FILE 21 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/memory_allocator.h
+FILE 22 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/mac/handler/minidump_generator.cc
 FILE 23 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/convert_UTF.c
 FILE 24 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/md5.cc
 FILE 25 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/string_conversion.cc
 FILE 26 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/bootstrap_compat.cc
 FILE 27 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/file_id.cc
 FILE 28 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/macho_id.cc
-FILE 29 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/macho_utilities.cc
+FILE 29 /usr/include/libkern/i386/_OSByteOrder.h
 FILE 30 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/byteswap.h
-FILE 31 /usr/include/libkern/i386/_OSByteOrder.h
+FILE 31 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/macho_utilities.cc
 FILE 32 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/macho_walker.cc
 FILE 33 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/string_utilities.cc
 FILE 34 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/common/mac/MachIPC.mm
@@ -61,12 +62,12 @@ INLINE_ORIGIN 21 google_breakpad::MachReceiveMessage::MachReceiveMessage()
 INLINE_ORIGIN 22 google_breakpad::MachMessage::MachMessage()
 INLINE_ORIGIN 23 std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>::operator()(google_breakpad::DynamicImageRef const&, google_breakpad::DynamicImageRef const&) const
 INLINE_ORIGIN 24 google_breakpad::DynamicImageRef::operator<(google_breakpad::DynamicImageRef const&) const
-INLINE_ORIGIN 25 unsigned int std::__1::__sort3<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
+INLINE_ORIGIN 25 std::__1::__sort3<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
 INLINE_ORIGIN 26 google_breakpad::DynamicImage::operator<(google_breakpad::DynamicImage const&)
 INLINE_ORIGIN 27 google_breakpad::DynamicImage::GetLoadAddress() const
-INLINE_ORIGIN 28 std::__1::enable_if<(is_move_constructible<google_breakpad::DynamicImageRef>::value)&&(is_move_assignable<google_breakpad::DynamicImageRef>::value), void>::type std::__1::swap<google_breakpad::DynamicImageRef>(google_breakpad::DynamicImageRef&, google_breakpad::DynamicImageRef&)
-INLINE_ORIGIN 29 void std::__1::__insertion_sort_3<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
-INLINE_ORIGIN 30 unsigned int std::__1::__sort4<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
+INLINE_ORIGIN 28 std::__1::swap<google_breakpad::DynamicImageRef>(google_breakpad::DynamicImageRef&, google_breakpad::DynamicImageRef&)
+INLINE_ORIGIN 29 std::__1::__insertion_sort_3<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
+INLINE_ORIGIN 30 std::__1::__sort4<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
 INLINE_ORIGIN 31 google_breakpad::DynamicImageRef::DynamicImageRef(google_breakpad::DynamicImageRef const&)
 INLINE_ORIGIN 32 google_breakpad::DynamicImageRef::DynamicImageRef(google_breakpad::DynamicImageRef const&)
 INLINE_ORIGIN 33 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::vector()
@@ -91,11 +92,11 @@ INLINE_ORIGIN 51 std::__1::allocator_traits<std::__1::allocator<google_breakpad:
 INLINE_ORIGIN 52 std::__1::allocator<google_breakpad::DynamicImageRef>::allocate(unsigned long, void const*)
 INLINE_ORIGIN 53 std::__1::__allocate(unsigned long)
 INLINE_ORIGIN 54 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__swap_out_circular_buffer(std::__1::__split_buffer<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef>&>&)
-INLINE_ORIGIN 55 void std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::__construct_backward<google_breakpad::DynamicImageRef*>(std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*&)
-INLINE_ORIGIN 56 void std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef const&>(std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef const&)
-INLINE_ORIGIN 57 void std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::__construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef const&>(std::__1::integral_constant<bool, true>, std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef const&)
-INLINE_ORIGIN 58 void std::__1::allocator<google_breakpad::DynamicImageRef>::construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef const&>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef const&)
-INLINE_ORIGIN 59 std::__1::enable_if<(is_move_constructible<google_breakpad::DynamicImageRef*>::value)&&(is_move_assignable<google_breakpad::DynamicImageRef*>::value), void>::type std::__1::swap<google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*&, google_breakpad::DynamicImageRef*&)
+INLINE_ORIGIN 55 std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::__construct_backward<google_breakpad::DynamicImageRef*>(std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*&)
+INLINE_ORIGIN 56 std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef const&>(std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef const&)
+INLINE_ORIGIN 57 std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::__construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef const&>(std::__1::integral_constant<bool, true>, std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef const&)
+INLINE_ORIGIN 58 std::__1::allocator<google_breakpad::DynamicImageRef>::construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef const&>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef const&)
+INLINE_ORIGIN 59 std::__1::swap<google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*&, google_breakpad::DynamicImageRef*&)
 INLINE_ORIGIN 60 std::__1::__split_buffer<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef>&>::~__split_buffer()
 INLINE_ORIGIN 61 std::__1::__split_buffer<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef>&>::~__split_buffer()
 INLINE_ORIGIN 62 std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::deallocate(std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, unsigned long)
@@ -117,28 +118,28 @@ INLINE_ORIGIN 77 google_breakpad::DynamicImage::DynamicImage(unsigned char*, uns
 INLINE_ORIGIN 78 google_breakpad::DynamicImage::IsValid()
 INLINE_ORIGIN 79 google_breakpad::DynamicImageRef::DynamicImageRef(google_breakpad::DynamicImage*)
 INLINE_ORIGIN 80 google_breakpad::DynamicImageRef::DynamicImageRef(google_breakpad::DynamicImage*)
-INLINE_ORIGIN 81 void std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>(std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef&&)
-INLINE_ORIGIN 82 void std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::__construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>(std::__1::integral_constant<bool, true>, std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef&&)
-INLINE_ORIGIN 83 void std::__1::allocator<google_breakpad::DynamicImageRef>::construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef&&)
+INLINE_ORIGIN 81 std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>(std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef&&)
+INLINE_ORIGIN 82 std::__1::allocator_traits<std::__1::allocator<google_breakpad::DynamicImageRef> >::__construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>(std::__1::integral_constant<bool, true>, std::__1::allocator<google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef&&)
+INLINE_ORIGIN 83 std::__1::allocator<google_breakpad::DynamicImageRef>::construct<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef&&)
 INLINE_ORIGIN 84 google_breakpad::DynamicImage::~DynamicImage()
 INLINE_ORIGIN 85 google_breakpad::DynamicImage::~DynamicImage()
 INLINE_ORIGIN 86 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::end()
 INLINE_ORIGIN 87 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::begin()
-INLINE_ORIGIN 88 void std::__1::sort<google_breakpad::DynamicImageRef>(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>)
-INLINE_ORIGIN 89 void std::__1::sort<google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*)
-INLINE_ORIGIN 90 void std::__1::sort<google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef> >(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>)
-INLINE_ORIGIN 91 std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> std::__1::unique<std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> >(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>)
-INLINE_ORIGIN 92 std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> std::__1::unique<std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef> >(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>)
-INLINE_ORIGIN 93 std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> std::__1::adjacent_find<std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&>(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
-INLINE_ORIGIN 94 bool std::__1::operator!=<google_breakpad::DynamicImageRef*>(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> const&, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> const&)
+INLINE_ORIGIN 88 std::__1::sort<google_breakpad::DynamicImageRef>(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>)
+INLINE_ORIGIN 89 std::__1::sort<google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*)
+INLINE_ORIGIN 90 std::__1::sort<google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef> >(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>)
+INLINE_ORIGIN 91 std::__1::unique<std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> >(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>)
+INLINE_ORIGIN 92 std::__1::unique<std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef> >(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>)
+INLINE_ORIGIN 93 std::__1::adjacent_find<std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&>(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>, std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
+INLINE_ORIGIN 94 std::__1::operator!=<google_breakpad::DynamicImageRef*>(std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> const&, std::__1::__wrap_iter<google_breakpad::DynamicImageRef*> const&)
 INLINE_ORIGIN 95 std::__1::__equal_to<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>::operator()(google_breakpad::DynamicImageRef const&, google_breakpad::DynamicImageRef const&) const
 INLINE_ORIGIN 96 google_breakpad::DynamicImageRef::operator==(google_breakpad::DynamicImageRef const&) const
 INLINE_ORIGIN 97 google_breakpad::DynamicImageRef::operator google_breakpad::DynamicImage*()
 INLINE_ORIGIN 98 std::__1::__wrap_iter<google_breakpad::DynamicImageRef*>::operator++()
 INLINE_ORIGIN 99 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::erase(std::__1::__wrap_iter<google_breakpad::DynamicImageRef const*>, std::__1::__wrap_iter<google_breakpad::DynamicImageRef const*>)
-INLINE_ORIGIN 100 bool std::__1::operator!=<google_breakpad::DynamicImageRef const*>(std::__1::__wrap_iter<google_breakpad::DynamicImageRef const*> const&, std::__1::__wrap_iter<google_breakpad::DynamicImageRef const*> const&)
-INLINE_ORIGIN 101 google_breakpad::DynamicImageRef* std::__1::move<google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*)
-INLINE_ORIGIN 102 std::__1::enable_if<(is_same<std::__1::remove_const<google_breakpad::DynamicImageRef>::type, google_breakpad::DynamicImageRef>::value)&&(is_trivially_copy_assignable<google_breakpad::DynamicImageRef>::value), google_breakpad::DynamicImageRef*>::type std::__1::__move<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*)
+INLINE_ORIGIN 100 std::__1::operator!=<google_breakpad::DynamicImageRef const*>(std::__1::__wrap_iter<google_breakpad::DynamicImageRef const*> const&, std::__1::__wrap_iter<google_breakpad::DynamicImageRef const*> const&)
+INLINE_ORIGIN 101 std::__1::move<google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*)
+INLINE_ORIGIN 102 std::__1::__move<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*)
 INLINE_ORIGIN 103 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__destruct_at_end(google_breakpad::DynamicImageRef*)
 INLINE_ORIGIN 104 std::__1::__vector_base<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__destruct_at_end(google_breakpad::DynamicImageRef*)
 INLINE_ORIGIN 105 std::__1::__vector_base<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__alloc()
@@ -153,10 +154,10 @@ INLINE_ORIGIN 113 std::__1::__compressed_pair<std::__1::basic_string<char, std::
 INLINE_ORIGIN 114 std::__1::__libcpp_compressed_pair_imp<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__rep, std::__1::allocator<char>, (unsigned int)2>::__libcpp_compressed_pair_imp()
 INLINE_ORIGIN 115 std::__1::char_traits<char>::length(char const*)
 INLINE_ORIGIN 116 google_breakpad::DynamicImage::Is64Bit()
-INLINE_ORIGIN 117 bool google_breakpad::FindTextSection<google_breakpad::MachO64>(google_breakpad::DynamicImage&)
+INLINE_ORIGIN 117 google_breakpad::FindTextSection<google_breakpad::MachO64>(google_breakpad::DynamicImage&)
 INLINE_ORIGIN 118 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::operator[](unsigned long) const
-INLINE_ORIGIN 119 bool google_breakpad::FindTextSection<google_breakpad::MachO32>(google_breakpad::DynamicImage&)
-INLINE_ORIGIN 120 unsigned int google_breakpad::GetFileTypeFromHeader<google_breakpad::MachO64>(google_breakpad::DynamicImage&)
+INLINE_ORIGIN 119 google_breakpad::FindTextSection<google_breakpad::MachO32>(google_breakpad::DynamicImage&)
+INLINE_ORIGIN 120 google_breakpad::GetFileTypeFromHeader<google_breakpad::MachO64>(google_breakpad::DynamicImage&)
 INLINE_ORIGIN 121 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::vector()
 INLINE_ORIGIN 122 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::vector()
 INLINE_ORIGIN 123 std::__1::__vector_base<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__vector_base()
@@ -174,28 +175,28 @@ INLINE_ORIGIN 134 google_breakpad::DynamicImage::GetFileType()
 INLINE_ORIGIN 135 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__recommend(unsigned long) const
 INLINE_ORIGIN 136 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::capacity() const
 INLINE_ORIGIN 137 std::__1::__vector_base<unsigned char, std::__1::allocator<unsigned char> >::capacity() const
-INLINE_ORIGIN 138 unsigned long const& std::__1::max<unsigned long>(unsigned long const&, unsigned long const&)
-INLINE_ORIGIN 139 unsigned long const& std::__1::max<unsigned long, std::__1::__less<unsigned long, unsigned long> >(unsigned long const&, unsigned long const&, std::__1::__less<unsigned long, unsigned long>)
+INLINE_ORIGIN 138 std::__1::max<unsigned long>(unsigned long const&, unsigned long const&)
+INLINE_ORIGIN 139 std::__1::max<unsigned long, std::__1::__less<unsigned long, unsigned long> >(unsigned long const&, unsigned long const&, std::__1::__less<unsigned long, unsigned long>)
 INLINE_ORIGIN 140 std::__1::__less<unsigned long, unsigned long>::operator()(unsigned long const&, unsigned long const&) const
 INLINE_ORIGIN 141 std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<unsigned char>&)
 INLINE_ORIGIN 142 std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<unsigned char>&)
 INLINE_ORIGIN 143 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__construct_at_end(unsigned long)
-INLINE_ORIGIN 144 void std::__1::allocator_traits<std::__1::allocator<unsigned char> >::construct<unsigned char, >(std::__1::allocator<unsigned char>&, unsigned char*, &&)
-INLINE_ORIGIN 145 void std::__1::allocator_traits<std::__1::allocator<unsigned char> >::__construct<unsigned char, >(std::__1::integral_constant<bool, true>, std::__1::allocator<unsigned char>&, unsigned char*, &&)
-INLINE_ORIGIN 146 void std::__1::allocator<unsigned char>::construct<unsigned char, >(unsigned char*, &&)
+INLINE_ORIGIN 144 std::__1::allocator_traits<std::__1::allocator<unsigned char> >::construct<unsigned char, >(std::__1::allocator<unsigned char>&, unsigned char*, &&)
+INLINE_ORIGIN 145 std::__1::allocator_traits<std::__1::allocator<unsigned char> >::__construct<unsigned char, >(std::__1::integral_constant<bool, true>, std::__1::allocator<unsigned char>&, unsigned char*, &&)
+INLINE_ORIGIN 146 std::__1::allocator<unsigned char>::construct<unsigned char, >(unsigned char*, &&)
 INLINE_ORIGIN 147 std::__1::allocator_traits<std::__1::allocator<unsigned char> >::allocate(std::__1::allocator<unsigned char>&, unsigned long)
 INLINE_ORIGIN 148 std::__1::allocator<unsigned char>::allocate(unsigned long, void const*)
 INLINE_ORIGIN 149 std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>::__construct_at_end(unsigned long)
 INLINE_ORIGIN 150 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__swap_out_circular_buffer(std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>&)
-INLINE_ORIGIN 151 std::__1::enable_if<(is_move_constructible<unsigned char*>::value)&&(is_move_assignable<unsigned char*>::value), void>::type std::__1::swap<unsigned char*>(unsigned char*&, unsigned char*&)
-INLINE_ORIGIN 152 std::__1::enable_if<((is_same<std::__1::allocator<unsigned char>, std::__1::allocator<unsigned char> >::value)||(!(__has_construct<std::__1::allocator<unsigned char>, unsigned char*, unsigned char>::value)))&&(is_trivially_move_constructible<unsigned char>::value), void>::type std::__1::allocator_traits<std::__1::allocator<unsigned char> >::__construct_backward<unsigned char>(std::__1::allocator<unsigned char>&, unsigned char*, unsigned char*, unsigned char*&)
+INLINE_ORIGIN 151 std::__1::swap<unsigned char*>(unsigned char*&, unsigned char*&)
+INLINE_ORIGIN 152 std::__1::allocator_traits<std::__1::allocator<unsigned char> >::__construct_backward<unsigned char>(std::__1::allocator<unsigned char>&, unsigned char*, unsigned char*, unsigned char*&)
 INLINE_ORIGIN 153 std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>::~__split_buffer()
 INLINE_ORIGIN 154 std::__1::__split_buffer<unsigned char, std::__1::allocator<unsigned char>&>::~__split_buffer()
 INLINE_ORIGIN 155 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::vector<unsigned char*>(std::__1::enable_if<(__is_forward_iterator<unsigned char*>::value)&&(is_constructible<unsigned char, std::__1::iterator_traits<unsigned char*>::reference>::value), unsigned char*>::type)
 INLINE_ORIGIN 156 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::vector<unsigned char*>(std::__1::enable_if<(__is_forward_iterator<unsigned char*>::value)&&(is_constructible<unsigned char, std::__1::iterator_traits<unsigned char*>::reference>::value), unsigned char*>::type)
 INLINE_ORIGIN 157 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::allocate(unsigned long)
-INLINE_ORIGIN 158 std::__1::enable_if<__is_forward_iterator<unsigned char*>::value, void>::type std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__construct_at_end<unsigned char*>(unsigned char*, unsigned char*, unsigned long)
-INLINE_ORIGIN 159 std::__1::enable_if<((is_same<std::__1::allocator<unsigned char>, std::__1::allocator<unsigned char> >::value)||(!(__has_construct<std::__1::allocator<unsigned char>, unsigned char*, unsigned char>::value)))&&(is_trivially_move_constructible<unsigned char>::value), void>::type std::__1::allocator_traits<std::__1::allocator<unsigned char> >::__construct_range_forward<unsigned char>(std::__1::allocator<unsigned char>&, unsigned char*, unsigned char*, unsigned char*&)
+INLINE_ORIGIN 158 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__construct_at_end<unsigned char*>(unsigned char*, unsigned char*, unsigned long)
+INLINE_ORIGIN 159 std::__1::allocator_traits<std::__1::allocator<unsigned char> >::__construct_range_forward<unsigned char>(std::__1::allocator<unsigned char>&, unsigned char*, unsigned char*, unsigned char*&)
 INLINE_ORIGIN 160 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__recommend(unsigned long) const
 INLINE_ORIGIN 161 google_breakpad::scoped_ptr<sigaction>::scoped_ptr(sigaction*)
 INLINE_ORIGIN 162 google_breakpad::scoped_ptr<sigaction>::scoped_ptr(sigaction*)
@@ -253,11 +254,11 @@ INLINE_ORIGIN 213 std::__1::__compressed_pair<MDMemoryDescriptor*, google_breakp
 INLINE_ORIGIN 214 std::__1::__libcpp_compressed_pair_imp<MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>, (unsigned int)0>::__libcpp_compressed_pair_imp(MDMemoryDescriptor*, google_breakpad::PageStdAllocator<MDMemoryDescriptor>)
 INLINE_ORIGIN 215 google_breakpad::PageAllocator::GetNPages(unsigned long)
 INLINE_ORIGIN 216 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__swap_out_circular_buffer(std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>&)
-INLINE_ORIGIN 217 void std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__construct_backward<MDMemoryDescriptor*>(google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor*, MDMemoryDescriptor*&)
-INLINE_ORIGIN 218 std::__1::enable_if<(is_move_constructible<MDMemoryDescriptor*>::value)&&(is_move_assignable<MDMemoryDescriptor*>::value), void>::type std::__1::swap<MDMemoryDescriptor*>(MDMemoryDescriptor*&, MDMemoryDescriptor*&)
-INLINE_ORIGIN 219 void std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::construct<MDMemoryDescriptor, MDMemoryDescriptor>(google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor&&)
-INLINE_ORIGIN 220 void std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__construct<MDMemoryDescriptor, MDMemoryDescriptor>(std::__1::integral_constant<bool, true>, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor&&)
-INLINE_ORIGIN 221 void std::__1::allocator<MDMemoryDescriptor>::construct<MDMemoryDescriptor, MDMemoryDescriptor>(MDMemoryDescriptor*, MDMemoryDescriptor&&)
+INLINE_ORIGIN 217 std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__construct_backward<MDMemoryDescriptor*>(google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor*, MDMemoryDescriptor*&)
+INLINE_ORIGIN 218 std::__1::swap<MDMemoryDescriptor*>(MDMemoryDescriptor*&, MDMemoryDescriptor*&)
+INLINE_ORIGIN 219 std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::construct<MDMemoryDescriptor, MDMemoryDescriptor>(google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor&&)
+INLINE_ORIGIN 220 std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__construct<MDMemoryDescriptor, MDMemoryDescriptor>(std::__1::integral_constant<bool, true>, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor&&)
+INLINE_ORIGIN 221 std::__1::allocator<MDMemoryDescriptor>::construct<MDMemoryDescriptor, MDMemoryDescriptor>(MDMemoryDescriptor*, MDMemoryDescriptor&&)
 INLINE_ORIGIN 222 google_breakpad::wasteful_vector<MDMemoryDescriptor>::~wasteful_vector()
 INLINE_ORIGIN 223 google_breakpad::wasteful_vector<MDMemoryDescriptor>::~wasteful_vector()
 INLINE_ORIGIN 224 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::~vector()
@@ -296,15 +297,15 @@ INLINE_ORIGIN 256 google_breakpad::TypedMDRVA<MDRawThreadList>::Flush()
 INLINE_ORIGIN 257 google_breakpad::TypedMDRVA<MDRawMemoryList>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
 INLINE_ORIGIN 258 google_breakpad::TypedMDRVA<MDRawMemoryList>::TypedMDRVA(google_breakpad::MinidumpFileWriter*)
 INLINE_ORIGIN 259 google_breakpad::MinidumpGenerator::GetThreadState(unsigned int, unsigned int*, unsigned int*)
-INLINE_ORIGIN 260 unsigned long const& std::__1::min<unsigned long>(unsigned long const&, unsigned long const&)
-INLINE_ORIGIN 261 unsigned long const& std::__1::min<unsigned long, std::__1::__less<unsigned long, unsigned long> >(unsigned long const&, unsigned long const&, std::__1::__less<unsigned long, unsigned long>)
+INLINE_ORIGIN 260 std::__1::min<unsigned long>(unsigned long const&, unsigned long const&)
+INLINE_ORIGIN 261 std::__1::min<unsigned long, std::__1::__less<unsigned long, unsigned long> >(unsigned long const&, unsigned long const&, std::__1::__less<unsigned long, unsigned long>)
 INLINE_ORIGIN 262 google_breakpad::MinidumpGenerator::CurrentPCForStack(unsigned int*)
 INLINE_ORIGIN 263 google_breakpad::MinidumpGenerator::CurrentPCForStackX86(unsigned int*)
 INLINE_ORIGIN 264 google_breakpad::MinidumpGenerator::CurrentPCForStackX86_64(unsigned int*)
 INLINE_ORIGIN 265 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::push_back(MDMemoryDescriptor const&)
-INLINE_ORIGIN 266 void std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::construct<MDMemoryDescriptor, MDMemoryDescriptor const&>(google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor const&)
-INLINE_ORIGIN 267 void std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__construct<MDMemoryDescriptor, MDMemoryDescriptor const&>(std::__1::integral_constant<bool, true>, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor const&)
-INLINE_ORIGIN 268 void std::__1::allocator<MDMemoryDescriptor>::construct<MDMemoryDescriptor, MDMemoryDescriptor const&>(MDMemoryDescriptor*, MDMemoryDescriptor const&)
+INLINE_ORIGIN 266 std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::construct<MDMemoryDescriptor, MDMemoryDescriptor const&>(google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor const&)
+INLINE_ORIGIN 267 std::__1::allocator_traits<google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__construct<MDMemoryDescriptor, MDMemoryDescriptor const&>(std::__1::integral_constant<bool, true>, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&, MDMemoryDescriptor*, MDMemoryDescriptor const&)
+INLINE_ORIGIN 268 std::__1::allocator<MDMemoryDescriptor>::construct<MDMemoryDescriptor, MDMemoryDescriptor const&>(MDMemoryDescriptor*, MDMemoryDescriptor const&)
 INLINE_ORIGIN 269 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::size() const
 INLINE_ORIGIN 270 google_breakpad::TypedMDRVA<MDRawMemoryList>::AllocateObjectAndArray(unsigned long, unsigned long)
 INLINE_ORIGIN 271 google_breakpad::TypedMDRVA<MDRawMemoryList>::CopyIndexAfterObject(unsigned int, void const*, unsigned long)
@@ -398,7 +399,7 @@ INLINE_ORIGIN 358 std::__1::__vector_base<unsigned short, std::__1::allocator<un
 INLINE_ORIGIN 359 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::resize(unsigned long)
 INLINE_ORIGIN 360 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::size() const
 INLINE_ORIGIN 361 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__destruct_at_end(unsigned short*)
-INLINE_ORIGIN 362 bool std::__1::operator!=<unsigned short const*>(std::__1::__wrap_iter<unsigned short const*> const&, std::__1::__wrap_iter<unsigned short const*> const&)
+INLINE_ORIGIN 362 std::__1::operator!=<unsigned short const*>(std::__1::__wrap_iter<unsigned short const*> const&, std::__1::__wrap_iter<unsigned short const*> const&)
 INLINE_ORIGIN 363 std::__1::__wrap_iter<unsigned short const*>::operator++()
 INLINE_ORIGIN 364 google_breakpad::scoped_array<unsigned char>::~scoped_array()
 INLINE_ORIGIN 365 google_breakpad::scoped_array<unsigned char>::~scoped_array()
@@ -411,29 +412,29 @@ INLINE_ORIGIN 371 std::__1::allocator_traits<std::__1::allocator<unsigned short>
 INLINE_ORIGIN 372 std::__1::allocator<unsigned short>::allocate(unsigned long, void const*)
 INLINE_ORIGIN 373 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__move_range(unsigned short*, unsigned short*, unsigned short*)
 INLINE_ORIGIN 374 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__construct_at_end(unsigned long, unsigned short const&)
-INLINE_ORIGIN 375 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::construct<unsigned short, unsigned short const&>(std::__1::allocator<unsigned short>&, unsigned short*, unsigned short const&)
-INLINE_ORIGIN 376 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct<unsigned short, unsigned short const&>(std::__1::integral_constant<bool, true>, std::__1::allocator<unsigned short>&, unsigned short*, unsigned short const&)
-INLINE_ORIGIN 377 void std::__1::allocator<unsigned short>::construct<unsigned short, unsigned short const&>(unsigned short*, unsigned short const&)
-INLINE_ORIGIN 378 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::construct<unsigned short, unsigned short>(std::__1::allocator<unsigned short>&, unsigned short*, unsigned short&&)
-INLINE_ORIGIN 379 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct<unsigned short, unsigned short>(std::__1::integral_constant<bool, true>, std::__1::allocator<unsigned short>&, unsigned short*, unsigned short&&)
-INLINE_ORIGIN 380 void std::__1::allocator<unsigned short>::construct<unsigned short, unsigned short>(unsigned short*, unsigned short&&)
-INLINE_ORIGIN 381 unsigned short* std::__1::move_backward<unsigned short*, unsigned short*>(unsigned short*, unsigned short*, unsigned short*)
-INLINE_ORIGIN 382 std::__1::enable_if<(is_same<std::__1::remove_const<unsigned short>::type, unsigned short>::value)&&(is_trivially_copy_assignable<unsigned short>::value), unsigned short*>::type std::__1::__move_backward<unsigned short, unsigned short>(unsigned short*, unsigned short*, unsigned short*)
-INLINE_ORIGIN 383 unsigned short* std::__1::fill_n<unsigned short*, unsigned long, unsigned short>(unsigned short*, unsigned long, unsigned short const&)
-INLINE_ORIGIN 384 unsigned short* std::__1::__fill_n<unsigned short*, unsigned long, unsigned short>(unsigned short*, unsigned long, unsigned short const&)
+INLINE_ORIGIN 375 std::__1::allocator_traits<std::__1::allocator<unsigned short> >::construct<unsigned short, unsigned short const&>(std::__1::allocator<unsigned short>&, unsigned short*, unsigned short const&)
+INLINE_ORIGIN 376 std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct<unsigned short, unsigned short const&>(std::__1::integral_constant<bool, true>, std::__1::allocator<unsigned short>&, unsigned short*, unsigned short const&)
+INLINE_ORIGIN 377 std::__1::allocator<unsigned short>::construct<unsigned short, unsigned short const&>(unsigned short*, unsigned short const&)
+INLINE_ORIGIN 378 std::__1::allocator_traits<std::__1::allocator<unsigned short> >::construct<unsigned short, unsigned short>(std::__1::allocator<unsigned short>&, unsigned short*, unsigned short&&)
+INLINE_ORIGIN 379 std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct<unsigned short, unsigned short>(std::__1::integral_constant<bool, true>, std::__1::allocator<unsigned short>&, unsigned short*, unsigned short&&)
+INLINE_ORIGIN 380 std::__1::allocator<unsigned short>::construct<unsigned short, unsigned short>(unsigned short*, unsigned short&&)
+INLINE_ORIGIN 381 std::__1::move_backward<unsigned short*, unsigned short*>(unsigned short*, unsigned short*, unsigned short*)
+INLINE_ORIGIN 382 std::__1::__move_backward<unsigned short, unsigned short>(unsigned short*, unsigned short*, unsigned short*)
+INLINE_ORIGIN 383 std::__1::fill_n<unsigned short*, unsigned long, unsigned short>(unsigned short*, unsigned long, unsigned short const&)
+INLINE_ORIGIN 384 std::__1::__fill_n<unsigned short*, unsigned long, unsigned short>(unsigned short*, unsigned long, unsigned short const&)
 INLINE_ORIGIN 385 std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>::__construct_at_end(unsigned long, unsigned short const&)
 INLINE_ORIGIN 386 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__swap_out_circular_buffer(std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>&, unsigned short*)
-INLINE_ORIGIN 387 std::__1::enable_if<((is_same<std::__1::allocator<unsigned short>, std::__1::allocator<unsigned short> >::value)||(!(__has_construct<std::__1::allocator<unsigned short>, unsigned short*, unsigned short>::value)))&&(is_trivially_move_constructible<unsigned short>::value), void>::type std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct_backward<unsigned short>(std::__1::allocator<unsigned short>&, unsigned short*, unsigned short*, unsigned short*&)
-INLINE_ORIGIN 388 std::__1::enable_if<((is_same<std::__1::allocator<unsigned short>, std::__1::allocator<unsigned short> >::value)||(!(__has_construct<std::__1::allocator<unsigned short>, unsigned short*, unsigned short>::value)))&&(is_trivially_move_constructible<unsigned short>::value), void>::type std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct_forward<unsigned short>(std::__1::allocator<unsigned short>&, unsigned short*, unsigned short*, unsigned short*&)
-INLINE_ORIGIN 389 std::__1::enable_if<(is_move_constructible<unsigned short*>::value)&&(is_move_assignable<unsigned short*>::value), void>::type std::__1::swap<unsigned short*>(unsigned short*&, unsigned short*&)
+INLINE_ORIGIN 387 std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct_backward<unsigned short>(std::__1::allocator<unsigned short>&, unsigned short*, unsigned short*, unsigned short*&)
+INLINE_ORIGIN 388 std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct_forward<unsigned short>(std::__1::allocator<unsigned short>&, unsigned short*, unsigned short*, unsigned short*&)
+INLINE_ORIGIN 389 std::__1::swap<unsigned short*>(unsigned short*&, unsigned short*&)
 INLINE_ORIGIN 390 std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>::~__split_buffer()
 INLINE_ORIGIN 391 std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>::~__split_buffer()
 INLINE_ORIGIN 392 std::__1::allocator_traits<std::__1::allocator<unsigned short> >::deallocate(std::__1::allocator<unsigned short>&, unsigned short*, unsigned long)
 INLINE_ORIGIN 393 std::__1::allocator<unsigned short>::deallocate(unsigned short*, unsigned long)
 INLINE_ORIGIN 394 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__construct_at_end(unsigned long)
-INLINE_ORIGIN 395 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::construct<unsigned short, >(std::__1::allocator<unsigned short>&, unsigned short*, &&)
-INLINE_ORIGIN 396 void std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct<unsigned short, >(std::__1::integral_constant<bool, true>, std::__1::allocator<unsigned short>&, unsigned short*, &&)
-INLINE_ORIGIN 397 void std::__1::allocator<unsigned short>::construct<unsigned short, >(unsigned short*, &&)
+INLINE_ORIGIN 395 std::__1::allocator_traits<std::__1::allocator<unsigned short> >::construct<unsigned short, >(std::__1::allocator<unsigned short>&, unsigned short*, &&)
+INLINE_ORIGIN 396 std::__1::allocator_traits<std::__1::allocator<unsigned short> >::__construct<unsigned short, >(std::__1::integral_constant<bool, true>, std::__1::allocator<unsigned short>&, unsigned short*, &&)
+INLINE_ORIGIN 397 std::__1::allocator<unsigned short>::construct<unsigned short, >(unsigned short*, &&)
 INLINE_ORIGIN 398 std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>::__construct_at_end(unsigned long)
 INLINE_ORIGIN 399 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__swap_out_circular_buffer(std::__1::__split_buffer<unsigned short, std::__1::allocator<unsigned short>&>&)
 INLINE_ORIGIN 400 google_breakpad::FileID::FileID(char const*)
@@ -452,13 +453,13 @@ INLINE_ORIGIN 412 MacFileUtilities::MachoWalker::WalkHeader64AtOffset(long long)
 INLINE_ORIGIN 413 MacFileUtilities::MachoWalker::ReadBytes(void*, unsigned long, long long)
 INLINE_ORIGIN 414 google_breakpad::scoped_array<unsigned char>::operator[](long) const
 INLINE_ORIGIN 415 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::find_first_not_of(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, unsigned long) const
-INLINE_ORIGIN 416 unsigned long std::__1::__str_find_first_not_of<char, unsigned long, std::__1::char_traits<char>, (unsigned long)18446744073709551615>(char const*, unsigned long, char const*, unsigned long, unsigned long)
+INLINE_ORIGIN 416 std::__1::__str_find_first_not_of<char, unsigned long, std::__1::char_traits<char>, (unsigned long)18446744073709551615>(char const*, unsigned long, char const*, unsigned long, unsigned long)
 INLINE_ORIGIN 417 std::__1::char_traits<char>::find(char const*, unsigned long, char const&)
 INLINE_ORIGIN 418 std::__1::char_traits<char>::to_int_type(char)
 INLINE_ORIGIN 419 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::substr(unsigned long, unsigned long) const
 INLINE_ORIGIN 420 std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::find_first_of(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, unsigned long) const
-INLINE_ORIGIN 421 unsigned long std::__1::__str_find_first_of<char, unsigned long, std::__1::char_traits<char>, (unsigned long)18446744073709551615>(char const*, unsigned long, char const*, unsigned long, unsigned long)
-INLINE_ORIGIN 422 char const* std::__1::__find_first_of_ce<char const*, char const*, bool (*)(char, char)>(char const*, char const*, char const*, char const*, bool (*)(char, char))
+INLINE_ORIGIN 421 std::__1::__str_find_first_of<char, unsigned long, std::__1::char_traits<char>, (unsigned long)18446744073709551615>(char const*, unsigned long, char const*, unsigned long, unsigned long)
+INLINE_ORIGIN 422 std::__1::__find_first_of_ce<char const*, char const*, bool (*)(char, char)>(char const*, char const*, char const*, char const*, bool (*)(char, char))
 INLINE_ORIGIN 423 std::__1::char_traits<char>::eq(char, char)
 INLINE_ORIGIN 424 google_breakpad::MachMessage::MachMessage()
 INLINE_ORIGIN 425 google_breakpad::MachMessage::SetDescriptorCount(int)
@@ -551,7 +552,8 @@ f2a 5 85 1
 f2f 5 86 1
 f34 d 316 0
 f41 f 327 0
-f50 1b 328 0
+f50 17 328 0
+f67 4 328 0
 f6b 7 166 0
 f72 4 167 0
 f76 5 175 0
@@ -576,7 +578,8 @@ ff0 16 183 0
 1076 5 86 1
 107b 11 316 0
 108c f 327 0
-109b 1c 328 0
+109b 18 328 0
+10b3 4 328 0
 10b7 3 195 0
 10ba 6 196 0
 10c0 5 202 0
@@ -586,7 +589,7 @@ ff0 16 183 0
 1118 1f 313 0
 FUNC 1140 5 0 google_breakpad::MinidumpFileWriter::WriteString(wchar_t const*, unsigned int, MDLocationDescriptor*)
 1140 5 245 0
-FUNC 1150 2cc 0 bool google_breakpad::MinidumpFileWriter::WriteStringCore<wchar_t>(wchar_t const*, unsigned int, MDLocationDescriptor*)
+FUNC 1150 2cc 0 google_breakpad::MinidumpFileWriter::WriteStringCore<wchar_t>(wchar_t const*, unsigned int, MDLocationDescriptor*)
 INLINE 0 222 0 5 119f 26
 INLINE 1 212 2 6 119f 26
 INLINE 2 210 2 7 119f c
@@ -644,8 +647,10 @@ INLINE 3 92 1 4 1297 29 12c5 d 133d 1f 13bb 45 1405 f
 131e 1f 66 1
 133d 1f 313 0
 135c 1f 83 1
-137b 21 313 0
-139c b 217 2
+137b 1f 313 0
+139a 2 313 0
+139c 8 217 2
+13a4 3 217 2
 13a7 f 216 2
 13b6 5 92 1
 13bb 27 313 0
@@ -656,7 +661,7 @@ INLINE 3 92 1 4 1297 29 12c5 d 133d 1f 13bb 45 1405 f
 1414 8 217 2
 FUNC 1420 5 0 google_breakpad::MinidumpFileWriter::WriteString(char const*, unsigned int, MDLocationDescriptor*)
 1420 5 250 0
-FUNC 1430 2cc 0 bool google_breakpad::MinidumpFileWriter::WriteStringCore<char>(char const*, unsigned int, MDLocationDescriptor*)
+FUNC 1430 2cc 0 google_breakpad::MinidumpFileWriter::WriteStringCore<char>(char const*, unsigned int, MDLocationDescriptor*)
 INLINE 0 222 0 5 147f 26
 INLINE 1 212 2 6 147f 26
 INLINE 2 210 2 7 147f c
@@ -714,8 +719,10 @@ INLINE 3 92 1 4 1577 29 15a5 d 161d 1f 169b 45 16e5 f
 15fe 1f 66 1
 161d 1f 313 0
 163c 1f 83 1
-165b 21 313 0
-167c b 217 2
+165b 1f 313 0
+167a 2 313 0
+167c 8 217 2
+1684 3 217 2
 1687 f 216 2
 1696 5 92 1
 169b 27 313 0
@@ -808,253 +815,258 @@ INLINE 0 347 0 4 1aa2 37 1b44 1f
 1aa2 b 313 0
 1aad 6 316 0
 1ab3 f 327 0
-1ac2 19 328 0
+1ac2 17 328 0
+1ad9 2 328 0
 1adb c 347 0
 1ae7 1f 344 0
 1b06 1f 345 0
 1b25 1f 346 0
 1b44 1f 313 0
 FUNC 1b70 1b3 0 google_breakpad::CrashGenerationClient::RequestDumpForException(int, int, int, unsigned int)
-INLINE 0 47 3 17 1bc3 14
-INLINE 1 117 4 18 1bc3 14 1be9 14 1c14 14 1c3d 14
-INLINE 0 48 3 17 1be9 14
-INLINE 0 49 3 17 1c14 14
-INLINE 0 50 3 19 1c3a 3
-INLINE 0 50 3 17 1c3d 14
-INLINE 0 66 3 20 1caa d
-INLINE 1 239 4 21 1caa d
-INLINE 2 239 4 22 1caa d
-1b70 33 41 3
-1ba3 5 44 3
-1ba8 12 46 3
-1bba 9 47 3
-1bc3 4 118 4
-1bc7 8 119 4
-1bcf 8 122 4
-1bd7 12 47 3
-1be9 4 118 4
-1bed 8 119 4
-1bf5 8 122 4
-1bfd 12 48 3
-1c0f 5 49 3
-1c14 4 118 4
-1c18 8 119 4
-1c20 8 122 4
-1c28 12 49 3
-1c3a 3 269 4
-1c3d 4 118 4
-1c41 8 119 4
-1c49 8 122 4
-1c51 12 50 3
-1c63 4 53 3
-1c67 5 54 3
-1c6c 5 55 3
-1c71 17 56 3
-1c88 15 59 3
-1c9d d 60 3
-1caa d 203 4
-1cb7 11 67 3
-1cc8 9 69 3
-1cd1 52 70 3
+INLINE 0 47 4 17 1bc3 14
+INLINE 1 117 3 18 1bc3 14 1be9 14 1c14 14 1c3d 14
+INLINE 0 48 4 17 1be9 14
+INLINE 0 49 4 17 1c14 14
+INLINE 0 50 4 19 1c3a 3
+INLINE 0 50 4 17 1c3d 14
+INLINE 0 66 4 20 1caa d
+INLINE 1 239 3 21 1caa d
+INLINE 2 239 3 22 1caa d
+1b70 33 41 4
+1ba3 5 44 4
+1ba8 12 46 4
+1bba 9 47 4
+1bc3 4 118 3
+1bc7 8 119 3
+1bcf 8 122 3
+1bd7 12 47 4
+1be9 4 118 3
+1bed 8 119 3
+1bf5 8 122 3
+1bfd 12 48 4
+1c0f 5 49 4
+1c14 4 118 3
+1c18 8 119 3
+1c20 8 122 3
+1c28 12 49 4
+1c3a 3 269 3
+1c3d 4 118 3
+1c41 8 119 3
+1c49 8 122 3
+1c51 12 50 4
+1c63 4 53 4
+1c67 5 54 4
+1c6c 5 55 4
+1c71 17 56 4
+1c88 15 59 4
+1c9d d 60 4
+1caa d 203 3
+1cb7 11 67 4
+1cc8 9 69 4
+1cd1 52 70 4
 FUNC 1d30 bb 0 google_breakpad::ReadTaskMemory(unsigned int, unsigned long long, unsigned long, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >&)
-INLINE 0 207 8 106 1d7e 20 1da5 d
-INLINE 1 1996 9 107 1d7e d
-INLINE 0 208 8 36 1d9e 5
-INLINE 1 2000 9 108 1da9 9
-INLINE 2 814 9 41 1da9 9
-1d30 17 185 8
-1d47 5 186 8
-1d4c 3 192 8
-1d4f 5 189 8
-1d54 c 192 8
-1d60 3 189 8
-1d63 d 194 8
-1d70 a 198 8
-1d7a 4 204 8
-1d7e d 642 9
-1d8b 5 1997 9
-1d90 e 1998 9
-1d9e 7 1501 9
-1da5 4 2000 9
-1da9 5 424 9
-1dae 4 425 9
-1db2 8 209 8
-1dba b 208 8
-1dc5 19 211 8
-1dde d 213 8
+INLINE 0 207 12 106 1d7e 20 1da5 d
+INLINE 1 1996 8 107 1d7e d
+INLINE 0 208 12 36 1d9e 5
+INLINE 1 2000 8 108 1da9 9
+INLINE 2 814 8 41 1da9 9
+1d30 17 185 12
+1d47 5 186 12
+1d4c 3 192 12
+1d4f 5 189 12
+1d54 c 192 12
+1d60 3 189 12
+1d63 d 194 12
+1d70 a 198 12
+1d7a 4 204 12
+1d7e d 642 8
+1d8b 5 1997 8
+1d90 e 1998 8
+1d9e 5 1501 8
+1da3 2 1501 8
+1da5 4 2000 8
+1da9 5 424 8
+1dae 4 425 8
+1db2 8 209 12
+1dba b 208 12
+1dc5 19 211 12
+1dde d 213 12
 FUNC 1df0 1ba 0 google_breakpad::DynamicImage::CalculateMemoryAndVersionInfo()
-INLINE 0 310 8 116 1e1e 5
-INLINE 0 311 8 117 1e23 b 1ee4 1b 1f02 99
-INLINE 1 247 8 118 1e23 3
-INLINE 0 313 8 119 1e2e 1b 1e4c 98
-INLINE 1 271 8 27 1e9f 4 1f5c 4
-1df0 e 301 8
-1dfe 20 305 8
-1e1e 5 162 6
-1e23 3 1510 9
-1e26 8 249 8
-1e2e b 249 8
-1e39 4 258 8
-1e3d c 254 8
-1e49 7 313 8
-1e50 b 258 8
-1e5b 6 259 8
-1e61 5 260 8
-1e66 14 264 8
-1e7a 7 265 8
-1e81 7 266 8
-1e88 b 267 8
-1e93 c 269 8
-1e9f 4 141 6
-1ea3 3 271 8
-1ea6 a 270 8
-1eb0 6 278 8
-1eb6 5 279 8
-1ebb a 283 8
-1ec5 e 288 8
-1ed3 3 293 8
-1ed6 e 258 8
-1ee4 b 249 8
-1eef 4 258 8
-1ef3 c 254 8
-1eff 11 311 8
-1f10 b 258 8
-1f1b 6 259 8
-1f21 5 260 8
-1f26 14 264 8
-1f3a 4 271 8
-1f3e 5 265 8
-1f43 b 267 8
-1f4e e 269 8
-1f5c 4 141 6
-1f60 8 271 8
-1f68 8 270 8
-1f70 6 278 8
-1f76 5 279 8
-1f7b a 283 8
-1f85 a 288 8
-1f8f 3 293 8
-1f92 9 258 8
-1f9b f 314 8
+INLINE 0 310 12 116 1e1e 5
+INLINE 0 311 12 117 1e23 b 1ee4 1b 1f02 99
+INLINE 1 247 12 118 1e23 3
+INLINE 0 313 12 119 1e2e 1b 1e4c 98
+INLINE 1 271 12 27 1e9f 4 1f5c 4
+1df0 e 301 12
+1dfe 20 305 12
+1e1e 5 162 5
+1e23 3 1510 8
+1e26 8 249 12
+1e2e b 249 12
+1e39 4 258 12
+1e3d c 254 12
+1e49 3 313 12
+1e4c 4 313 12
+1e50 b 258 12
+1e5b 6 259 12
+1e61 5 260 12
+1e66 14 264 12
+1e7a 7 265 12
+1e81 7 266 12
+1e88 b 267 12
+1e93 c 269 12
+1e9f 4 141 5
+1ea3 3 271 12
+1ea6 a 270 12
+1eb0 6 278 12
+1eb6 5 279 12
+1ebb a 283 12
+1ec5 e 288 12
+1ed3 3 293 12
+1ed6 e 258 12
+1ee4 b 249 12
+1eef 4 258 12
+1ef3 c 254 12
+1eff 3 311 12
+1f02 e 311 12
+1f10 b 258 12
+1f1b 6 259 12
+1f21 5 260 12
+1f26 14 264 12
+1f3a 4 271 12
+1f3e 5 265 12
+1f43 b 267 12
+1f4e e 269 12
+1f5c 4 141 5
+1f60 8 271 12
+1f68 8 270 12
+1f70 6 278 12
+1f76 5 279 12
+1f7b a 283 12
+1f85 a 288 12
+1f8f 3 293 12
+1f92 9 258 12
+1f9b f 314 12
 FUNC 1fb0 7 0 google_breakpad::DynamicImage::GetFileType()
-INLINE 0 329 8 120 1fb0 6
-INLINE 1 323 8 118 1fb0 3
-1fb0 3 1510 9
-1fb3 3 324 8
-1fb6 1 332 8
+INLINE 0 329 12 120 1fb0 6
+INLINE 1 323 12 118 1fb0 3
+1fb0 3 1510 8
+1fb3 3 324 12
+1fb6 1 332 12
 FUNC 1fc0 b8 0 google_breakpad::DynamicImages::DynamicImages(unsigned int)
-INLINE 0 341 8 121 1fdc 18
-INLINE 1 485 9 122 1fdc 18
-INLINE 2 484 9 123 1fdc 18
-INLINE 0 342 8 124 1ff4 44
-INLINE 1 514 8 125 1ff4 1e 2016 a
-INLINE 1 517 8 126 2020 6
-INLINE 0 343 8 127 2045 2b
-INLINE 1 458 9 128 2045 2b
-INLINE 2 458 9 129 2045 2b
-INLINE 3 452 9 130 204d 1e
-INLINE 4 369 9 104 204d 1e
-INLINE 5 425 9 105 2056 11
-INLINE 3 453 9 62 206b 5
+INLINE 0 341 12 121 1fdc 18
+INLINE 1 485 8 122 1fdc 18
+INLINE 2 484 8 123 1fdc 18
+INLINE 0 342 12 124 1ff4 44
+INLINE 1 514 12 125 1ff4 1e 2016 a
+INLINE 1 517 12 126 2020 6
+INLINE 0 343 12 127 2045 2b
+INLINE 1 458 8 128 2045 2b
+INLINE 2 458 8 129 2045 2b
+INLINE 3 452 8 130 204d 1e
+INLINE 4 369 8 104 204d 1e
+INLINE 5 425 8 105 2056 11
+INLINE 3 453 8 62 206b 5
 INLINE 4 1508 10 63 206b 5
 INLINE 5 1743 10 44 206b 5
-1fc0 c 341 8
-1fcc 2 339 8
-1fce a 340 8
-1fd8 4 341 8
-1fdc 18 433 9
-1ff4 8 391 8
-1ffc 16 392 8
-2012 4 516 8
-2016 a 397 8
-2020 6 271 6
-2026 a 520 8
-2030 8 518 8
-2038 d 343 8
-2045 8 450 9
-204d 9 424 9
-2056 11 0 9
-2067 4 425 9
-206b d 177 11
+1fc0 c 341 12
+1fcc 2 339 12
+1fce a 340 12
+1fd8 4 341 12
+1fdc 18 433 8
+1ff4 8 391 12
+1ffc 16 392 12
+2012 4 516 12
+2016 a 397 12
+2020 6 271 5
+2026 a 520 12
+2030 8 518 12
+2038 d 343 12
+2045 8 450 8
+204d 9 424 8
+2056 11 0 8
+2067 4 425 8
+206b 5 177 9
+2070 8 177 9
 FUNC 2080 d6 0 google_breakpad::DynamicImages::DetermineTaskCPUType(unsigned int)
-2080 16 552 8
-2096 10 553 8
-20a6 9 557 8
-20af 1d 558 8
-20cc 4 559 8
-20d0 b 560 8
-20db c 561 8
-20e7 d 562 8
-20f4 18 565 8
-210c b 566 8
-2117 15 567 8
-212c b 571 8
-2137 1f 560 8
+2080 16 552 12
+2096 10 553 12
+20a6 9 557 12
+20af 1d 558 12
+20cc 4 559 12
+20d0 b 560 12
+20db c 561 12
+20e7 d 562 12
+20f4 18 565 12
+210c b 566 12
+2117 15 567 12
+212c b 571 12
+2137 1f 560 12
 FUNC 2160 52 0 google_breakpad::DynamicImages::ReadImageInfoForTask()
-INLINE 0 514 8 125 2168 1e 218a a
-INLINE 0 517 8 126 2194 6
-2160 8 513 8
-2168 8 391 8
-2170 16 392 8
-2186 4 516 8
-218a a 397 8
-2194 6 271 6
-219a a 520 8
-21a4 8 518 8
-21ac 6 522 8
+INLINE 0 514 12 125 2168 1e 218a a
+INLINE 0 517 12 126 2194 6
+2160 8 513 12
+2168 8 391 12
+2170 16 392 12
+2186 4 516 12
+218a a 397 12
+2194 6 271 5
+219a a 520 12
+21a4 8 518 12
+21ac 6 522 12
 FUNC 21c0 5 0 google_breakpad::DynamicImages::DynamicImages(unsigned int)
-21c0 5 341 8
+21c0 5 341 12
 FUNC 21d0 34 0 google_breakpad::DynamicImages::GetDyldAllImageInfosPointer()
-21d0 c 391 8
-21dc 18 392 8
-21f4 2 393 8
-21f6 6 392 8
-21fc 8 406 8
-FUNC 2210 5d0 0 void google_breakpad::ReadImageInfo<google_breakpad::MachO64>(google_breakpad::DynamicImages&, unsigned long long)
-INLINE 0 424 8 33 2224 17
-INLINE 1 485 9 34 2224 17 2261 11 241f 12
-INLINE 2 484 9 35 2224 17 2261 11 241f 12
-INLINE 0 432 8 36 2255 8
-INLINE 0 439 8 33 2261 11
-INLINE 0 511 8 37 2294 1b 22af 24 2799 1b 27b4 24
-INLINE 1 458 9 38 2294 1b 22af 24 261a 21 277e 1b 2799 1b 27b4 24
-INLINE 2 458 9 39 2294 1b 22af 24 261a 21 277e 1b 2799 1b 27b4 24
-INLINE 3 452 9 40 229e c 22bc 12 262a c 2788 c 27a3 c 27c1 12
-INLINE 4 369 9 41 229e c 22bc 12 262a c 2788 c 27a3 c 27c1 12
-INLINE 3 453 9 42 22aa 5 22ce 5 2636 5 2794 5 27af 5 27d3 5
+21d0 c 391 12
+21dc 18 392 12
+21f4 2 393 12
+21f6 6 392 12
+21fc 8 406 12
+FUNC 2210 5d0 0 google_breakpad::ReadImageInfo<google_breakpad::MachO64>(google_breakpad::DynamicImages&, unsigned long long)
+INLINE 0 424 12 33 2224 17
+INLINE 1 485 8 34 2224 17 2261 11 241f 12
+INLINE 2 484 8 35 2224 17 2261 11 241f 12
+INLINE 0 432 12 36 2255 8
+INLINE 0 439 12 33 2261 11
+INLINE 0 511 12 37 2294 3f 2799 3f
+INLINE 1 458 8 38 2294 3f 261a 21 277e 5a
+INLINE 2 458 8 39 2294 3f 261a 21 277e 5a
+INLINE 3 452 8 40 229e c 22bc 12 262a c 2788 c 27a3 c 27c1 12
+INLINE 4 369 8 41 229e c 22bc 12 262a c 2788 c 27a3 c 27c1 12
+INLINE 3 453 8 42 22aa 5 22ce 5 2636 5 2794 5 27af 5 27d3 5
 INLINE 4 1508 10 43 22aa 5 22ce 5 2636 5 2794 5 27af 5 27d3 5
 INLINE 5 1743 10 44 22aa 5 22ce 5 23e9 8 2636 5 2794 5 27af 5 27d3 5
-INLINE 0 447 8 36 22e5 5
-INLINE 0 448 8 45 22ef 55 2347 aa
-INLINE 1 1535 9 46 22ef 16
-INLINE 2 645 9 47 22ef 16
-INLINE 1 1538 9 48 230e 5 231b 6 2324 6
-INLINE 1 1538 9 49 2313 8 2321 3 232a 6
-INLINE 2 310 12 50 2313 8 2321 3 232a 6
-INLINE 3 311 12 51 2313 8
+INLINE 0 447 12 36 22e5 5
+INLINE 0 448 12 45 22ef 55 2347 aa
+INLINE 1 1535 8 46 22ef 16
+INLINE 2 645 8 47 22ef 16
+INLINE 1 1538 8 48 230e 5 231b 6 2324 6
+INLINE 1 1538 8 49 2313 8 2321 3 232a 6
+INLINE 2 310 11 50 2313 8 2321 3 232a 6
+INLINE 3 311 11 51 2313 8
 INLINE 4 1500 10 52 2313 8
 INLINE 5 1741 10 53 2313 8
-INLINE 1 1539 9 54 2330 14 2347 9d
-INLINE 2 893 9 55 2330 14 2347 20 236f 5e
+INLINE 1 1539 8 54 2330 14 2347 9d
+INLINE 2 893 8 55 2330 14 2347 20 236f 5e
 INLINE 3 1630 10 56 2347 d 2358 4 2375 47 23c0 4
 INLINE 4 1514 10 57 2347 d 2358 4 2375 47 23c0 4
 INLINE 5 1668 10 58 2347 d 2358 4 2375 47 23c0 4
 INLINE 6 1752 10 31 2347 d 2358 4 2375 47 23c0 4
-INLINE 7 210 6 32 2347 d 2358 4 2375 47 23c0 4
-INLINE 2 894 9 59 2367 5 23cd d
-INLINE 2 895 9 59 23da 5
-INLINE 2 896 9 59 23df 5
-INLINE 1 1540 9 60 23e4 d
-INLINE 2 340 12 61 23e4 d
-INLINE 3 343 12 62 23e9 8
+INLINE 7 210 5 32 2347 d 2358 4 2375 47 23c0 4
+INLINE 2 894 8 59 2367 5 23cd d
+INLINE 2 895 8 59 23da 5
+INLINE 2 896 8 59 23df 5
+INLINE 1 1540 8 60 23e4 d
+INLINE 2 340 11 61 23e4 d
+INLINE 3 343 11 62 23e9 8
 INLINE 4 1508 10 63 23e9 8
-INLINE 0 495 8 64 23fa 5 25a1 20 25f9 17
-INLINE 0 454 8 33 241f 12
-INLINE 0 462 8 36 244e 5
-INLINE 0 476 8 65 2476 11
+INLINE 0 495 12 64 23fa 5 25a1 20 25f9 17
+INLINE 0 454 12 33 241f 12
+INLINE 0 462 12 36 244e 5
+INLINE 0 476 12 65 2476 11
 INLINE 1 1945 13 66 2476 11
 INLINE 2 1949 13 67 2476 11
-INLINE 0 481 8 68 24a5 6b 2737 8
+INLINE 0 481 12 68 24a5 6b 2737 8
 INLINE 1 2476 13 69 24a5 6b 2737 8
 INLINE 2 2462 13 70 24a5 21
 INLINE 3 3163 13 71 24a5 7
@@ -1064,131 +1076,135 @@ INLINE 3 3165 13 74 24ba 3
 INLINE 3 3166 13 75 24bd 9
 INLINE 2 2463 13 76 24c6 c 2737 8
 INLINE 2 2466 13 67 24f9 17
-INLINE 0 486 8 36 252a 5
-INLINE 0 486 8 77 255a 23
-INLINE 0 494 8 78 2585 d
-INLINE 0 495 8 79 2594 d
-INLINE 1 208 6 80 2594 d
-INLINE 1 1609 9 81 25ad 3
+INLINE 0 486 12 36 252a 5
+INLINE 0 486 12 77 255a 23
+INLINE 0 494 12 78 2585 d
+INLINE 0 495 12 79 2594 d
+INLINE 1 208 5 80 2594 d
+INLINE 1 1609 8 81 25ad 3
 INLINE 2 1514 10 82 25ad 3
 INLINE 3 1668 10 83 25ad 3
 INLINE 4 1752 10 31 25ad 3
-INLINE 5 210 6 32 25ad 3
-INLINE 0 497 8 84 25c1 29
-INLINE 1 109 6 85 25c1 29
-INLINE 2 109 6 37 25cd 1d
-INLINE 3 458 9 38 25cd 1d
-INLINE 4 458 9 39 25cd 1d
-INLINE 5 452 9 40 25db a
-INLINE 6 369 9 41 25db a
-INLINE 5 453 9 42 25e5 5
+INLINE 5 210 5 32 25ad 3
+INLINE 0 497 12 84 25c1 29
+INLINE 1 109 5 85 25c1 29
+INLINE 2 109 5 37 25cd 1d
+INLINE 3 458 8 38 25cd 1d
+INLINE 4 458 8 39 25cd 1d
+INLINE 5 452 8 40 25db a
+INLINE 6 369 8 41 25db a
+INLINE 5 453 8 42 25e5 5
 INLINE 6 1508 10 43 25e5 5
 INLINE 7 1743 10 44 25e5 5
-INLINE 0 499 8 37 261a 21 277e 1b
-INLINE 0 502 8 86 2655 4 2661 9
-INLINE 0 502 8 87 265e 3
-INLINE 0 502 8 88 266a 5
-INLINE 1 4066 5 89 266a 5
-INLINE 2 4050 5 90 266a 5
-INLINE 0 508 8 87 266f 3
-INLINE 0 509 8 86 2672 4
-INLINE 0 508 8 91 2676 69 26e5 3
-INLINE 1 2235 5 92 2676 69
-INLINE 2 2214 5 93 2676 24
-INLINE 3 1085 5 94 2676 5
-INLINE 3 1088 5 94 267f 6
-INLINE 3 1090 5 95 2685 b
-INLINE 4 665 5 96 2685 b
-INLINE 5 219 6 97 2689 3
-INLINE 5 218 6 27 268c 4
-INLINE 2 2216 5 94 269e 5
-INLINE 2 2221 5 98 26a3 9 26b4 10
-INLINE 2 2223 5 98 26b0 4
-INLINE 2 2221 5 94 26c4 3
-INLINE 2 2222 5 95 26c9 12
-INLINE 3 665 5 96 26c9 12
-INLINE 4 218 6 27 26cc 4
-INLINE 4 219 6 97 26d0 3
-INLINE 2 2224 5 98 26db 4
-INLINE 0 510 8 86 26df 6
-INLINE 0 510 8 99 26e8 4b
-INLINE 1 1696 9 100 26e8 9
-INLINE 1 1697 9 101 26f1 17 270c 4
-INLINE 2 1913 5 102 26f1 17 270c 4
-INLINE 1 1697 9 103 2708 4 2710 23
-INLINE 2 814 9 104 2708 4 2710 23
-INLINE 3 425 9 105 2719 11
-2210 14 413 8
-2224 17 433 9
-223b 16 425 8
-2251 4 428 8
-2255 8 1501 9
-225d 4 442 8
-2261 11 433 9
-2272 4 440 8
-2276 4 441 8
-227a c 442 8
-2286 a 440 8
-2290 4 443 8
-2294 5 453 9
-2299 5 450 9
-229e 7 424 9
-22a5 5 425 9
-22aa 5 177 11
-22af 8 453 9
-22b7 5 450 9
-22bc a 424 9
-22c6 8 425 9
-22ce 5 177 11
-22d3 12 511 8
-22e5 5 1501 9
-22ea 5 448 8
-22ef 16 372 9
-2305 9 1535 9
-230e 5 642 9
-2313 8 169 11
-231b 6 642 9
-2321 3 312 12
-2324 6 642 9
-232a 6 313 12
+INLINE 0 499 12 37 261a 21 277e 1b
+INLINE 0 502 12 86 2655 4 2661 9
+INLINE 0 502 12 87 265e 3
+INLINE 0 502 12 88 266a 5
+INLINE 1 4066 6 89 266a 5
+INLINE 2 4050 6 90 266a 5
+INLINE 0 508 12 87 266f 3
+INLINE 0 509 12 86 2672 4
+INLINE 0 508 12 91 2676 69 26e5 3
+INLINE 1 2235 6 92 2676 69
+INLINE 2 2214 6 93 2676 24
+INLINE 3 1085 6 94 2676 5
+INLINE 3 1088 6 94 267f 6
+INLINE 3 1090 6 95 2685 b
+INLINE 4 665 6 96 2685 b
+INLINE 5 219 5 97 2689 3
+INLINE 5 218 5 27 268c 4
+INLINE 2 2216 6 94 269e 5
+INLINE 2 2221 6 98 26a3 9 26b4 10
+INLINE 2 2223 6 98 26b0 4
+INLINE 2 2221 6 94 26c4 3
+INLINE 2 2222 6 95 26c9 12
+INLINE 3 665 6 96 26c9 12
+INLINE 4 218 5 27 26cc 4
+INLINE 4 219 5 97 26d0 3
+INLINE 2 2224 6 98 26db 4
+INLINE 0 510 12 86 26df 6
+INLINE 0 510 12 99 26e8 4b
+INLINE 1 1696 8 100 26e8 9
+INLINE 1 1697 8 101 26f1 17 270c 4
+INLINE 2 1913 6 102 26f1 17 270c 4
+INLINE 1 1697 8 103 2708 4 2710 23
+INLINE 2 814 8 104 2708 4 2710 23
+INLINE 3 425 8 105 2719 11
+2210 14 413 12
+2224 17 433 8
+223b 16 425 12
+2251 4 428 12
+2255 8 1501 8
+225d 4 442 12
+2261 11 433 8
+2272 4 440 12
+2276 4 441 12
+227a c 442 12
+2286 a 440 12
+2290 4 443 12
+2294 5 453 8
+2299 5 450 8
+229e 7 424 8
+22a5 5 425 8
+22aa 5 177 9
+22af 8 453 8
+22b7 5 450 8
+22bc a 424 8
+22c6 8 425 8
+22ce 5 177 9
+22d3 12 511 12
+22e5 5 1501 8
+22ea 5 448 12
+22ef 16 372 8
+2305 9 1535 8
+230e 5 642 8
+2313 8 169 9
+231b 6 642 8
+2321 3 312 11
+2324 6 642 8
+232a 6 313 11
 2330 14 1630 10
-2344 c 448 8
-2350 4 210 6
+2344 3 448 12
+2347 9 448 12
+2350 4 210 5
 2354 4 1630 10
-2358 4 210 6
+2358 4 210 5
 235c 4 1631 10
 2360 7 1628 10
-2367 8 3618 7
-236f 11 1630 10
-2380 3c 210 6
+2367 5 3618 7
+236c 3 3618 7
+236f 6 1630 10
+2375 b 1630 10
+2380 3c 210 5
 23bc 4 1630 10
-23c0 4 210 6
+23c0 4 210 5
 23c4 4 1630 10
 23c8 5 1628 10
 23cd 8 3617 7
 23d5 5 3618 7
 23da 5 3618 7
 23df 5 3618 7
-23e4 5 342 12
-23e9 8 177 11
-23f1 9 450 8
-23fa 5 1606 9
-23ff 21 450 8
-2420 11 433 9
-2431 4 455 8
-2435 4 456 8
-2439 d 455 8
-2446 8 458 8
-244e 5 1501 9
-2453 8 467 8
-245b 4 469 8
-245f 4 470 8
-2463 b 469 8
-246e 8 472 8
+23e4 5 342 11
+23e9 8 177 9
+23f1 9 450 12
+23fa 5 1606 8
+23ff 20 450 12
+241f 1 450 12
+2420 11 433 8
+2431 4 455 12
+2435 4 456 12
+2439 d 455 12
+2446 8 458 12
+244e 5 1501 8
+2453 8 467 12
+245b 4 469 12
+245f 4 470 12
+2463 b 469 12
+246e 8 472 12
 2476 11 1798 13
-2487 4 481 8
-248b 9 477 8
-2494 11 481 8
+2487 4 481 12
+248b 9 477 12
+2494 11 481 12
 24a5 7 1697 13
 24ac 9 1741 13
 24b5 5 1776 13
@@ -1197,137 +1213,143 @@ INLINE 3 425 9 105 2719 11
 24c6 c 1471 13
 24d2 27 2464 13
 24f9 17 1798 13
-2510 d 481 8
-251d d 486 8
-252a 5 1501 9
-252f 4 488 8
-2533 15 489 8
-2548 3 490 8
-254b 8 491 8
-2553 7 492 8
-255a 23 128 6
-257d 8 486 8
-2585 d 171 6
-2592 2 494 8
-2594 d 208 6
-25a1 5 1613 9
-25a6 7 1606 9
-25ad 3 210 6
-25b0 11 1613 9
-25c1 c 109 6
-25cd 4 453 9
-25d1 a 450 9
-25db 6 424 9
-25e1 4 425 9
-25e5 5 177 11
-25ea f 497 8
-25f9 17 1616 9
-2610 10 499 8
-2620 5 453 9
-2625 5 450 9
-262a 7 424 9
-2631 5 425 9
-2636 5 177 11
-263b 1a 450 8
-2655 9 1484 9
-265e 3 1468 9
-2661 9 1484 9
-266a 5 4041 5
-266f 3 1468 9
-2672 4 1484 9
+2510 d 481 12
+251d d 486 12
+252a 5 1501 8
+252f 4 488 12
+2533 15 489 12
+2548 3 490 12
+254b 8 491 12
+2553 7 492 12
+255a 23 128 5
+257d 8 486 12
+2585 d 171 5
+2592 2 494 12
+2594 d 208 5
+25a1 5 1613 8
+25a6 7 1606 8
+25ad 3 210 5
+25b0 11 1613 8
+25c1 c 109 5
+25cd 4 453 8
+25d1 a 450 8
+25db 6 424 8
+25e1 4 425 8
+25e5 5 177 9
+25ea f 497 12
+25f9 17 1616 8
+2610 a 499 12
+261a 6 499 12
+2620 5 453 8
+2625 5 450 8
+262a 7 424 8
+2631 5 425 8
+2636 5 177 9
+263b 1a 450 12
+2655 4 1484 8
+2659 5 1484 8
+265e 3 1468 8
+2661 9 1484 8
+266a 5 4041 6
+266f 3 1468 8
+2672 4 1484 8
 2676 5 1358 14
-267b 5 1087 5
+267b 4 1087 6
+267f 1 1087 6
 2680 5 1358 14
-2685 4 218 6
-2689 3 224 6
-268c 4 141 6
-2690 a 1090 5
-269a 4 2214 5
+2685 4 218 5
+2689 3 224 5
+268c 4 141 5
+2690 a 1090 6
+269a 4 2214 6
 269e 5 1358 14
 26a3 9 1190 14
-26ac 4 2223 5
-26b0 10 1190 14
-26c0 4 1190 14
+26ac 4 2223 6
+26b0 4 1190 14
+26b4 10 1190 14
 26c4 3 1358 14
-26c7 2 2221 5
-26c9 3 218 6
-26cc 4 141 6
-26d0 3 224 6
-26d3 8 218 6
+26c7 2 2221 6
+26c9 3 218 5
+26cc 4 141 5
+26d0 3 224 5
+26d3 8 218 5
 26db 4 1190 14
-26df 6 1484 9
-26e5 3 2235 5
+26df 6 1484 8
+26e5 3 2235 6
 26e8 9 1358 14
-26f1 f 1902 5
-2700 8 1904 5
-2708 4 424 9
-270c 4 1905 5
-2710 9 424 9
-2719 11 0 9
-272a d 425 9
-2737 1a 1471 13
-2751 1c 486 8
-276d 11 499 8
-277e 5 453 9
-2783 5 450 9
-2788 7 424 9
-278f 5 425 9
-2794 5 177 11
-2799 5 453 9
-279e 5 450 9
-27a3 7 424 9
-27aa 5 425 9
-27af 5 177 11
-27b4 8 453 9
-27bc 5 450 9
-27c1 a 424 9
-27cb 8 425 9
-27d3 d 177 11
-FUNC 27e0 5d0 0 void google_breakpad::ReadImageInfo<google_breakpad::MachO32>(google_breakpad::DynamicImages&, unsigned long long)
-INLINE 0 424 8 33 27f4 17
-INLINE 1 485 9 34 27f4 17 2831 11 29ef 12
-INLINE 2 484 9 35 27f4 17 2831 11 29ef 12
-INLINE 0 432 8 36 2825 8
-INLINE 0 439 8 33 2831 11
-INLINE 0 511 8 37 2863 1b 287e 24 2d69 1b 2d84 24
-INLINE 1 458 9 38 2863 1b 287e 24 2bea 21 2d4e 1b 2d69 1b 2d84 24
-INLINE 2 458 9 39 2863 1b 287e 24 2bea 21 2d4e 1b 2d69 1b 2d84 24
-INLINE 3 452 9 40 286d c 288b 12 2bfa c 2d58 c 2d73 c 2d91 12
-INLINE 4 369 9 41 286d c 288b 12 2bfa c 2d58 c 2d73 c 2d91 12
-INLINE 3 453 9 42 2879 5 289d 5 2c06 5 2d64 5 2d7f 5 2da3 5
+26f1 f 1902 6
+2700 8 1904 6
+2708 4 424 8
+270c 4 1905 6
+2710 9 424 8
+2719 11 0 8
+272a 9 425 8
+2733 4 425 8
+2737 8 1471 13
+273f 12 1471 13
+2751 1c 486 12
+276d 11 499 12
+277e 5 453 8
+2783 5 450 8
+2788 7 424 8
+278f 5 425 8
+2794 5 177 9
+2799 5 453 8
+279e 5 450 8
+27a3 7 424 8
+27aa 5 425 8
+27af 5 177 9
+27b4 8 453 8
+27bc 5 450 8
+27c1 a 424 8
+27cb 8 425 8
+27d3 5 177 9
+27d8 8 177 9
+FUNC 27e0 5d0 0 google_breakpad::ReadImageInfo<google_breakpad::MachO32>(google_breakpad::DynamicImages&, unsigned long long)
+INLINE 0 424 12 33 27f4 17
+INLINE 1 485 8 34 27f4 17 2831 11 29ef 12
+INLINE 2 484 8 35 27f4 17 2831 11 29ef 12
+INLINE 0 432 12 36 2825 8
+INLINE 0 439 12 33 2831 11
+INLINE 0 511 12 37 2863 3f 2d69 3f
+INLINE 1 458 8 38 2863 3f 2bea 21 2d4e 5a
+INLINE 2 458 8 39 2863 3f 2bea 21 2d4e 5a
+INLINE 3 452 8 40 286d c 288b 12 2bfa c 2d58 c 2d73 c 2d91 12
+INLINE 4 369 8 41 286d c 288b 12 2bfa c 2d58 c 2d73 c 2d91 12
+INLINE 3 453 8 42 2879 5 289d 5 2c06 5 2d64 5 2d7f 5 2da3 5
 INLINE 4 1508 10 43 2879 5 289d 5 2c06 5 2d64 5 2d7f 5 2da3 5
 INLINE 5 1743 10 44 2879 5 289d 5 29b9 8 2c06 5 2d64 5 2d7f 5 2da3 5
-INLINE 0 447 8 36 28b4 5
-INLINE 0 448 8 45 28be 5a 291b a6
-INLINE 1 1535 9 46 28be 16
-INLINE 2 645 9 47 28be 16
-INLINE 1 1538 9 48 28dd 5 28ef 6 28f8 6
-INLINE 1 1538 9 49 28e2 d 28f5 3 28fe 6
-INLINE 2 310 12 50 28e2 d 28f5 3 28fe 6
-INLINE 3 311 12 51 28e2 d
+INLINE 0 447 12 36 28b4 5
+INLINE 0 448 12 45 28be 5a 291b a6
+INLINE 1 1535 8 46 28be 16
+INLINE 2 645 8 47 28be 16
+INLINE 1 1538 8 48 28dd 5 28ef 6 28f8 6
+INLINE 1 1538 8 49 28e2 d 28f5 3 28fe 6
+INLINE 2 310 11 50 28e2 d 28f5 3 28fe 6
+INLINE 3 311 11 51 28e2 d
 INLINE 4 1500 10 52 28e2 d
 INLINE 5 1741 10 53 28ea 5
-INLINE 1 1539 9 54 2904 14 291b 99
-INLINE 2 893 9 55 2904 14 291b 1c 293f 5e
+INLINE 1 1539 8 54 2904 14 291b 99
+INLINE 2 893 8 55 2904 14 291b 1c 293f 5e
 INLINE 3 1630 10 56 291b 9 2928 4 2945 47 2990 4
 INLINE 4 1514 10 57 291b 9 2928 4 2945 47 2990 4
 INLINE 5 1668 10 58 291b 9 2928 4 2945 47 2990 4
 INLINE 6 1752 10 31 291b 9 2928 4 2945 47 2990 4
-INLINE 7 210 6 32 291b 9 2928 4 2945 47 2990 4
-INLINE 2 894 9 59 2937 5 299d d
-INLINE 2 895 9 59 29aa 5
-INLINE 2 896 9 59 29af 5
-INLINE 1 1540 9 60 29b4 d
-INLINE 2 340 12 61 29b4 d
-INLINE 3 343 12 62 29b9 8
+INLINE 7 210 5 32 291b 9 2928 4 2945 47 2990 4
+INLINE 2 894 8 59 2937 5 299d d
+INLINE 2 895 8 59 29aa 5
+INLINE 2 896 8 59 29af 5
+INLINE 1 1540 8 60 29b4 d
+INLINE 2 340 11 61 29b4 d
+INLINE 3 343 11 62 29b9 8
 INLINE 4 1508 10 63 29b9 8
-INLINE 0 495 8 64 29ca 5 2b71 20 2bc9 17
-INLINE 0 454 8 33 29ef 12
-INLINE 0 462 8 36 2a1e 5
-INLINE 0 476 8 65 2a46 11
+INLINE 0 495 12 64 29ca 5 2b71 20 2bc9 17
+INLINE 0 454 12 33 29ef 12
+INLINE 0 462 12 36 2a1e 5
+INLINE 0 476 12 65 2a46 11
 INLINE 1 1945 13 66 2a46 11
 INLINE 2 1949 13 67 2a46 11
-INLINE 0 481 8 68 2a75 6b 2d07 8
+INLINE 0 481 12 68 2a75 6b 2d07 8
 INLINE 1 2476 13 69 2a75 6b 2d07 8
 INLINE 2 2462 13 70 2a75 21
 INLINE 3 3163 13 71 2a75 7
@@ -1337,130 +1359,134 @@ INLINE 3 3165 13 74 2a8a 3
 INLINE 3 3166 13 75 2a8d 9
 INLINE 2 2463 13 76 2a96 c 2d07 8
 INLINE 2 2466 13 67 2ac9 17
-INLINE 0 486 8 36 2afa 5
-INLINE 0 486 8 77 2b2a 23
-INLINE 0 494 8 78 2b55 d
-INLINE 0 495 8 79 2b64 d
-INLINE 1 208 6 80 2b64 d
-INLINE 1 1609 9 81 2b7d 3
+INLINE 0 486 12 36 2afa 5
+INLINE 0 486 12 77 2b2a 23
+INLINE 0 494 12 78 2b55 d
+INLINE 0 495 12 79 2b64 d
+INLINE 1 208 5 80 2b64 d
+INLINE 1 1609 8 81 2b7d 3
 INLINE 2 1514 10 82 2b7d 3
 INLINE 3 1668 10 83 2b7d 3
 INLINE 4 1752 10 31 2b7d 3
-INLINE 5 210 6 32 2b7d 3
-INLINE 0 497 8 84 2b91 29
-INLINE 1 109 6 85 2b91 29
-INLINE 2 109 6 37 2b9d 1d
-INLINE 3 458 9 38 2b9d 1d
-INLINE 4 458 9 39 2b9d 1d
-INLINE 5 452 9 40 2bab a
-INLINE 6 369 9 41 2bab a
-INLINE 5 453 9 42 2bb5 5
+INLINE 5 210 5 32 2b7d 3
+INLINE 0 497 12 84 2b91 29
+INLINE 1 109 5 85 2b91 29
+INLINE 2 109 5 37 2b9d 1d
+INLINE 3 458 8 38 2b9d 1d
+INLINE 4 458 8 39 2b9d 1d
+INLINE 5 452 8 40 2bab a
+INLINE 6 369 8 41 2bab a
+INLINE 5 453 8 42 2bb5 5
 INLINE 6 1508 10 43 2bb5 5
 INLINE 7 1743 10 44 2bb5 5
-INLINE 0 499 8 37 2bea 21 2d4e 1b
-INLINE 0 502 8 86 2c25 4 2c31 9
-INLINE 0 502 8 87 2c2e 3
-INLINE 0 502 8 88 2c3a 5
-INLINE 1 4066 5 89 2c3a 5
-INLINE 2 4050 5 90 2c3a 5
-INLINE 0 508 8 87 2c3f 3
-INLINE 0 509 8 86 2c42 4
-INLINE 0 508 8 91 2c46 69 2cb5 3
-INLINE 1 2235 5 92 2c46 69
-INLINE 2 2214 5 93 2c46 24
-INLINE 3 1085 5 94 2c46 5
-INLINE 3 1088 5 94 2c4f 6
-INLINE 3 1090 5 95 2c55 b
-INLINE 4 665 5 96 2c55 b
-INLINE 5 219 6 97 2c59 3
-INLINE 5 218 6 27 2c5c 4
-INLINE 2 2216 5 94 2c6e 5
-INLINE 2 2221 5 98 2c73 9 2c84 10
-INLINE 2 2223 5 98 2c80 4
-INLINE 2 2221 5 94 2c94 3
-INLINE 2 2222 5 95 2c99 12
-INLINE 3 665 5 96 2c99 12
-INLINE 4 218 6 27 2c9c 4
-INLINE 4 219 6 97 2ca0 3
-INLINE 2 2224 5 98 2cab 4
-INLINE 0 510 8 86 2caf 6
-INLINE 0 510 8 99 2cb8 4b
-INLINE 1 1696 9 100 2cb8 9
-INLINE 1 1697 9 101 2cc1 17 2cdc 4
-INLINE 2 1913 5 102 2cc1 17 2cdc 4
-INLINE 1 1697 9 103 2cd8 4 2ce0 23
-INLINE 2 814 9 104 2cd8 4 2ce0 23
-INLINE 3 425 9 105 2ce9 11
-27e0 14 413 8
-27f4 17 433 9
-280b 16 425 8
-2821 4 428 8
-2825 8 1501 9
-282d 4 442 8
-2831 11 433 9
-2842 4 440 8
-2846 3 441 8
-2849 c 442 8
-2855 a 440 8
-285f 4 443 8
-2863 5 453 9
-2868 5 450 9
-286d 7 424 9
-2874 5 425 9
-2879 5 177 11
-287e 8 453 9
-2886 5 450 9
-288b a 424 9
-2895 8 425 9
-289d 5 177 11
-28a2 12 511 8
-28b4 5 1501 9
-28b9 5 448 8
-28be 16 372 9
-28d4 9 1535 9
-28dd 5 642 9
+INLINE 0 499 12 37 2bea 21 2d4e 1b
+INLINE 0 502 12 86 2c25 4 2c31 9
+INLINE 0 502 12 87 2c2e 3
+INLINE 0 502 12 88 2c3a 5
+INLINE 1 4066 6 89 2c3a 5
+INLINE 2 4050 6 90 2c3a 5
+INLINE 0 508 12 87 2c3f 3
+INLINE 0 509 12 86 2c42 4
+INLINE 0 508 12 91 2c46 69 2cb5 3
+INLINE 1 2235 6 92 2c46 69
+INLINE 2 2214 6 93 2c46 24
+INLINE 3 1085 6 94 2c46 5
+INLINE 3 1088 6 94 2c4f 6
+INLINE 3 1090 6 95 2c55 b
+INLINE 4 665 6 96 2c55 b
+INLINE 5 219 5 97 2c59 3
+INLINE 5 218 5 27 2c5c 4
+INLINE 2 2216 6 94 2c6e 5
+INLINE 2 2221 6 98 2c73 9 2c84 10
+INLINE 2 2223 6 98 2c80 4
+INLINE 2 2221 6 94 2c94 3
+INLINE 2 2222 6 95 2c99 12
+INLINE 3 665 6 96 2c99 12
+INLINE 4 218 5 27 2c9c 4
+INLINE 4 219 5 97 2ca0 3
+INLINE 2 2224 6 98 2cab 4
+INLINE 0 510 12 86 2caf 6
+INLINE 0 510 12 99 2cb8 4b
+INLINE 1 1696 8 100 2cb8 9
+INLINE 1 1697 8 101 2cc1 17 2cdc 4
+INLINE 2 1913 6 102 2cc1 17 2cdc 4
+INLINE 1 1697 8 103 2cd8 4 2ce0 23
+INLINE 2 814 8 104 2cd8 4 2ce0 23
+INLINE 3 425 8 105 2ce9 11
+27e0 14 413 12
+27f4 17 433 8
+280b 16 425 12
+2821 4 428 12
+2825 8 1501 8
+282d 4 442 12
+2831 11 433 8
+2842 4 440 12
+2846 3 441 12
+2849 c 442 12
+2855 a 440 12
+285f 4 443 12
+2863 5 453 8
+2868 5 450 8
+286d 7 424 8
+2874 5 425 8
+2879 5 177 9
+287e 8 453 8
+2886 5 450 8
+288b a 424 8
+2895 8 425 8
+289d 5 177 9
+28a2 12 511 12
+28b4 5 1501 8
+28b9 5 448 12
+28be 16 372 8
+28d4 9 1535 8
+28dd 5 642 8
 28e2 8 1741 10
-28ea 5 169 11
-28ef 6 642 9
-28f5 3 312 12
-28f8 6 642 9
-28fe 6 313 12
+28ea 5 169 9
+28ef 6 642 8
+28f5 3 312 11
+28f8 6 642 8
+28fe 6 313 11
 2904 14 1630 10
-2918 8 448 8
-2920 4 210 6
+2918 3 448 12
+291b 5 448 12
+2920 4 210 5
 2924 4 1630 10
-2928 4 210 6
+2928 4 210 5
 292c 4 1631 10
 2930 7 1628 10
-2937 8 3618 7
-293f 11 1630 10
-2950 3c 210 6
+2937 5 3618 7
+293c 3 3618 7
+293f 6 1630 10
+2945 b 1630 10
+2950 3c 210 5
 298c 4 1630 10
-2990 4 210 6
+2990 4 210 5
 2994 4 1630 10
 2998 5 1628 10
 299d 8 3617 7
 29a5 5 3618 7
 29aa 5 3618 7
 29af 5 3618 7
-29b4 5 342 12
-29b9 8 177 11
-29c1 9 450 8
-29ca 5 1606 9
-29cf 21 450 8
-29f0 11 433 9
-2a01 4 455 8
-2a05 4 456 8
-2a09 d 455 8
-2a16 8 458 8
-2a1e 5 1501 9
-2a23 8 467 8
-2a2b 4 469 8
-2a2f 4 470 8
-2a33 b 469 8
-2a3e 8 472 8
+29b4 5 342 11
+29b9 8 177 9
+29c1 9 450 12
+29ca 5 1606 8
+29cf 20 450 12
+29ef 1 450 12
+29f0 11 433 8
+2a01 4 455 12
+2a05 4 456 12
+2a09 d 455 12
+2a16 8 458 12
+2a1e 5 1501 8
+2a23 8 467 12
+2a2b 4 469 12
+2a2f 4 470 12
+2a33 b 469 12
+2a3e 8 472 12
 2a46 11 1798 13
-2a57 1e 481 8
+2a57 1e 481 12
 2a75 7 1697 13
 2a7c 9 1741 13
 2a85 5 1776 13
@@ -1469,201 +1495,213 @@ INLINE 3 425 9 105 2ce9 11
 2a96 c 1471 13
 2aa2 27 2464 13
 2ac9 17 1798 13
-2ae0 d 481 8
-2aed d 486 8
-2afa 5 1501 9
-2aff 4 488 8
-2b03 15 489 8
-2b18 3 490 8
-2b1b 8 491 8
-2b23 7 492 8
-2b2a 23 128 6
-2b4d 8 486 8
-2b55 d 171 6
-2b62 2 494 8
-2b64 d 208 6
-2b71 5 1613 9
-2b76 7 1606 9
-2b7d 3 210 6
-2b80 11 1613 9
-2b91 c 109 6
-2b9d 4 453 9
-2ba1 a 450 9
-2bab 6 424 9
-2bb1 4 425 9
-2bb5 5 177 11
-2bba f 497 8
-2bc9 17 1616 9
-2be0 10 499 8
-2bf0 5 453 9
-2bf5 5 450 9
-2bfa 7 424 9
-2c01 5 425 9
-2c06 5 177 11
-2c0b 1a 450 8
-2c25 9 1484 9
-2c2e 3 1468 9
-2c31 9 1484 9
-2c3a 5 4041 5
-2c3f 3 1468 9
-2c42 4 1484 9
+2ae0 d 481 12
+2aed d 486 12
+2afa 5 1501 8
+2aff 4 488 12
+2b03 15 489 12
+2b18 3 490 12
+2b1b 8 491 12
+2b23 7 492 12
+2b2a 23 128 5
+2b4d 8 486 12
+2b55 d 171 5
+2b62 2 494 12
+2b64 d 208 5
+2b71 5 1613 8
+2b76 7 1606 8
+2b7d 3 210 5
+2b80 11 1613 8
+2b91 c 109 5
+2b9d 4 453 8
+2ba1 a 450 8
+2bab 6 424 8
+2bb1 4 425 8
+2bb5 5 177 9
+2bba f 497 12
+2bc9 17 1616 8
+2be0 a 499 12
+2bea 6 499 12
+2bf0 5 453 8
+2bf5 5 450 8
+2bfa 7 424 8
+2c01 5 425 8
+2c06 5 177 9
+2c0b 1a 450 12
+2c25 4 1484 8
+2c29 5 1484 8
+2c2e 3 1468 8
+2c31 9 1484 8
+2c3a 5 4041 6
+2c3f 3 1468 8
+2c42 4 1484 8
 2c46 5 1358 14
-2c4b 5 1087 5
+2c4b 4 1087 6
+2c4f 1 1087 6
 2c50 5 1358 14
-2c55 4 218 6
-2c59 3 224 6
-2c5c 4 141 6
-2c60 a 1090 5
-2c6a 4 2214 5
+2c55 4 218 5
+2c59 3 224 5
+2c5c 4 141 5
+2c60 a 1090 6
+2c6a 4 2214 6
 2c6e 5 1358 14
 2c73 9 1190 14
-2c7c 4 2223 5
-2c80 10 1190 14
-2c90 4 1190 14
+2c7c 4 2223 6
+2c80 4 1190 14
+2c84 10 1190 14
 2c94 3 1358 14
-2c97 2 2221 5
-2c99 3 218 6
-2c9c 4 141 6
-2ca0 3 224 6
-2ca3 8 218 6
+2c97 2 2221 6
+2c99 3 218 5
+2c9c 4 141 5
+2ca0 3 224 5
+2ca3 8 218 5
 2cab 4 1190 14
-2caf 6 1484 9
-2cb5 3 2235 5
+2caf 6 1484 8
+2cb5 3 2235 6
 2cb8 9 1358 14
-2cc1 f 1902 5
-2cd0 8 1904 5
-2cd8 4 424 9
-2cdc 4 1905 5
-2ce0 9 424 9
-2ce9 11 0 9
-2cfa d 425 9
-2d07 1a 1471 13
-2d21 1c 486 8
-2d3d 11 499 8
-2d4e 5 453 9
-2d53 5 450 9
-2d58 7 424 9
-2d5f 5 425 9
-2d64 5 177 11
-2d69 5 453 9
-2d6e 5 450 9
-2d73 7 424 9
-2d7a 5 425 9
-2d7f 5 177 11
-2d84 8 453 9
-2d8c 5 450 9
-2d91 a 424 9
-2d9b 8 425 9
-2da3 d 177 11
+2cc1 f 1902 6
+2cd0 8 1904 6
+2cd8 4 424 8
+2cdc 4 1905 6
+2ce0 9 424 8
+2ce9 11 0 8
+2cfa 9 425 8
+2d03 4 425 8
+2d07 8 1471 13
+2d0f 12 1471 13
+2d21 1c 486 12
+2d3d 11 499 12
+2d4e 5 453 8
+2d53 5 450 8
+2d58 7 424 8
+2d5f 5 425 8
+2d64 5 177 9
+2d69 5 453 8
+2d6e 5 450 8
+2d73 7 424 8
+2d7a 5 425 8
+2d7f 5 177 9
+2d84 8 453 8
+2d8c 5 450 8
+2d91 a 424 8
+2d9b 8 425 8
+2da3 5 177 9
+2da8 8 177 9
 FUNC 2db0 4a 0 google_breakpad::DynamicImages::GetExecutableImage()
-INLINE 0 529 8 131 2db0 8 2df5 4
-INLINE 1 254 6 48 2db0 8
-INLINE 0 526 8 132 2db8 11 2dcb c 2ddd a
-INLINE 1 538 8 133 2db8 7
-INLINE 2 250 6 48 2db8 7
-INLINE 1 541 8 131 2dcb 9
-INLINE 2 255 6 97 2dcb 9
-INLINE 1 542 8 134 2dd4 3
-INLINE 2 329 8 120 2dd4 3
-INLINE 3 323 8 118 2dd4 3
-INLINE 1 255 6 97 2df5 4
-2db0 8 642 9
-2db8 7 642 9
-2dbf a 540 8
-2dc9 7 526 8
-2dd0 4 224 6
-2dd4 3 1510 9
-2dd7 6 526 8
-2ddd c 540 8
-2de9 3 533 8
-2dec 9 528 8
-2df5 4 224 6
-2df9 1 533 8
+INLINE 0 529 12 131 2db0 8 2df5 4
+INLINE 1 254 5 48 2db0 8
+INLINE 0 526 12 132 2db8 11 2dcb c 2ddd a
+INLINE 1 538 12 133 2db8 7
+INLINE 2 250 5 48 2db8 7
+INLINE 1 541 12 131 2dcb 9
+INLINE 2 255 5 97 2dcb 9
+INLINE 1 542 12 134 2dd4 3
+INLINE 2 329 12 120 2dd4 3
+INLINE 3 323 12 118 2dd4 3
+INLINE 1 255 5 97 2df5 4
+2db0 8 642 8
+2db8 7 642 8
+2dbf a 540 12
+2dc9 2 526 12
+2dcb 5 526 12
+2dd0 4 224 5
+2dd4 3 1510 8
+2dd7 6 526 12
+2ddd a 540 12
+2de7 2 540 12
+2de9 3 533 12
+2dec 9 528 12
+2df5 4 224 5
+2df9 1 533 12
 FUNC 2e00 3a 0 google_breakpad::DynamicImages::GetExecutableImageIndex()
-INLINE 0 538 8 133 2e00 14
-INLINE 1 250 6 48 2e00 14
-INLINE 0 541 8 131 2e1d 7
-INLINE 1 255 6 97 2e1d 7
-INLINE 0 542 8 134 2e24 9
-INLINE 1 329 8 120 2e24 9
-INLINE 2 323 8 118 2e24 9
-2e00 14 642 9
-2e14 c 540 8
-2e20 4 224 6
-2e24 9 1510 9
-2e2d c 540 8
-2e39 1 548 8
+INLINE 0 538 12 133 2e00 14
+INLINE 1 250 5 48 2e00 14
+INLINE 0 541 12 131 2e1d 7
+INLINE 1 255 5 97 2e1d 7
+INLINE 0 542 12 134 2e24 9
+INLINE 1 329 12 120 2e24 9
+INLINE 2 323 12 118 2e24 9
+2e00 14 642 8
+2e14 9 540 12
+2e1d 3 540 12
+2e20 4 224 5
+2e24 9 1510 8
+2e2d c 540 12
+2e39 1 548 12
 FUNC 2e40 1c3 0 std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__append(unsigned long)
-INLINE 0 1041 9 107 2e64 6 2e9e 9 2f39 11
-INLINE 0 1041 9 135 2e6a 34
-INLINE 1 965 9 136 2e77 a
-INLINE 2 645 9 137 2e77 a
-INLINE 1 968 9 138 2e97 3
-INLINE 2 2656 5 139 2e97 3
-INLINE 3 2648 5 140 2e97 3
-INLINE 0 1041 9 141 2ea7 14 2f4a 11 2fae 3
-INLINE 1 310 12 142 2ea7 14 2f4a 11 2fae 3
-INLINE 0 1037 9 143 2ebb 7e
-INLINE 1 984 9 144 2ecb 8 2ef0 3 2eff 4 2f0f 4 2f1f 4
+INLINE 0 1041 8 107 2e64 6 2e9e 9 2f39 11
+INLINE 0 1041 8 135 2e6a 34
+INLINE 1 965 8 136 2e77 a
+INLINE 2 645 8 137 2e77 a
+INLINE 1 968 8 138 2e97 3
+INLINE 2 2656 6 139 2e97 3
+INLINE 3 2648 6 140 2e97 3
+INLINE 0 1041 8 141 2ea7 14 2f4a 11 2fae 3
+INLINE 1 310 11 142 2ea7 14 2f4a 11 2fae 3
+INLINE 0 1037 8 143 2ebb 7e
+INLINE 1 984 8 144 2ecb 8 2ef0 3 2eff 4 2f0f 4 2f1f 4
 INLINE 2 1514 10 145 2ecb 8 2ef0 3 2eff 4 2f0f 4 2f1f 4 2f6e 5 2f89 1b
 INLINE 3 1668 10 146 2ecb 8 2ef0 3 2eff 4 2f0f 4 2f1f 4 2f6e 5 2f89 1b
-INLINE 2 311 12 147 2f4a e
+INLINE 2 311 11 147 2f4a e
 INLINE 3 1500 10 148 2f4a e
 INLINE 4 1741 10 53 2f4a e
-INLINE 0 1042 9 149 2f5b 53
-INLINE 1 203 12 144 2f6e 5 2f89 1b
-INLINE 0 1043 9 150 2fb1 28
-INLINE 1 894 9 151 2fb1 3 2fce 3
-INLINE 1 893 9 152 2fb8 16
-INLINE 1 895 9 151 2fd1 4
-INLINE 1 896 9 151 2fd5 4
-INLINE 0 1044 9 153 2fd9 1b
-INLINE 1 340 12 154 2fd9 1b
-INLINE 2 343 12 42 2fde 16
+INLINE 0 1042 8 149 2f5b 53
+INLINE 1 203 11 144 2f6e 5 2f89 1b
+INLINE 0 1043 8 150 2fb1 28
+INLINE 1 894 8 151 2fb1 3 2fce 3
+INLINE 1 893 8 152 2fb8 16
+INLINE 1 895 8 151 2fd1 4
+INLINE 1 896 8 151 2fd5 4
+INLINE 0 1044 8 153 2fd9 1b
+INLINE 1 340 11 154 2fd9 1b
+INLINE 2 343 11 42 2fde 16
 INLINE 3 1508 10 43 2fde 16
 INLINE 4 1743 10 44 2fde 16
-2e40 11 1035 9
-2e51 13 1036 9
-2e64 6 642 9
-2e6a 5 963 9
-2e6f 8 964 9
-2e77 a 372 9
-2e81 13 966 9
-2e94 3 968 9
-2e97 3 702 5
-2e9a 4 968 9
-2e9e 9 642 9
-2ea7 14 311 12
-2ebb 15 981 9
+2e40 11 1035 8
+2e51 13 1036 8
+2e64 6 642 8
+2e6a 5 963 8
+2e6f 8 964 8
+2e77 a 372 8
+2e81 13 966 8
+2e94 3 968 8
+2e97 3 702 6
+2e9a 4 968 8
+2e9e 9 642 8
+2ea7 14 311 11
+2ebb 10 981 8
+2ecb 5 981 8
 2ed0 3 1752 10
-2ed3 b 985 9
-2ede 3 986 9
-2ee1 5 988 9
-2ee6 a 981 9
+2ed3 b 985 8
+2ede 3 986 8
+2ee1 5 988 8
+2ee6 a 981 8
 2ef0 3 1752 10
-2ef3 c 985 9
+2ef3 c 985 8
 2eff 4 1752 10
-2f03 c 985 9
+2f03 c 985 8
 2f0f 4 1752 10
-2f13 c 985 9
+2f13 c 985 8
 2f1f 4 1752 10
-2f23 b 985 9
-2f2e b 988 9
-2f39 11 642 9
-2f4a e 169 11
-2f58 3 312 12
-2f5b 15 201 12
+2f23 b 985 8
+2f2e b 988 8
+2f39 11 642 8
+2f4a e 169 9
+2f58 3 312 11
+2f5b 13 201 11
+2f6e 2 201 11
 2f70 3 1752 10
-2f73 3 204 12
-2f76 3 205 12
-2f79 a 206 12
-2f83 d 201 12
+2f73 3 204 11
+2f76 3 205 11
+2f79 a 206 11
+2f83 6 201 11
+2f89 7 201 11
 2f90 14 1752 10
-2fa4 4 204 12
-2fa8 6 206 12
-2fae 3 313 12
+2fa4 4 204 11
+2fa8 6 206 11
+2fae 3 313 11
 2fb1 3 3617 7
-2fb4 4 893 9
+2fb4 4 893 8
 2fb8 3 1647 10
 2fbb 3 1648 10
 2fbe 5 1649 10
@@ -1671,724 +1709,745 @@ INLINE 4 1743 10 44 2fde 16
 2fce 3 3618 7
 2fd1 4 3618 7
 2fd5 4 3618 7
-2fd9 5 342 12
-2fde 16 177 11
-2ff4 f 1045 9
+2fd9 5 342 11
+2fde 16 177 9
+2ff4 f 1045 8
 FUNC 3010 1bb 0 google_breakpad::ReadTaskString(unsigned int, unsigned long long)
-INLINE 0 162 8 109 3023 bf
-INLINE 0 168 8 33 30f6 11
-INLINE 1 485 9 34 30f6 11
-INLINE 2 484 9 35 30f6 11
-INLINE 0 171 8 65 311a 19
-INLINE 1 1945 13 66 311a 19 3133 19
-INLINE 2 1949 13 67 311a 19 3133 19
-INLINE 0 176 8 65 3133 19
-INLINE 0 173 8 36 314c 5
-INLINE 0 173 8 110 3151 2d
+INLINE 0 162 12 109 3023 bf
+INLINE 0 168 12 33 30f6 11
+INLINE 1 485 8 34 30f6 11
+INLINE 2 484 8 35 30f6 11
+INLINE 0 171 12 65 311a 19
+INLINE 1 1945 13 66 311a 32
+INLINE 2 1949 13 67 311a 32
+INLINE 0 176 12 65 3133 19
+INLINE 0 173 12 36 314c 5
+INLINE 0 173 12 110 3151 2d
 INLINE 1 2019 13 111 3151 2d
 INLINE 2 1364 13 112 3151 17
 INLINE 3 2421 10 113 3151 17
 INLINE 4 2421 10 114 3151 17
 INLINE 2 2021 13 115 3168 8
-INLINE 0 174 8 37 317e 1b 31a8 1b
-INLINE 1 458 9 38 317e 1b 31a8 1b
-INLINE 2 458 9 39 317e 1b 31a8 1b
-INLINE 3 452 9 40 3188 c 31b2 c
-INLINE 4 369 9 41 3188 c 31b2 c
-INLINE 3 453 9 42 3194 5 31be 5
+INLINE 0 174 12 37 317e 1b 31a8 1b
+INLINE 1 458 8 38 317e 1b 31a8 1b
+INLINE 2 458 8 39 317e 1b 31a8 1b
+INLINE 3 452 8 40 3188 c 31b2 c
+INLINE 4 369 8 41 3188 c 31b2 c
+INLINE 3 453 8 42 3194 5 31be 5
 INLINE 4 1508 10 43 3194 5 31be 5
 INLINE 5 1743 10 44 3194 5 31be 5
-3010 13 156 8
-3023 5 92 8
-3028 8 94 8
-3030 21 96 8
-3051 7 103 8
-3058 4 110 8
-305c d 142 8
-3069 a 121 8
-3073 9 112 8
-307c 9 118 8
-3085 3 121 8
-3088 1e 120 8
-30a6 7 126 8
-30ad 2 134 8
-30af 2 135 8
-30b1 c 140 8
-30bd e 135 8
-30cb 7 134 8
-30d2 a 136 8
-30dc 6 140 8
-30e2 5 164 8
-30e7 f 166 8
-30f6 11 433 9
-3107 13 169 8
+3010 13 156 12
+3023 5 92 12
+3028 8 94 12
+3030 21 96 12
+3051 7 103 12
+3058 4 110 12
+305c d 142 12
+3069 a 121 12
+3073 9 112 12
+307c 9 118 12
+3085 3 121 12
+3088 1e 120 12
+30a6 7 126 12
+30ad 2 134 12
+30af 2 135 12
+30b1 c 140 12
+30bd e 135 12
+30cb 7 134 12
+30d2 a 136 12
+30dc 6 140 12
+30e2 5 164 12
+30e7 f 166 12
+30f6 11 433 8
+3107 13 169 12
 311a 19 1798 13
 3133 19 1798 13
-314c 5 1501 9
+314c 5 1501 8
 3151 17 2242 10
 3168 8 644 13
 3170 e 2021 13
-317e 5 453 9
-3183 5 450 9
-3188 7 424 9
-318f 5 425 9
-3194 5 177 11
-3199 f 177 8
-31a8 5 453 9
-31ad 5 450 9
-31b2 7 424 9
-31b9 5 425 9
-31be d 177 11
+317e 5 453 8
+3183 5 450 8
+3188 7 424 8
+318f 5 425 8
+3194 5 177 9
+3199 f 177 12
+31a8 5 453 8
+31ad 5 450 8
+31b2 7 424 8
+31b9 5 425 8
+31be 5 177 9
+31c3 8 177 9
 FUNC 31d0 116 0 google_breakpad::DynamicImage::DynamicImage(unsigned char*, unsigned long, unsigned long long, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, unsigned long, unsigned int, int)
-INLINE 0 118 6 155 31fc 69
-INLINE 1 1164 9 156 31fc 69
-INLINE 2 524 9 35 31fc 17
-INLINE 2 1171 9 157 3225 8 3235 11
-INLINE 2 1172 9 158 322d 8 3246 1f
-INLINE 3 1024 9 159 322d 8 3246 1f
-INLINE 0 130 6 37 32c7 17
-INLINE 1 458 9 38 32c7 17
-INLINE 2 458 9 39 32c7 17
-INLINE 3 452 9 40 32cf a
-INLINE 4 369 9 41 32cf a
-INLINE 3 453 9 42 32d9 5
+INLINE 0 118 5 155 31fc 69
+INLINE 1 1164 8 156 31fc 69
+INLINE 2 524 8 35 31fc 17
+INLINE 2 1171 8 157 3225 8 3235 11
+INLINE 2 1172 8 158 322d 8 3246 1f
+INLINE 3 1024 8 159 322d 8 3246 1f
+INLINE 0 130 5 37 32c7 17
+INLINE 1 458 8 38 32c7 17
+INLINE 2 458 8 39 32c7 17
+INLINE 3 452 8 40 32cf a
+INLINE 4 369 8 41 32cf a
+INLINE 3 453 8 42 32d9 5
 INLINE 4 1508 10 43 32d9 5
 INLINE 5 1743 10 44 32d9 5
-31d0 2c 128 6
-31fc 17 433 9
-3213 12 1169 9
-3225 8 931 9
+31d0 2c 128 5
+31fc 17 433 8
+3213 12 1169 8
+3225 8 931 8
 322d 8 1618 10
-3235 7 932 9
-323c a 933 9
+3235 7 932 8
+323c a 933 8
 3246 10 1615 10
 3256 b 1617 10
 3261 4 1618 10
-3265 4 119 6
-3269 4 120 6
-326d 4 125 6
-3271 1f 122 6
-3290 8 125 6
-3298 9 126 6
-32a1 4 127 6
-32a5 7 128 6
-32ac 1b 129 6
-32c7 3 453 9
-32ca 5 450 9
-32cf 6 424 9
-32d5 4 425 9
-32d9 d 177 11
-FUNC 32f0 185 0 void std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__push_back_slow_path<google_breakpad::DynamicImageRef>(google_breakpad::DynamicImageRef&&)
-INLINE 0 1575 9 48 3301 e 334e 10 3374 e
-INLINE 0 1575 9 160 3312 3c
-INLINE 1 965 9 46 3323 11
-INLINE 2 645 9 47 3323 11
-INLINE 1 968 9 138 3347 3
-INLINE 2 2656 5 139 3347 3
-INLINE 3 2648 5 140 3347 3
-INLINE 0 1575 9 49 335e c 3382 18
-INLINE 1 310 12 50 335e c 3382 18
-INLINE 2 311 12 51 3382 10
+3265 4 119 5
+3269 4 120 5
+326d 4 125 5
+3271 1f 122 5
+3290 8 125 5
+3298 9 126 5
+32a1 4 127 5
+32a5 7 128 5
+32ac 1b 129 5
+32c7 3 453 8
+32ca 5 450 8
+32cf 6 424 8
+32d5 4 425 8
+32d9 5 177 9
+32de 8 177 9
+FUNC 32f0 185 0 std::__1::vector<google_breakpad::DynamicImageRef, std::__1::allocator<google_breakpad::DynamicImageRef> >::__push_back_slow_path<google_breakpad::DynamicImageRef>(google_breakpad::DynamicImageRef&&)
+INLINE 0 1575 8 48 3301 e 334e 10 3374 e
+INLINE 0 1575 8 160 3312 3c
+INLINE 1 965 8 46 3323 11
+INLINE 2 645 8 47 3323 11
+INLINE 1 968 8 138 3347 3
+INLINE 2 2656 6 139 3347 3
+INLINE 3 2648 6 140 3347 3
+INLINE 0 1575 8 49 335e c 3382 18
+INLINE 1 310 11 50 335e c 3382 18
+INLINE 2 311 11 51 3382 10
 INLINE 3 1500 10 52 3382 10
 INLINE 4 1741 10 53 338a 8
-INLINE 0 1577 9 81 339a 7
+INLINE 0 1577 8 81 339a 7
 INLINE 1 1514 10 82 339a 7
 INLINE 2 1668 10 83 339a 7
 INLINE 3 1752 10 31 339a 7
-INLINE 4 210 6 32 339a 7
-INLINE 0 1579 9 54 33a6 a5
-INLINE 1 893 9 55 33a6 97
+INLINE 4 210 5 32 339a 7
+INLINE 0 1579 8 54 33a6 a5
+INLINE 1 893 8 55 33a6 97
 INLINE 2 1630 10 56 33c6 e 33d8 4 33eb 41 3430 4
 INLINE 3 1514 10 57 33c6 e 33d8 4 33eb 41 3430 4
 INLINE 4 1668 10 58 33c6 e 33d8 4 33eb 41 3430 4
 INLINE 5 1752 10 31 33c6 e 33d8 4 33eb 41 3430 4
-INLINE 6 210 6 32 33c6 e 33d8 4 33eb 41 3430 4
-INLINE 1 894 9 59 343d 6
-INLINE 1 895 9 59 3443 4
-INLINE 1 896 9 59 3447 4
-INLINE 0 1580 9 60 344b 1b
-INLINE 1 340 12 61 344b 1b
-INLINE 2 343 12 62 3450 16
+INLINE 6 210 5 32 33c6 e 33d8 4 33eb 41 3430 4
+INLINE 1 894 8 59 343d 6
+INLINE 1 895 8 59 3443 4
+INLINE 1 896 8 59 3447 4
+INLINE 0 1580 8 60 344b 1b
+INLINE 1 340 11 61 344b 1b
+INLINE 2 343 11 62 3450 16
 INLINE 3 1508 10 63 3450 16
 INLINE 4 1743 10 44 3450 16
-32f0 11 1573 9
-3301 e 642 9
-330f 3 1575 9
-3312 9 963 9
-331b 8 964 9
-3323 11 372 9
-3334 f 966 9
-3343 4 968 9
-3347 3 702 5
-334a 4 968 9
-334e 10 642 9
-335e 16 311 12
-3374 e 642 9
+32f0 11 1573 8
+3301 e 642 8
+330f 3 1575 8
+3312 9 963 8
+331b 8 964 8
+3323 11 372 8
+3334 f 966 8
+3343 4 968 8
+3347 3 702 6
+334a 4 968 8
+334e 10 642 8
+335e c 311 11
+336a a 311 11
+3374 e 642 8
 3382 8 1741 10
-338a 8 169 11
-3392 4 312 12
-3396 4 313 12
-339a 7 210 6
-33a1 5 1578 9
+338a 8 169 9
+3392 4 312 11
+3396 4 313 11
+339a 7 210 5
+33a1 5 1578 8
 33a6 c 1628 10
-33b2 1e 1630 10
-33d0 4 210 6
+33b2 14 1630 10
+33c6 a 1630 10
+33d0 4 210 5
 33d4 4 1630 10
-33d8 4 210 6
+33d8 4 210 5
 33dc 4 1631 10
 33e0 5 1628 10
-33e5 b 1630 10
-33f0 3c 210 6
+33e5 6 1630 10
+33eb 5 1630 10
+33f0 3c 210 5
 342c 4 1630 10
-3430 4 210 6
+3430 4 210 5
 3434 4 1630 10
 3438 5 1628 10
 343d 3 3617 7
 3440 3 3618 7
 3443 4 3618 7
 3447 4 3618 7
-344b 5 342 12
-3450 16 177 11
-3466 f 1580 9
-FUNC 3480 5f9 0 void std::__1::__sort<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
-INLINE 0 3951 5 23 3505 3
-INLINE 1 702 5 24 3505 3 3564 d 3581 13 3627 7 362e 5 3641 13 3658 4 36dc 3 36df 3 36e2 4 36e6 4 36ea d 372f 8 373e e 3752 12 377b c 3814 b
-INLINE 0 3891 5 25 3517 3f 35a8 48
-INLINE 1 3605 5 23 3517 15 3530 3 390e c 391e 3
-INLINE 2 702 5 24 3517 15 352c 4 3530 3 3533 9 35bc c 35e0 3 38a6 d 38ba 7 38e2 5 38eb 6 390e c 391a 4 391e 3 3921 9 39a0 c 39ea 3 3a1b a 3a28 7 3a40 8 3a48 4 3a5e 4
-INLINE 3 214 6 26 3528 4 352c 4 3530 3 3536 6 35c4 4 38bd 4 38eb 6 3916 4 391a 4 391e 3 3924 6 39a8 4 3a2b 4 3a48 4
-INLINE 4 167 6 27 3528 4 352c 4 3536 6 35c4 4 38bd 4 3916 4 391a 4 3924 6 39a8 4 3a2b 4 3a48 4
-INLINE 1 3627 5 23 352c 4 35e0 3 391a 4 39ea 3
-INLINE 1 3619 5 23 3533 9 3921 9
-INLINE 1 3621 5 28 3545 11 3933 9
-INLINE 0 3914 5 23 3564 d
-INLINE 2 214 6 26 3567 a 362a 4 3658 4 36e6 4 36ea d 3733 4 3748 4 3783 4 381b 4
-INLINE 0 3920 5 23 357a 1a 36df 3 36e6 4
-INLINE 1 3610 5 28 35b5 7 3999 7
-INLINE 1 3612 5 23 35bc c 39a0 c
-INLINE 1 3614 5 28 35ce a 39b6 d
-INLINE 1 3625 5 28 35d8 8 39e2 8
-INLINE 1 3629 5 28 35e9 7 39f7 c
-INLINE 0 3922 5 28 360b 7
-INLINE 0 3941 5 28 3620 7
-INLINE 0 3937 5 23 3627 7 3641 13 3658 4
-INLINE 3 167 6 27 362a 4 36e6 4 36ea 4 3733 4 3783 4 381b 4
-INLINE 0 3935 5 23 362e 5
-INLINE 0 3902 5 23 36dc 3 36e2 4 36ea d
-INLINE 0 3953 5 28 36fc 10
-INLINE 0 3977 5 28 3719 d
-INLINE 0 3973 5 23 372f 8 3752 12
-INLINE 0 3970 5 23 373e e
-INLINE 0 3987 5 23 377b c
-INLINE 0 3989 5 28 378d 8
-INLINE 0 3855 5 23 3814 b
-INLINE 0 3856 5 28 3829 c
-INLINE 0 3870 5 29 3835 59 3896 21 38ba d 38d3 2c
-INLINE 1 3733 5 25 3835 59
-INLINE 2 3612 5 23 3835 4 3841 4 3965 4 3971 4
-INLINE 3 702 5 24 3835 4 3839 8 3841 4 3845 3 3848 a 3965 4 3969 8 3971 4 3975 3 3978 a
-INLINE 2 3605 5 23 3839 8 3845 3 3969 8 3975 3
-INLINE 4 214 6 26 383d 4 3841 4 3845 3 384c 6 396d 4 3971 4 3975 3 397c 6
-INLINE 5 167 6 27 383d 4 3841 4 384c 6 396d 4 3971 4 397c 6
-INLINE 2 3627 5 23 3848 a 3978 a
-INLINE 2 3621 5 28 3857 6 3987 9
-INLINE 2 3610 5 28 3862 8 39c8 8
-INLINE 2 3614 5 28 386f a 39d5 8
-INLINE 2 3625 5 28 3879 8 3a03 8
-INLINE 2 3629 5 28 3886 8 3a10 8
-INLINE 1 3736 5 23 38a6 d 38ba 7
-INLINE 1 3745 5 23 38e2 5 38eb 6
-INLINE 0 3859 5 25 390e 2e 3990 33 39e2 21
-INLINE 0 3862 5 30 3965 2b 39c3 1f 3a03 76
-INLINE 1 3642 5 25 3965 2b 39c3 1a 3a03 15
-INLINE 1 3645 5 28 39dd 5 3a18 3 3a25 3 3a39 7
+344b 5 342 11
+3450 16 177 9
+3466 f 1580 8
+FUNC 3480 5f9 0 std::__1::__sort<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
+INLINE 0 3951 6 23 3505 3
+INLINE 1 702 6 24 3505 3 3564 d 3581 13 3627 c 3641 13 3658 4 36dc 1b 372f 8 373e e 3752 12 377b c 3814 b
+INLINE 0 3891 6 25 3517 3f 35a8 48
+INLINE 1 3605 6 23 3517 15 3530 3 390e c 391e 3
+INLINE 2 702 6 24 3517 25 35bc c 35e0 3 38a6 d 38ba 7 38e2 5 38eb 6 390e 1c 39a0 c 39ea 3 3a1b a 3a28 7 3a40 c 3a5e 4
+INLINE 3 214 5 26 3528 b 3536 6 35c4 4 38bd 4 38eb 6 3916 b 3924 6 39a8 4 3a2b 4 3a48 4
+INLINE 4 167 5 27 3528 8 3536 6 35c4 4 38bd 4 3916 8 3924 6 39a8 4 3a2b 4 3a48 4
+INLINE 1 3627 6 23 352c 4 35e0 3 391a 4 39ea 3
+INLINE 1 3619 6 23 3533 9 3921 9
+INLINE 1 3621 6 28 3545 11 3933 9
+INLINE 0 3914 6 23 3564 d
+INLINE 2 214 5 26 3567 a 362a 4 3658 4 36e6 11 3733 4 3748 4 3783 4 381b 4
+INLINE 0 3920 6 23 357a 1a 36df 3 36e6 4
+INLINE 1 3610 6 28 35b5 7 3999 7
+INLINE 1 3612 6 23 35bc c 39a0 c
+INLINE 1 3614 6 28 35ce a 39b6 d
+INLINE 1 3625 6 28 35d8 8 39e2 8
+INLINE 1 3629 6 28 35e9 7 39f7 c
+INLINE 0 3922 6 28 360b 7
+INLINE 0 3941 6 28 3620 7
+INLINE 0 3937 6 23 3627 7 3641 13 3658 4
+INLINE 3 167 5 27 362a 4 36e6 8 3733 4 3783 4 381b 4
+INLINE 0 3935 6 23 362e 5
+INLINE 0 3902 6 23 36dc 3 36e2 4 36ea d
+INLINE 0 3953 6 28 36fc 10
+INLINE 0 3977 6 28 3719 d
+INLINE 0 3973 6 23 372f 8 3752 12
+INLINE 0 3970 6 23 373e e
+INLINE 0 3987 6 23 377b c
+INLINE 0 3989 6 28 378d 8
+INLINE 0 3855 6 23 3814 b
+INLINE 0 3856 6 28 3829 c
+INLINE 0 3870 6 29 3835 59 3896 21 38ba d 38d3 2c
+INLINE 1 3733 6 25 3835 59
+INLINE 2 3612 6 23 3835 4 3841 4 3965 4 3971 4
+INLINE 3 702 6 24 3835 1d 3965 1d
+INLINE 2 3605 6 23 3839 8 3845 3 3969 8 3975 3
+INLINE 4 214 5 26 383d b 384c 6 396d b 397c 6
+INLINE 5 167 5 27 383d 8 384c 6 396d 8 397c 6
+INLINE 2 3627 6 23 3848 a 3978 a
+INLINE 2 3621 6 28 3857 6 3987 9
+INLINE 2 3610 6 28 3862 8 39c8 8
+INLINE 2 3614 6 28 386f a 39d5 8
+INLINE 2 3625 6 28 3879 8 3a03 8
+INLINE 2 3629 6 28 3886 8 3a10 8
+INLINE 1 3736 6 23 38a6 d 38ba 7
+INLINE 1 3745 6 23 38e2 5 38eb 6
+INLINE 0 3859 6 25 390e 2e 3990 33 39e2 21
+INLINE 0 3862 6 30 3965 2b 39c3 1f 3a03 76
+INLINE 1 3642 6 25 3965 2b 39c3 1a 3a03 15
+INLINE 1 3645 6 28 39dd 5 3a18 3 3a25 3 3a39 7
 INLINE 2 3617 7 31 39dd 5 3a18 3 3a25 3
-INLINE 3 210 6 32 39dd 5 3a18 3 3a25 3
-INLINE 1 3643 5 23 3a1b a 3a28 7
-INLINE 1 3647 5 23 3a40 8
-INLINE 1 3651 5 23 3a48 4 3a5e 4
-INLINE 1 3649 5 28 3a56 8
-INLINE 1 3653 5 28 3a6c d
-3480 1a 3839 5
-349a 16 4022 5
-34b0 4 3876 5
-34b4 1c 3838 5
-34d0 f 4016 5
-34df 21 4018 5
-3500 5 3908 5
-3505 3 213 6
-3508 18 3951 5
-3520 4 213 6
-3524 4 214 6
-3528 4 141 6
-352c 4 141 6
-3530 3 167 6
-3533 3 213 6
-3536 6 141 6
-353c 9 3619 5
+INLINE 3 210 5 32 39dd 5 3a18 3 3a25 3
+INLINE 1 3643 6 23 3a1b a 3a28 7
+INLINE 1 3647 6 23 3a40 8
+INLINE 1 3651 6 23 3a48 4 3a5e 4
+INLINE 1 3649 6 28 3a56 8
+INLINE 1 3653 6 28 3a6c d
+3480 1a 3839 6
+349a 16 4022 6
+34b0 4 3876 6
+34b4 1c 3838 6
+34d0 f 4016 6
+34df 21 4018 6
+3500 5 3908 6
+3505 3 213 5
+3508 f 3951 6
+3517 9 3951 6
+3520 4 213 5
+3524 4 214 5
+3528 4 141 5
+352c 4 141 5
+3530 3 167 5
+3533 3 213 5
+3536 6 141 5
+353c 9 3619 6
 3545 4 3618 7
-3549 17 3619 7
-3560 4 3912 5
-3564 3 214 6
-3567 a 167 6
-3571 9 3918 5
-357a 16 0 5
-3590 4 214 6
-3594 6 3920 5
-359a 16 3918 5
-35b0 5 3607 5
+3549 d 3619 7
+3556 a 3619 7
+3560 4 3912 6
+3564 3 214 5
+3567 a 167 5
+3571 9 3918 6
+357a 7 0 6
+3581 f 0 6
+3590 4 214 5
+3594 6 3920 6
+359a e 3918 6
+35a8 8 3918 6
+35b0 5 3607 6
 35b5 4 3618 7
 35b9 3 3619 7
-35bc 4 213 6
-35c0 4 214 6
-35c4 4 141 6
-35c8 6 3612 5
+35bc 4 213 5
+35c0 4 214 5
+35c4 4 141 5
+35c8 6 3612 6
 35ce 4 3618 7
 35d2 6 3619 7
 35d8 4 3618 7
 35dc 4 3619 7
-35e0 3 213 6
-35e3 6 3627 5
+35e0 3 213 5
+35e3 6 3627 6
 35e9 4 3618 7
-35ed 1e 3619 7
+35ed 3 3619 7
+35f0 1b 3619 7
 360b 4 3618 7
 360f 3 3619 7
-3612 e 3931 5
+3612 e 3931 6
 3620 4 3618 7
 3624 3 3619 7
-3627 3 213 6
-362a 6 141 6
-3630 3 214 6
-3633 4 3936 5
-3637 6 3935 5
-363d 13 3898 5
-3650 4 214 6
-3654 4 3937 5
-3658 4 167 6
-365c 2 3937 5
-365e 5 3939 5
-3663 d 3848 5
-3670 a 3849 5
-367a a 3868 5
-3684 17 3882 5
-369b 5 3883 5
-36a0 d 3880 5
-36ad e 3884 5
-36bb 3 3885 5
-36be 4 3884 5
-36c2 1a 3885 5
-36dc 3 213 6
-36df 3 213 6
-36e2 4 214 6
-36e6 4 141 6
-36ea 4 141 6
-36ee 12 167 6
+3627 3 213 5
+362a 4 141 5
+362e 2 141 5
+3630 3 214 5
+3633 4 3936 6
+3637 6 3935 6
+363d 4 3898 6
+3641 f 3898 6
+3650 4 214 5
+3654 4 3937 6
+3658 4 167 5
+365c 2 3937 6
+365e 5 3939 6
+3663 d 3848 6
+3670 a 3849 6
+367a a 3868 6
+3684 17 3882 6
+369b 5 3883 6
+36a0 d 3880 6
+36ad e 3884 6
+36bb 3 3885 6
+36be 4 3884 6
+36c2 1a 3885 6
+36dc 3 213 5
+36df 3 213 5
+36e2 4 214 5
+36e6 4 141 5
+36ea 4 141 5
+36ee 9 167 5
+36f7 5 167 5
+36fc 4 167 5
 3700 4 3618 7
 3704 4 3619 7
 3708 4 3618 7
-370c 2 3954 5
-370e 4 3960 5
-3712 e 3963 5
+370c 2 3954 6
+370e 4 3960 6
+3712 7 3963 6
+3719 7 3963 6
 3720 3 3618 7
 3723 3 3619 7
-3726 2 3978 5
-3728 7 3981 5
-372f 4 214 6
-3733 4 141 6
-3737 9 3970 5
-3740 8 213 6
-3748 4 167 6
-374c 2 3970 5
-374e 12 3898 5
-3760 4 213 6
-3764 a 3973 5
-376e 8 3975 5
-3776 5 3987 5
-377b 4 213 6
-377f 4 214 6
-3783 4 141 6
-3787 6 3987 5
+3726 2 3978 6
+3728 7 3981 6
+372f 4 214 5
+3733 4 141 5
+3737 7 3970 6
+373e 2 3970 6
+3740 8 213 5
+3748 4 167 5
+374c 2 3970 6
+374e 4 3898 6
+3752 e 3898 6
+3760 4 213 5
+3764 a 3973 6
+376e 8 3975 6
+3776 5 3987 6
+377b 4 213 5
+377f 4 214 5
+3783 4 141 5
+3787 6 3987 6
 378d 4 3618 7
 3791 4 3619 7
-3795 2 3990 5
-3797 9 3994 5
-37a0 15 3996 5
-37b5 24 3997 5
-37d9 3b 4014 5
-3814 3 213 6
-3817 4 214 6
-381b 4 141 6
-381f a 3855 5
+3795 2 3990 6
+3797 9 3994 6
+37a0 15 3996 6
+37b5 24 3997 6
+37d9 3b 4014 6
+3814 3 213 5
+3817 4 214 5
+381b 4 141 5
+381f a 3855 6
 3829 4 3618 7
 382d 8 3619 7
-3835 4 214 6
-3839 4 213 6
-383d 4 141 6
-3841 4 141 6
-3845 3 167 6
-3848 4 213 6
-384c 6 141 6
-3852 5 3619 5
+3835 4 214 5
+3839 4 213 5
+383d 4 141 5
+3841 4 141 5
+3845 3 167 5
+3848 4 213 5
+384c 6 141 5
+3852 5 3619 6
 3857 6 3618 7
-385d 5 3607 5
+385d 5 3607 6
 3862 4 3618 7
 3866 4 3619 7
-386a 5 3612 5
+386a 5 3612 6
 386f 4 3618 7
 3873 6 3619 7
 3879 4 3618 7
 387d 4 3619 7
-3881 5 3627 5
+3881 5 3627 6
 3886 4 3618 7
 388a 4 3619 7
-388e 8 3870 5
-3896 1a 3734 5
-38b0 3 214 6
-38b3 4 3734 5
-38b7 3 3870 5
-38ba 3 213 6
-38bd 4 141 6
-38c1 6 3736 5
-38c7 c 3870 5
-38d3 a 3743 5
-38dd 5 3745 5
-38e2 5 214 6
-38e7 4 3745 5
-38eb 6 167 6
-38f1 5 3746 5
-38f6 9 3734 5
-38ff f 4027 5
-390e 4 214 6
-3912 4 213 6
-3916 4 141 6
-391a 4 141 6
-391e 3 167 6
-3921 3 213 6
-3924 6 141 6
-392a 9 3619 5
+388e 8 3870 6
+3896 10 3734 6
+38a6 a 3734 6
+38b0 3 214 5
+38b3 4 3734 6
+38b7 3 3870 6
+38ba 3 213 5
+38bd 4 141 5
+38c1 6 3736 6
+38c7 c 3870 6
+38d3 a 3743 6
+38dd 5 3745 6
+38e2 5 214 5
+38e7 4 3745 6
+38eb 6 167 5
+38f1 5 3746 6
+38f6 9 3734 6
+38ff f 4027 6
+390e 4 214 5
+3912 4 213 5
+3916 4 141 5
+391a 4 141 5
+391e 3 167 5
+3921 3 213 5
+3924 6 141 5
+392a 9 3619 6
 3933 4 3618 7
 3937 5 3619 7
-393c 29 3865 5
-3965 4 214 6
-3969 4 213 6
-396d 4 141 6
-3971 4 141 6
-3975 3 167 6
-3978 4 213 6
-397c 6 141 6
-3982 5 3619 5
+393c 29 3865 6
+3965 4 214 5
+3969 4 213 5
+396d 4 141 5
+3971 4 141 5
+3975 3 167 5
+3978 4 213 5
+397c 6 141 5
+3982 5 3619 6
 3987 9 3618 7
-3990 9 3607 5
+3990 9 3607 6
 3999 4 3618 7
 399d 3 3619 7
-39a0 4 214 6
-39a4 4 213 6
-39a8 4 141 6
-39ac a 3612 5
+39a0 4 214 5
+39a4 4 213 5
+39a8 4 141 5
+39ac a 3612 6
 39b6 4 3618 7
 39ba 9 3619 7
-39c3 5 3607 5
+39c3 5 3607 6
 39c8 4 3618 7
 39cc 4 3619 7
-39d0 5 3612 5
+39d0 5 3612 6
 39d5 4 3618 7
 39d9 4 3619 7
-39dd 5 210 6
+39dd 5 210 5
 39e2 4 3618 7
 39e6 4 3619 7
-39ea 3 213 6
-39ed a 3627 5
+39ea 3 213 5
+39ed a 3627 6
 39f7 4 3618 7
 39fb 8 3619 7
 3a03 4 3618 7
 3a07 4 3619 7
-3a0b 5 3627 5
+3a0b 5 3627 6
 3a10 4 3618 7
 3a14 4 3619 7
-3a18 3 210 6
-3a1b a 214 6
-3a25 3 210 6
-3a28 3 213 6
-3a2b 4 141 6
-3a2f a 3643 5
+3a18 3 210 5
+3a1b a 214 5
+3a25 3 210 5
+3a28 3 213 5
+3a2b 4 141 5
+3a2f a 3643 6
 3a39 4 3618 7
 3a3d 3 3619 7
-3a40 4 214 6
-3a44 4 213 6
-3a48 4 141 6
-3a4c a 3647 5
+3a40 4 214 5
+3a44 4 213 5
+3a48 4 141 5
+3a4c a 3647 6
 3a56 4 3618 7
 3a5a 4 3619 7
-3a5e 4 214 6
-3a62 a 3651 5
+3a5e 4 214 5
+3a62 a 3651 6
 3a6c 4 3618 7
 3a70 9 3619 7
-FUNC 3aa0 142 0 unsigned int std::__1::__sort5<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
-INLINE 0 3668 5 30 3aa0 d5
-INLINE 1 3642 5 25 3aa0 50 3afa 1f
-INLINE 2 3605 5 23 3aa0 d 3ab1 3
-INLINE 3 702 5 24 3aa0 d 3aad 4 3ab1 3 3ab4 9 3ada a 3b00 8
-INLINE 4 214 6 26 3aa9 4 3aad 4 3ab1 3 3ab7 6 3ae0 4
-INLINE 5 167 6 27 3aa9 4 3aad 4 3ab7 6 3ae0 4
-INLINE 2 3627 5 23 3aad 4 3b00 8
-INLINE 2 3619 5 23 3ab4 9
-INLINE 2 3621 5 28 3ac2 d
-INLINE 2 3610 5 28 3ad4 6
-INLINE 2 3612 5 23 3ada a
-INLINE 2 3614 5 28 3aea 6
-INLINE 1 3643 5 23 3af0 a 3b2a 7
-INLINE 2 702 5 24 3af0 a 3b2a 7 3b3d a 3b53 a
-INLINE 2 3625 5 28 3afa 6
-INLINE 2 3629 5 28 3b0e b
-INLINE 1 3645 5 28 3b19 11 3b37 6
+FUNC 3aa0 142 0 std::__1::__sort5<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
+INLINE 0 3668 6 30 3aa0 d5
+INLINE 1 3642 6 25 3aa0 50 3afa 1f
+INLINE 2 3605 6 23 3aa0 d 3ab1 3
+INLINE 3 702 6 24 3aa0 1d 3ada a 3b00 8
+INLINE 4 214 5 26 3aa9 b 3ab7 6 3ae0 4
+INLINE 5 167 5 27 3aa9 8 3ab7 6 3ae0 4
+INLINE 2 3627 6 23 3aad 4 3b00 8
+INLINE 2 3619 6 23 3ab4 9
+INLINE 2 3621 6 28 3ac2 d
+INLINE 2 3610 6 28 3ad4 6
+INLINE 2 3612 6 23 3ada a
+INLINE 2 3614 6 28 3aea 6
+INLINE 1 3643 6 23 3af0 a 3b2a 7
+INLINE 2 702 6 24 3af0 a 3b2a 7 3b3d a 3b53 a
+INLINE 2 3625 6 28 3afa 6
+INLINE 2 3629 6 28 3b0e b
+INLINE 1 3645 6 28 3b19 11 3b37 6
 INLINE 2 3617 7 31 3b19 11
-INLINE 3 210 6 32 3b19 11
-INLINE 3 214 6 26 3b2d 4 3b43 4 3b59 4
-INLINE 4 167 6 27 3b2d 4 3b43 4 3b59 4
-INLINE 1 3647 5 23 3b3d a
-INLINE 1 3649 5 28 3b4d 6
-INLINE 1 3651 5 23 3b53 a
-INLINE 1 3653 5 28 3b63 6
-INLINE 0 3669 5 23 3b75 a
-INLINE 1 702 5 24 3b75 a 3b8b a 3ba1 a 3bb7 a
-INLINE 2 214 6 26 3b7b 4 3b91 4 3ba7 4 3bbd 4
-INLINE 3 167 6 27 3b7b 4 3b91 4 3ba7 4 3bbd 4
-INLINE 0 3671 5 28 3b85 6
-INLINE 0 3673 5 23 3b8b a
-INLINE 0 3675 5 28 3b9b 6
-INLINE 0 3677 5 23 3ba1 a
-INLINE 0 3679 5 28 3bb1 6
-INLINE 0 3681 5 23 3bb7 a
-INLINE 0 3683 5 28 3bc7 6
-3aa0 6 213 6
-3aa6 3 214 6
-3aa9 4 141 6
-3aad 4 141 6
-3ab1 3 167 6
-3ab4 3 213 6
-3ab7 6 141 6
-3abd 5 3619 5
+INLINE 3 210 5 32 3b19 11
+INLINE 3 214 5 26 3b2d 4 3b43 4 3b59 4
+INLINE 4 167 5 27 3b2d 4 3b43 4 3b59 4
+INLINE 1 3647 6 23 3b3d a
+INLINE 1 3649 6 28 3b4d 6
+INLINE 1 3651 6 23 3b53 a
+INLINE 1 3653 6 28 3b63 6
+INLINE 0 3669 6 23 3b75 a
+INLINE 1 702 6 24 3b75 a 3b8b a 3ba1 a 3bb7 a
+INLINE 2 214 5 26 3b7b 4 3b91 4 3ba7 4 3bbd 4
+INLINE 3 167 5 27 3b7b 4 3b91 4 3ba7 4 3bbd 4
+INLINE 0 3671 6 28 3b85 6
+INLINE 0 3673 6 23 3b8b a
+INLINE 0 3675 6 28 3b9b 6
+INLINE 0 3677 6 23 3ba1 a
+INLINE 0 3679 6 28 3bb1 6
+INLINE 0 3681 6 23 3bb7 a
+INLINE 0 3683 6 28 3bc7 6
+3aa0 6 213 5
+3aa6 3 214 5
+3aa9 4 141 5
+3aad 4 141 5
+3ab1 3 167 5
+3ab4 3 213 5
+3ab7 6 141 5
+3abd 5 3619 6
 3ac2 3 3618 7
 3ac5 a 3619 7
-3acf 5 3607 5
+3acf 5 3607 6
 3ad4 3 3618 7
 3ad7 3 3619 7
-3ada 3 213 6
-3add 3 214 6
-3ae0 4 141 6
-3ae4 6 3612 5
+3ada 3 213 5
+3add 3 214 5
+3ae0 4 141 5
+3ae4 6 3612 6
 3aea 3 3618 7
 3aed 3 3619 7
-3af0 a 214 6
+3af0 a 214 5
 3afa 3 3618 7
 3afd 3 3619 7
-3b00 8 213 6
-3b08 6 3627 5
+3b00 8 213 5
+3b08 6 3627 6
 3b0e 3 3618 7
 3b11 8 3619 7
-3b19 11 210 6
-3b2a 3 213 6
-3b2d 4 141 6
-3b31 6 3643 5
+3b19 11 210 5
+3b2a 3 213 5
+3b2d 4 141 5
+3b31 6 3643 6
 3b37 3 3618 7
 3b3a 3 3619 7
-3b3d 3 213 6
-3b40 3 214 6
-3b43 4 141 6
-3b47 6 3647 5
+3b3d 3 213 5
+3b40 3 214 5
+3b43 4 141 5
+3b47 6 3647 6
 3b4d 3 3618 7
 3b50 3 3619 7
-3b53 3 213 6
-3b56 3 214 6
-3b59 4 141 6
-3b5d 6 3651 5
+3b53 3 213 5
+3b56 3 214 5
+3b59 4 141 5
+3b5d 6 3651 6
 3b63 3 3618 7
 3b66 3 3619 7
-3b69 5 3654 5
-3b6e 4 3646 5
-3b72 3 3650 5
-3b75 3 213 6
-3b78 3 214 6
-3b7b 4 141 6
-3b7f 6 3669 5
+3b69 5 3654 6
+3b6e 4 3646 6
+3b72 3 3650 6
+3b75 3 213 5
+3b78 3 214 5
+3b7b 4 141 5
+3b7f 6 3669 6
 3b85 3 3618 7
 3b88 3 3619 7
-3b8b 3 213 6
-3b8e 3 214 6
-3b91 4 141 6
-3b95 6 3673 5
+3b8b 3 213 5
+3b8e 3 214 5
+3b91 4 141 5
+3b95 6 3673 6
 3b9b 3 3618 7
 3b9e 3 3619 7
-3ba1 3 213 6
-3ba4 3 214 6
-3ba7 4 141 6
-3bab 6 3677 5
+3ba1 3 213 5
+3ba4 3 214 5
+3ba7 4 141 5
+3bab 6 3677 6
 3bb1 3 3618 7
 3bb4 3 3619 7
-3bb7 3 213 6
-3bba 3 214 6
-3bbd 4 141 6
-3bc1 6 3681 5
+3bb7 3 213 5
+3bba 3 214 5
+3bbd 4 141 5
+3bc1 6 3681 6
 3bc7 3 3618 7
 3bca 3 3619 7
-3bcd 5 3684 5
-3bd2 4 3672 5
-3bd6 5 3676 5
-3bdb 3 3680 5
-3bde 4 3689 5
-FUNC 3bf0 2b3 0 bool std::__1::__insertion_sort_incomplete<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
-INLINE 0 3762 5 23 3c1c b
-INLINE 1 702 5 24 3c1c b 3da2 11 3dba 7 3de1 5 3dea 6
-INLINE 2 214 6 26 3c23 4 3dbd 4 3dea 6
-INLINE 3 167 6 27 3c23 4 3dbd 4
-INLINE 0 3763 5 28 3c31 c
-INLINE 0 3777 5 25 3c3d 31 3ced 23 3d6b 19
-INLINE 1 3612 5 23 3c3d 3 3c48 4 3d21 b
-INLINE 2 702 5 24 3c3d 3 3c40 8 3c48 4 3c4c 3 3c4f e 3c6e b 3c79 4 3c7d 3 3c80 e 3d21 b 3e19 4 3e44 a 3e59 8 3e6f 8 3e77 4 3e89 3
-INLINE 1 3605 5 23 3c40 8 3c4c 3 3c6e b 3c7d 3
-INLINE 3 214 6 26 3c44 4 3c48 4 3c4c 3 3c53 a 3c75 4 3c79 4 3c7d 3 3c84 a 3d28 4 3e5d 4 3e77 4
-INLINE 4 167 6 27 3c44 4 3c48 4 3c53 a 3c75 4 3c79 4 3c84 a 3d28 4 3e5d 4 3e77 4
-INLINE 1 3627 5 23 3c4f e 3c79 4 3e19 4
-INLINE 1 3621 5 28 3c66 8 3c97 c
-INLINE 0 3766 5 25 3c6e 35 3d10 32 3e12 1b
-INLINE 1 3619 5 23 3c80 e
-INLINE 0 3769 5 30 3cc0 2d 3d42 29 3e2d 6c
-INLINE 1 3642 5 25 3cc0 2d 3d42 21 3e2d 14
-INLINE 2 3612 5 23 3cc0 3 3ccb 4
-INLINE 3 702 5 24 3cc0 3 3cc3 8 3ccb 4 3ccf 3 3cd2 a
-INLINE 2 3605 5 23 3cc3 8 3ccf 3
-INLINE 4 214 6 26 3cc7 4 3ccb 4 3ccf 3 3cd6 6
-INLINE 5 167 6 27 3cc7 4 3ccb 4 3cd6 6
-INLINE 2 3627 5 23 3cd2 a
-INLINE 2 3621 5 28 3ce5 8
-INLINE 1 3610 5 28 3cf6 8 3d19 8
-INLINE 1 3614 5 28 3d07 9 3d36 c
-INLINE 2 3610 5 28 3d4b 8
-INLINE 2 3614 5 28 3d5c 7
-INLINE 1 3645 5 28 3d63 8 3e41 3 3e56 3 3e67 8
+3bcd 5 3684 6
+3bd2 4 3672 6
+3bd6 5 3676 6
+3bdb 3 3680 6
+3bde 4 3689 6
+FUNC 3bf0 2b3 0 std::__1::__insertion_sort_incomplete<std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&, google_breakpad::DynamicImageRef*>(google_breakpad::DynamicImageRef*, google_breakpad::DynamicImageRef*, std::__1::__less<google_breakpad::DynamicImageRef, google_breakpad::DynamicImageRef>&)
+INLINE 0 3762 6 23 3c1c b
+INLINE 1 702 6 24 3c1c b 3da2 11 3dba 7 3de1 5 3dea 6
+INLINE 2 214 5 26 3c23 4 3dbd 4 3dea 6
+INLINE 3 167 5 27 3c23 4 3dbd 4
+INLINE 0 3763 6 28 3c31 c
+INLINE 0 3777 6 25 3c3d 31 3ced 23 3d6b 19
+INLINE 1 3612 6 23 3c3d 3 3c48 4 3d21 b
+INLINE 2 702 6 24 3c3d 20 3c6e 20 3d21 b 3e19 4 3e44 a 3e59 8 3e6f c 3e89 3
+INLINE 1 3605 6 23 3c40 8 3c4c 3 3c6e b 3c7d 3
+INLINE 3 214 5 26 3c44 b 3c53 a 3c75 b 3c84 a 3d28 4 3e5d 4 3e77 4
+INLINE 4 167 5 27 3c44 8 3c53 a 3c75 8 3c84 a 3d28 4 3e5d 4 3e77 4
+INLINE 1 3627 6 23 3c4f e 3c79 4 3e19 4
+INLINE 1 3621 6 28 3c66 8 3c97 c
+INLINE 0 3766 6 25 3c6e 35 3d10 32 3e12 1b
+INLINE 1 3619 6 23 3c80 e
+INLINE 0 3769 6 30 3cc0 2d 3d42 29 3e2d 6c
+INLINE 1 3642 6 25 3cc0 2d 3d42 21 3e2d 14
+INLINE 2 3612 6 23 3cc0 3 3ccb 4
+INLINE 3 702 6 24 3cc0 1c
+INLINE 2 3605 6 23 3cc3 8 3ccf 3
+INLINE 4 214 5 26 3cc7 b 3cd6 6
+INLINE 5 167 5 27 3cc7 8 3cd6 6
+INLINE 2 3627 6 23 3cd2 a
+INLINE 2 3621 6 28 3ce5 8
+INLINE 1 3610 6 28 3cf6 8 3d19 8
+INLINE 1 3614 6 28 3d07 9 3d36 c
+INLINE 2 3610 6 28 3d4b 8
+INLINE 2 3614 6 28 3d5c 7
+INLINE 1 3645 6 28 3d63 8 3e41 3 3e56 3 3e67 8
 INLINE 2 3617 7 31 3d63 8 3e41 3 3e56 3
-INLINE 3 210 6 32 3d63 8 3e41 3 3e56 3
-INLINE 1 3625 5 28 3d6b 7 3e12 7
-INLINE 1 3629 5 28 3d77 d 3e23 a
-INLINE 0 3782 5 23 3da2 11 3dba 7
-INLINE 0 3791 5 23 3de1 5 3dea 6
-INLINE 2 3625 5 28 3e2d 7
-INLINE 2 3629 5 28 3e39 8
-INLINE 1 3643 5 23 3e44 a 3e59 8
-INLINE 1 3647 5 23 3e6f 8
-INLINE 1 3651 5 23 3e77 4 3e89 3
-INLINE 1 3649 5 28 3e81 8
-INLINE 1 3653 5 28 3e92 7
-3bf0 a 3755 5
-3bfa 22 3756 5
-3c1c 4 213 6
-3c20 3 214 6
-3c23 4 141 6
-3c27 a 3762 5
+INLINE 3 210 5 32 3d63 8 3e41 3 3e56 3
+INLINE 1 3625 6 28 3d6b 7 3e12 7
+INLINE 1 3629 6 28 3d77 d 3e23 a
+INLINE 0 3782 6 23 3da2 11 3dba 7
+INLINE 0 3791 6 23 3de1 5 3dea 6
+INLINE 2 3625 6 28 3e2d 7
+INLINE 2 3629 6 28 3e39 8
+INLINE 1 3643 6 23 3e44 a 3e59 8
+INLINE 1 3647 6 23 3e6f 8
+INLINE 1 3651 6 23 3e77 4 3e89 3
+INLINE 1 3649 6 28 3e81 8
+INLINE 1 3653 6 28 3e92 7
+3bf0 a 3755 6
+3bfa 22 3756 6
+3c1c 4 213 5
+3c20 3 214 5
+3c23 4 141 5
+3c27 a 3762 6
 3c31 3 3618 7
 3c34 9 3619 7
-3c3d 3 214 6
-3c40 4 213 6
-3c44 4 141 6
-3c48 4 141 6
-3c4c 3 167 6
-3c4f 4 213 6
-3c53 a 141 6
-3c5d 9 3619 5
+3c3d 3 214 5
+3c40 4 213 5
+3c44 4 141 5
+3c48 4 141 5
+3c4c 3 167 5
+3c4f 4 213 5
+3c53 a 141 5
+3c5d 9 3619 6
 3c66 8 3618 7
-3c6e 3 214 6
-3c71 4 213 6
-3c75 4 141 6
-3c79 4 141 6
-3c7d 3 167 6
-3c80 4 213 6
-3c84 a 141 6
-3c8e 9 3619 5
+3c6e 3 214 5
+3c71 4 213 5
+3c75 4 141 5
+3c79 4 141 5
+3c7d 3 167 5
+3c80 4 213 5
+3c84 a 141 5
+3c8e 9 3619 6
 3c97 3 3618 7
 3c9a 9 3619 7
-3ca3 1d 3772 5
-3cc0 3 214 6
-3cc3 4 213 6
-3cc7 4 141 6
-3ccb 4 141 6
-3ccf 3 167 6
-3cd2 4 213 6
-3cd6 6 141 6
-3cdc 9 3619 5
+3ca3 1d 3772 6
+3cc0 3 214 5
+3cc3 4 213 5
+3cc7 4 141 5
+3ccb 4 141 5
+3ccf 3 167 5
+3cd2 4 213 5
+3cd6 6 141 5
+3cdc 9 3619 6
 3ce5 8 3618 7
-3ced 9 3607 5
+3ced 9 3607 6
 3cf6 4 3618 7
 3cfa 4 3619 7
-3cfe 9 3612 5
+3cfe 9 3612 6
 3d07 3 3618 7
 3d0a 6 3619 7
-3d10 9 3607 5
+3d10 9 3607 6
 3d19 4 3618 7
 3d1d 4 3619 7
-3d21 3 214 6
-3d24 4 213 6
-3d28 4 141 6
-3d2c a 3612 5
+3d21 3 214 5
+3d24 4 213 5
+3d28 4 141 5
+3d2c a 3612 6
 3d36 3 3618 7
 3d39 9 3619 7
-3d42 9 3607 5
+3d42 9 3607 6
 3d4b 4 3618 7
 3d4f 4 3619 7
-3d53 9 3612 5
+3d53 9 3612 6
 3d5c 3 3618 7
 3d5f 4 3619 7
-3d63 8 210 6
+3d63 8 210 5
 3d6b 3 3618 7
 3d6e 4 3619 7
-3d72 5 3627 5
+3d72 5 3627 6
 3d77 4 3618 7
-3d7b c 3619 7
-3d87 29 3780 5
-3db0 3 214 6
-3db3 7 3780 5
-3dba 3 213 6
-3dbd 4 141 6
-3dc1 12 3782 5
-3dd3 9 3789 5
-3ddc 5 3791 5
-3de1 5 214 6
-3de6 4 3791 5
-3dea 6 167 6
-3df0 4 3792 5
-3df4 3 3793 5
-3df7 a 3794 5
-3e01 6 3793 5
-3e07 b 3780 5
+3d7b 9 3619 7
+3d84 3 3619 7
+3d87 1b 3780 6
+3da2 e 3780 6
+3db0 3 214 5
+3db3 7 3780 6
+3dba 3 213 5
+3dbd 4 141 5
+3dc1 12 3782 6
+3dd3 9 3789 6
+3ddc 5 3791 6
+3de1 5 214 5
+3de6 4 3791 6
+3dea 6 167 5
+3df0 4 3792 6
+3df4 3 3793 6
+3df7 a 3794 6
+3e01 6 3793 6
+3e07 b 3780 6
 3e12 3 3618 7
 3e15 4 3619 7
-3e19 4 213 6
-3e1d 6 3627 5
+3e19 4 213 5
+3e1d 6 3627 6
 3e23 4 3618 7
 3e27 6 3619 7
 3e2d 3 3618 7
 3e30 4 3619 7
-3e34 5 3627 5
+3e34 5 3627 6
 3e39 4 3618 7
 3e3d 4 3619 7
-3e41 3 210 6
-3e44 12 214 6
-3e56 3 210 6
-3e59 4 213 6
-3e5d 4 141 6
-3e61 6 3643 5
+3e41 3 210 5
+3e44 a 214 5
+3e4e 8 214 5
+3e56 3 210 5
+3e59 4 213 5
+3e5d 4 141 5
+3e61 6 3643 6
 3e67 4 3618 7
 3e6b 4 3619 7
-3e6f 4 214 6
-3e73 4 213 6
-3e77 4 141 6
-3e7b 6 3647 5
+3e6f 4 214 5
+3e73 4 213 5
+3e77 4 141 5
+3e7b 6 3647 6
 3e81 4 3618 7
 3e85 4 3619 7
-3e89 3 214 6
-3e8c 6 3651 5
+3e89 3 214 5
+3e8c 6 3651 6
 3e92 3 3618 7
 3e95 4 3619 7
-3e99 a 3799 5
+3e99 a 3799 6
 FUNC 3ec0 5 0 google_breakpad::breakpad_exc_server(mach_msg_header_t*, mach_msg_header_t*)
 3ec0 5 207 15
 FUNC 3ed0 20 0 catch_exception_raise
@@ -2669,11 +2728,11 @@ INLINE 1 1945 13 66 4a11 10
 INLINE 2 1949 13 67 4a11 10
 INLINE 0 328 15 182 4a32 1c
 INLINE 0 340 15 164 4a4e 10
-INLINE 1 1631 13 165 4a4e 10 4a6f d 4a7c f
-INLINE 2 1633 13 166 4a4e 10 4a6f d 4a7c f
+INLINE 1 1631 13 165 4a4e 10 4a6f 1c
+INLINE 2 1633 13 166 4a4e 10 4a6f 1c
 INLINE 3 1791 13 71 4a4e 5 4a73 4 4a7c 4
 INLINE 3 1791 13 167 4a53 5 4a6f 4 4a80 5
-INLINE 0 343 15 164 4a6f d 4a7c f
+INLINE 0 343 15 164 4a6f 1c
 INLINE 0 347 15 183 4ab3 8 4acf 8 4b01 18
 INLINE 1 46 19 184 4ab3 8 4acf 8 4b01 18
 49e0 1d 321 15
@@ -2700,7 +2759,8 @@ INLINE 1 46 19 184 4ab3 8 4acf 8 4b01 18
 4a9b 18 347 15
 4ab3 8 47 19
 4abb 14 347 15
-4acf 10 47 19
+4acf 8 47 19
+4ad7 8 47 19
 4adf 22 347 15
 4b01 18 47 19
 FUNC 4b20 252 0 google_breakpad::ExceptionHandler::WriteMinidumpWithException(int, int, int, __darwin_ucontext*, unsigned int, bool, bool)
@@ -2734,8 +2794,10 @@ INLINE 0 406 15 182 4c8e 13
 4c0e 2 1697 13
 4c10 6 1460 13
 4c16 5 1749 13
-4c1b 6 1759 13
-4c21 10 1474 13
+4c1b 4 1759 13
+4c1f 2 1759 13
+4c21 9 1474 13
+4c2a 7 1474 13
 4c31 9 396 15
 4c3a 4 397 15
 4c3e f 398 15
@@ -2757,7 +2819,8 @@ INLINE 0 406 15 182 4c8e 13
 4d13 a 411 15
 4d1d 9 424 15
 4d26 9 421 15
-4d2f 27 119 16
+4d2f 1f 119 16
+4d4e 8 119 16
 4d56 f 411 15
 4d65 d 424 15
 FUNC 4d80 2d2 0 google_breakpad::ExceptionHandler::WaitForMessage(void*)
@@ -2767,7 +2830,8 @@ INLINE 0 601 15 193 4ee5 b
 INLINE 0 552 15 194 4fad 1d 4fcc 32
 4d80 26 483 15
 4da6 11 555 15
-4db7 19 828 15
+4db7 e 828 15
+4dc5 b 828 15
 4dd0 4 606 15
 4dd4 1c 605 15
 4df0 c 490 15
@@ -2778,7 +2842,8 @@ INLINE 0 552 15 194 4fad 1d 4fcc 32
 4e34 e 565 15
 4e42 11 828 15
 4e53 8 832 15
-4e5b 5 566 15
+4e5b 2 566 15
+4e5d 3 566 15
 4e60 11 833 15
 4e71 11 834 15
 4e82 c 832 15
@@ -2791,7 +2856,8 @@ INLINE 0 552 15 194 4fad 1d 4fcc 32
 4efd e 514 15
 4f0b 15 828 15
 4f20 8 832 15
-4f28 8 517 15
+4f28 2 517 15
+4f2a 6 517 15
 4f30 13 833 15
 4f43 11 834 15
 4f54 c 832 15
@@ -2800,7 +2866,8 @@ INLINE 0 552 15 194 4fad 1d 4fcc 32
 4fa3 a 542 15
 4fad 15 846 15
 4fc2 8 850 15
-4fca 6 552 15
+4fca 2 552 15
+4fcc 4 552 15
 4fd0 11 851 15
 4fe1 11 852 15
 4ff2 c 850 15
@@ -2855,10 +2922,10 @@ FUNC 5230 47 0 google_breakpad::ExceptionHandler::SignalHandler(int, __siginfo*,
 526f 8 633 15
 FUNC 5280 161 0 google_breakpad::ExceptionHandler::InstallHandler()
 INLINE 0 652 15 197 535d e
-INLINE 0 658 15 174 5372 13 5385 d 5395 8
-INLINE 1 96 16 175 5372 13 5385 d 5395 8
+INLINE 0 658 15 174 5372 20 5395 8
+INLINE 1 96 16 175 5372 20 5395 8
 INLINE 0 668 15 198 53b5 10
-INLINE 1 82 11 199 53b5 10
+INLINE 1 82 9 199 53b5 10
 5280 9 635 15
 5289 e 637 15
 5297 a 640 15
@@ -2886,308 +2953,317 @@ INLINE 1 82 11 199 53b5 10
 5364 7 133 16
 536b 7 653 15
 5372 13 98 16
-5385 10 98 16
-5395 13 98 16
+5385 d 98 16
+5392 3 98 16
+5395 8 98 16
+539d b 98 16
 53a8 d 667 15
-53b5 10 82 11
+53b5 10 82 9
 53c5 d 667 15
 53d2 f 670 15
 FUNC 53f0 316 0 google_breakpad::MinidumpGenerator::MinidumpGenerator()
-INLINE 0 83 21 200 5441 4 544a 3 5461 217
-INLINE 1 219 22 201 5441 4 544a 3 5461 217
-INLINE 2 220 22 202 5441 4 544a 3 54bc 1bc
-INLINE 3 1538 9 203 5441 4 544a 3 54bc 8b 5555 7
-INLINE 4 310 12 204 5441 4 544a 3 54bc 8b 5555 7
-INLINE 5 311 12 205 5441 4 544a 3 54bc 8b
+INLINE 0 83 22 200 5441 4 544a 3 5461 217
+INLINE 1 219 21 201 5441 4 544a 3 5461 217
+INLINE 2 220 21 202 5441 4 544a 3 54bc 1bc
+INLINE 3 1538 8 203 5441 4 544a 3 54bc 8b 5555 7
+INLINE 4 310 11 204 5441 4 544a 3 54bc 8b 5555 7
+INLINE 5 311 11 205 5441 4 544a 3 54bc 8b
 INLINE 6 1500 10 206 5441 4 544a 3 54bc 8b
-INLINE 0 72 21 207 5445 5 545d 4 56b9 4
-INLINE 1 67 22 208 5445 5 545d 4 56b9 4
-INLINE 7 190 22 209 544a 3 54bc 8b
-INLINE 2 219 22 210 5461 5b
-INLINE 3 496 9 211 5461 5b
-INLINE 4 443 9 212 5461 5b
+INLINE 0 72 22 207 5445 5 545d 4 56b9 4
+INLINE 1 67 21 208 5445 5 545d 4 56b9 4
+INLINE 7 190 21 209 544a 3 54bc 8b
+INLINE 2 219 21 210 5461 5b
+INLINE 3 496 8 211 5461 5b
+INLINE 4 443 8 212 5461 5b
 INLINE 5 2427 10 213 5461 5b
 INLINE 6 2427 10 214 5461 5b
-INLINE 8 91 22 215 54cb 3d
-INLINE 3 1539 9 216 554a b 555c 11c
-INLINE 4 893 9 217 555c 3 5568 fe
-INLINE 4 894 9 218 555f 9 5666 4
+INLINE 8 91 21 215 54cb 3d
+INLINE 3 1539 8 216 554a b 555c 11c
+INLINE 4 893 8 217 555c 3 5568 fe
+INLINE 4 894 8 218 555f 9 5666 4
 INLINE 5 1630 10 219 5583 15 559c 8 55c3 8c
 INLINE 6 1514 10 220 5583 15 559c 8 55c3 8c
 INLINE 7 1668 10 221 5583 15 559c 8 55c3 8c
-INLINE 4 895 9 218 566a 7
-INLINE 4 896 9 218 5671 7
-INLINE 0 85 21 222 568c 2d
-INLINE 1 216 22 223 568c 2d
-INLINE 2 216 22 224 568c 2d
-INLINE 3 458 9 225 568c 2d
-INLINE 4 452 9 226 5695 24
-INLINE 5 369 9 227 5695 24
-INLINE 6 425 9 228 56a1 11
-INLINE 0 85 21 229 56bd 36
-INLINE 1 70 22 230 56bd 36
-INLINE 2 71 22 231 56bd 18 56d8 13
-53f0 17 83 21
-5407 c 73 21
-5413 10 75 21
-5423 d 78 21
-5430 9 79 21
-5439 8 80 21
-5441 4 190 22
-5445 5 63 22
-544a 3 90 22
-544d 10 82 21
-545d 4 63 22
+INLINE 4 895 8 218 566a 7
+INLINE 4 896 8 218 5671 7
+INLINE 0 85 22 222 568c 2d
+INLINE 1 216 21 223 568c 2d
+INLINE 2 216 21 224 568c 2d
+INLINE 3 458 8 225 568c 2d
+INLINE 4 452 8 226 5695 24
+INLINE 5 369 8 227 5695 24
+INLINE 6 425 8 228 56a1 11
+INLINE 0 85 22 229 56bd 36
+INLINE 1 70 21 230 56bd 36
+INLINE 2 71 21 231 56bd 18 56d8 13
+53f0 17 83 22
+5407 c 73 22
+5413 10 75 22
+5423 d 78 22
+5430 9 79 22
+5439 8 80 22
+5441 4 190 21
+5445 5 63 21
+544a 3 90 21
+544d 10 82 22
+545d 4 63 21
 5461 5b 2065 10
-54bc f 90 22
-54cb 24 119 22
-54ef 6 121 22
-54f5 7 131 22
-54fc 4 132 22
-5500 4 133 22
-5504 4 135 22
-5508 5 92 22
-550d 4 98 22
-5511 17 96 22
-5528 4 95 22
-552c 15 98 22
-5541 9 100 22
-554a b 893 9
-5555 7 313 12
+54bc f 90 21
+54cb 24 119 21
+54ef 6 121 21
+54f5 7 131 21
+54fc 4 132 21
+5500 4 133 21
+5504 4 135 21
+5508 5 92 21
+550d 4 98 21
+5511 17 96 21
+5528 4 95 21
+552c 15 98 21
+5541 6 100 21
+5547 3 100 21
+554a b 893 8
+5555 7 313 11
 555c 3 1628 10
 555f 9 3618 7
-5568 28 1630 10
+5568 1b 1630 10
+5583 d 1630 10
 5590 8 1752 10
 5598 4 1630 10
 559c 8 1752 10
 55a4 4 1631 10
 55a8 a 1628 10
-55b2 1e 1630 10
+55b2 11 1630 10
+55c3 d 1630 10
 55d0 7f 1752 10
 564f 4 1630 10
 5653 13 1628 10
 5666 4 3618 7
 566a 7 3618 7
 5671 7 3618 7
-5678 5 84 21
-567d f 85 21
-568c 9 450 9
-5695 c 424 9
-56a1 11 0 9
-56b2 7 425 9
-56b9 4 64 22
-56bd 18 143 22
-56d5 3 71 22
-56d8 3 144 22
-56db 10 145 22
-56eb b 71 22
-56f6 10 85 21
+5678 5 84 22
+567d f 85 22
+568c 9 450 8
+5695 c 424 8
+56a1 11 0 8
+56b2 7 425 8
+56b9 4 64 21
+56bd 18 143 21
+56d5 3 71 21
+56d8 3 144 21
+56db 10 145 21
+56eb 8 71 21
+56f3 3 71 21
+56f6 10 85 22
 FUNC 5710 259 0 google_breakpad::MinidumpGenerator::GatherSystemInformation()
-INLINE 0 186 21 164 58a0 10
+INLINE 0 186 22 164 58a0 10
 INLINE 1 1631 13 165 58a0 10
 INLINE 2 1633 13 166 58a0 10
 INLINE 3 1791 13 71 58a0 5
 INLINE 3 1791 13 167 58a5 5
-5710 20 123 21
-5730 21 125 21
-5751 f 192 21
-5760 15 132 21
-5775 d 136 21
-5782 8 137 21
-578a 5 138 21
-578f 15 141 21
-57a4 13 151 21
-57b7 19 152 21
-57d0 5 158 21
-57d5 5 160 21
-57da c 161 21
-57e6 e 163 21
-57f4 13 151 21
-5807 5 152 21
-580c 5 153 21
-5811 b 154 21
-581c 8 165 21
-5824 8 166 21
-582c 9 167 21
-5835 14 171 21
-5849 8 173 21
-5851 9 174 21
-585a 12 178 21
-586c 17 180 21
-5883 8 181 21
-588b d 182 21
-5898 8 184 21
+5710 20 123 22
+5730 21 125 22
+5751 f 192 22
+5760 15 132 22
+5775 d 136 22
+5782 8 137 22
+578a 5 138 22
+578f 15 141 22
+57a4 13 151 22
+57b7 19 152 22
+57d0 5 158 22
+57d5 5 160 22
+57da c 161 22
+57e6 e 163 22
+57f4 13 151 22
+5807 5 152 22
+580c 5 153 22
+5811 b 154 22
+581c 8 165 22
+5824 8 166 22
+582c 9 167 22
+5835 14 171 22
+5849 8 173 22
+5851 9 174 22
+585a 12 178 22
+586c 17 180 22
+5883 8 181 22
+588b d 182 22
+5898 8 184 22
 58a0 5 1697 13
 58a5 5 1785 13
 58aa 6 1791 13
-58b0 11 186 21
-58c1 12 189 21
-58d3 15 190 21
-58e8 1a 191 21
-5902 28 192 21
-592a 28 142 21
-5952 17 192 21
+58b0 11 186 22
+58c1 12 189 22
+58d3 15 190 22
+58e8 1a 191 22
+5902 28 192 22
+592a 28 142 22
+5952 17 192 22
 FUNC 5970 5 0 google_breakpad::MinidumpGenerator::MinidumpGenerator()
-5970 5 83 21
+5970 5 83 22
 FUNC 5980 343 0 google_breakpad::MinidumpGenerator::MinidumpGenerator(unsigned int, unsigned int)
-INLINE 0 101 21 200 59c4 4 59cd 3 59e4 214
-INLINE 1 219 22 201 59c4 4 59cd 3 59e4 214
-INLINE 2 220 22 202 59c4 4 59cd 3 5a3f 1b9
-INLINE 3 1538 9 203 59c4 4 59cd 3 5a3f 8b 5ad8 7
-INLINE 4 310 12 204 59c4 4 59cd 3 5a3f 8b 5ad8 7
-INLINE 5 311 12 205 59c4 4 59cd 3 5a3f 8b
+INLINE 0 101 22 200 59c4 4 59cd 3 59e4 214
+INLINE 1 219 21 201 59c4 4 59cd 3 59e4 214
+INLINE 2 220 21 202 59c4 4 59cd 3 5a3f 1b9
+INLINE 3 1538 8 203 59c4 4 59cd 3 5a3f 8b 5ad8 7
+INLINE 4 310 11 204 59c4 4 59cd 3 5a3f 8b 5ad8 7
+INLINE 5 311 11 205 59c4 4 59cd 3 5a3f 8b
 INLINE 6 1500 10 206 59c4 4 59cd 3 5a3f 8b
-INLINE 0 89 21 207 59c8 5 59e0 4 5c82 4
-INLINE 1 67 22 208 59c8 5 59e0 4 5c82 4
-INLINE 7 190 22 209 59cd 3 5a3f 8b
-INLINE 2 219 22 210 59e4 5b
-INLINE 3 496 9 211 59e4 5b
-INLINE 4 443 9 212 59e4 5b
+INLINE 0 89 22 207 59c8 5 59e0 4 5c82 4
+INLINE 1 67 21 208 59c8 5 59e0 4 5c82 4
+INLINE 7 190 21 209 59cd 3 5a3f 8b
+INLINE 2 219 21 210 59e4 5b
+INLINE 3 496 8 211 59e4 5b
+INLINE 4 443 8 212 59e4 5b
 INLINE 5 2427 10 213 59e4 5b
 INLINE 6 2427 10 214 59e4 5b
-INLINE 8 91 22 215 5a4e 3d
-INLINE 3 1539 9 216 5acd b 5adf 119
-INLINE 4 893 9 217 5adf 3 5aeb fb
-INLINE 4 894 9 218 5ae2 9 5be6 4
+INLINE 8 91 21 215 5a4e 3d
+INLINE 3 1539 8 216 5acd b 5adf 119
+INLINE 4 893 8 217 5adf 3 5aeb fb
+INLINE 4 894 8 218 5ae2 9 5be6 4
 INLINE 5 1630 10 219 5b06 12 5b1c 8 5b43 8c
 INLINE 6 1514 10 220 5b06 12 5b1c 8 5b43 8c
 INLINE 7 1668 10 221 5b06 12 5b1c 8 5b43 8c
-INLINE 4 895 9 218 5bea 7
-INLINE 4 896 9 218 5bf1 7
-INLINE 0 104 21 232 5c2f 3
-INLINE 0 111 21 222 5c55 2d
-INLINE 1 216 22 223 5c55 2d
-INLINE 2 216 22 224 5c55 2d
-INLINE 3 458 9 225 5c55 2d
-INLINE 4 452 9 226 5c5e 24
-INLINE 5 369 9 227 5c5e 24
-INLINE 6 425 9 228 5c6a 11
-INLINE 0 111 21 229 5c86 25 5cbb 8
-INLINE 1 70 22 230 5c86 25 5cbb 8
-INLINE 2 71 22 231 5c86 f 5c98 13
-5980 1a 101 21
-599a c 91 21
-59a6 10 93 21
-59b6 4 96 21
-59ba 3 97 21
-59bd 7 98 21
-59c4 4 190 22
-59c8 5 63 22
-59cd 3 90 22
-59d0 10 100 21
-59e0 4 63 22
+INLINE 4 895 8 218 5bea 7
+INLINE 4 896 8 218 5bf1 7
+INLINE 0 104 22 232 5c2f 3
+INLINE 0 111 22 222 5c55 2d
+INLINE 1 216 21 223 5c55 2d
+INLINE 2 216 21 224 5c55 2d
+INLINE 3 458 8 225 5c55 2d
+INLINE 4 452 8 226 5c5e 24
+INLINE 5 369 8 227 5c5e 24
+INLINE 6 425 8 228 5c6a 11
+INLINE 0 111 22 229 5c86 25 5cbb 8
+INLINE 1 70 21 230 5c86 25 5cbb 8
+INLINE 2 71 21 231 5c86 f 5c98 13
+5980 1a 101 22
+599a c 91 22
+59a6 10 93 22
+59b6 4 96 22
+59ba 3 97 22
+59bd 7 98 22
+59c4 4 190 21
+59c8 5 63 21
+59cd 3 90 21
+59d0 10 100 22
+59e0 4 63 21
 59e4 5b 2065 10
-5a3f f 90 22
-5a4e 24 119 22
-5a72 6 121 22
-5a78 7 131 22
-5a7f 4 132 22
-5a83 4 133 22
-5a87 4 135 22
-5a8b 5 92 22
-5a90 4 98 22
-5a94 17 96 22
-5aab 4 95 22
-5aaf 15 98 22
-5ac4 9 100 22
-5acd b 893 9
-5ad8 7 313 12
+5a3f f 90 21
+5a4e 24 119 21
+5a72 6 121 21
+5a78 7 131 21
+5a7f 4 132 21
+5a83 4 133 21
+5a87 4 135 21
+5a8b 5 92 21
+5a90 4 98 21
+5a94 17 96 21
+5aab 4 95 21
+5aaf 15 98 21
+5ac4 6 100 21
+5aca 3 100 21
+5acd b 893 8
+5ad8 7 313 11
 5adf 3 1628 10
 5ae2 9 3618 7
-5aeb 25 1630 10
+5aeb 1b 1630 10
+5b06 a 1630 10
 5b10 8 1752 10
 5b18 4 1630 10
 5b1c 8 1752 10
 5b24 4 1631 10
 5b28 a 1628 10
-5b32 1e 1630 10
+5b32 11 1630 10
+5b43 d 1630 10
 5b50 7f 1752 10
 5bcf 4 1630 10
 5bd3 13 1628 10
 5be6 4 3618 7
 5bea 7 3618 7
 5bf1 7 3618 7
-5bf8 c 102 21
-5c04 f 106 21
-5c13 1c 103 21
-5c2f 3 268 6
-5c32 3 104 21
-5c35 5 110 21
-5c3a c 111 21
-5c46 f 103 21
-5c55 9 450 9
-5c5e c 424 9
-5c6a 11 0 9
-5c7b 7 425 9
-5c82 4 64 22
-5c86 f 143 22
-5c95 3 71 22
-5c98 3 144 22
-5c9b 10 145 22
-5cab 10 111 21
-5cbb 8 71 22
+5bf8 c 102 22
+5c04 f 106 22
+5c13 1c 103 22
+5c2f 3 268 5
+5c32 3 104 22
+5c35 5 110 22
+5c3a c 111 22
+5c46 f 103 22
+5c55 9 450 8
+5c5e c 424 8
+5c6a 11 0 8
+5c7b 7 425 8
+5c82 4 64 21
+5c86 f 143 21
+5c95 3 71 21
+5c98 3 144 21
+5c9b 10 145 21
+5cab 10 111 22
+5cbb 8 71 21
 FUNC 5cd0 5 0 google_breakpad::MinidumpGenerator::MinidumpGenerator(unsigned int, unsigned int)
-5cd0 5 101 21
+5cd0 5 101 22
 FUNC 5ce0 94 0 google_breakpad::MinidumpGenerator::~MinidumpGenerator()
-INLINE 0 114 21 233 5cfb 8
-INLINE 0 115 21 222 5d0b 2d
-INLINE 1 216 22 223 5d0b 2d
-INLINE 2 216 22 224 5d0b 2d
-INLINE 3 458 9 225 5d0b 2d
-INLINE 4 452 9 226 5d14 24
-INLINE 5 369 9 227 5d14 24
-INLINE 6 425 9 228 5d20 11
-INLINE 0 115 21 229 5d38 23 5d6c 8
-INLINE 1 70 22 230 5d38 23 5d6c 8
-INLINE 2 71 22 231 5d38 d 5d48 13
-5ce0 12 113 21
-5cf2 9 114 21
-5cfb 8 243 6
-5d03 8 114 21
-5d0b 9 450 9
-5d14 c 424 9
-5d20 11 0 9
-5d31 7 425 9
-5d38 d 143 22
-5d45 3 71 22
-5d48 3 144 22
-5d4b 10 145 22
-5d5b 11 115 21
-5d6c 8 71 22
+INLINE 0 114 22 233 5cfb 8
+INLINE 0 115 22 222 5d0b 2d
+INLINE 1 216 21 223 5d0b 2d
+INLINE 2 216 21 224 5d0b 2d
+INLINE 3 458 8 225 5d0b 2d
+INLINE 4 452 8 226 5d14 24
+INLINE 5 369 8 227 5d14 24
+INLINE 6 425 8 228 5d20 11
+INLINE 0 115 22 229 5d38 23 5d6c 8
+INLINE 1 70 21 230 5d38 23 5d6c 8
+INLINE 2 71 21 231 5d38 d 5d48 13
+5ce0 12 113 22
+5cf2 9 114 22
+5cfb 8 243 5
+5d03 8 114 22
+5d0b 9 450 8
+5d14 c 424 8
+5d20 11 0 8
+5d31 7 425 8
+5d38 d 143 21
+5d45 3 71 21
+5d48 3 144 21
+5d4b 10 145 21
+5d5b 11 115 22
+5d6c 8 71 21
 FUNC 5d80 5 0 google_breakpad::MinidumpGenerator::~MinidumpGenerator()
-5d80 5 113 21
+5d80 5 113 22
 FUNC 5d90 12 0 google_breakpad::MinidumpGenerator::~MinidumpGenerator()
-INLINE 0 113 21 234 5d94 5
-5d90 4 113 21
-5d94 5 113 21
-5d99 9 113 21
+INLINE 0 113 22 234 5d94 5
+5d90 4 113 22
+5d94 5 113 22
+5d99 9 113 22
 FUNC 5db0 5 0 google_breakpad::MinidumpGenerator::SetTaskContext(__darwin_ucontext*)
-5db0 4 195 21
-5db4 1 196 21
+5db0 4 195 22
+5db4 1 196 22
 FUNC 5dc0 114 0 google_breakpad::MinidumpGenerator::UniqueNameInDirectory(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*)
-INLINE 0 209 21 188 5e15 18
+INLINE 0 209 22 188 5e15 18
 INLINE 1 1474 13 189 5e15 13
 INLINE 2 1460 13 190 5e15 b 5e4f 5 5e63 3
 INLINE 2 1460 13 71 5e20 2
-INLINE 0 214 21 235 5e4f 27
+INLINE 0 214 22 235 5e4f 27
 INLINE 1 2677 13 189 5e4f 5 5e63 3 5e68 6
 INLINE 1 2677 13 165 5e54 f 5e66 2
 INLINE 2 1633 13 166 5e54 f 5e66 2
 INLINE 3 1791 13 71 5e54 4 5e66 2
 INLINE 3 1791 13 167 5e58 5
-5dc0 16 199 21
-5dd6 a 200 21
-5de0 d 201 21
-5ded d 202 21
-5dfa 8 203 21
-5e02 8 204 21
-5e0a b 205 21
+5dc0 16 199 22
+5dd6 a 200 22
+5de0 d 201 22
+5ded d 202 22
+5dfa 8 203 22
+5e02 8 204 22
+5e0a b 205 22
 5e15 b 1749 13
 5e20 2 1697 13
 5e22 6 1460 13
 5e28 5 1474 13
-5e2d 10 210 21
-5e3d 12 211 21
+5e2d 10 210 22
+5e3d 12 211 22
 5e4f 5 1749 13
 5e54 4 1697 13
 5e58 5 1785 13
@@ -3196,29 +3272,29 @@ INLINE 3 1791 13 167 5e58 5
 5e66 2 1697 13
 5e68 6 1460 13
 5e6e 8 2677 13
-5e76 f 215 21
-5e85 5 217 21
-5e8a 12 218 21
-5e9c 38 221 21
+5e76 f 215 22
+5e85 5 217 22
+5e8a 12 218 22
+5e9c 38 221 22
 FUNC 5ee0 2b3 0 google_breakpad::MinidumpGenerator::Write(char const*)
-INLINE 0 242 21 236 5f08 3a
+INLINE 0 242 22 236 5f08 3a
 INLINE 1 212 2 237 5f08 3a
 INLINE 2 210 2 7 5f08 d 5f42 8
 INLINE 3 160 2 8 5f0d 4
-INLINE 0 243 21 238 5f42 23
+INLINE 0 243 22 238 5f42 23
 INLINE 1 212 2 239 5f42 23
-INLINE 0 245 21 240 5f65 17
-INLINE 0 256 21 241 5fa0 27
-INLINE 0 264 21 242 5ff1 4
-INLINE 0 272 21 243 6035 23 60ef 1f
-INLINE 0 274 21 244 6084 2b 611a 8 612c 5 613b 21 618b 8
+INLINE 0 245 22 240 5f65 17
+INLINE 0 256 22 241 5fa0 27
+INLINE 0 264 22 242 5ff1 4
+INLINE 0 272 22 243 6035 23 60ef 1f
+INLINE 0 274 22 244 6084 2b 611a 8 612c 5 613b 21 618b 8
 INLINE 1 214 2 245 6084 2b 611a 8 612c 5 613b 21 618b 8
 INLINE 2 217 2 246 6098 17 6145 17
-INLINE 0 274 21 247 60af 1f 6112 8 615c 2f
+INLINE 0 274 22 247 60af 1f 6112 8 615c 2f
 INLINE 1 214 2 248 60af 1f 6112 8 615c 2f
 INLINE 2 217 2 249 60b6 18 6163 18
-5ee0 14 223 21
-5ef4 14 241 21
+5ee0 14 223 22
+5ef4 14 241 22
 5f08 5 159 2
 5f0d 4 117 2
 5f11 4 160 2
@@ -3228,397 +3304,422 @@ INLINE 2 217 2 249 60b6 18 6163 18
 5f4a 1b 211 2
 5f65 8 46 1
 5f6d f 47 1
-5f7c d 245 21
-5f89 15 252 21
-5f9e 2 256 21
+5f7c d 245 22
+5f89 15 252 22
+5f9e 2 256 22
 5fa0 12 59 1
 5fb2 15 60 1
-5fc7 d 256 21
-5fd4 f 260 21
-5fe3 a 262 21
-5fed 4 263 21
+5fc7 d 256 22
+5fd4 f 260 22
+5fe3 a 262 22
+5fed 4 263 22
 5ff1 4 168 2
-5ff5 1b 264 21
-6010 20 269 21
-6030 5 271 21
+5ff5 1b 264 22
+6010 20 269 22
+6030 5 271 22
 6035 b 73 1
 6040 18 74 1
-6058 2c 268 21
+6058 2c 268 22
 6084 14 216 2
 6098 17 92 1
 60af 7 216 2
-60b6 21 92 1
-60d7 6 275 21
-60dd 12 276 21
-60ef 23 73 1
+60b6 18 92 1
+60ce 9 92 1
+60d7 6 275 22
+60dd 12 276 22
+60ef 1f 73 1
+610e 4 73 1
 6112 8 217 2
-611a 12 217 2
+611a 8 217 2
+6122 a 217 2
 612c 5 216 2
-6131 a 276 21
+6131 a 276 22
 613b a 216 2
 6145 17 92 1
 615c 7 216 2
-6163 20 92 1
+6163 18 92 1
+617b 8 92 1
 6183 8 217 2
 618b 8 217 2
 FUNC 61a0 246 0 google_breakpad::MinidumpGenerator::WriteThreadListStream(MDRawDirectory*)
-INLINE 0 990 21 250 61bb 5c
+INLINE 0 990 22 250 61bb 5c
 INLINE 1 212 2 251 61bb 5c
 INLINE 2 210 2 7 61bb c
 INLINE 3 160 2 8 61c0 3
-INLINE 0 1027 21 252 622d a 6337 1e 63aa 8 63b7 2f
+INLINE 0 1027 22 252 622d a 6337 1e 63aa 8 63b7 2f
 INLINE 1 214 2 253 622d a 6337 1e 63aa 8 63b7 2f
-INLINE 0 1003 21 254 6244 8 624f 23 6389 1f
-INLINE 0 1008 21 10 6281 f
-INLINE 0 1022 21 255 62f5 29 636a 1f
+INLINE 0 1003 22 254 6244 8 624f 23 6389 1f
+INLINE 0 1008 22 10 6281 f
+INLINE 0 1022 22 255 62f5 29 636a 1f
 INLINE 2 217 2 256 633d 18 63be 18
-61a0 17 989 21
-61b7 4 990 21
+61a0 17 989 22
+61b7 4 990 22
 61bb 5 159 2
 61c0 3 117 2
 61c3 4 160 2
 61c7 50 211 2
-6217 16 995 21
+6217 16 995 22
 622d a 216 2
-6237 4 1000 21
-623b 9 999 21
+6237 4 1000 22
+623b 9 999 22
 6244 8 66 1
-624c 3 1003 21
+624c 3 1003 22
 624f 8 67 1
 6257 16 68 1
 626d 5 67 1
-6272 8 1003 21
-627a 7 1007 21
+6272 8 1003 22
+627a 7 1007 22
 6281 4 177 2
 6285 4 175 2
 6289 7 177 2
-6290 4 1008 21
-6294 4 1010 21
-6298 11 1015 21
-62a9 2c 1016 21
-62d5 d 1018 21
-62e2 13 1019 21
+6290 4 1008 22
+6294 4 1010 22
+6298 11 1015 22
+62a9 2c 1016 22
+62d5 d 1018 22
+62e2 13 1019 22
 62f5 7 83 1
 62fc 5 84 1
 6301 9 86 1
 630a 3 85 1
 630d 4 86 1
 6311 d 84 1
-631e 3 1022 21
-6321 4 1015 21
-6325 3 1016 21
-6328 f 1015 21
+631e 3 1022 22
+6321 4 1015 22
+6325 3 1016 22
+6328 f 1015 22
 6337 6 216 2
 633d 18 92 1
-6355 15 1027 21
+6355 15 1027 22
 636a 1f 83 1
-6389 21 66 1
-63aa d 217 2
+6389 1f 66 1
+63a8 2 66 1
+63aa 8 217 2
+63b2 5 217 2
 63b7 7 216 2
-63be 20 92 1
+63be 18 92 1
+63d6 8 92 1
 63de 8 217 2
 FUNC 63f0 51f 0 google_breakpad::MinidumpGenerator::WriteMemoryListStream(MDRawDirectory*)
-INLINE 0 1031 21 257 641d 39
+INLINE 0 1031 22 257 641d 39
 INLINE 1 212 2 258 641d 39
 INLINE 2 210 2 7 641d d
 INLINE 3 160 2 8 6422 4
-INLINE 0 1043 21 259 646d ab
-INLINE 1 921 21 260 64bf 3
-INLINE 2 2591 5 261 64bf 3
-INLINE 3 2583 5 140 64bf 3
-INLINE 0 1044 21 262 6527 28 686b 1f
-INLINE 1 460 21 263 653e 9
-INLINE 1 462 21 264 6547 8
-INLINE 0 1067 21 138 65b6 3
-INLINE 1 2656 5 139 65b6 3
-INLINE 2 2648 5 140 65b6 3
-INLINE 0 1070 21 260 65c8 3
-INLINE 1 2591 5 261 65c8 3
-INLINE 2 2583 5 140 65c8 3
-INLINE 0 1080 21 265 65d4 2e 660e a
-INLINE 1 1590 9 266 65e4 11
+INLINE 0 1043 22 259 646d ab
+INLINE 1 921 22 260 64bf 3
+INLINE 2 2591 6 261 64bf 3
+INLINE 3 2583 6 140 64bf 3
+INLINE 0 1044 22 262 6527 28 686b 1f
+INLINE 1 460 22 263 653e 9
+INLINE 1 462 22 264 6547 8
+INLINE 0 1067 22 138 65b6 3
+INLINE 1 2656 6 139 65b6 3
+INLINE 2 2648 6 140 65b6 3
+INLINE 0 1070 22 260 65c8 3
+INLINE 1 2591 6 261 65c8 3
+INLINE 2 2583 6 140 65c8 3
+INLINE 0 1080 22 265 65d4 2e 660e a
+INLINE 1 1590 8 266 65e4 11
 INLINE 2 1514 10 267 65e4 11
 INLINE 3 1668 10 268 65e4 11
-INLINE 0 1086 21 269 661e 18
-INLINE 0 1087 21 270 6636 16 6847 1f
-INLINE 0 1092 21 10 665a f
-INLINE 0 1098 21 271 667e d 6693 17 6828 1f
-INLINE 0 1098 21 272 668b 8
-INLINE 0 1104 21 14 66c2 1f
+INLINE 0 1086 22 269 661e 18
+INLINE 0 1087 22 270 6636 16 6847 1f
+INLINE 0 1092 22 10 665a f
+INLINE 0 1098 22 271 667e d 6693 17 6828 1f
+INLINE 0 1098 22 272 668b 8
+INLINE 0 1104 22 14 66c2 1f
 INLINE 1 161 2 7 66c2 1f
 INLINE 2 160 2 8 66ca 4
-INLINE 0 1110 21 33 6705 14
-INLINE 1 485 9 34 6705 14
-INLINE 2 484 9 35 6705 14
-INLINE 0 1118 21 36 673a 5
-INLINE 0 1118 21 15 6746 14
-INLINE 0 1119 21 37 675a 1b 68b0 1d
-INLINE 1 458 9 38 675a 1b 68b0 1d
-INLINE 2 458 9 39 675a 1b 68b0 1d
-INLINE 3 452 9 40 6764 c 68ba c
-INLINE 4 369 9 41 6764 c 68ba c
-INLINE 3 453 9 42 6770 5 68c6 7
+INLINE 0 1110 22 33 6705 14
+INLINE 1 485 8 34 6705 14
+INLINE 2 484 8 35 6705 14
+INLINE 0 1118 22 36 673a 5
+INLINE 0 1118 22 15 6746 14
+INLINE 0 1119 22 37 675a 1b 68b0 1d
+INLINE 1 458 8 38 675a 1b 68b0 1d
+INLINE 2 458 8 39 675a 1b 68b0 1d
+INLINE 3 452 8 40 6764 c 68ba c
+INLINE 4 369 8 41 6764 c 68ba c
+INLINE 3 453 8 42 6770 5 68c6 7
 INLINE 4 1508 10 43 6770 5 68c6 7
 INLINE 5 1743 10 44 6770 5 68c6 7
-INLINE 0 1133 21 273 677c 1f 68d3 8 68e0 2f
+INLINE 0 1133 22 273 677c 1f 68d3 8 68e0 2f
 INLINE 1 214 2 274 677c 1f 68d3 8 68e0 2f
 INLINE 2 217 2 275 6783 18 68e7 18
-INLINE 0 1121 21 15 67d0 14
-INLINE 0 1126 21 10 67e4 15
-INLINE 0 1128 21 271 67fe 2a 688a 1f
-63f0 29 1030 21
-6419 4 1031 21
+INLINE 0 1121 22 15 67d0 14
+INLINE 0 1126 22 10 67e4 15
+INLINE 0 1128 22 271 67fe 2a 688a 1f
+63f0 29 1030 22
+6419 4 1031 22
 641d 5 159 2
 6422 4 117 2
 6426 4 160 2
 642a 2c 211 2
-6456 4 1043 21
-645a b 1038 21
-6465 8 1040 21
-646d 10 896 21
-647d 4 918 21
-6481 f 897 21
-6490 12 918 21
-64a2 4 921 21
-64a6 a 918 21
-64b0 3 921 21
-64b3 c 922 21
-64bf 3 702 5
-64c2 4 921 21
-64c6 b 923 21
-64d1 5 922 21
-64d6 14 923 21
-64ea 1a 931 21
-6504 14 961 21
-6518 f 1043 21
-6527 17 443 21
-653e 9 794 21
-6547 8 802 21
-654f 5 1048 21
-6554 8 1050 21
-655c 8 1052 21
-6564 22 1057 21
-6586 c 1063 21
-6592 5 1071 21
-6597 17 1063 21
-65ae 4 1068 21
-65b2 4 1070 21
-65b6 3 702 5
-65b9 7 1067 21
-65c0 5 1066 21
-65c5 3 1072 21
-65c8 3 702 5
-65cb 5 1072 21
-65d0 4 1074 21
-65d4 10 1587 9
+6456 4 1043 22
+645a b 1038 22
+6465 8 1040 22
+646d 10 896 22
+647d 4 918 22
+6481 f 897 22
+6490 12 918 22
+64a2 4 921 22
+64a6 a 918 22
+64b0 3 921 22
+64b3 c 922 22
+64bf 3 702 6
+64c2 4 921 22
+64c6 b 923 22
+64d1 5 922 22
+64d6 14 923 22
+64ea 1a 931 22
+6504 14 961 22
+6518 f 1043 22
+6527 17 443 22
+653e 9 794 22
+6547 8 802 22
+654f 5 1048 22
+6554 8 1050 22
+655c 8 1052 22
+6564 22 1057 22
+6586 c 1063 22
+6592 5 1071 22
+6597 17 1063 22
+65ae 4 1068 22
+65b2 4 1070 22
+65b6 3 702 6
+65b9 7 1067 22
+65c0 5 1066 22
+65c5 3 1072 22
+65c8 3 702 6
+65cb 5 1072 22
+65d0 4 1074 22
+65d4 10 1587 8
 65e4 11 1752 10
-65f5 12 1593 9
-6607 7 1080 21
-660e 10 1596 9
-661e 18 642 9
+65f5 d 1593 8
+6602 5 1593 8
+6607 7 1080 22
+660e a 1596 8
+6618 6 1596 8
+661e 18 642 8
 6636 8 67 1
 663e e 68 1
-664c 8 1087 21
-6654 6 1091 21
+664c 8 1087 22
+6654 6 1091 22
 665a 4 177 2
 665e 4 175 2
 6662 7 177 2
-6669 4 1092 21
-666d 13 1094 21
+6669 4 1092 22
+666d 11 1094 22
+667e 2 1094 22
 6680 b 83 1
-668b 8 1501 9
+668b 8 1501 8
 6693 5 84 1
 6698 4 85 1
 669c e 84 1
-66aa f 1097 21
-66b9 9 1102 21
+66aa f 1097 22
+66b9 9 1102 22
 66c2 8 159 2
 66ca 4 117 2
 66ce 7 160 2
 66d5 c 161 2
-66e1 19 1105 21
-66fa b 1108 21
-6705 14 433 9
-6719 4 1111 21
-671d 5 1112 21
-6722 4 1113 21
-6726 10 1111 21
-6736 4 1114 21
-673a 5 1501 9
-673f 7 1118 21
+66e1 19 1105 22
+66fa b 1108 22
+6705 14 433 8
+6719 4 1111 22
+671d 5 1112 22
+6722 4 1113 22
+6726 10 1111 22
+6736 4 1114 22
+673a 5 1501 8
+673f 7 1118 22
 6746 14 186 2
-675a 5 453 9
-675f 5 450 9
-6764 7 424 9
-676b 5 425 9
-6770 c 177 11
+675a 5 453 8
+675f 5 450 8
+6764 7 424 8
+676b 5 425 8
+6770 5 177 9
+6775 7 177 9
 677c 7 216 2
-6783 30 92 1
-67b3 14 1133 21
-67c7 5 1122 21
-67cc 4 1123 21
+6783 18 92 1
+679b 18 92 1
+67b3 14 1133 22
+67c7 5 1122 22
+67cc 4 1123 22
 67d0 14 186 2
 67e4 7 177 2
 67eb 7 175 2
 67f2 7 177 2
-67f9 5 1126 21
+67f9 5 1126 22
 67fe b 83 1
 6809 1f 84 1
 6828 1f 83 1
-6847 24 66 1
-686b 1f 465 21
-688a 26 83 1
-68b0 5 453 9
-68b5 5 450 9
-68ba 7 424 9
-68c1 5 425 9
-68c6 d 177 11
-68d3 d 217 2
+6847 1f 66 1
+6866 5 66 1
+686b 1f 465 22
+688a 1f 83 1
+68a9 7 83 1
+68b0 5 453 8
+68b5 5 450 8
+68ba 7 424 8
+68c1 5 425 8
+68c6 7 177 9
+68cd 6 177 9
+68d3 8 217 2
+68db 5 217 2
 68e0 7 216 2
-68e7 20 92 1
+68e7 18 92 1
+68ff 8 92 1
 6907 8 217 2
 FUNC 6910 25d 0 google_breakpad::MinidumpGenerator::WriteSystemInfoStream(MDRawDirectory*)
-INLINE 0 1172 21 276 6935 54
+INLINE 0 1172 22 276 6935 54
 INLINE 1 212 2 277 6935 54
 INLINE 2 210 2 7 6935 c
 INLINE 3 160 2 8 693a 3
-INLINE 0 1174 21 278 6989 17
-INLINE 0 1178 21 10 69af f
-INLINE 0 1292 21 279 6aeb 1f 6b2f 8 6b3e 2f
+INLINE 0 1174 22 278 6989 17
+INLINE 0 1178 22 10 69af f
+INLINE 0 1292 22 279 6aeb 1f 6b2f 8 6b3e 2f
 INLINE 1 214 2 280 6aeb 1f 6b2f 8 6b3e 2f
 INLINE 2 217 2 281 6af2 18 6b45 18
-6910 21 1171 21
-6931 4 1172 21
+6910 21 1171 22
+6931 4 1172 22
 6935 5 159 2
 693a 3 117 2
 693d 4 160 2
 6941 48 211 2
 6989 8 46 1
 6991 f 47 1
-69a0 8 1174 21
-69a8 7 1177 21
+69a0 8 1174 22
+69a8 7 1177 22
 69af 4 177 2
 69b3 4 175 2
 69b7 7 177 2
-69be 4 1178 21
-69c2 9 1182 21
-69cb 1b 1183 21
-69e6 3 1206 21
-69e9 14 1186 21
-69fd 2 1237 21
-69ff 3 1206 21
-6a02 d 1207 21
-6a0f 10 1237 21
-6a1f f 1241 21
-6a2e 5 1246 21
-6a33 5 1260 21
-6a38 5 1245 21
-6a3d 5 1249 21
-6a42 b 1250 21
-6a4d 2 1249 21
-6a4f 5 1248 21
-6a54 10 1253 21
-6a64 b 1256 21
-6a6f 7 1255 21
-6a76 8 1260 21
-6a7e 6 1262 21
-6a84 a 1261 21
-6a8e 7 1269 21
-6a95 8 1273 21
-6a9d 8 1277 21
-6aa5 1a 1282 21
-6abf 8 1286 21
-6ac7 a 1287 21
-6ad1 a 1288 21
-6adb 10 1289 21
+69be 4 1178 22
+69c2 9 1182 22
+69cb 1b 1183 22
+69e6 3 1206 22
+69e9 14 1186 22
+69fd 2 1237 22
+69ff 3 1206 22
+6a02 d 1207 22
+6a0f 10 1237 22
+6a1f f 1241 22
+6a2e 5 1246 22
+6a33 5 1260 22
+6a38 5 1245 22
+6a3d 5 1249 22
+6a42 b 1250 22
+6a4d 2 1249 22
+6a4f 5 1248 22
+6a54 10 1253 22
+6a64 b 1256 22
+6a6f 7 1255 22
+6a76 8 1260 22
+6a7e 6 1262 22
+6a84 a 1261 22
+6a8e 7 1269 22
+6a95 8 1273 22
+6a9d 8 1277 22
+6aa5 1a 1282 22
+6abf 8 1286 22
+6ac7 a 1287 22
+6ad1 a 1288 22
+6adb 10 1289 22
 6aeb 7 216 2
-6af2 29 92 1
-6b1b 14 1292 21
-6b2f f 217 2
+6af2 18 92 1
+6b0a 11 92 1
+6b1b 14 1292 22
+6b2f 8 217 2
+6b37 7 217 2
 6b3e 7 216 2
-6b45 20 92 1
+6b45 18 92 1
+6b5d 8 92 1
 6b65 8 217 2
 FUNC 6b70 28d 0 google_breakpad::MinidumpGenerator::WriteModuleListStream(MDRawDirectory*)
-INLINE 0 1491 21 282 6b8b 20
+INLINE 0 1491 22 282 6b8b 20
 INLINE 1 212 2 283 6b8b 20
 INLINE 2 210 2 7 6b8b 11
 INLINE 3 160 2 8 6b90 3
-INLINE 0 1494 21 133 6bb4 e
-INLINE 1 250 6 48 6bb4 e
-INLINE 0 1497 21 284 6bca 9 6bd6 1d 6d76 1f
-INLINE 0 1501 21 10 6c02 f
-INLINE 0 1506 21 285 6c1a 4c
-INLINE 0 1512 21 286 6c86 2c 6d95 1f
-INLINE 0 1521 21 286 6ce8 28 6d57 1f
-INLINE 0 1526 21 287 6d21 22 6db8 8 6dcb 32
+INLINE 0 1494 22 133 6bb4 e
+INLINE 1 250 5 48 6bb4 e
+INLINE 0 1497 22 284 6bca 9 6bd6 1d 6d76 1f
+INLINE 0 1501 22 10 6c02 f
+INLINE 0 1506 22 285 6c1a 4c
+INLINE 0 1512 22 286 6c86 2c 6d95 1f
+INLINE 0 1521 22 286 6ce8 28 6d57 1f
+INLINE 0 1526 22 287 6d21 22 6db8 8 6dcb 32
 INLINE 1 214 2 288 6d21 22 6db8 8 6dcb 32
 INLINE 2 217 2 289 6d2b 18 6dd5 18
-6b70 17 1490 21
-6b87 4 1491 21
+6b70 17 1490 22
+6b87 4 1491 22
 6b8b 5 159 2
 6b90 3 117 2
 6b93 4 160 2
 6b97 5 161 2
 6b9c f 211 2
-6bab 9 1493 21
-6bb4 e 642 9
-6bc2 8 1495 21
+6bab 9 1493 22
+6bb4 e 642 8
+6bc2 8 1495 22
 6bca 9 66 1
-6bd3 3 1497 21
+6bd3 3 1497 22
 6bd6 b 67 1
 6be1 12 68 1
-6bf3 8 1497 21
-6bfb 7 1500 21
+6bf3 8 1497 22
+6bfb 7 1500 22
 6c02 4 177 2
 6c06 4 175 2
 6c0a 7 177 2
-6c11 4 1501 21
-6c15 5 1502 21
-6c1a e 1400 21
-6c28 8 1401 21
-6c30 7 1404 21
-6c37 7 1407 21
-6c3e 12 1410 21
-6c50 8 1411 21
-6c58 6 1413 21
-6c5e b 1410 21
-6c69 1d 1508 21
+6c11 4 1501 22
+6c15 5 1502 22
+6c1a e 1400 22
+6c28 8 1401 22
+6c30 7 1404 22
+6c37 7 1407 22
+6c3e 12 1410 22
+6c50 8 1411 22
+6c58 6 1413 22
+6c5e 8 1410 22
+6c66 3 1410 22
+6c69 1d 1508 22
 6c86 e 83 1
 6c94 5 84 1
 6c99 4 85 1
 6c9d 3 86 1
-6ca0 30 84 1
-6cd0 5 1516 21
-6cd5 13 1517 21
+6ca0 12 84 1
+6cb2 1e 84 1
+6cd0 5 1516 22
+6cd5 13 1517 22
 6ce8 a 83 1
 6cf2 5 84 1
 6cf7 4 85 1
 6cfb 8 86 1
 6d03 d 84 1
-6d10 3 1521 21
-6d13 e 1515 21
+6d10 3 1521 22
+6d13 e 1515 22
 6d21 a 216 2
 6d2b 18 92 1
-6d43 14 1526 21
+6d43 14 1526 22
 6d57 1f 83 1
 6d76 1f 66 1
-6d95 23 83 1
-6db8 13 217 2
+6d95 1f 83 1
+6db4 4 83 1
+6db8 8 217 2
+6dc0 b 217 2
 6dcb a 216 2
-6dd5 20 92 1
+6dd5 18 92 1
+6ded 8 92 1
 6df5 8 217 2
 FUNC 6e00 259 0 google_breakpad::MinidumpGenerator::WriteMiscInfoStream(MDRawDirectory*)
-INLINE 0 1529 21 290 6e21 24
+INLINE 0 1529 22 290 6e21 24
 INLINE 1 212 2 291 6e21 24
 INLINE 2 210 2 7 6e21 1a
 INLINE 3 160 2 8 6e29 3
-INLINE 0 1531 21 292 6e45 1d
-INLINE 0 1535 21 10 6e70 15
-INLINE 0 1577 21 293 6fbc 2b 700b 8 701e 3b
+INLINE 0 1531 22 292 6e45 1d
+INLINE 0 1535 22 10 6e70 15
+INLINE 0 1577 22 293 6fbc 2b 700b 8 701e 3b
 INLINE 1 214 2 294 6fbc 2b 700b 8 701e 3b
 INLINE 2 217 2 295 6fc6 21 7028 21
-6e00 1d 1528 21
-6e1d 4 1529 21
+6e00 1d 1528 22
+6e1d 4 1529 22
 6e21 8 159 2
 6e29 3 117 2
 6e2c 7 160 2
@@ -3626,185 +3727,195 @@ INLINE 2 217 2 295 6fc6 21 7028 21
 6e3b a 211 2
 6e45 b 46 1
 6e50 12 47 1
-6e62 8 1531 21
-6e6a 6 1534 21
+6e62 8 1531 22
+6e6a 6 1534 22
 6e70 7 177 2
 6e77 7 175 2
 6e7e 7 177 2
-6e85 4 1535 21
-6e89 12 1538 21
-6e9b c 1544 21
-6ea7 11 1548 21
-6eb8 4 1551 21
-6ebc 7 1550 21
-6ec3 4 1553 21
-6ec7 7 1552 21
-6ece 1d 1555 21
-6eeb 7 1556 21
-6ef2 7 1555 21
-6ef9 8 1559 21
-6f01 28 1560 21
-6f29 7 1562 21
-6f30 7 1561 21
-6f37 8 1568 21
-6f3f 1a 1569 21
-6f59 1a 1570 21
-6f73 7 1571 21
-6f7a 8 1572 21
-6f82 1a 1573 21
-6f9c 20 1574 21
+6e85 4 1535 22
+6e89 12 1538 22
+6e9b c 1544 22
+6ea7 11 1548 22
+6eb8 4 1551 22
+6ebc 7 1550 22
+6ec3 4 1553 22
+6ec7 7 1552 22
+6ece 1d 1555 22
+6eeb 7 1556 22
+6ef2 7 1555 22
+6ef9 8 1559 22
+6f01 28 1560 22
+6f29 7 1562 22
+6f30 7 1561 22
+6f37 8 1568 22
+6f3f 1a 1569 22
+6f59 1a 1570 22
+6f73 7 1571 22
+6f7a 8 1572 22
+6f82 1a 1573 22
+6f9c 20 1574 22
 6fbc a 216 2
-6fc6 35 92 1
-6ffb 10 1577 21
-700b 13 217 2
+6fc6 21 92 1
+6fe7 14 92 1
+6ffb 10 1577 22
+700b 8 217 2
+7013 b 217 2
 701e a 216 2
-7028 29 92 1
+7028 21 92 1
+7049 8 92 1
 7051 8 217 2
 FUNC 7060 10b 0 google_breakpad::MinidumpGenerator::WriteBreakpadInfoStream(MDRawDirectory*)
-INLINE 0 1581 21 296 7071 26
+INLINE 0 1581 22 296 7071 26
 INLINE 1 212 2 297 7071 26
 INLINE 2 210 2 7 7071 b
 INLINE 3 160 2 8 7075 3
-INLINE 0 1583 21 298 7097 16
-INLINE 0 1587 21 10 70b8 f
-INLINE 0 1602 21 299 710a 1e 7132 8 713d 2e
+INLINE 0 1583 22 298 7097 16
+INLINE 0 1587 22 10 70b8 f
+INLINE 0 1602 22 299 710a 1e 7132 8 713d 2e
 INLINE 1 214 2 300 710a 1e 7132 8 713d 2e
 INLINE 2 217 2 301 7111 17 7144 17
-7060 d 1580 21
-706d 4 1581 21
+7060 d 1580 22
+706d 4 1581 22
 7071 4 159 2
 7075 3 117 2
 7078 4 160 2
 707c 1b 211 2
 7097 8 46 1
 709f e 47 1
-70ad 4 1583 21
-70b1 7 1586 21
+70ad 4 1583 22
+70b1 7 1586 22
 70b8 4 177 2
 70bc 4 175 2
 70c0 7 177 2
-70c7 4 1587 21
-70cb 3 1594 21
-70ce a 1590 21
-70d8 8 1591 21
-70e0 7 1593 21
-70e7 a 1594 21
-70f1 8 1596 21
-70f9 7 1597 21
-7100 a 1598 21
+70c7 4 1587 22
+70cb 3 1594 22
+70ce a 1590 22
+70d8 8 1591 22
+70e0 7 1593 22
+70e7 a 1594 22
+70f1 8 1596 22
+70f9 7 1597 22
+7100 a 1598 22
 710a 7 216 2
 7111 17 92 1
-7128 a 1602 21
-7132 b 217 2
+7128 a 1602 22
+7132 8 217 2
+713a 3 217 2
 713d 7 216 2
-7144 1f 92 1
+7144 17 92 1
+715b 8 92 1
 7163 8 217 2
 FUNC 7170 113 0 google_breakpad::MinidumpGenerator::CalculateStackSize(unsigned long long)
-7170 14 278 21
-7184 5 279 21
-7189 8 281 21
-7191 8 283 21
-7199 9 288 21
-71a2 25 293 21
-71c7 16 297 21
-71dd b 311 21
-71e8 18 314 21
-7200 f 329 21
-720f d 313 21
-721c 8 317 21
-7224 8 318 21
-722c 1b 319 21
-7247 12 322 21
-7259 7 325 21
-7260 14 333 21
-7274 f 334 21
+7170 14 278 22
+7184 5 279 22
+7189 8 281 22
+7191 8 283 22
+7199 9 288 22
+71a2 25 293 22
+71c7 16 297 22
+71dd b 311 22
+71e8 18 314 22
+7200 f 329 22
+720f d 313 22
+721c 8 317 22
+7224 8 318 22
+722c 1b 319 22
+7247 12 322 22
+7259 7 325 22
+7260 14 333 22
+7274 f 334 22
 FUNC 7290 176 0 google_breakpad::MinidumpGenerator::WriteStackFromStartAddress(unsigned long long, MDMemoryDescriptor*)
-INLINE 0 339 21 14 72a9 15
+INLINE 0 339 22 14 72a9 15
 INLINE 1 161 2 7 72a9 15
 INLINE 2 160 2 8 72ae 3
-INLINE 0 365 21 33 72ef 11
-INLINE 1 485 9 34 72ef 11
-INLINE 2 484 9 35 72ef 11
-INLINE 0 373 21 36 731f 5
-INLINE 0 373 21 15 7324 14
-INLINE 0 374 21 37 733b 1b 73e3 1b
-INLINE 1 458 9 38 733b 1b 73e3 1b
-INLINE 2 458 9 39 733b 1b 73e3 1b
-INLINE 3 452 9 40 7345 c 73ed c
-INLINE 4 369 9 41 7345 c 73ed c
-INLINE 3 453 9 42 7351 5 73f9 5
+INLINE 0 365 22 33 72ef 11
+INLINE 1 485 8 34 72ef 11
+INLINE 2 484 8 35 72ef 11
+INLINE 0 373 22 36 731f 5
+INLINE 0 373 22 15 7324 14
+INLINE 0 374 22 37 733b 1b 73e3 1b
+INLINE 1 458 8 38 733b 1b 73e3 1b
+INLINE 2 458 8 39 733b 1b 73e3 1b
+INLINE 3 452 8 40 7345 c 73ed c
+INLINE 4 369 8 41 7345 c 73ed c
+INLINE 3 453 8 42 7351 5 73f9 5
 INLINE 4 1508 10 43 7351 5 73f9 5
 INLINE 5 1743 10 44 7351 5 73f9 5
-INLINE 0 358 21 15 7379 23
-INLINE 0 375 21 15 73a0 17
-INLINE 0 380 21 10 73ba f
-7290 15 338 21
-72a5 4 339 21
+INLINE 0 358 22 15 7379 23
+INLINE 0 375 22 15 73a0 17
+INLINE 0 380 22 10 73ba f
+7290 15 338 22
+72a5 4 339 22
 72a9 5 159 2
 72ae 3 117 2
 72b1 4 160 2
 72b5 9 161 2
-72be d 342 21
-72cb 9 344 21
-72d4 10 361 21
-72e4 b 364 21
-72ef 11 433 9
-7300 16 366 21
-7316 9 369 21
-731f 5 1501 9
-7324 17 186 2
-733b 5 453 9
-7340 5 450 9
-7345 7 424 9
-734c 5 425 9
-7351 e 177 11
-735f e 350 21
-736d c 355 21
-7379 27 186 2
+72be d 342 22
+72cb 9 344 22
+72d4 10 361 22
+72e4 b 364 22
+72ef 11 433 8
+7300 16 366 22
+7316 9 369 22
+731f 5 1501 8
+7324 14 186 2
+7338 3 186 2
+733b 5 453 8
+7340 5 450 8
+7345 7 424 8
+734c 5 425 8
+7351 5 177 9
+7356 9 177 9
+735f e 350 22
+736d c 355 22
+7379 23 186 2
+739c 4 186 2
 73a0 17 186 2
-73b7 3 379 21
+73b7 3 379 22
 73ba 4 177 2
 73be 4 175 2
 73c2 7 177 2
-73c9 4 380 21
-73cd 6 382 21
-73d3 10 383 21
-73e3 5 453 9
-73e8 5 450 9
-73ed 7 424 9
-73f4 5 425 9
-73f9 d 177 11
+73c9 4 380 22
+73cd 6 382 22
+73d3 10 383 22
+73e3 5 453 8
+73e8 5 450 8
+73ed 7 424 8
+73f4 5 425 8
+73f9 5 177 9
+73fe 8 177 9
 FUNC 7410 24 0 google_breakpad::MinidumpGenerator::WriteStack(unsigned int*, MDMemoryDescriptor*)
-INLINE 0 404 21 302 7420 5
-INLINE 0 406 21 303 7425 b
-7410 10 387 21
-7420 5 775 21
-7425 4 785 21
-7429 9 786 21
-7432 2 411 21
+INLINE 0 404 22 302 7420 5
+INLINE 0 406 22 303 7425 b
+7410 10 387 22
+7420 5 775 22
+7425 4 785 22
+7429 7 786 22
+7430 2 786 22
+7432 2 411 22
 FUNC 7440 8 0 google_breakpad::MinidumpGenerator::WriteStackX86(unsigned int*, MDMemoryDescriptor*)
-7440 3 775 21
-7443 5 776 21
+7440 3 775 22
+7443 5 776 22
 FUNC 7450 9 0 google_breakpad::MinidumpGenerator::WriteStackX86_64(unsigned int*, MDMemoryDescriptor*)
-7450 4 785 21
-7454 5 786 21
+7450 4 785 22
+7454 5 786 22
 FUNC 7460 22 0 google_breakpad::MinidumpGenerator::WriteContext(unsigned int*, MDLocationDescriptor*)
-7460 10 415 21
-7470 7 432 21
-7477 9 434 21
-7480 2 439 21
+7460 10 415 22
+7470 7 432 22
+7477 9 434 22
+7480 2 439 22
 FUNC 7490 1a7 0 google_breakpad::MinidumpGenerator::WriteContextX86(unsigned int*, MDLocationDescriptor*)
-INLINE 0 808 21 304 74b6 1b
+INLINE 0 808 22 304 74b6 1b
 INLINE 1 212 2 305 74b6 1b
 INLINE 2 210 2 7 74b6 11
 INLINE 3 160 2 8 74bb 3
-INLINE 0 812 21 306 74d1 1a
-INLINE 0 815 21 10 74f3 f
-INLINE 0 843 21 307 75b2 22 75fa 8 7605 32
+INLINE 0 812 22 306 74d1 1a
+INLINE 0 815 22 10 74f3 f
+INLINE 0 843 22 307 75b2 22 75fa 8 7605 32
 INLINE 1 214 2 308 75b2 22 75fa 8 7605 32
 INLINE 2 217 2 309 75bc 18 760f 18
-7490 22 807 21
-74b2 4 808 21
+7490 22 807 22
+74b2 4 808 22
 74b6 5 159 2
 74bb 3 117 2
 74be 4 160 2
@@ -3812,47 +3923,50 @@ INLINE 2 217 2 309 75bc 18 760f 18
 74c7 a 211 2
 74d1 b 46 1
 74dc f 47 1
-74eb 8 812 21
+74eb 8 812 22
 74f3 4 177 2
 74f7 4 175 2
 74fb 7 177 2
-7502 3 815 21
-7505 8 821 21
-750d 9 822 21
-7516 a 823 21
-7520 a 824 21
-752a a 825 21
-7534 a 826 21
-753e a 827 21
-7548 a 828 21
-7552 a 829 21
-755c a 831 21
-7566 a 832 21
-7570 a 833 21
-757a a 834 21
-7584 a 835 21
-758e a 836 21
-7598 a 837 21
-75a2 10 839 21
+7502 3 815 22
+7505 8 821 22
+750d 9 822 22
+7516 a 823 22
+7520 a 824 22
+752a a 825 22
+7534 a 826 22
+753e a 827 22
+7548 a 828 22
+7552 a 829 22
+755c a 831 22
+7566 a 832 22
+7570 a 833 22
+757a a 834 22
+7584 a 835 22
+758e a 836 22
+7598 a 837 22
+75a2 10 839 22
 75b2 a 216 2
-75bc 2c 92 1
-75e8 12 843 21
-75fa b 217 2
+75bc 18 92 1
+75d4 14 92 1
+75e8 12 843 22
+75fa 8 217 2
+7602 3 217 2
 7605 a 216 2
-760f 20 92 1
+760f 18 92 1
+7627 8 92 1
 762f 8 217 2
 FUNC 7640 1c1 0 google_breakpad::MinidumpGenerator::WriteContextX86_64(unsigned int*, MDLocationDescriptor*)
-INLINE 0 848 21 310 7666 1a
+INLINE 0 848 22 310 7666 1a
 INLINE 1 212 2 311 7666 1a
 INLINE 2 210 2 7 7666 10
 INLINE 3 160 2 8 766a 3
-INLINE 0 852 21 312 7680 19
-INLINE 0 855 21 10 76a1 f
-INLINE 0 890 21 313 777e 21 77c5 8 77d0 31
+INLINE 0 852 22 312 7680 19
+INLINE 0 855 22 10 76a1 f
+INLINE 0 890 22 313 777e 21 77c5 8 77d0 31
 INLINE 1 214 2 314 777e 21 77c5 8 77d0 31
 INLINE 2 217 2 315 7788 17 77da 17
-7640 22 847 21
-7662 4 848 21
+7640 22 847 22
+7662 4 848 22
 7666 4 159 2
 766a 3 117 2
 766d 4 160 2
@@ -3860,134 +3974,137 @@ INLINE 2 217 2 315 7788 17 77da 17
 7676 a 211 2
 7680 b 46 1
 768b e 47 1
-7699 8 852 21
+7699 8 852 22
 76a1 4 177 2
 76a5 4 175 2
 76a9 7 177 2
-76b0 3 855 21
-76b3 8 861 21
-76bb b 862 21
-76c6 c 863 21
-76d2 c 864 21
-76de c 866 21
-76ea c 867 21
-76f6 c 868 21
-7702 c 869 21
-770e c 870 21
-771a c 872 21
-7726 c 874 21
-7732 c 876 21
-773e c 877 21
-774a a 883 21
-7754 c 884 21
-7760 c 885 21
-776c 12 886 21
+76b0 3 855 22
+76b3 8 861 22
+76bb b 862 22
+76c6 c 863 22
+76d2 c 864 22
+76de c 866 22
+76ea c 867 22
+76f6 c 868 22
+7702 c 869 22
+770e c 870 22
+771a c 872 22
+7726 c 874 22
+7732 c 876 22
+773e c 877 22
+774a a 883 22
+7754 c 884 22
+7760 c 885 22
+776c 12 886 22
 777e a 216 2
-7788 2b 92 1
-77b3 12 890 21
-77c5 b 217 2
+7788 17 92 1
+779f 14 92 1
+77b3 12 890 22
+77c5 8 217 2
+77cd 3 217 2
 77d0 a 216 2
-77da 1f 92 1
+77da 17 92 1
+77f1 8 92 1
 77f9 8 217 2
 FUNC 7810 3d 0 google_breakpad::MinidumpGenerator::CurrentPCForStack(unsigned int*)
-INLINE 0 460 21 263 7820 3
-INLINE 0 462 21 264 7825 7
-7810 10 443 21
-7820 3 794 21
-7823 2 468 21
-7825 7 802 21
-782c 2 468 21
-782e 1f 465 21
+INLINE 0 460 22 263 7820 3
+INLINE 0 462 22 264 7825 7
+7810 10 443 22
+7820 3 794 22
+7823 2 468 22
+7825 7 802 22
+782c 2 468 22
+782e 1f 465 22
 FUNC 7850 4 0 google_breakpad::MinidumpGenerator::CurrentPCForStackX86(unsigned int*)
-7850 4 794 21
+7850 4 794 22
 FUNC 7860 8 0 google_breakpad::MinidumpGenerator::CurrentPCForStackX86_64(unsigned int*)
-7860 8 802 21
+7860 8 802 22
 FUNC 7870 b5 0 google_breakpad::MinidumpGenerator::GetThreadState(unsigned int, unsigned int*, unsigned int*)
-INLINE 0 921 21 260 78d2 3
-INLINE 1 2591 5 261 78d2 3
-INLINE 2 2583 5 140 78d2 3
-7870 12 895 21
-7882 10 896 21
-7892 3 918 21
-7895 10 897 21
-78a5 11 918 21
-78b6 3 921 21
-78b9 a 918 21
-78c3 3 921 21
-78c6 c 922 21
-78d2 3 702 5
-78d5 4 921 21
-78d9 3 923 21
-78dc 8 922 21
-78e4 7 923 21
-78eb 19 931 21
-7904 d 961 21
-7911 9 962 21
-791a b 963 21
+INLINE 0 921 22 260 78d2 3
+INLINE 1 2591 6 261 78d2 3
+INLINE 2 2583 6 140 78d2 3
+7870 12 895 22
+7882 10 896 22
+7892 3 918 22
+7895 10 897 22
+78a5 11 918 22
+78b6 3 921 22
+78b9 a 918 22
+78c3 3 921 22
+78c6 c 922 22
+78d2 3 702 6
+78d5 4 921 22
+78d9 3 923 22
+78dc 8 922 22
+78e4 7 923 22
+78eb 19 931 22
+7904 d 961 22
+7911 9 962 22
+791a b 963 22
 FUNC 7930 1a6 0 google_breakpad::MinidumpGenerator::WriteThreadStream(unsigned int, MDRawThread*)
-INLINE 0 971 21 259 7964 92 79fe 4
-INLINE 0 972 21 316 7a02 4 7a0a 27
-INLINE 1 406 21 303 7a1b 7 7a26 b
-INLINE 1 404 21 302 7a22 4
-INLINE 0 975 21 265 7a35 29 7a62 8
-INLINE 1 1590 9 266 7a45 f
+INLINE 0 971 22 259 7964 92 79fe 4
+INLINE 0 972 22 316 7a02 4 7a0a 27
+INLINE 1 406 22 303 7a1b 7 7a26 b
+INLINE 1 404 22 302 7a22 4
+INLINE 0 975 22 265 7a35 29 7a62 8
+INLINE 1 1590 8 266 7a45 f
 INLINE 2 1514 10 267 7a45 f
 INLINE 3 1668 10 268 7a45 f
-INLINE 0 977 21 317 7a6e 1d 7a96 8
-7930 2c 966 21
-795c 8 968 21
-7964 11 896 21
-7975 3 918 21
-7978 12 897 21
-798a c 922 21
-7996 1c 918 21
-79b2 9 923 21
-79bb 5 922 21
-79c0 7 923 21
-79c7 27 931 21
-79ee 8 961 21
-79f6 8 971 21
-79fe 4 931 21
-7a02 4 387 21
-7a06 4 972 21
-7a0a 11 387 21
-7a1b 7 785 21
-7a22 4 775 21
-7a26 b 786 21
-7a31 4 972 21
-7a35 10 1587 9
+INLINE 0 977 22 317 7a6e 1d 7a96 8
+7930 2c 966 22
+795c 8 968 22
+7964 11 896 22
+7975 3 918 22
+7978 12 897 22
+798a c 922 22
+7996 1c 918 22
+79b2 9 923 22
+79bb 5 922 22
+79c0 7 923 22
+79c7 27 931 22
+79ee 8 961 22
+79f6 8 971 22
+79fe 4 931 22
+7a02 4 387 22
+7a06 4 972 22
+7a0a 11 387 22
+7a1b 7 785 22
+7a22 4 775 22
+7a26 b 786 22
+7a31 4 972 22
+7a35 10 1587 8
 7a45 f 1752 10
-7a54 a 1593 9
-7a5e 4 975 21
-7a62 8 1596 9
-7a6a 4 977 21
-7a6e 15 415 21
-7a83 8 434 21
-7a8b b 977 21
-7a96 8 432 21
-7a9e 4 977 21
-7aa2 1d 980 21
-7abf 17 986 21
+7a54 a 1593 8
+7a5e 4 975 22
+7a62 8 1596 8
+7a6a 4 977 22
+7a6e 15 415 22
+7a83 8 434 22
+7a8b b 977 22
+7a96 8 432 22
+7a9e 4 977 22
+7aa2 1d 980 22
+7abf 17 986 22
 FUNC 7ae0 272 0 google_breakpad::MinidumpGenerator::WriteExceptionStream(MDRawDirectory*)
-INLINE 0 1137 21 318 7b09 1b
+INLINE 0 1137 22 318 7b09 1b
 INLINE 1 212 2 319 7b09 1b
 INLINE 2 210 2 7 7b09 11
 INLINE 3 160 2 8 7b0e 3
-INLINE 0 1139 21 320 7b24 1a
-INLINE 0 1143 21 10 7b4d f
-INLINE 0 1156 21 259 7b7f a7 7c2e 4
-INLINE 1 921 21 260 7bd5 3
-INLINE 2 2591 5 261 7bd5 3
-INLINE 3 2583 5 140 7bd5 3
-INLINE 0 1159 21 317 7c32 3 7c3d 31
-INLINE 0 1165 21 262 7c82 20 7cf4 1f
-INLINE 1 460 21 263 7c91 9
-INLINE 1 462 21 264 7c9a 8
-INLINE 0 1168 21 321 7ca9 22 7d13 8 7d20 32
+INLINE 0 1139 22 320 7b24 1a
+INLINE 0 1143 22 10 7b4d f
+INLINE 0 1156 22 259 7b7f a7 7c2e 4
+INLINE 1 921 22 260 7bd5 3
+INLINE 2 2591 6 261 7bd5 3
+INLINE 3 2583 6 140 7bd5 3
+INLINE 0 1159 22 317 7c32 3 7c3d 31
+INLINE 0 1165 22 262 7c82 20 7cf4 1f
+INLINE 1 460 22 263 7c91 9
+INLINE 1 462 22 264 7c9a 8
+INLINE 0 1168 22 321 7ca9 22 7d13 8 7d20 32
 INLINE 1 214 2 322 7ca9 22 7d13 8 7d20 32
 INLINE 2 217 2 323 7cb3 18 7d2a 18
-7ae0 25 1136 21
-7b05 4 1137 21
+7ae0 25 1136 22
+7b05 4 1137 22
 7b09 5 159 2
 7b0e 3 117 2
 7b11 4 160 2
@@ -3995,364 +4112,378 @@ INLINE 2 217 2 323 7cb3 18 7d2a 18
 7b1a a 211 2
 7b24 b 46 1
 7b2f f 47 1
-7b3e 8 1139 21
-7b46 7 1142 21
+7b3e 8 1139 22
+7b46 7 1142 22
 7b4d 4 177 2
 7b51 4 175 2
 7b55 7 177 2
-7b5c 4 1143 21
-7b60 7 1145 21
-7b67 8 1149 21
-7b6f 8 1150 21
-7b77 8 1153 21
-7b7f 10 896 21
-7b8f 4 918 21
-7b93 13 897 21
-7ba6 12 918 21
-7bb8 4 921 21
-7bbc a 918 21
-7bc6 3 921 21
-7bc9 c 922 21
-7bd5 3 702 5
-7bd8 4 921 21
-7bdc b 923 21
-7be7 5 922 21
-7bec d 923 21
-7bf9 19 931 21
-7c12 14 961 21
-7c26 8 1156 21
-7c2e 4 931 21
-7c32 3 415 21
-7c35 8 1159 21
-7c3d f 415 21
-7c4c 12 432 21
-7c5e 10 434 21
-7c6e 4 1159 21
-7c72 6 1162 21
-7c78 a 1163 21
-7c82 f 443 21
-7c91 9 794 21
-7c9a 8 802 21
-7ca2 7 1165 21
+7b5c 4 1143 22
+7b60 7 1145 22
+7b67 8 1149 22
+7b6f 8 1150 22
+7b77 8 1153 22
+7b7f 10 896 22
+7b8f 4 918 22
+7b93 13 897 22
+7ba6 12 918 22
+7bb8 4 921 22
+7bbc a 918 22
+7bc6 3 921 22
+7bc9 c 922 22
+7bd5 3 702 6
+7bd8 4 921 22
+7bdc b 923 22
+7be7 5 922 22
+7bec d 923 22
+7bf9 19 931 22
+7c12 14 961 22
+7c26 8 1156 22
+7c2e 4 931 22
+7c32 3 415 22
+7c35 8 1159 22
+7c3d f 415 22
+7c4c 12 432 22
+7c5e 10 434 22
+7c6e 4 1159 22
+7c72 6 1162 22
+7c78 a 1163 22
+7c82 f 443 22
+7c91 9 794 22
+7c9a 8 802 22
+7ca2 7 1165 22
 7ca9 a 216 2
-7cb3 2c 92 1
-7cdf 15 1168 21
-7cf4 1f 465 21
-7d13 d 217 2
+7cb3 18 92 1
+7ccb 14 92 1
+7cdf 15 1168 22
+7cf4 1f 465 22
+7d13 8 217 2
+7d1b 5 217 2
 7d20 a 216 2
-7d2a 20 92 1
+7d2a 18 92 1
+7d42 8 92 1
 7d4a 8 217 2
 FUNC 7d60 399 0 google_breakpad::MinidumpGenerator::WriteModuleStream(unsigned int, MDRawModule*)
-INLINE 0 1298 21 131 7d84 1f
-INLINE 1 254 6 48 7d84 f
-INLINE 1 255 6 97 7d9f 4
-INLINE 0 1307 21 324 7e29 d
-INLINE 0 1308 21 164 7e36 4 7e3e e
+INLINE 0 1298 22 131 7d84 1f
+INLINE 1 254 5 48 7d84 f
+INLINE 1 255 5 97 7d9f 4
+INLINE 0 1307 22 324 7e29 d
+INLINE 0 1308 22 164 7e36 4 7e3e e
 INLINE 1 1631 13 165 7e36 4 7e3e e 807e f
 INLINE 2 1633 13 166 7e36 4 7e3e e 807e f
 INLINE 3 1791 13 71 7e36 4 807e 9
 INLINE 3 1791 13 167 7e3e a
-INLINE 0 1311 21 325 7e60 4
-INLINE 0 1312 21 326 7e6c 4
-INLINE 0 1318 21 285 7e7e 21 801a 29
-INLINE 0 1328 21 327 8059 4
-INLINE 0 1335 21 328 807a 4
-INLINE 0 1335 21 164 807e f
-7d60 17 1295 21
-7d77 d 1296 21
-7d84 f 642 9
-7d93 9 254 6
-7d9c 3 255 6
-7d9f 4 224 6
-7da3 9 1300 21
-7dac 7d 1303 21
-7e29 d 136 6
+INLINE 0 1311 22 325 7e60 4
+INLINE 0 1312 22 326 7e6c 4
+INLINE 0 1318 22 285 7e7e 21 801a 29
+INLINE 0 1328 22 327 8059 4
+INLINE 0 1335 22 328 807a 4
+INLINE 0 1335 22 164 807e f
+7d60 17 1295 22
+7d77 d 1296 22
+7d84 f 642 8
+7d93 9 254 5
+7d9c 3 255 5
+7d9f 4 224 5
+7da3 9 1300 22
+7dac 7d 1303 22
+7e29 d 136 5
 7e36 4 1697 13
-7e3a 4 1308 21
+7e3a 4 1308 22
 7e3e a 1785 13
 7e48 4 1791 13
-7e4c 14 1308 21
-7e60 4 147 6
-7e64 8 1311 21
-7e6c 4 150 6
-7e70 5 1312 21
-7e75 9 1313 21
-7e7e d 1400 21
-7e8b 7 1401 21
-7e92 d 1404 21
-7e9f b 1341 21
-7eaa 9 1342 21
-7eb3 c 1346 21
-7ebf 3 1357 21
-7ec2 11 1358 21
-7ed3 d 1359 21
-7ee0 7d 1363 21
-7f5d 7 1361 21
-7f64 9 1365 21
-7f6d 13 1371 21
-7f80 c 1365 21
-7f8c 6 1366 21
-7f92 10 1371 21
-7fa2 3 1392 21
-7fa5 e 1365 21
-7fb3 a 1338 21
-7fbd 27 1374 21
-7fe4 8 1377 21
-7fec 8 1378 21
-7ff4 9 1379 21
-7ffd 1d 1385 21
-801a 7 1407 21
-8021 f 1410 21
-8030 7 1411 21
-8037 6 1413 21
-803d 8 1410 21
-8045 5 1318 21
-804a 9 1319 21
-8053 6 1320 21
-8059 4 164 6
-805d 2 1331 21
-805f 3 1332 21
-8062 8 1330 21
-806a b 1331 21
-8075 5 1332 21
-807a 4 156 6
+7e4c 14 1308 22
+7e60 4 147 5
+7e64 8 1311 22
+7e6c 4 150 5
+7e70 5 1312 22
+7e75 9 1313 22
+7e7e d 1400 22
+7e8b 7 1401 22
+7e92 d 1404 22
+7e9f b 1341 22
+7eaa 9 1342 22
+7eb3 c 1346 22
+7ebf 3 1357 22
+7ec2 11 1358 22
+7ed3 d 1359 22
+7ee0 7d 1363 22
+7f5d 7 1361 22
+7f64 9 1365 22
+7f6d 13 1371 22
+7f80 c 1365 22
+7f8c 6 1366 22
+7f92 10 1371 22
+7fa2 3 1392 22
+7fa5 e 1365 22
+7fb3 a 1338 22
+7fbd 27 1374 22
+7fe4 8 1377 22
+7fec 8 1378 22
+7ff4 9 1379 22
+7ffd 1d 1385 22
+801a 7 1407 22
+8021 f 1410 22
+8030 7 1411 22
+8037 6 1413 22
+803d 6 1410 22
+8043 2 1410 22
+8045 5 1318 22
+804a 9 1319 22
+8053 6 1320 22
+8059 4 164 5
+805d 2 1331 22
+805f 3 1332 22
+8062 8 1330 22
+806a b 1331 22
+8075 5 1332 22
+807a 4 156 5
 807e 9 1697 13
 8087 6 1791 13
-808d 14 1335 21
-80a1 11 1338 21
-80b2 12 1397 21
-80c4 28 1346 21
-80ec d 1338 21
+808d 14 1335 22
+80a1 11 1338 22
+80b2 12 1397 22
+80c4 28 1346 22
+80ec d 1338 22
 FUNC 8100 4e 0 google_breakpad::MinidumpGenerator::FindExecutableModule()
-8100 c 1400 21
-810c 7 1401 21
-8113 6 1404 21
-8119 7 1407 21
-8120 10 1410 21
-8130 7 1411 21
-8137 6 1413 21
-813d 8 1410 21
-8145 9 1420 21
+8100 c 1400 22
+810c 7 1401 22
+8113 6 1404 22
+8119 7 1407 22
+8120 10 1410 22
+8130 7 1411 22
+8137 6 1413 22
+813d 8 1410 22
+8145 9 1420 22
 FUNC 8150 3a2 0 google_breakpad::MinidumpGenerator::WriteCVRecord(MDRawModule*, int, char const*, bool)
-INLINE 0 1424 21 329 8183 4e
+INLINE 0 1424 22 329 8183 4e
 INLINE 1 212 2 330 8183 4e
 INLINE 2 210 2 7 8183 12
 INLINE 3 160 2 8 818b 3
-INLINE 0 1437 21 331 81fb 26 8453 1f
-INLINE 0 1440 21 332 8229 2b 8477 1f
-INLINE 0 1443 21 10 825c 15
-INLINE 0 1487 21 333 8400 2b 84ac 8 84b7 3b
+INLINE 0 1437 22 331 81fb 26 8453 1f
+INLINE 0 1440 22 332 8229 2b 8477 1f
+INLINE 0 1443 22 10 825c 15
+INLINE 0 1487 22 333 8400 2b 84ac 8 84b7 3b
 INLINE 1 214 2 334 8400 2b 84ac 8 84b7 3b
 INLINE 2 217 2 335 840a 21 84c1 21
-8150 2f 1423 21
-817f 4 1424 21
+8150 2f 1423 22
+817f 4 1424 22
 8183 8 159 2
 818b 3 117 2
 818e 7 160 2
 8195 3c 211 2
-81d1 d 1427 21
-81de 3 1430 21
-81e1 4 1431 21
-81e5 b 1430 21
-81f0 b 1435 21
+81d1 d 1427 22
+81de 3 1430 22
+81e1 4 1431 22
+81e5 b 1430 22
+81f0 b 1435 22
 81fb a 66 1
 8205 b 67 1
 8210 11 68 1
-8221 8 1437 21
+8221 8 1437 22
 8229 e 83 1
 8237 8 84 1
 823f 7 85 1
 8246 3 86 1
 8249 b 84 1
-8254 8 1440 21
+8254 8 1440 22
 825c 7 177 2
 8263 7 175 2
 826a 7 177 2
-8271 4 1443 21
-8275 b 1445 21
-8280 b 1446 21
-828b 5 1451 21
-8290 4 1453 21
-8294 4 1454 21
-8298 10 1452 21
-82a8 1f 1455 21
-82c7 4 1456 21
-82cb 27 1457 21
-82f2 5 1458 21
-82f7 4 1460 21
-82fb c 1461 21
-8307 19 1462 21
-8320 8 1466 21
-8328 15 1468 21
-833d b 1469 21
-8348 2 1468 21
-834a b 1470 21
-8355 2 1469 21
-8357 2 1470 21
-8359 7 1467 21
-8360 19 1473 21
-8379 8 1472 21
-8381 c 1475 21
-838d 8 1474 21
-8395 16 1476 21
-83ab 7 1477 21
-83b2 c 1478 21
-83be 7 1479 21
-83c5 e 1480 21
-83d3 e 1481 21
-83e1 e 1482 21
-83ef 11 1483 21
+8271 4 1443 22
+8275 b 1445 22
+8280 b 1446 22
+828b 5 1451 22
+8290 4 1453 22
+8294 4 1454 22
+8298 10 1452 22
+82a8 1f 1455 22
+82c7 4 1456 22
+82cb 27 1457 22
+82f2 5 1458 22
+82f7 4 1460 22
+82fb c 1461 22
+8307 19 1462 22
+8320 8 1466 22
+8328 15 1468 22
+833d b 1469 22
+8348 2 1468 22
+834a b 1470 22
+8355 2 1469 22
+8357 2 1470 22
+8359 7 1467 22
+8360 19 1473 22
+8379 8 1472 22
+8381 c 1475 22
+838d 8 1474 22
+8395 16 1476 22
+83ab 7 1477 22
+83b2 c 1478 22
+83be 7 1479 22
+83c5 e 1480 22
+83d3 e 1481 22
+83e1 e 1482 22
+83ef 11 1483 22
 8400 a 216 2
-840a 35 92 1
-843f 14 1487 21
-8453 24 66 1
-8477 2c 83 1
-84a3 9 1458 21
-84ac b 217 2
+840a 21 92 1
+842b 14 92 1
+843f 14 1487 22
+8453 1f 66 1
+8472 5 66 1
+8477 1f 83 1
+8496 d 83 1
+84a3 9 1458 22
+84ac 8 217 2
+84b4 3 217 2
 84b7 a 216 2
-84c1 29 92 1
+84c1 21 92 1
+84e2 8 92 1
 84ea 8 217 2
 FUNC 8500 ad 0 google_breakpad::DynamicImages::~DynamicImages()
-INLINE 0 244 6 133 8508 12 8561 8 856c 6
-INLINE 1 250 6 48 8508 12 8561 8 856c 6
-INLINE 0 245 6 97 8521 13
-INLINE 0 245 6 84 8539 20
-INLINE 1 109 6 85 8539 20
-INLINE 2 109 6 37 8542 17
-INLINE 3 458 9 38 8542 17
-INLINE 4 458 9 39 8542 17
-INLINE 5 452 9 40 854a a
-INLINE 6 369 9 41 854a a
-INLINE 5 453 9 42 8554 5
+INLINE 0 244 5 133 8508 12 8561 8 856c 6
+INLINE 1 250 5 48 8508 12 8561 8 856c 6
+INLINE 0 245 5 97 8521 13
+INLINE 0 245 5 84 8539 20
+INLINE 1 109 5 85 8539 20
+INLINE 2 109 5 37 8542 17
+INLINE 3 458 8 38 8542 17
+INLINE 4 458 8 39 8542 17
+INLINE 5 452 8 40 854a a
+INLINE 6 369 8 41 854a a
+INLINE 5 453 8 42 8554 5
 INLINE 6 1508 10 43 8554 5
 INLINE 7 1743 10 44 8554 5
-INLINE 0 247 6 127 857e 29
-INLINE 1 458 9 128 857e 29
-INLINE 2 458 9 129 857e 29
-INLINE 3 452 9 130 8583 1a
-INLINE 4 369 9 104 8583 1a
-INLINE 5 425 9 105 8588 11
-INLINE 3 453 9 62 859d a
+INLINE 0 247 5 127 857e 29
+INLINE 1 458 8 128 857e 29
+INLINE 2 458 8 129 857e 29
+INLINE 3 452 8 130 8583 1a
+INLINE 4 369 8 104 8583 1a
+INLINE 5 425 8 105 8588 11
+INLINE 3 453 8 62 859d a
 INLINE 4 1508 10 63 859d a
 INLINE 5 1743 10 44 859d a
-8500 8 243 6
-8508 12 642 9
-851a 16 244 6
-8530 4 224 6
-8534 5 245 6
-8539 9 109 6
-8542 3 453 9
-8545 5 450 9
-854a 6 424 9
-8550 4 425 9
-8554 5 177 11
-8559 8 245 6
-8561 8 642 9
-8569 3 244 6
-856c 6 642 9
-8572 c 244 6
-857e 5 450 9
-8583 5 424 9
-8588 11 0 9
-8599 4 425 9
-859d a 177 11
-85a7 6 247 6
+8500 8 243 5
+8508 12 642 8
+851a 7 244 5
+8521 f 244 5
+8530 4 224 5
+8534 5 245 5
+8539 9 109 5
+8542 3 453 8
+8545 5 450 8
+854a 6 424 8
+8550 4 425 8
+8554 5 177 9
+8559 8 245 5
+8561 8 642 8
+8569 3 244 5
+856c 6 642 8
+8572 c 244 5
+857e 5 450 8
+8583 5 424 8
+8588 11 0 8
+8599 4 425 8
+859d a 177 9
+85a7 6 247 5
 FUNC 85b0 158 0 std::__1::__split_buffer<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&>::__split_buffer(unsigned long, unsigned long, google_breakpad::PageStdAllocator<MDMemoryDescriptor>&)
-INLINE 0 309 12 336 85c4 c
+INLINE 0 309 11 336 85c4 c
 INLINE 1 2427 10 337 85c4 c
 INLINE 2 2427 10 338 85c4 c
-INLINE 0 311 12 205 85d9 db 86e0 24
+INLINE 0 311 11 205 85d9 db 86e0 24
 INLINE 1 1500 10 206 85d9 db 86e0 24
-INLINE 2 190 22 209 85ed ba 86e0 24
-INLINE 3 91 22 215 8622 43
-85b0 14 310 12
+INLINE 2 190 21 209 85ed ba 86e0 24
+INLINE 3 91 21 215 8622 43
+85b0 14 310 11
 85c4 c 2065 10
-85d0 9 311 12
-85d9 7 186 22
-85e0 a 187 22
-85ea 3 190 22
-85ed 3 90 22
-85f0 20 78 22
-8610 12 90 22
-8622 26 119 22
-8648 a 121 22
-8652 7 131 22
-8659 4 132 22
-865d 4 133 22
-8661 4 135 22
-8665 9 92 22
-866e 4 90 22
-8672 3 98 22
-8675 15 96 22
-868a 4 95 22
-868e 15 98 22
-86a3 4 100 22
-86a7 9 190 22
-86b0 4 188 22
-86b4 3 311 12
-86b7 f 312 12
-86c6 b 313 12
-86d1 f 314 12
-86e0 3 79 22
-86e3 7 80 22
-86ea 5 81 22
-86ef 4 78 22
-86f3 15 83 22
-FUNC 8710 272 0 void std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__push_back_slow_path<MDMemoryDescriptor const&>(MDMemoryDescriptor const&)
-INLINE 0 1575 9 269 871f e 877c 10
-INLINE 0 1575 9 339 8730 14 8748 2a
-INLINE 1 965 9 340 8741 3 8748 e
-INLINE 2 645 9 341 8741 3 8748 e
-INLINE 0 1574 9 228 8744 4
-INLINE 1 351 9 342 8744 4
+85d0 9 311 11
+85d9 7 186 21
+85e0 a 187 21
+85ea 3 190 21
+85ed 3 90 21
+85f0 20 78 21
+8610 12 90 21
+8622 26 119 21
+8648 a 121 21
+8652 7 131 21
+8659 4 132 21
+865d 4 133 21
+8661 4 135 21
+8665 9 92 21
+866e 4 90 21
+8672 3 98 21
+8675 15 96 21
+868a 4 95 21
+868e 15 98 21
+86a3 4 100 21
+86a7 9 190 21
+86b0 4 188 21
+86b4 3 311 11
+86b7 f 312 11
+86c6 b 313 11
+86d1 f 314 11
+86e0 3 79 21
+86e3 7 80 21
+86ea 5 81 21
+86ef 4 78 21
+86f3 11 83 21
+8704 4 83 21
+FUNC 8710 272 0 std::__1::vector<MDMemoryDescriptor, google_breakpad::PageStdAllocator<MDMemoryDescriptor> >::__push_back_slow_path<MDMemoryDescriptor const&>(MDMemoryDescriptor const&)
+INLINE 0 1575 8 269 871f e 877c 10
+INLINE 0 1575 8 339 8730 14 8748 2a
+INLINE 1 965 8 340 8741 3 8748 e
+INLINE 2 645 8 341 8741 3 8748 e
+INLINE 0 1574 8 228 8744 4
+INLINE 1 351 8 342 8744 4
 INLINE 2 2479 10 343 8744 4
-INLINE 1 968 9 138 8769 3
-INLINE 2 2656 5 139 8769 3
-INLINE 3 2648 5 140 8769 3
-INLINE 0 1575 9 203 878c 5
-INLINE 0 1577 9 266 8796 e
+INLINE 1 968 8 138 8769 3
+INLINE 2 2656 6 139 8769 3
+INLINE 3 2648 6 140 8769 3
+INLINE 0 1575 8 203 878c 5
+INLINE 0 1577 8 266 8796 e
 INLINE 1 1514 10 267 8796 e
 INLINE 2 1668 10 268 8796 e
-INLINE 0 1579 9 216 87b2 1ab
-INLINE 1 893 9 217 87b9 169
+INLINE 0 1579 8 216 87b2 1ab
+INLINE 1 893 8 217 87b9 169
 INLINE 2 1630 10 219 87df 9 87ec 8 8818 18 883e 10 885c 10 887a 10 8898 10 88b6 10 88d4 10 88f2 f
 INLINE 3 1514 10 220 87df 9 87ec 8 8818 18 883e 10 885c 10 887a 10 8898 10 88b6 10 88d4 10 88f2 f
 INLINE 4 1668 10 221 87df 9 87ec 8 8818 18 883e 10 885c 10 887a 10 8898 10 88b6 10 88d4 10 88f2 f
-INLINE 1 894 9 218 8922 3 8930 d
-INLINE 1 895 9 218 8925 b 893d 9
-INLINE 1 896 9 218 8946 12
-INLINE 0 1580 9 344 895d 1b
-INLINE 1 340 12 345 895d 1b
-INLINE 2 341 12 346 895d 1b
-INLINE 3 86 12 347 895d 1b
-INLINE 4 141 12 348 895d 1b
-INLINE 5 296 12 349 8962 11
-8710 f 1573 9
-871f e 642 9
-872d 3 1575 9
-8730 9 963 9
-8739 8 964 9
-8741 3 372 9
+INLINE 1 894 8 218 8922 3 8930 d
+INLINE 1 895 8 218 8925 b 893d 9
+INLINE 1 896 8 218 8946 12
+INLINE 0 1580 8 344 895d 1b
+INLINE 1 340 11 345 895d 1b
+INLINE 2 341 11 346 895d 1b
+INLINE 3 86 11 347 895d 1b
+INLINE 4 141 11 348 895d 1b
+INLINE 5 296 11 349 8962 11
+8710 f 1573 8
+871f e 642 8
+872d 3 1575 8
+8730 9 963 8
+8739 8 964 8
+8741 3 372 8
 8744 4 2123 10
-8748 e 372 9
-8756 f 966 9
-8765 4 968 9
-8769 3 702 5
-876c 10 968 9
-877c 10 642 9
-878c 5 310 12
-8791 5 1577 9
+8748 e 372 8
+8756 f 966 8
+8765 4 968 8
+8769 3 702 6
+876c 6 968 8
+8772 a 968 8
+877c 10 642 8
+878c 5 310 11
+8791 5 1577 8
 8796 e 1752 10
-87a4 e 1578 9
-87b2 7 893 9
+87a4 e 1578 8
+87b2 7 893 8
 87b9 9 1628 10
-87c2 1e 1630 10
+87c2 1d 1630 10
+87df 1 1630 10
 87e0 8 1752 10
 87e8 4 1630 10
 87ec 8 1752 10
 87f4 e 1631 10
 8802 5 1628 10
-8807 19 1630 10
+8807 11 1630 10
+8818 8 1630 10
 8820 10 1752 10
 8830 e 1631 10
 883e 10 1752 10
@@ -4380,11 +4511,11 @@ INLINE 5 296 12 349 8962 11
 8946 4 3617 7
 894a 9 3618 7
 8953 5 3619 7
-8958 5 897 9
-895d 5 295 12
-8962 11 0 12
-8973 5 296 12
-8978 a 1580 9
+8958 5 897 8
+895d 5 295 11
+8962 11 0 11
+8973 5 296 11
+8978 a 1580 8
 FUNC 8990 1a3 0 ConvertUTF32toUTF16
 8990 9 85 23
 8999 5 86 23
@@ -4519,22 +4650,29 @@ INLINE 0 349 23 350 8f91 1f 8fc4 38 9002 24 902e 5 903b 5 9046 8 9056 5 9061 5
 8f7e f 346 23
 8f8d 4 350 23
 8f91 17 316 23
-8fa8 12 332 23
+8fa8 8 332 23
+8fb0 a 332 23
 8fba a 350 23
 8fc4 1c 319 23
 8fe0 14 320 23
-8ff4 a 321 23
+8ff4 8 321 23
+8ffc 2 321 23
 8ffe 4 350 23
 9002 1f 323 23
-9021 7 325 23
+9021 5 325 23
+9026 2 325 23
 9028 6 350 23
-902e 7 326 23
+902e 5 326 23
+9033 2 326 23
 9035 6 350 23
-903b 7 327 23
+903b 5 327 23
+9040 2 327 23
 9042 4 350 23
-9046 a 329 23
+9046 8 329 23
+904e 2 329 23
 9050 6 350 23
-9056 7 328 23
+9056 5 328 23
+905b 2 328 23
 905d 4 350 23
 9061 5 334 23
 9066 4 350 23
@@ -4559,7 +4697,8 @@ INLINE 0 366 23 350 912e ce
 91ba 22 332 23
 91dc b 326 23
 91e7 b 327 23
-91f2 e 328 23
+91f2 a 328 23
+91fc 4 328 23
 9200 20 373 23
 9220 4 376 23
 9224 5 377 23
@@ -4661,7 +4800,8 @@ INLINE 0 490 23 350 9695 c5 9838 cd
 971d 20 332 23
 973d a 326 23
 9747 a 327 23
-9751 f 328 23
+9751 9 328 23
+975a 6 328 23
 9760 15 497 23
 9775 4 500 23
 9779 5 501 23
@@ -4681,7 +4821,8 @@ INLINE 0 490 23 350 9695 c5 9838 cd
 9800 10 529 23
 9810 3 525 23
 9813 4 522 23
-9817 29 483 23
+9817 21 483 23
+9838 8 483 23
 9840 a 316 23
 984a e 315 23
 9858 19 319 23
@@ -4693,7 +4834,8 @@ INLINE 0 490 23 350 9695 c5 9838 cd
 98c8 20 332 23
 98e8 a 326 23
 98f2 a 327 23
-98fc 14 328 23
+98fc 9 328 23
+9905 b 328 23
 9910 19 497 23
 9929 4 500 23
 992d 5 501 23
@@ -4868,177 +5010,191 @@ a46d b 148 24
 FUNC a480 ed 0 google_breakpad::UTF8ToUTF16(char const*, std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >*)
 INLINE 0 47 25 351 a49a 3
 INLINE 0 46 25 352 a49d 1e
-INLINE 1 741 9 353 a49d 1e
-INLINE 2 369 9 354 a49d 1e
-INLINE 3 425 9 355 a4a6 11 a550 11
+INLINE 1 741 8 353 a49d 1e
+INLINE 2 369 8 354 a49d 1e
+INLINE 3 425 8 355 a4a6 11 a550 11
 INLINE 0 48 25 356 a4d2 3
 INLINE 0 49 25 357 a4da 7
-INLINE 1 645 9 358 a4da 7
+INLINE 1 645 8 358 a4da 7
 INLINE 0 55 25 359 a4fe 14 a51a 4 a527 3e
-INLINE 1 1996 9 360 a4fe 14 a51a 4 a527 9
+INLINE 1 1996 8 360 a4fe 14 a51a 4 a527 9
 INLINE 0 55 25 356 a517 3
-INLINE 1 2000 9 361 a54b 1a
-INLINE 2 814 9 354 a54b 1a
+INLINE 1 2000 8 361 a54b 1a
+INLINE 2 814 8 354 a54b 1a
 a480 d 41 25
 a48d 5 42 25
 a492 5 43 25
 a497 3 44 25
-a49a 3 1468 9
-a49d 9 424 9
-a4a6 11 0 9
-a4b7 4 425 9
+a49a 3 1468 8
+a49d 9 424 8
+a4a6 11 0 8
+a4b7 4 425 8
 a4bb 17 47 25
-a4d2 3 1501 9
+a4d2 3 1501 8
 a4d5 5 48 25
-a4da 7 372 9
+a4da 7 372 8
 a4e1 e 49 25
 a4ef b 50 25
 a4fa 4 55 25
-a4fe 14 642 9
+a4fe 14 642 8
 a512 5 55 25
-a517 3 1501 9
-a51a 4 642 9
+a517 3 1501 8
+a51a 4 642 8
 a51e 9 55 25
-a527 9 642 9
-a530 8 1997 9
-a538 a 1998 9
-a542 5 1999 9
-a547 4 2000 9
-a54b 5 424 9
-a550 11 0 9
-a561 4 425 9
+a527 9 642 8
+a530 8 1997 8
+a538 a 1998 8
+a542 5 1999 8
+a547 4 2000 8
+a54b 5 424 8
+a550 11 0 8
+a561 4 425 8
 a565 8 56 25
 FUNC a570 685 0 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::insert(std::__1::__wrap_iter<unsigned short const*>, unsigned long, unsigned short const&)
-INLINE 0 1872 9 360 a5ad a
-INLINE 0 1872 9 368 a5b7 45
-INLINE 1 965 9 357 a5c4 16
-INLINE 2 645 9 358 a5c4 16
-INLINE 1 968 9 138 a5da 3
-INLINE 2 2656 5 139 a5da 3
-INLINE 3 2648 5 140 a5da 3
-INLINE 0 1872 9 369 a60d 24 a949 4 aa62 9
-INLINE 1 310 12 370 a60d 24 a949 4 aa62 9
-INLINE 2 311 12 371 a620 11
+INLINE 0 1872 8 360 a5ad a
+INLINE 0 1872 8 368 a5b7 45
+INLINE 1 965 8 357 a5c4 16
+INLINE 2 645 8 358 a5c4 16
+INLINE 1 968 8 138 a5da 3
+INLINE 2 2656 6 139 a5da 3
+INLINE 3 2648 6 140 a5da 3
+INLINE 0 1872 8 369 a60d 24 a949 4 aa62 9
+INLINE 1 310 11 370 a60d 24 a949 4 aa62 9
+INLINE 2 311 11 371 a620 11
 INLINE 3 1500 10 372 a620 11
 INLINE 4 1741 10 53 a624 d
-INLINE 0 1861 9 373 a63d c a761 12b ab17 de
-INLINE 0 1855 9 374 a652 fa
-INLINE 1 1006 9 375 a68b 11 a6a3 16 a6d8 e a6f8 3f
+INLINE 0 1861 8 373 a63d c a761 12b ab17 de
+INLINE 0 1855 8 374 a652 fa
+INLINE 1 1006 8 375 a68b 11 a6a3 16 a6d8 e a6f8 3f
 INLINE 2 1514 10 376 a68b 11 a6a3 16 a6d8 e a6f8 3f a98c 11 a9a5 14 a9d8 e a9f8 3f
 INLINE 3 1668 10 377 a68b 11 a6a3 16 a6d8 e a6f8 3f a98c 11 a9a5 14 a9d8 e a9f8 3f
-INLINE 1 1708 9 378 a7cd 39 a813 4b ab38 1c ab81 50
+INLINE 1 1708 8 378 a7cd 39 a813 4b ab38 1c ab81 50
 INLINE 2 1514 10 379 a7f1 15 a819 45 ab38 1c ab81 50
 INLINE 3 1668 10 380 a7f1 15 a819 45 ab38 1c ab81 50
-INLINE 1 1711 9 381 a879 13
-INLINE 2 1953 5 382 a879 13
-INLINE 0 1866 9 383 a89d a9 aac5 42
-INLINE 1 2072 5 384 a89d a9 aac5 42
-INLINE 0 1873 9 385 a94d f4 aa6b 5
-INLINE 1 222 12 375 a98c 11 a9a5 14 a9d8 e a9f8 3f
-INLINE 0 1874 9 386 aa41 21 aa70 39
-INLINE 1 908 9 387 aa41 21
-INLINE 1 909 9 388 aa7e 16
-INLINE 1 910 9 389 aa99 3
-INLINE 1 911 9 389 aa9c 4
-INLINE 1 912 9 389 aaa0 9
-INLINE 0 1875 9 390 aaa9 a
-INLINE 1 340 12 391 aaa9 a
-INLINE 2 343 12 392 aaae 5
+INLINE 1 1711 8 381 a879 13
+INLINE 2 1953 6 382 a879 13
+INLINE 0 1866 8 383 a89d a9 aac5 42
+INLINE 1 2072 6 384 a89d a9 aac5 42
+INLINE 0 1873 8 385 a94d f4 aa6b 5
+INLINE 1 222 11 375 a98c 11 a9a5 14 a9d8 e a9f8 3f
+INLINE 0 1874 8 386 aa41 21 aa70 39
+INLINE 1 908 8 387 aa41 21
+INLINE 1 909 8 388 aa7e 16
+INLINE 1 910 8 389 aa99 3
+INLINE 1 911 8 389 aa9c 4
+INLINE 1 912 8 389 aaa0 9
+INLINE 0 1875 8 390 aaa9 a
+INLINE 1 340 11 391 aaa9 a
+INLINE 2 343 11 392 aaae 5
 INLINE 3 1508 10 393 aaae 5
 INLINE 4 1743 10 44 aaae 5
-a570 1a 1839 9
-a58a 9 1846 9
-a593 1a 1848 9
-a5ad a 642 9
-a5b7 5 963 9
-a5bc 8 964 9
-a5c4 16 372 9
-a5da 3 702 5
-a5dd 4 968 9
-a5e1 1b 966 9
-a5fc 11 1872 9
-a60d 13 311 12
+a570 1a 1839 8
+a58a 9 1846 8
+a593 1a 1848 8
+a5ad a 642 8
+a5b7 5 963 8
+a5bc 8 964 8
+a5c4 16 372 8
+a5da 3 702 6
+a5dd 4 968 8
+a5e1 1b 966 8
+a5fc 11 1872 8
+a60d 13 311 11
 a620 4 1741 10
-a624 d 169 11
-a631 c 1852 9
-a63d f 1709 9
-a64c 6 1854 9
-a652 39 1003 9
+a624 d 169 9
+a631 c 1852 8
+a63d c 1709 8
+a649 3 1709 8
+a64c 6 1854 8
+a652 39 1003 8
 a68b 11 1752 10
-a69c 14 775 9
+a69c 7 775 8
+a6a3 d 775 8
 a6b0 9 1752 10
-a6b9 f 1003 9
-a6c8 18 775 9
+a6b9 f 1003 8
+a6c8 10 775 8
+a6d8 8 775 8
 a6e0 6 1752 10
-a6e6 4 1007 9
-a6ea 3 1008 9
-a6ed 5 1010 9
-a6f2 e 775 9
+a6e6 4 1007 8
+a6ea 3 1008 8
+a6ed 5 1010 8
+a6f2 6 775 8
+a6f8 8 775 8
 a700 37 1752 10
-a737 a 1010 9
-a741 7 1003 9
-a748 4 1006 9
-a74c c 1858 9
-a758 9 1861 9
-a761 c 1706 9
-a76d 60 1707 9
-a7cd 33 1513 10
+a737 a 1010 8
+a741 7 1003 8
+a748 4 1006 8
+a74c c 1858 8
+a758 9 1861 8
+a761 c 1706 8
+a76d 60 1707 8
+a7cd 24 1513 10
+a7f1 f 1513 10
 a800 6 1752 10
-a806 d 1707 9
-a813 d 1513 10
+a806 d 1707 8
+a813 6 1513 10
+a819 7 1513 10
 a820 3e 1752 10
-a85e 17 1707 9
-a875 4 1709 9
-a879 5 1939 5
-a87e 6 1941 5
-a884 8 1942 5
-a88c 9 1864 9
-a895 4 1865 9
-a899 4 1864 9
-a89d 2c 2046 5
-a8c9 1d 2047 5
-a8e6 c 2046 5
-a8f2 45 2047 5
-a937 12 2046 5
-a949 4 312 12
-a94d 3f 220 12
+a85e 17 1707 8
+a875 4 1709 8
+a879 5 1939 6
+a87e 6 1941 6
+a884 8 1942 6
+a88c 9 1864 8
+a895 4 1865 8
+a899 4 1864 8
+a89d 2c 2046 6
+a8c9 1d 2047 6
+a8e6 c 2046 6
+a8f2 45 2047 6
+a937 f 2046 6
+a946 3 2046 6
+a949 4 312 11
+a94d 3f 220 11
 a98c 11 1752 10
-a99d 13 115 12
+a99d 8 115 11
+a9a5 b 115 11
 a9b0 9 1752 10
-a9b9 f 220 12
-a9c8 18 115 12
+a9b9 f 220 11
+a9c8 10 115 11
+a9d8 8 115 11
 a9e0 6 1752 10
-a9e6 4 223 12
-a9ea 3 224 12
-a9ed 5 225 12
-a9f2 e 115 12
+a9e6 4 223 11
+a9ea 3 224 11
+a9ed 5 225 11
+a9f2 6 115 11
+a9f8 8 115 11
 aa00 37 1752 10
-aa37 a 225 12
+aa37 a 225 11
 aa41 6 1648 10
 aa47 5 1649 10
 aa4c 16 1650 10
-aa62 9 313 12
-aa6b 5 220 12
-aa70 e 909 9
+aa62 9 313 11
+aa6b 5 220 11
+aa70 e 909 8
 aa7e 3 1583 10
 aa81 5 1584 10
 aa86 b 1586 10
-aa91 8 1587 10
+aa91 3 1587 10
+aa94 5 1587 10
 aa99 3 3618 7
 aa9c 4 3618 7
 aaa0 9 3618 7
-aaa9 5 342 12
-aaae 5 177 11
-aab3 12 1878 9
-aac5 b 2046 5
-aad0 2e 2047 5
-aafe 19 2046 5
-ab17 29 1709 9
+aaa9 5 342 11
+aaae 5 177 9
+aab3 12 1878 8
+aac5 b 2046 6
+aad0 2e 2047 6
+aafe 9 2046 6
+ab07 10 2046 6
+ab17 21 1709 8
+ab38 8 1709 8
 ab40 14 1752 10
-ab54 d 1707 9
-ab61 2f 1709 9
+ab54 d 1707 8
+ab61 20 1709 8
+ab81 f 1709 8
 ab90 41 1752 10
-abd1 24 1707 9
+abd1 24 1707 8
 FUNC ac00 7f 0 google_breakpad::UTF8ToUTF16Char(char const*, int, unsigned short*)
 ac00 14 58 25
 ac14 5 59 25
@@ -5056,45 +5212,45 @@ ac70 f 83 25
 FUNC ac80 ed 0 google_breakpad::UTF32ToUTF16(wchar_t const*, std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >*)
 INLINE 0 91 25 351 ac9d 3
 INLINE 0 90 25 352 aca0 1e
-INLINE 1 741 9 353 aca0 1e
-INLINE 2 369 9 354 aca0 1e
-INLINE 3 425 9 355 aca9 11 ad4e 11
+INLINE 1 741 8 353 aca0 1e
+INLINE 2 369 8 354 aca0 1e
+INLINE 3 425 8 355 aca9 11 ad4e 11
 INLINE 0 92 25 356 acd3 3
 INLINE 0 93 25 357 acda 7
-INLINE 1 645 9 358 acda 7
+INLINE 1 645 8 358 acda 7
 INLINE 0 99 25 359 acfd 14 ad18 4 ad25 3e
-INLINE 1 1996 9 360 acfd 14 ad18 4 ad25 9
+INLINE 1 1996 8 360 acfd 14 ad18 4 ad25 9
 INLINE 0 99 25 356 ad15 3
-INLINE 1 2000 9 361 ad49 1a
-INLINE 2 814 9 354 ad49 1a
+INLINE 1 2000 8 361 ad49 1a
+INLINE 2 814 8 354 ad49 1a
 ac80 f 85 25
 ac8f 5 86 25
 ac94 5 87 25
 ac99 4 88 25
-ac9d 3 1468 9
-aca0 9 424 9
-aca9 11 0 9
-acba 4 425 9
+ac9d 3 1468 8
+aca0 9 424 8
+aca9 11 0 8
+acba 4 425 8
 acbe 15 91 25
-acd3 3 1501 9
+acd3 3 1501 8
 acd6 4 92 25
-acda 7 372 9
+acda 7 372 8
 ace1 d 93 25
 acee b 94 25
 acf9 4 99 25
-acfd 14 642 9
+acfd 14 642 8
 ad11 4 99 25
-ad15 3 1501 9
-ad18 4 642 9
+ad15 3 1501 8
+ad18 4 642 8
 ad1c 9 99 25
-ad25 9 642 9
-ad2e 8 1997 9
-ad36 a 1998 9
-ad40 5 1999 9
-ad45 4 2000 9
-ad49 5 424 9
-ad4e 11 0 9
-ad5f 4 425 9
+ad25 9 642 8
+ad2e 8 1997 8
+ad36 a 1998 8
+ad40 5 1999 8
+ad45 4 2000 8
+ad49 5 424 8
+ad4e 11 0 8
+ad5f 4 425 8
 ad63 a 100 25
 FUNC ad70 4c 0 google_breakpad::UTF32ToUTF16Char(wchar_t, unsigned short*)
 ad70 11 102 25
@@ -5113,7 +5269,7 @@ INLINE 0 128 25 360 add9 4 ade8 c
 INLINE 0 131 25 362 ae0a 9 aece d
 INLINE 0 131 25 363 ae7c 4
 INLINE 0 149 25 110 af23 18 af52 16
-INLINE 1 2019 13 111 af23 18 af3f 13 af52 16
+INLINE 1 2019 13 111 af23 18 af3f 29
 INLINE 2 1364 13 112 af23 18
 INLINE 3 2421 10 113 af23 18
 INLINE 4 2421 10 114 af23 18
@@ -5124,11 +5280,11 @@ INLINE 1 201 16 365 af68 8 b05c a
 INLINE 0 153 25 366 af70 d b069 d
 INLINE 1 201 16 367 af70 d b069 d
 adc0 11 121 25
-add1 3 642 9
+add1 3 642 8
 add4 5 122 25
-add9 4 642 9
+add9 4 642 8
 addd b 126 25
-ade8 c 642 9
+ade8 c 642 8
 adf4 16 128 25
 ae0a 9 1358 14
 ae13 5d 130 25
@@ -5139,7 +5295,7 @@ aea0 2e 132 25
 aece d 1358 14
 aedb 10 134 25
 aeeb 3 138 25
-aeee 3 642 9
+aeee 3 642 8
 aef1 4 139 25
 aef5 b 140 25
 af00 3 138 25
@@ -5156,70 +5312,73 @@ af70 d 203 16
 af7d 24 153 25
 afa1 89 132 25
 b02a 32 130 25
-b05c d 203 16
-b069 15 203 16
+b05c a 203 16
+b066 3 203 16
+b069 d 203 16
+b076 8 203 16
 FUNC b080 114 0 std::__1::vector<unsigned short, std::__1::allocator<unsigned short> >::__append(unsigned long)
-INLINE 0 1041 9 360 b0a7 c b0c7 4 b0f6 9
-INLINE 0 1041 9 368 b0b3 14 b0cb 2b
-INLINE 1 965 9 357 b0c0 7 b0cb 9
-INLINE 2 645 9 358 b0c0 7 b0cb 9
-INLINE 1 968 9 138 b0d4 3
-INLINE 2 2656 5 139 b0d4 3
-INLINE 3 2648 5 140 b0d4 3
-INLINE 0 1041 9 369 b0ff 11 b129 8
-INLINE 1 310 12 370 b0ff 11 b129 8
-INLINE 2 311 12 371 b104 c
+INLINE 0 1041 8 360 b0a7 c b0c7 4 b0f6 9
+INLINE 0 1041 8 368 b0b3 14 b0cb 2b
+INLINE 1 965 8 357 b0c0 7 b0cb 9
+INLINE 2 645 8 358 b0c0 7 b0cb 9
+INLINE 1 968 8 138 b0d4 3
+INLINE 2 2656 6 139 b0d4 3
+INLINE 3 2648 6 140 b0d4 3
+INLINE 0 1041 8 369 b0ff 11 b129 8
+INLINE 1 310 11 370 b0ff 11 b129 8
+INLINE 2 311 11 371 b104 c
 INLINE 3 1500 10 372 b104 c
 INLINE 4 1741 10 53 b109 7
-INLINE 0 1037 9 394 b110 17
-INLINE 1 984 9 395 b114 8
+INLINE 0 1037 8 394 b110 17
+INLINE 1 984 8 395 b114 8
 INLINE 2 1514 10 396 b114 8 b139 8
 INLINE 3 1668 10 397 b114 8 b139 8
-INLINE 0 1042 9 398 b131 14
-INLINE 1 203 12 395 b139 8
-INLINE 0 1043 9 399 b145 25
-INLINE 1 893 9 387 b145 16
-INLINE 1 894 9 389 b15b 3
-INLINE 1 895 9 389 b15e 4
-INLINE 1 896 9 389 b162 8
-INLINE 0 1044 9 390 b16a 1b
-INLINE 1 340 12 391 b16a 1b
-INLINE 2 343 12 392 b16f 16
+INLINE 0 1042 8 398 b131 14
+INLINE 1 203 11 395 b139 8
+INLINE 0 1043 8 399 b145 25
+INLINE 1 893 8 387 b145 16
+INLINE 1 894 8 389 b15b 3
+INLINE 1 895 8 389 b15e 4
+INLINE 1 896 8 389 b162 8
+INLINE 0 1044 8 390 b16a 1b
+INLINE 1 340 11 391 b16a 1b
+INLINE 2 343 11 392 b16f 16
 INLINE 3 1508 10 393 b16f 16
 INLINE 4 1743 10 44 b16f 16
-b080 11 1035 9
-b091 16 1036 9
-b0a7 c 642 9
-b0b3 5 963 9
-b0b8 8 964 9
-b0c0 7 372 9
-b0c7 4 642 9
-b0cb 9 372 9
-b0d4 3 702 5
-b0d7 4 968 9
-b0db 1b 966 9
-b0f6 9 642 9
-b0ff 5 311 12
+b080 11 1035 8
+b091 16 1036 8
+b0a7 c 642 8
+b0b3 5 963 8
+b0b8 8 964 8
+b0c0 7 372 8
+b0c7 4 642 8
+b0cb 9 372 8
+b0d4 3 702 6
+b0d7 4 968 8
+b0db 1b 966 8
+b0f6 9 642 8
+b0ff 5 311 11
 b104 5 1741 10
-b109 7 169 11
-b110 4 981 9
+b109 7 169 9
+b110 4 981 8
 b114 8 1752 10
-b11c 5 981 9
-b121 8 984 9
-b129 4 312 12
-b12d 4 313 12
-b131 8 201 12
+b11c 5 981 8
+b121 6 984 8
+b127 2 984 8
+b129 4 312 11
+b12d 4 313 11
+b131 8 201 11
 b139 8 1752 10
-b141 4 201 12
+b141 4 201 11
 b145 3 1648 10
 b148 5 1649 10
 b14d e 1650 10
 b15b 3 3618 7
 b15e 4 3618 7
 b162 8 3618 7
-b16a 5 342 12
-b16f 16 177 11
-b185 f 1045 9
+b16a 5 342 11
+b16f 16 177 9
+b185 f 1045 8
 FUNC b1a0 5 0 breakpad::BootstrapRegister(unsigned int, char*, unsigned int)
 b1a0 5 38 26
 FUNC b1b0 16 0 google_breakpad::FileID::FileID(char const*)
@@ -5413,13 +5572,15 @@ be79 5 284 28
 be7e 9 283 28
 be87 e 284 28
 be95 10 130 28
-bea5 b 284 28
+bea5 5 284 28
+beaa 6 284 28
 beb0 13 138 28
 bec3 1b 146 28
 bede 2a 149 28
 bf08 13 137 28
 bf1b 7 140 28
-bf22 13 150 28
+bf22 7 150 28
+bf29 c 150 28
 bf35 4 286 28
 bf39 20 274 28
 bf59 19 291 28
@@ -5436,13 +5597,15 @@ c004 5 318 28
 c009 9 316 28
 c012 5 319 28
 c017 19 130 28
-c030 10 318 28
+c030 5 318 28
+c035 b 318 28
 c040 13 138 28
 c053 1b 146 28
 c06e 2a 149 28
 c098 13 137 28
 c0ab 7 140 28
-c0b2 e 150 28
+c0b2 7 150 28
+c0b9 7 150 28
 c0c0 4 321 28
 c0c4 1c 307 28
 c0e0 1c 308 28
@@ -5451,13 +5614,15 @@ c107 5 318 28
 c10c 9 316 28
 c115 5 319 28
 c11a 19 130 28
-c133 d 318 28
+c133 5 318 28
+c138 8 318 28
 c140 13 138 28
 c153 1b 146 28
 c16e 2a 149 28
 c198 13 137 28
 c1ab 7 140 28
-c1b2 e 150 28
+c1b2 7 150 28
+c1b9 7 150 28
 c1c0 4 321 28
 c1c4 2c 307 28
 c1f0 1c 275 28
@@ -5466,13 +5631,15 @@ c217 5 284 28
 c21c 9 283 28
 c225 d 284 28
 c232 10 130 28
-c242 e 284 28
+c242 5 284 28
+c247 9 284 28
 c250 13 138 28
 c263 1b 146 28
 c27e 2a 149 28
 c2a8 13 137 28
 c2bb 7 140 28
-c2c2 e 150 28
+c2c2 7 150 28
+c2c9 7 150 28
 c2d0 4 286 28
 c2d4 2d 274 28
 c301 17 327 28
@@ -5484,225 +5651,227 @@ c356 1c 230 28
 c372 11 233 28
 c383 9 235 28
 FUNC c390 f 0 breakpad_swap_uuid_command(breakpad_uuid_command*)
-INLINE 0 41 29 404 c392 2
+INLINE 0 41 31 404 c392 2
 INLINE 1 43 30 405 c392 2 c399 2
-INLINE 0 42 29 404 c399 2
-c390 2 41 29
-c392 2 60 31
-c394 2 41 29
-c396 3 42 29
-c399 2 60 31
-c39b 3 42 29
-c39e 1 43 29
+INLINE 0 42 31 404 c399 2
+c390 2 41 31
+c392 2 60 29
+c394 2 41 31
+c396 3 42 31
+c399 2 60 29
+c39b 3 42 31
+c39e 1 43 31
 FUNC c3a0 f 0 breakpad_swap_load_command(load_command*)
-INLINE 0 46 29 404 c3a2 2
+INLINE 0 46 31 404 c3a2 2
 INLINE 1 43 30 405 c3a2 2 c3a9 2
-INLINE 0 47 29 404 c3a9 2
-c3a0 2 46 29
-c3a2 2 60 31
-c3a4 2 46 29
-c3a6 3 47 29
-c3a9 2 60 31
-c3ab 3 47 29
-c3ae 1 48 29
+INLINE 0 47 31 404 c3a9 2
+c3a0 2 46 31
+c3a2 2 60 29
+c3a4 2 46 31
+c3a6 3 47 31
+c3a9 2 60 29
+c3ab 3 47 31
+c3ae 1 48 31
 FUNC c3b0 22 0 breakpad_swap_dylib_command(dylib_command*)
-INLINE 0 51 29 404 c3b4 9
+INLINE 0 51 31 404 c3b4 9
 INLINE 1 43 30 405 c3b4 9 c3c4 2 c3cc 2
-INLINE 0 56 29 404 c3c4 2
-INLINE 0 57 29 404 c3cc 2
-c3b0 4 51 29
-c3b4 9 60 31
-c3bd 4 51 29
-c3c1 3 56 29
-c3c4 2 60 31
-c3c6 3 56 29
-c3c9 3 57 29
-c3cc 2 60 31
-c3ce 3 57 29
-c3d1 1 58 29
+INLINE 0 56 31 404 c3c4 2
+INLINE 0 57 31 404 c3cc 2
+c3b0 4 51 31
+c3b4 9 60 29
+c3bd 4 51 31
+c3c1 3 56 31
+c3c4 2 60 29
+c3c6 3 56 31
+c3c9 3 57 31
+c3cc 2 60 29
+c3ce 3 57 31
+c3d1 1 58 31
 FUNC c3e0 35 0 breakpad_swap_segment_command(segment_command*)
-INLINE 0 61 29 404 c3e2 2
+INLINE 0 61 31 404 c3e2 2
 INLINE 1 43 30 405 c3e2 2 c3e9 2 c3f3 d
-INLINE 0 62 29 404 c3e9 2
-INLINE 0 64 29 404 c3f3 d
-INLINE 0 68 29 406 c40a 5
+INLINE 0 62 31 404 c3e9 2
+INLINE 0 64 31 404 c3f3 d
+INLINE 0 68 31 406 c40a 5
 INLINE 1 46 30 405 c40a 5
-c3e0 2 61 29
-c3e2 2 60 31
-c3e4 2 61 29
-c3e6 3 62 29
-c3e9 2 60 31
-c3eb 3 62 29
-c3ee 5 64 29
-c3f3 d 60 31
-c400 5 64 29
-c405 5 68 29
-c40a 5 60 31
-c40f 5 68 29
-c414 1 72 29
+c3e0 2 61 31
+c3e2 2 60 29
+c3e4 2 61 31
+c3e6 3 62 31
+c3e9 2 60 29
+c3eb 3 62 31
+c3ee 5 64 31
+c3f3 d 60 29
+c400 5 64 31
+c405 5 68 31
+c40a 5 60 29
+c40f 5 68 31
+c414 1 72 31
 FUNC c420 6d 0 breakpad_swap_segment_command_64(segment_command_64*)
-INLINE 0 75 29 404 c423 4
+INLINE 0 75 31 404 c423 4
 INLINE 1 43 30 405 c423 4 c42d 2
-INLINE 0 76 29 404 c42d 2
-INLINE 0 78 29 407 c437 d
+INLINE 0 76 31 404 c42d 2
+INLINE 0 78 31 407 c437 d
 INLINE 1 44 30 408 c437 d c44e 5
-INLINE 0 80 29 407 c44e 5
-INLINE 0 83 29 406 c47e 9
+INLINE 0 80 31 407 c44e 5
+INLINE 0 83 31 406 c47e 9
 INLINE 1 46 30 405 c47e 9
-c420 3 75 29
-c423 4 60 31
-c427 2 75 29
-c429 4 76 29
-c42d 2 60 31
-c42f 3 76 29
-c432 5 78 29
-c437 d 74 31
-c444 5 78 29
-c449 5 80 29
-c44e 5 74 31
-c453 5 80 29
-c458 4 83 29
-c45c 4 85 29
-c460 4 83 29
-c464 4 84 29
-c468 c 83 29
-c474 4 86 29
-c478 6 83 29
-c47e 9 60 31
-c487 5 83 29
-c48c 1 87 29
+c420 3 75 31
+c423 4 60 29
+c427 2 75 31
+c429 4 76 31
+c42d 2 60 29
+c42f 3 76 31
+c432 5 78 31
+c437 d 74 29
+c444 5 78 31
+c449 5 80 31
+c44e 5 74 29
+c453 5 80 31
+c458 4 83 31
+c45c 4 85 31
+c460 4 83 31
+c464 4 84 31
+c468 c 83 31
+c474 4 86 31
+c478 6 83 31
+c47e 9 60 29
+c487 5 83 31
+c48c 1 87 31
 FUNC c490 f 0 breakpad_swap_fat_header(fat_header*)
-INLINE 0 90 29 404 c492 2
+INLINE 0 90 31 404 c492 2
 INLINE 1 43 30 405 c492 2 c499 2
-INLINE 0 91 29 404 c499 2
-c490 2 90 29
-c492 2 60 31
-c494 2 90 29
-c496 3 91 29
-c499 2 60 31
-c49b 3 91 29
-c49e 1 92 29
+INLINE 0 91 31 404 c499 2
+c490 2 90 31
+c492 2 60 29
+c494 2 90 31
+c496 3 91 31
+c499 2 60 29
+c49b 3 91 31
+c49e 1 92 31
 FUNC c4a0 87 0 breakpad_swap_fat_arch(fat_arch*, unsigned int)
-INLINE 0 96 29 406 c4b6 9 c4e1 8 c4f5 5 c50c 5
+INLINE 0 96 31 406 c4b6 9 c4e1 8 c4f5 5 c50c 5
 INLINE 1 46 30 405 c4b6 9 c4e1 8 c4f5 5 c50c 5
-INLINE 0 100 29 404 c4c6 2 c502 2 c518 2
+INLINE 0 100 31 404 c4c6 2 c502 2 c518 2
 INLINE 1 43 30 405 c4c6 2 c502 2 c518 2
-c4a0 a 95 29
-c4aa c 96 29
-c4b6 9 60 31
-c4bf 4 96 29
-c4c3 3 100 29
-c4c6 2 60 31
-c4c8 8 100 29
-c4d0 11 96 29
-c4e1 f 60 31
-c4f0 5 96 29
-c4f5 5 60 31
-c4fa 5 96 29
-c4ff 3 100 29
-c502 2 60 31
-c504 3 100 29
-c507 5 96 29
-c50c 5 60 31
-c511 5 96 29
-c516 2 100 29
-c518 2 60 31
-c51a 2 100 29
-c51c a 95 29
-c526 1 102 29
+c4a0 a 95 31
+c4aa c 96 31
+c4b6 9 60 29
+c4bf 4 96 31
+c4c3 3 100 31
+c4c6 2 60 29
+c4c8 8 100 31
+c4d0 11 96 31
+c4e1 8 60 29
+c4e9 7 60 29
+c4f0 5 96 31
+c4f5 5 60 29
+c4fa 5 96 31
+c4ff 3 100 31
+c502 2 60 29
+c504 3 100 31
+c507 5 96 31
+c50c 5 60 29
+c511 5 96 31
+c516 2 100 31
+c518 2 60 29
+c51a 2 100 31
+c51c a 95 31
+c526 1 102 31
 FUNC c530 2a 0 breakpad_swap_mach_header(mach_header*)
-INLINE 0 105 29 404 c534 9
+INLINE 0 105 31 404 c534 9
 INLINE 1 43 30 405 c534 9 c544 2 c54c 2 c554 2
-INLINE 0 109 29 404 c544 2
-INLINE 0 110 29 404 c54c 2
-INLINE 0 111 29 404 c554 2
-c530 4 105 29
-c534 9 60 31
-c53d 4 105 29
-c541 3 109 29
-c544 2 60 31
-c546 3 109 29
-c549 3 110 29
-c54c 2 60 31
-c54e 3 110 29
-c551 3 111 29
-c554 2 60 31
-c556 3 111 29
-c559 1 112 29
+INLINE 0 109 31 404 c544 2
+INLINE 0 110 31 404 c54c 2
+INLINE 0 111 31 404 c554 2
+c530 4 105 31
+c534 9 60 29
+c53d 4 105 31
+c541 3 109 31
+c544 2 60 29
+c546 3 109 31
+c549 3 110 31
+c54c 2 60 29
+c54e 3 110 31
+c551 3 111 31
+c554 2 60 29
+c556 3 111 31
+c559 1 112 31
 FUNC c560 25 0 breakpad_swap_mach_header_64(mach_header_64*)
-INLINE 0 115 29 404 c564 d
+INLINE 0 115 31 404 c564 d
 INLINE 1 43 30 405 c564 d c57a 5
-INLINE 0 119 29 404 c57a 5
-c560 4 115 29
-c564 d 60 31
-c571 4 115 29
-c575 5 119 29
-c57a 5 60 31
-c57f 5 119 29
-c584 1 123 29
+INLINE 0 119 31 404 c57a 5
+c560 4 115 31
+c564 d 60 29
+c571 4 115 31
+c575 5 119 31
+c57a 5 60 29
+c57f 5 119 31
+c584 1 123 31
 FUNC c590 c8 0 breakpad_swap_section(section*, unsigned int)
-INLINE 0 128 29 404 c5a7 d c5e9 8 c605 5 c62b 5
+INLINE 0 128 31 404 c5a7 d c5e9 8 c605 5 c62b 5
 INLINE 1 43 30 405 c5a7 d c5be 5 c5cb 2 c5e9 8 c605 5 c614 5 c621 2 c62b 5 c63a 5 c646 2
-INLINE 0 133 29 404 c5be 5 c614 5 c63a 5
-INLINE 0 137 29 404 c5cb 2 c621 2 c646 2
-c590 a 127 29
-c59a d 128 29
-c5a7 d 60 31
-c5b4 5 128 29
-c5b9 5 133 29
-c5be 5 60 31
-c5c3 5 133 29
-c5c8 3 137 29
-c5cb 2 60 31
-c5cd 8 137 29
-c5d5 14 128 29
-c5e9 17 60 31
-c600 5 128 29
-c605 5 60 31
-c60a 5 128 29
-c60f 5 133 29
-c614 5 60 31
-c619 5 133 29
-c61e 3 137 29
-c621 2 60 31
-c623 3 137 29
-c626 5 128 29
-c62b 5 60 31
-c630 5 128 29
-c635 5 133 29
-c63a 5 60 31
-c63f 5 133 29
-c644 2 137 29
-c646 2 60 31
-c648 2 137 29
-c64a d 127 29
-c657 1 139 29
+INLINE 0 133 31 404 c5be 5 c614 5 c63a 5
+INLINE 0 137 31 404 c5cb 2 c621 2 c646 2
+c590 a 127 31
+c59a d 128 31
+c5a7 d 60 29
+c5b4 5 128 31
+c5b9 5 133 31
+c5be 5 60 29
+c5c3 5 133 31
+c5c8 3 137 31
+c5cb 2 60 29
+c5cd 8 137 31
+c5d5 14 128 31
+c5e9 8 60 29
+c5f1 f 60 29
+c600 5 128 31
+c605 5 60 29
+c60a 5 128 31
+c60f 5 133 31
+c614 5 60 29
+c619 5 133 31
+c61e 3 137 31
+c621 2 60 29
+c623 3 137 31
+c626 5 128 31
+c62b 5 60 29
+c630 5 128 31
+c635 5 133 31
+c63a 5 60 29
+c63f 5 133 31
+c644 2 137 31
+c646 2 60 29
+c648 2 137 31
+c64a d 127 31
+c657 1 139 31
 FUNC c660 5e 0 breakpad_swap_section_64(section_64*, unsigned int)
-INLINE 0 144 29 407 c685 5
+INLINE 0 144 31 407 c685 5
 INLINE 1 44 30 408 c685 5
-INLINE 0 147 29 404 c694 5
+INLINE 0 147 31 404 c694 5
 INLINE 1 43 30 405 c694 5 c6a1 2 c6a9 2 c6b0 2
-INLINE 0 151 29 404 c6a1 2
-INLINE 0 152 29 404 c6a9 2
-INLINE 0 153 29 404 c6b0 2
-c660 6 143 29
-c666 1f 144 29
-c685 5 74 31
-c68a 5 144 29
-c68f 5 147 29
-c694 5 60 31
-c699 5 147 29
-c69e 3 151 29
-c6a1 2 60 31
-c6a3 3 151 29
-c6a6 3 152 29
-c6a9 2 60 31
-c6ab 3 152 29
-c6ae 2 153 29
-c6b0 2 60 31
-c6b2 2 153 29
-c6b4 9 143 29
-c6bd 1 155 29
+INLINE 0 151 31 404 c6a1 2
+INLINE 0 152 31 404 c6a9 2
+INLINE 0 153 31 404 c6b0 2
+c660 6 143 31
+c666 1f 144 31
+c685 5 74 29
+c68a 5 144 31
+c68f 5 147 31
+c694 5 60 29
+c699 5 147 31
+c69e 3 151 31
+c6a1 2 60 29
+c6a3 3 151 31
+c6a6 3 152 31
+c6a9 2 60 29
+c6ab 3 152 31
+c6ae 2 153 31
+c6b0 2 60 29
+c6b2 2 153 31
+c6b4 9 143 31
+c6bd 1 155 31
 FUNC c6c0 4d 0 MacFileUtilities::MachoWalker::MachoWalker(char const*, bool (*)(MacFileUtilities::MachoWalker*, load_command*, long long, bool, void*), void*)
 c6c0 7 59 32
 c6c7 6 52 32
@@ -5768,7 +5937,8 @@ c85b 5 103 32
 c860 d 106 32
 c86d 5 107 32
 c872 f 112 32
-c881 1c 115 32
+c881 1a 115 32
+c89b 2 115 32
 c89d 9 99 32
 c8a6 27 112 32
 c8cd 4 233 32
@@ -5800,14 +5970,16 @@ c9d5 37 141 32
 ca0c 4 112 32
 ca10 5 102 32
 ca15 e 106 32
-ca23 e 107 32
+ca23 9 107 32
+ca2c 5 107 32
 ca31 d 112 32
 ca3e 7 169 32
 ca45 4 112 32
 ca49 9 102 32
 ca52 e 106 32
 ca60 a 107 32
-ca6a 18 112 32
+ca6a 5 112 32
+ca6f 13 112 32
 ca82 16 115 32
 ca98 a 153 32
 caa2 6 156 32
@@ -5819,11 +5991,13 @@ cae6 5 160 32
 caeb 6 159 32
 caf1 1f 165 32
 cb10 27 115 32
-cb37 d 112 32
+cb37 8 112 32
+cb3f 5 112 32
 cb44 5 175 32
 cb49 d 177 32
 cb56 b 181 32
-cb61 1f 189 32
+cb61 15 189 32
+cb76 a 189 32
 cb80 4 112 32
 cb84 5 102 32
 cb89 9 103 32
@@ -5912,7 +6086,8 @@ FUNC cfb0 1ab 0 MacFileUtilities::MachoWalker::WalkHeaderCore(long long, unsigne
 INLINE 0 252 32 413 cfe1 69 d09e 52 d134 11
 cfb0 1a 249 32
 cfca f 250 32
-cfd9 17 255 32
+cfd9 8 255 32
+cfe1 f 255 32
 cff0 4 112 32
 cff4 b 102 32
 cfff 9 103 32
@@ -5923,7 +6098,8 @@ d04a a 252 32
 d054 8 256 32
 d05c 2b 259 32
 d087 7 262 32
-d08e 12 250 32
+d08e 10 250 32
+d09e 2 250 32
 d0a0 4 112 32
 d0a4 b 102 32
 d0af 9 103 32
@@ -5934,7 +6110,8 @@ d0f0 24 259 32
 d114 7 262 32
 d11b 19 250 32
 d134 5 107 32
-d139 13 112 32
+d139 c 112 32
+d145 7 112 32
 d14c f 266 32
 FUNC d160 107 0 MacStringUtils::ConvertToString(__CFString const*)
 INLINE 0 39 33 65 d17e 1a
@@ -5956,7 +6133,8 @@ d1fd 5 50 33
 d202 b 51 33
 d20d 8 203 16
 d215 11 54 33
-d226 29 220 16
+d226 1f 220 16
+d245 a 220 16
 d24f 8 203 16
 d257 10 54 33
 FUNC d270 31d 0 MacStringUtils::IntegerValueAtIndex(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, unsigned int)
@@ -5969,10 +6147,10 @@ INLINE 0 57 33 65 d2ad 10
 INLINE 1 1945 13 66 d2ad 10
 INLINE 2 1949 13 67 d2ad 10
 INLINE 0 64 33 415 d2c0 d6
-INLINE 1 3595 13 165 d2c0 4 d2c4 5 d2cc 4 d2d4 11 d31a 1e d33c d d34c 3
-INLINE 2 1633 13 166 d2c0 4 d2c4 5 d2cc 4 d2d4 11 d31a 1e d33c d d34c 3 d44b 12 d474 5 d47d 18 d49b 5 d4a5 11 d4bc 2
-INLINE 3 1791 13 167 d2c0 4 d2c4 5
-INLINE 1 3595 13 189 d2c9 3 d2d0 4 d2e5 23 d308 12 d338 4 d349 3 d34f 4
+INLINE 1 3595 13 165 d2c0 9 d2cc 4 d2d4 11 d31a 1e d33c d d34c 3
+INLINE 2 1633 13 166 d2c0 9 d2cc 4 d2d4 11 d31a 1e d33c d d34c 3 d44b 12 d474 5 d47d 18 d49b 5 d4a5 11 d4bc 2
+INLINE 3 1791 13 167 d2c0 9
+INLINE 1 3595 13 189 d2c9 3 d2d0 4 d2e5 35 d338 4 d349 3 d34f 4
 INLINE 2 1460 13 71 d2c9 3
 INLINE 3 1791 13 168 d2cc 4 d2de 7 d47d 9 d4a5 5
 INLINE 2 1460 13 191 d2d0 4 d2e5 23 d479 4 d4a0 5
@@ -6000,7 +6178,7 @@ INLINE 1 3509 13 189 d46a a d479 4 d495 6 d4a0 5 d4b6 6 d4be 4
 INLINE 1 3509 13 165 d474 5 d47d 18 d49b 5 d4a5 11 d4bc 2
 INLINE 1 3508 13 421 d4c2 5f
 INLINE 2 1039 13 422 d4d4 b d4e5 24
-INLINE 3 1052 5 423 d4e5 f
+INLINE 3 1052 6 423 d4e5 f
 d270 16 56 33
 d286 11 2242 10
 d297 16 2021 13
@@ -6013,7 +6191,8 @@ d2cc 4 1779 13
 d2d0 4 1759 13
 d2d4 a 1697 13
 d2de 7 1779 13
-d2e5 2b 1759 13
+d2e5 23 1759 13
+d308 8 1759 13
 d310 a 1749 13
 d31a a 1697 13
 d324 14 1791 13
@@ -6025,7 +6204,8 @@ d34c 3 1697 13
 d34f 4 1460 13
 d353 a 1076 13
 d35d 4 1079 13
-d361 f 646 13
+d361 5 646 13
+d366 a 646 13
 d370 4 662 13
 d374 b 646 13
 d37f 5 1080 13
@@ -6036,7 +6216,8 @@ d3af 4 1460 13
 d3b3 6 69 33
 d3b9 1b 3369 13
 d3d4 e 1697 13
-d3e2 e 1741 13
+d3e2 8 1741 13
+d3ea 6 1741 13
 d3f0 5 1776 13
 d3f5 3 636 13
 d3f8 9 1756 13
@@ -6067,17 +6248,21 @@ d4bc 2 1697 13
 d4be 4 1460 13
 d4c2 a 1037 13
 d4cc 8 1040 13
-d4d4 8 1050 5
-d4dc 3 1052 5
-d4df 11 1039 13
+d4d4 8 1050 6
+d4dc 3 1052 6
+d4df 6 1039 13
+d4e5 b 1039 13
 d4f0 4 638 13
-d4f4 8 1051 5
-d4fc 17 1050 5
+d4f4 8 1051 6
+d4fc d 1050 6
+d509 a 1050 6
 d513 5 1041 13
-d518 11 1043 13
+d518 9 1043 13
+d521 8 1043 13
 d529 18 63 33
 d541 26 82 33
-d567 f 1471 13
+d567 8 1471 13
+d56f 7 1471 13
 d576 17 82 33
 FUNC d590 44 0 google_breakpad::MachSendMessage::MachSendMessage(int)
 INLINE 0 39 34 424 d59c a
@@ -6086,10 +6271,10 @@ INLINE 0 49 34 426 d5bc 3
 INLINE 0 50 34 427 d5bf e
 INLINE 1 68 34 428 d5c6 7
 d590 c 39 34
-d59c a 203 4
+d59c a 203 3
 d5a6 10 44 34
 d5b6 6 138 34
-d5bc 3 177 4
+d5bc 3 177 3
 d5bf 7 65 34
 d5c6 7 87 34
 d5cd 7 51 34
@@ -6104,14 +6289,14 @@ d5f9 1 142 34
 FUNC d600 73 0 google_breakpad::MachMessage::SetData(void*, int)
 INLINE 0 58 34 428 d604 1f
 INLINE 1 81 34 429 d604 4 d60b c d654 c
-INLINE 2 172 4 430 d604 4 d60b 8 d654 8
+INLINE 2 172 3 430 d604 4 d60b 8 d654 8
 INLINE 0 66 34 430 d63f 8
 INLINE 0 68 34 428 d654 1d
 d600 4 56 34
 d604 4 94 34
 d608 3 85 34
 d60b 8 94 34
-d613 4 172 4
+d613 4 172 3
 d617 6 82 34
 d61d 3 85 34
 d620 3 87 34
@@ -6122,7 +6307,7 @@ d63a 5 66 34
 d63f 8 94 34
 d647 d 66 34
 d654 8 94 34
-d65c 4 172 4
+d65c 4 172 3
 d660 6 82 34
 d666 6 85 34
 d66c 5 87 34
@@ -6136,15 +6321,15 @@ INLINE 2 68 34 428 d6a6 7
 d680 c 39 34
 d68c a 44 34
 d696 6 138 34
-d69c 3 177 4
+d69c 3 177 3
 d69f 7 65 34
 d6a6 7 87 34
 d6ad 7 51 34
 FUNC d6c0 1c 0 google_breakpad::MachMessage::CalculateSize()
 INLINE 0 81 34 429 d6c0 c
-INLINE 1 172 4 430 d6c0 8
+INLINE 1 172 3 430 d6c0 8
 d6c0 8 94 34
-d6c8 4 172 4
+d6c8 4 172 3
 d6cc 6 82 34
 d6d2 6 85 34
 d6d8 3 87 34
@@ -6159,14 +6344,14 @@ d706 1 107 34
 FUNC d710 aa 0 google_breakpad::MachMessage::AddDescriptor(google_breakpad::MachMsgPortDescriptor const&)
 INLINE 0 113 34 428 d71a 1b d749 5
 INLINE 1 81 34 429 d71a c d749 5 d776 4 d799 8
-INLINE 2 172 4 430 d71a 8 d749 5 d776 4 d799 4
+INLINE 2 172 3 430 d71a 8 d749 5 d776 4 d799 4
 INLINE 0 125 34 432 d75e 18
 INLINE 0 128 34 428 d776 4 d799 19
 INLINE 0 126 34 425 d77e 13 d794 5
 INLINE 0 126 34 433 d791 3
 d710 a 111 34
 d71a 8 94 34
-d722 4 172 4
+d722 4 172 3
 d726 6 82 34
 d72c 6 85 34
 d732 3 87 34
@@ -6181,11 +6366,11 @@ d77e 3 135 34
 d781 2 138 34
 d783 8 140 34
 d78b 6 138 34
-d791 3 186 4
+d791 3 186 3
 d794 3 137 34
 d797 2 138 34
 d799 4 94 34
-d79d 4 172 4
+d79d 4 172 3
 d7a1 6 82 34
 d7a7 6 85 34
 d7ad 5 87 34
@@ -6202,7 +6387,7 @@ INLINE 0 158 34 435 d7ea 8
 d7e0 2 156 34
 d7e2 5 157 34
 d7e7 3 149 34
-d7ea 8 135 4
+d7ea 8 135 3
 d7f2 1 161 34
 FUNC d800 83 0 google_breakpad::ReceivePort::ReceivePort(char const*)
 d800 e 167 34


### PR DESCRIPTION
Fixes #713.

In the FunctionBuilder, which is used for the DWARF reader and for the breakpad reader, we were already splitting lines which were extending beyond the end of an inlinee. Now we also split lines which extend into the beginning of the next inlinee.

This fixes all "overlapping line" warnings in the debuginfo_debug example when run on the macos/crash.dSYM. Those overlapping lines were caused by "self lines" which overlapped with "inlinee lines".

I've also updated crash.inlines.sym with a file that I freshly generated using a dump_syms build which includes this symbolic fix. Now the crash.inlines.sym file no longer has overlapping inlinees.