### PR TITLE
ci: Update CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,18 +22,11 @@ jobs:
     runs-on: macos-${{ matrix.macos-version }}
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-          profile: minimal
-          override: true
+      - run: rustup toolchain install stable --profile minimal --target ${{ matrix.target }} --no-self-update
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.6
 
@@ -60,9 +53,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v3
 
       - if: matrix.build-arch == 'manylinux2014_aarch64'
         uses: docker/setup-qemu-action@v1
@@ -82,11 +73,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 2.7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,36 +16,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
+      - run: rustup toolchain install stable --profile minimal --component rustfmt --component clippy --no-self-update
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - run: make style-python
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --workspace --all-targets -- -D clippy::all
+        run: cargo clippy --all-features --workspace --tests --examples -- -D clippy::all
 
       - run: make lint-python
 
@@ -55,23 +42,13 @@ jobs:
     env:
       RUSTDOCFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rust-docs
+      - run: rustup toolchain install stable --profile minimal --component rust-docs --no-self-update
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --workspace --all-features --no-deps
+      - run: cargo doc --workspace --all-features --document-private-items --no-deps
 
   test-rust:
     strategy:
@@ -83,23 +60,14 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - run: rustup toolchain install stable --profile minimal --no-self-update
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --all-features --all-targets
+        run: cargo test --workspace --all-features --all-targets
 
   test-python:
     strategy:
@@ -114,21 +82,15 @@ jobs:
       SYMBOLIC_DEBUG: 1
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - run: rustup toolchain install stable --profile minimal --no-self-update
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - run: make test-python
 
@@ -143,46 +105,32 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - run: rustup toolchain install stable --profile minimal --no-self-update
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cbindgen
+      - run: cargo install cbindgen
 
       - run: cd symbolic-cabi && make test
 
   codecov:
     name: Code Coverage
     runs-on: ubuntu-latest
-    continue-on-error: true # well, its nightly and highly experimental
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          components: llvm-tools-preview
-          override: true
+      - name: Install rust stable toolchain
+        run: rustup toolchain install stable --profile minimal --component llvm-tools-preview --no-self-update
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
-      - uses: Swatinem/fucov@v1
-        with:
-          args: --workspace --all-features
+      - uses: taiki-e/install-action@cargo-llvm-cov
+
+      - run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
       - uses: codecov/codecov-action@e156083f13aff6830c92fc5faa23505779fbf649
         with:
-          directory: coverage
+          files: lcov.info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,16 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     name: "Release a new version"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - run: rustup toolchain install stable --profile minimal --no-self-update
 
       - name: Prepare release
         uses: getsentry/action-prepare-release@v1

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -18,34 +18,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
-          components: clippy
+      - name: Install rust stable toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --component clippy --no-self-update
+          rustup default ${{ matrix.rust }}
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --workspace --tests --examples -- -D clippy::all
+      - run: cargo clippy --all-features --workspace --tests --examples -- -D clippy::all
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --all-features
+      - run: cargo test --workspace --all-features
 
   weekly-audit:
     name: Audit
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
+      # FIXME: find a maintained alternative to audit-check
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/symbolic-ppdb/src/format/metadata.rs
+++ b/symbolic-ppdb/src/format/metadata.rs
@@ -189,7 +189,7 @@ impl Column {
 /// There are three types of indices recorded here:
 /// * Heap indices (`string_heap`, `guid_heap`, `blob_heap`) are indices into other sections
 ///   of the Portable PDB file. Their sizes are determined by the `heap_sizes` bitvector in the #~ stream
-///   header, see https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.6-metadata-stream.md.
+///   header, see <https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.6-metadata-stream.md>.
 /// * Table indices (`<something>_table`) are indices into individual tables in this stream. Their sizes
 ///   are determined by the number of rows in the target table.
 /// * Composite indices are indices that may point into one of several tables in this stream. Their sizes are
@@ -239,7 +239,7 @@ struct IndexSizes {
 
 /// A stream representing the "metadata heap", which comprises a number of metadata tables.
 ///
-/// See https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.6-metadata-stream.md for a definition
+/// See <https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.6-metadata-stream.md> for a definition
 /// of the stream's format. Note that this stream contains all tables described in the ECMA-335 specification and
 /// the Portable PDB specification.
 #[derive(Debug, Clone)]
@@ -597,7 +597,7 @@ impl<'data> MetadataStream<'data> {
 
     /// Returns the size in bytes of an index into this Portable PDB file's `#String` heap.
     ///
-    /// See https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.6-metadata-stream.md for an explanation.
+    /// See <https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.6-metadata-stream.md> for an explanation.
     fn string_index_size(&self) -> usize {
         if self.header.heap_sizes & 0x1 == 0 {
             2
@@ -608,7 +608,7 @@ impl<'data> MetadataStream<'data> {
 
     /// Returns the size in bytes of an index into this Portable PDB file's `#Guid` heap.
     ///
-    /// See https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.6-metadata-stream.md for an explanation.
+    /// See <https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.6-metadata-stream.md> for an explanation.
     fn guid_index_size(&self) -> usize {
         if self.header.heap_sizes & 0x2 == 0 {
             2
@@ -619,7 +619,7 @@ impl<'data> MetadataStream<'data> {
 
     /// Returns the size in bytes of an index into this Portable PDB file's `#Blob` heap.
     ///
-    /// See https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.6-metadata-stream.md for an explanation.
+    /// See <https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.6-metadata-stream.md> for an explanation.
     fn blob_index_size(&self) -> usize {
         if self.header.heap_sizes & 0x4 == 0 {
             2

--- a/symbolic-ppdb/src/format/streams.rs
+++ b/symbolic-ppdb/src/format/streams.rs
@@ -7,7 +7,7 @@ use super::{FormatError, FormatErrorKind};
 
 /// A stream representing the "blob heap", which contains "blobs" of arbitrary binary data.
 ///
-/// See https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.4-us-and-blob-heaps.md.
+/// See <https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.4-us-and-blob-heaps.md>.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct BlobStream<'data> {
     buf: &'data [u8],
@@ -34,7 +34,7 @@ impl<'data> BlobStream<'data> {
 
 /// The file's #PDB stream.
 ///
-/// See https://github.com/dotnet/runtime/blob/main/docs/design/specs/PortablePdb-Metadata.md#pdb-stream.
+/// See <https://github.com/dotnet/runtime/blob/main/docs/design/specs/PortablePdb-Metadata.md#pdb-stream>.
 #[derive(Debug, Clone)]
 pub(crate) struct PdbStream<'data> {
     header: &'data PdbStreamHeader,
@@ -73,7 +73,7 @@ impl<'data> PdbStream<'data> {
 
 /// A stream representing the "string heap", which contains UTF-8 string data.
 ///
-/// See https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.3-strings-heap.md.
+/// See <https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.3-strings-heap.md>.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct StringStream<'data> {
     buf: &'data [u8],
@@ -97,7 +97,7 @@ impl<'data> StringStream<'data> {
 
 /// A stream representing the "user string heap".
 ///
-/// See https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.4-us-and-blob-heaps.md.
+/// See <https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.4-us-and-blob-heaps.md>.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct UsStream<'data> {
     _buf: &'data [u8],
@@ -109,7 +109,7 @@ impl<'data> UsStream<'data> {
 }
 /// A stream representing the "GUID heap", which contains GUIDs.
 ///
-/// See https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.5-guid-heap.md.
+/// See <https://github.com/stakx/ecma-335/blob/master/docs/ii.24.2.5-guid-heap.md>.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct GuidStream<'data> {
     buf: &'data [uuid::Bytes],

--- a/symbolic-symcache/src/writer.rs
+++ b/symbolic-symcache/src/writer.rs
@@ -510,7 +510,7 @@ impl<'a> SymCacheConverter<'a> {
 /// Undecorates a Windows C-decorated symbol name.
 ///
 /// The decoration rules are explained here:
-/// https://docs.microsoft.com/en-us/cpp/build/reference/decorated-names?view=vs-2019
+/// <https://docs.microsoft.com/en-us/cpp/build/reference/decorated-names?view=vs-2019>
 ///
 /// - __cdecl Leading underscore (_)
 /// - __stdcall Leading underscore (_) and a trailing at sign (@) followed by the number of bytes in the parameter list in decimal
@@ -519,7 +519,7 @@ impl<'a> SymCacheConverter<'a> {
 /// > In a 64-bit environment, C or extern "C" functions are only decorated when using the __vectorcall calling convention."
 ///
 /// This code is adapted from `dump_syms`:
-/// See https://github.com/mozilla/dump_syms/blob/325cf2c61b2cacc55a7f1af74081b57237c7f9de/src/symbol.rs#L169-L216
+/// See <https://github.com/mozilla/dump_syms/blob/325cf2c61b2cacc55a7f1af74081b57237c7f9de/src/symbol.rs#L169-L216>
 fn undecorate_win_symbol(name: &str) -> &str {
     if name.starts_with('?') || name.contains([':', '(', '<']) {
         return name;


### PR DESCRIPTION
- Switches to newest actions versions, except for `actions-rs/audit-check`.
- We are not using submodules anymore.
- Switches Code Coverage action to `cargo-llvm-cov`.