### PR TITLE
ci: add shared danger workflow

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,9 @@
+name: Danger
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+
+jobs:
+  danger:
+    uses: getsentry/github-workflows/.github/workflows/danger.yml@v2


### PR DESCRIPTION
So that [this](https://github.com/getsentry/symbolic/pull/729#issuecomment-1339027444) wouldn't happen. 
I assumed changelog is auto-generated like on some of the other repos Sentry that don't use danget to check whether there's a changelog :)