### PR TITLE
Use cross-compilation for aarch64 release-build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - "release/**"
       
 env:
-  MANYLINUX_VERSION: manylinux2014
+  MANYLINUX_VERSION: manylinux_2_28
 
 jobs:
   python-wheel-mac:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,13 +54,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
+      
       - if: matrix.build-arch == 'manylinux2014_aarch64'
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: arm64
-
-      - name: Build in Docker
+        name: Build in Docker (cross-compile host:amd64, target:aarch64)
+        run: make wheel-manylinux-aarch64 IMAGE=messense/manylinux2014-cross:aarch64-amd64
+      
+      - if: matrix.build-arch != 'manylinux2014_aarch64'
+        name: Build in Docker
         run: make wheel-manylinux IMAGE=quay.io/pypa/${{ matrix.build-arch }}
 
       - uses: actions/upload-artifact@v3.1.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "release/**"
+      
+env:
+  MANYLINUX_VERSION: manylinux2014
 
 jobs:
   python-wheel-mac:
@@ -45,9 +48,9 @@ jobs:
       fail-fast: false
       matrix:
         build-arch:
-          - manylinux2014_i686
-          - manylinux2014_x86_64
-          - manylinux2014_aarch64
+          - i686
+          - x86_64
+          - aarch64
 
     name: Python Linux ${{ matrix.build-arch }}
     runs-on: ubuntu-latest
@@ -55,13 +58,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       
-      - if: matrix.build-arch == 'manylinux2014_aarch64'
+      - if: matrix.build-arch == 'aarch64'
         name: Build in Docker (cross-compile host:amd64, target:aarch64)
-        run: make wheel-manylinux-aarch64 IMAGE=messense/manylinux2014-cross:aarch64-amd64
+        run: make wheel-manylinux-aarch64 IMAGE=messense/$MANYLINUX_VERSION-cross:aarch64-amd64
       
-      - if: matrix.build-arch != 'manylinux2014_aarch64'
+      - if: matrix.build-arch != 'aarch64'
         name: Build in Docker
-        run: make wheel-manylinux IMAGE=quay.io/pypa/${{ matrix.build-arch }}
+        run: make wheel-manylinux IMAGE=quay.io/pypa/$MANYLINUX_VERSION_${{ matrix.build-arch }}
 
       - uses: actions/upload-artifact@v3.1.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,8 +64,8 @@ jobs:
         run: make wheel-manylinux IMAGE=quay.io/pypa/manylinux_2_28_x86_64
 
       - if: matrix.build-arch == 'i686'
-        name: Build in Docker (manylinux_2_24_i686)
-        run: make wheel-manylinux IMAGE=quay.io/pypa/manylinux_2_24_i686
+        name: Build in Docker (manylinux2014_i686)
+        run: make wheel-manylinux IMAGE=quay.io/pypa/manylinux2014_i686
 
       - uses: actions/upload-artifact@v3.1.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,11 +60,11 @@ jobs:
 
       - if: matrix.build-arch == 'aarch64'
         name: Build in Docker (cross-compile host:amd64, target:aarch64)
-        run: make wheel-manylinux-aarch64 IMAGE=messense/${{ MANYLINUX_VERSION }}-cross:aarch64-amd64
+        run: make wheel-manylinux-aarch64 IMAGE=messense/"$MANYLINUX_VERSION"-cross:aarch64-amd64
       
       - if: matrix.build-arch != 'aarch64'
         name: Build in Docker
-        run: make wheel-manylinux IMAGE=quay.io/pypa/${{ MANYLINUX_VERSION }}_${{ matrix.build-arch }}
+        run: make wheel-manylinux IMAGE=quay.io/pypa/"$MANYLINUX_VERSION"_${{ matrix.build-arch }}
 
       - uses: actions/upload-artifact@v3.1.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,14 +57,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      
+
       - if: matrix.build-arch == 'aarch64'
         name: Build in Docker (cross-compile host:amd64, target:aarch64)
-        run: make wheel-manylinux-aarch64 IMAGE=messense/$MANYLINUX_VERSION-cross:aarch64-amd64
+        run: make wheel-manylinux-aarch64 IMAGE=messense/${{ MANYLINUX_VERSION }}-cross:aarch64-amd64
       
       - if: matrix.build-arch != 'aarch64'
         name: Build in Docker
-        run: make wheel-manylinux IMAGE=quay.io/pypa/$MANYLINUX_VERSION_${{ matrix.build-arch }}
+        run: make wheel-manylinux IMAGE=quay.io/pypa/${{ MANYLINUX_VERSION }}_${{ matrix.build-arch }}
 
       - uses: actions/upload-artifact@v3.1.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 2.7
+          python-version: 3.6
 
       - run: make sdist
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,12 +58,12 @@ jobs:
       - uses: actions/checkout@v3
 
       - if: matrix.build-arch == 'aarch64'
-        name: Build in Docker (${{ matrix.build-arch }})
-        run: make wheel-manylinux-aarch64 IMAGE=messense/"$MANYLINUX_VERSION"-cross:${{ matrix.build-arch }}-amd64
+        name: Build in Docker (aarch64)
+        run: make wheel-manylinux-aarch64 IMAGE=messense/"$MANYLINUX_VERSION"-cross:aarch64-amd64
       
       - if: matrix.build-arch == 'x86_64'
-        name: Build in Docker (${{ matrix.build-arch }})
-        run: make wheel-manylinux IMAGE=quay.io/pypa/"$MANYLINUX_VERSION"_${{ matrix.build-arch }}
+        name: Build in Docker (x86_64)
+        run: make wheel-manylinux IMAGE=quay.io/pypa/"$MANYLINUX_VERSION"_x86_64
 
       - uses: actions/upload-artifact@v3.1.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - "release/**"
 
+env:
+  MANYLINUX_VERSION: manylinux_2_28
+
 jobs:
   python-wheel-mac:
     strategy:
@@ -45,7 +48,6 @@ jobs:
       fail-fast: false
       matrix:
         build-arch:
-          - i686
           - x86_64
           - aarch64
 
@@ -56,16 +58,12 @@ jobs:
       - uses: actions/checkout@v3
 
       - if: matrix.build-arch == 'aarch64'
-        name: Build in Docker (cross-compile manylinux_2_28, host:x86_64, target:aarch64)
-        run: make wheel-manylinux-aarch64 IMAGE=messense/manylinux_2_28-cross:aarch64-amd64
+        name: Build in Docker (${{ matrix.build-arch }})
+        run: make wheel-manylinux-aarch64 IMAGE=messense/"$MANYLINUX_VERSION"-cross:${{ matrix.build-arch }}-amd64
       
       - if: matrix.build-arch == 'x86_64'
-        name: Build in Docker (manylinux_2_28_x86_64)
-        run: make wheel-manylinux IMAGE=quay.io/pypa/manylinux_2_28_x86_64
-
-      - if: matrix.build-arch == 'i686'
-        name: Build in Docker (manylinux2014_i686)
-        run: make wheel-manylinux IMAGE=quay.io/pypa/manylinux2014_i686
+        name: Build in Docker (${{ matrix.build-arch }})
+        run: make wheel-manylinux IMAGE=quay.io/pypa/"$MANYLINUX_VERSION"_${{ matrix.build-arch }}
 
       - uses: actions/upload-artifact@v3.1.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: 3.7
 
       - run: make sdist
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - "release/**"
-      
-env:
-  MANYLINUX_VERSION: manylinux_2_28
 
 jobs:
   python-wheel-mac:
@@ -59,12 +56,16 @@ jobs:
       - uses: actions/checkout@v3
 
       - if: matrix.build-arch == 'aarch64'
-        name: Build in Docker (cross-compile host:amd64, target:aarch64)
-        run: make wheel-manylinux-aarch64 IMAGE=messense/"$MANYLINUX_VERSION"-cross:aarch64-amd64
+        name: Build in Docker (cross-compile manylinux_2_28, host:x86_64, target:aarch64)
+        run: make wheel-manylinux-aarch64 IMAGE=messense/manylinux_2_28-cross:aarch64-amd64
       
-      - if: matrix.build-arch != 'aarch64'
-        name: Build in Docker
-        run: make wheel-manylinux IMAGE=quay.io/pypa/"$MANYLINUX_VERSION"_${{ matrix.build-arch }}
+      - if: matrix.build-arch == 'x86_64'
+        name: Build in Docker (manylinux_2_28_x86_64)
+        run: make wheel-manylinux IMAGE=quay.io/pypa/manylinux_2_28_x86_64
+
+      - if: matrix.build-arch == 'i686'
+        name: Build in Docker (manylinux_2_24_i686)
+        run: make wheel-manylinux IMAGE=quay.io/pypa/manylinux_2_24_i686
 
       - uses: actions/upload-artifact@v3.1.1
         with:

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,11 @@ wheel-manylinux:
 	docker run --rm -v $(CURDIR):/work -w /work/py $(IMAGE) sh manylinux.sh
 .PHONY: wheel-manylinux
 
+wheel-manylinux-aarch64:
+	docker run --rm -v $(CURDIR):/work -w /work/py $(IMAGE) sh manylinux_aarch64.sh
+.PHONY: wheel-manylinux-aarch64
+
+
 # Tests
 
 test: test-rust test-python

--- a/py/manylinux.sh
+++ b/py/manylinux.sh
@@ -5,26 +5,21 @@ set -e
 yum -y -q -e 0 install gcc libffi-devel
 
 # upgrade wheel
-$LINUX32 /opt/python/cp36-cp36m/bin/pip install --upgrade wheel
+/opt/python/cp36-cp36m/bin/pip install --upgrade wheel
 
 # Install Rust
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 export PATH=~/.cargo/bin:$PATH
-
-# Build wheels
-if [ "$AUDITWHEEL_ARCH" == "i686" ]; then
-  LINUX32=linux32
-fi
 
 cat > ~/.cargo/config <<EOF
 [net]
 git-fetch-with-cli = true
 EOF
 
-$LINUX32 /opt/python/cp36-cp36m/bin/python setup.py bdist_wheel
+/opt/python/cp36-cp36m/bin/python setup.py bdist_wheel
 
 # Audit wheels
 for wheel in dist/*-linux_*.whl; do
-  auditwheel repair $wheel -w dist/
-  rm $wheel
+  auditwheel repair "$wheel" -w dist/
+  rm "$wheel"
 done

--- a/py/manylinux_aarch64.sh
+++ b/py/manylinux_aarch64.sh
@@ -47,6 +47,6 @@ cross-python setup.py bdist_wheel
 # audit wheel (use cross-pip so we get an aarch64 auditwheel)
 cross-pip install auditwheel
 for wheel in dist/*-linux_*.whl; do
-  auditwheel repair --plat manylinux2014_aarch64 "$wheel" -w dist/
+  auditwheel repair --plat manylinux_2_28_aarch64 "$wheel" -w dist/
   rm "$wheel"
 done

--- a/py/manylinux_aarch64.sh
+++ b/py/manylinux_aarch64.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -xeu
+
+# build a aarch64 libffi
+export CC="$TARGET_CC"
+export CXX="$TARGET_CXX"
+wget https://github.com/libffi/libffi/releases/download/v3.4.4/libffi-3.4.4.tar.gz
+tar -xzf libffi-3.4.4.tar.gz
+rm libffi-3.4.4.tar.gz
+cd libffi-3.4.4
+./configure --prefix=/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot/usr --with-sysroot=/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot --host=aarch64-unknown-linux-gnu
+make
+make install
+cd ..
+rm -rf libffi-3.4.4
+
+# install Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+export PATH=~/.cargo/bin:"$PATH"
+. "$HOME/.cargo/env"
+rustup target add aarch64-unknown-linux-gnu
+cat > ~/.cargo/config <<EOF
+[net]
+git-fetch-with-cli = true
+EOF
+
+# setup a python wheel cross-compilation environment
+python -m pip install --upgrade pip
+python -m pip install crossenv
+rm -rf venv
+python -m crossenv /opt/python/cp310-cp310/bin/python3 --cc "$TARGET_CC" --cxx "$TARGET_CXX" --sysroot "$TARGET_SYSROOT" --env LIBRARY_PATH= venv
+. venv/bin/activate
+
+# now continue wheel building from within the crossenv
+# make sure python subprocesses don't find build setuptools
+build-pip uninstall -y setuptools
+
+# make sure cffi is part of the build python
+build-pip install cffi
+
+# setuptools and wheel must be cross modules so we get aarch64 artifacts
+cross-pip install --upgrade setuptools wheel
+
+# finally build wheel
+cross-python setup.py bdist_wheel
+
+# audit wheel (use cross-pip so we get an aarch64 auditwheel)
+cross-pip install auditwheel
+for wheel in dist/*-linux_*.whl; do
+  auditwheel repair --plat manylinux2014_aarch64 "$wheel" -w dist/
+  rm "$wheel"
+done


### PR DESCRIPTION
This is a replacement draft for #699. Differences are:

* it doesn't change the existing workflows for `i686` and `x86_64` 
* it introduces a minor conditional on the path from the GHA to the `aarch64`-specific build-script
* the `aarch64`-specific build script is run in a minimal cross-compilation container which provides
  * a `manylinux2014` compatible cross-compilation toolchain (which can be easily switched to manylinux_2_28 if needed)
  * a `pypa manylinux` environment
* the build script differs from the normal build script in that
  * it must build `libffi` with the cross-compilation toolchain
  * sets up a python `crossenv` so we don't have to load and start yet another container to build the` aarch64` wheel

#skip-changelog