### PR TITLE
Fix clippy and doctests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Run cargo test
-        run: cargo test --workspace --all-features --all-targets
+      - run: cargo test --workspace --all-features --all-targets
+      - run: cargo test --workspace --all-features --doc
 
   test-python:
     strategy:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -27,7 +27,8 @@ jobs:
 
       - run: cargo clippy --all-features --workspace --tests --examples -- -D clippy::all
 
-      - run: cargo test --workspace --all-features
+      - run: cargo test --workspace --all-features --all-targets
+      - run: cargo test --workspace --all-features --doc
 
   weekly-audit:
     name: Audit

--- a/examples/minidump_stackwalk/src/main.rs
+++ b/examples/minidump_stackwalk/src/main.rs
@@ -280,7 +280,7 @@ impl<'a> minidump_processor::SymbolProvider for LocalSymbolProvider<'a> {
             module.code_identifier(),
             module.debug_identifier().unwrap_or_default(),
         );
-        tracing::Span::current().record("module.id", &tracing::field::debug(&id));
+        tracing::Span::current().record("module.id", tracing::field::debug(&id));
 
         let mut symcaches = self.symcaches.lock().unwrap();
 
@@ -337,7 +337,7 @@ impl<'a> minidump_processor::SymbolProvider for LocalSymbolProvider<'a> {
             module.code_identifier(),
             module.debug_identifier().unwrap_or_default(),
         );
-        tracing::Span::current().record("module.id", &tracing::field::debug(&id));
+        tracing::Span::current().record("module.id", tracing::field::debug(&id));
 
         let mut cfi = self.cfi_files.lock().unwrap();
 

--- a/symbolic-ppdb/src/lib.rs
+++ b/symbolic-ppdb/src/lib.rs
@@ -14,11 +14,13 @@
 //!   and parse them with [`PortablePdbCache::parse`].
 //! * Look up line information for a function on a `PortablePdbCache` with
 //!   [`PortablePdbCache::lookup`].
+//!
 //! ## Example
 //! ```
+//! use symbolic_testutils::fixture;
 //! use symbolic_ppdb::{LineInfo, PortablePdb, PortablePdbCacheConverter, PortablePdbCache};
-//! let buf = std::fs::read("tests/fixtures/integration.pdb").unwrap();
 //!
+//! let buf = std::fs::read(fixture("windows/portable.pdb")).unwrap();
 //! let pdb = PortablePdb::parse(&buf).unwrap();
 //!
 //! let mut converter = PortablePdbCacheConverter::new();
@@ -32,7 +34,9 @@
 //! ```
 //!
 //! # Structure of a Portable PDB file
-//! An ECMA-335 file is divided into sections called _streams_. The possible streams are
+//!
+//! An ECMA-335 file is divided into sections called _streams_. The possible streams are:
+//!
 //! * `#~` ("metadata"), comprising information about classes, methods, modules, &c.,
 //!   organized into tables adhering to various schemas. The original ECMA-335 tables
 //!   are described in Section II.22 of the ECMA-335 spec, the tables added by Portable PDB are described


### PR DESCRIPTION
Fix nightly clippy lints

Runs CI on `--all-targets` and `--doc` separately, as you can’t mix those two :-(

#skip-changelog