### PR TITLE
ref(sourcemapcache): Implement AsSelf for SourceMapCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `PortablePdbDebugSession` now returns files referenced in the Portable PDB file. ([#729](https://github.com/getsentry/symbolic/pull/729))
 - `PortablePdbDebugSession` now returns source files embedded in the Portable PDB file. ([#734](https://github.com/getsentry/symbolic/pull/734))
+- Implement `symbolic_common::AsSelf` `for SourceMapCache` ([#742](https://github.com/getsentry/symbolic/pull/742))
 
 **Breaking changes**:
 

--- a/symbolic-sourcemapcache/Cargo.toml
+++ b/symbolic-sourcemapcache/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2021"
 js-source-scopes = "0.3.1"
 thiserror = "1.0.31"
 sourcemap = "6.1.0"
+symbolic-common = { version = "10.2.1", path = "../symbolic-common" }
 tracing = "0.1.36"
 watto = { version = "0.1.0", features = ["writer", "strings"] }
 itertools = "0.10.3"

--- a/symbolic-sourcemapcache/src/lookup.rs
+++ b/symbolic-sourcemapcache/src/lookup.rs
@@ -1,3 +1,4 @@
+use symbolic_common::AsSelf;
 use watto::{align_to, Pod, StringTable};
 
 use crate::{ScopeLookupResult, SourcePosition};
@@ -76,6 +77,14 @@ pub struct SourceMapCache<'data> {
     files: &'data [raw::File],
     line_offsets: &'data [raw::LineOffset],
     string_bytes: &'data [u8],
+}
+
+impl<'slf, 'a: 'slf> AsSelf<'slf> for SourceMapCache<'a> {
+    type Ref = SourceMapCache<'slf>;
+
+    fn as_self(&'slf self) -> &Self::Ref {
+        self
+    }
 }
 
 impl<'data> std::fmt::Debug for SourceMapCache<'data> {


### PR DESCRIPTION
This simplifies the usage for self-referential data, where `SelfCell` is required and allows us to remove the unnecessary wrapper from cabi and in the future from symbolicator.