### PR TITLE
fix: Discard invalid line records and inlinees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Fixes**:
+
+- Discard invalid line records and inlinees when parsing functions. ([#747](https://github.com/getsentry/symbolic/pull/747))
+
 **Features**:
 
 - `PortablePdbDebugSession` now returns files referenced in the Portable PDB file. ([#729](https://github.com/getsentry/symbolic/pull/729))

--- a/symbolic-debuginfo/src/function_builder.rs
+++ b/symbolic-debuginfo/src/function_builder.rs
@@ -56,6 +56,7 @@ impl<'s> FunctionBuilder<'s> {
         call_file: FileInfo<'s>,
         call_line: u64,
     ) {
+        // An inlinee that starts before the function is obviously bogus.
         if address < self.address {
             return;
         }
@@ -79,6 +80,7 @@ impl<'s> FunctionBuilder<'s> {
         file: FileInfo<'s>,
         line: u64,
     ) {
+        // A line record that starts before the function is obviously bogus.
         if address < self.address {
             return;
         }

--- a/symbolic-debuginfo/src/function_builder.rs
+++ b/symbolic-debuginfo/src/function_builder.rs
@@ -56,6 +56,10 @@ impl<'s> FunctionBuilder<'s> {
         call_file: FileInfo<'s>,
         call_line: u64,
     ) {
+        if address < self.address {
+            return;
+        }
+
         self.inlinees.push(Reverse(FunctionBuilderInlinee {
             depth,
             address,
@@ -75,6 +79,10 @@ impl<'s> FunctionBuilder<'s> {
         file: FileInfo<'s>,
         line: u64,
     ) {
+        if address < self.address {
+            return;
+        }
+
         self.lines.push(LineInfo {
             address,
             size,


### PR DESCRIPTION
As described in https://github.com/getsentry/symbolic/issues/746, broken Breakpad files sometimes contain line records that start before the function they supposedly belong to. This PR discards those records when parsing functions. It also does the same for inlinees, although we haven't actually seen this happen.

Should we report this to the user somehow or is it ok to discard the records silently?