### PR TITLE
chore(ppdb): add to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Symbolic provides the following functionality:
   - Mach, ELF and PE symbol tables
   - Mach, ELF and PE embedded DWARF data
   - PDB CodeView debug information
+  - .NET Portable PDB
   - Breakpad symbol files
 - Demangling support
   - C++ (GCC, clang and MSVC)


### PR DESCRIPTION
Should we point out Unity's IL2CPP support on the README too somehow?

#skip-changelog