### PR TITLE
ref(smcache): Add context lines and source printing to our example

### DIFF
--- a/examples/sourcemapcache_debug/src/main.rs
+++ b/examples/sourcemapcache_debug/src/main.rs
@@ -82,7 +82,7 @@ fn execute(matches: &ArgMatches) -> Result<()> {
 
         if matches.get_flag("print_source") {
             println!("Source:");
-            for (i, line) in &mut file.source().unwrap().split("\n").enumerate() {
+            for (i, line) in &mut file.source().unwrap().split('\n').enumerate() {
                 println!("{:>5}: {line}", format!("#{i}"));
             }
         }


### PR DESCRIPTION
Mostly to ease debugging with our support team.

#skip-changelog