### PR TITLE
fix(ppdb): Parse streams in the correct order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Make sure to parse `PortablePdb` streams in the correct order. ([#760](https://github.com/getsentry/symbolic/pull/760))
+
 ## 11.1.0
 
 **Features**:

--- a/symbolic-debuginfo/tests/test_objects.rs
+++ b/symbolic-debuginfo/tests/test_objects.rs
@@ -748,10 +748,9 @@ fn test_ppdb_has_sources() -> Result<(), Error> {
         assert_eq!(object.has_sources(), true);
     }
     {
-        // This is a special case with a broken file, see symbolic-ppdb tests.
         let view = ByteView::open(fixture("android/Sentry.Samples.Maui.pdb"))?;
         let object = Object::parse(&view)?;
-        assert_eq!(object.has_sources(), false);
+        assert_eq!(object.has_sources(), true);
     }
     Ok(())
 }

--- a/symbolic-ppdb/tests/test_ppdb.rs
+++ b/symbolic-ppdb/tests/test_ppdb.rs
@@ -75,16 +75,14 @@ fn test_embedded_sources_contents() {
     );
 }
 
-/// This is here to prevent regression. The following test PDB was built in sentry-dotnet MAUI
-/// sample for net6.0-android and failed with: `InvalidCustomDebugInformationTag(0)`
 #[test]
-fn test_embedded_sources_with_metadata_broken() {
+fn test_embedded_sources_with_metadata_maui() {
     let buf = std::fs::read(fixture("android/Sentry.Samples.Maui.pdb")).unwrap();
 
     let ppdb = PortablePdb::parse(&buf).unwrap();
     let iter = ppdb.get_embedded_sources().unwrap();
     let items = iter.collect::<Result<Vec<_>, _>>().unwrap();
-    assert_eq!(items.len(), 0);
+    assert_eq!(items.len(), 5);
 }
 
 #[test]


### PR DESCRIPTION
Ppdb parsing incorrectly assumed that the `#Pdb` stream would always be physically located before the `#~` stream and just parsed them in order. Since the `#Pdb` stream contains table size information that must be known during `#~` parsing, this led to the bug described in #759.

The fix is simply to initially collect the locations of all the streams and then parse the `#Pdb` stream before the others.