### PR TITLE
feat: Added debug IDs to source bundle javascript files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Added debug IDs to source bundle JavaScript files and source maps. ([#762](https://github.com/getsentry/symbolic/pull/762))
+
 **Breaking changes**:
 
 - Change `DebugSession::source_by_path()` to return `SourceCode` enum with either file content or a URL to fetch it from. ([#758](https://github.com/getsentry/symbolic/pull/758))

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -70,6 +70,7 @@ sourcebundle = [
     "regex",
     "serde_json",
     "zip",
+    "debugid/serde"
 ]
 # WASM processing
 wasm = ["bitvec", "dwarf", "wasmparser"]
@@ -77,6 +78,7 @@ wasm = ["bitvec", "dwarf", "wasmparser"]
 [dependencies]
 bitvec = { version = "1.0.0", optional = true, features = ["alloc"] }
 dmsort = "1.0.1"
+debugid = { version = "0.8.0" }
 elementtree = { version = "1.2.2", optional = true }
 elsa = { version = "1.4.0", optional = true }
 fallible-iterator = "0.2.0"

--- a/symbolic-debuginfo/src/base.rs
+++ b/symbolic-debuginfo/src/base.rs
@@ -6,6 +6,8 @@ use std::str::FromStr;
 
 use symbolic_common::{clean_path, join_path, Arch, CodeId, DebugId, Name};
 
+use crate::sourcebundle::SourceFileDescriptor;
+
 pub(crate) trait Parse<'data>: Sized {
     type Error;
 
@@ -670,17 +672,6 @@ impl fmt::Debug for Function<'_> {
 /// A dynamically dispatched iterator over items with the given lifetime.
 pub type DynIterator<'a, T> = Box<dyn Iterator<Item = T> + 'a>;
 
-/// Represents a source file referenced by a debug information object file.
-#[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SourceCode<'a> {
-    /// Verbatim source code/file contents.
-    Content(Cow<'a, str>),
-
-    /// Url (usually https) where the content can be fetched from.
-    Url(Cow<'a, str>),
-}
-
 /// A stateful session for interfacing with debug information.
 ///
 /// Debug sessions can be obtained via [`ObjectLike::debug_session`]. Since computing a session may
@@ -728,8 +719,10 @@ pub trait DebugSession<'session> {
     fn files(&'session self) -> Self::FileIterator;
 
     /// Looks up a file's source by its full canonicalized path.
-    /// Returns either source contents, if it was embedded, or a source link.
-    fn source_by_path(&self, path: &str) -> Result<Option<SourceCode<'_>>, Self::Error>;
+    ///
+    /// Returns a descriptor that has all the information available of the source.  It can
+    /// either contain the source contents directly, if it was embedded, or a source link.
+    fn source_by_path(&self, path: &str) -> Result<Option<SourceFileDescriptor<'_>>, Self::Error>;
 }
 
 /// An object containing debug information.

--- a/symbolic-debuginfo/src/base.rs
+++ b/symbolic-debuginfo/src/base.rs
@@ -672,7 +672,7 @@ pub type DynIterator<'a, T> = Box<dyn Iterator<Item = T> + 'a>;
 
 /// Represents a source file referenced by a debug information object file.
 #[non_exhaustive]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SourceCode<'a> {
     /// Verbatim source code/file contents.
     Content(Cow<'a, str>),

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -13,6 +13,7 @@ use symbolic_common::{Arch, AsSelf, CodeId, DebugId, Language, Name, NameManglin
 
 use crate::base::*;
 use crate::function_builder::FunctionBuilder;
+use crate::sourcebundle::SourceFileDescriptor;
 use crate::Parse;
 
 #[derive(Clone, Debug)]
@@ -1277,7 +1278,10 @@ impl<'data> BreakpadDebugSession<'data> {
     }
 
     /// See [DebugSession::source_by_path] for more information.
-    pub fn source_by_path(&self, _path: &str) -> Result<Option<SourceCode<'_>>, BreakpadError> {
+    pub fn source_by_path(
+        &self,
+        _path: &str,
+    ) -> Result<Option<SourceFileDescriptor<'_>>, BreakpadError> {
         Ok(None)
     }
 }
@@ -1295,7 +1299,7 @@ impl<'data, 'session> DebugSession<'session> for BreakpadDebugSession<'data> {
         self.files()
     }
 
-    fn source_by_path(&self, path: &str) -> Result<Option<SourceCode<'_>>, Self::Error> {
+    fn source_by_path(&self, path: &str) -> Result<Option<SourceFileDescriptor<'_>>, Self::Error> {
         self.source_by_path(path)
     }
 }

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -29,6 +29,7 @@ use crate::base::*;
 use crate::function_builder::FunctionBuilder;
 #[cfg(feature = "macho")]
 use crate::macho::BcSymbolMap;
+use crate::sourcebundle::SourceFileDescriptor;
 
 /// This is a fake BcSymbolMap used when macho support is turned off since they are unfortunately
 /// part of the dwarf interface
@@ -1332,7 +1333,10 @@ impl<'data> DwarfDebugSession<'data> {
     }
 
     /// See [DebugSession::source_by_path] for more information.
-    pub fn source_by_path(&self, _path: &str) -> Result<Option<SourceCode<'_>>, DwarfError> {
+    pub fn source_by_path(
+        &self,
+        _path: &str,
+    ) -> Result<Option<SourceFileDescriptor<'_>>, DwarfError> {
         Ok(None)
     }
 }
@@ -1350,7 +1354,7 @@ impl<'data, 'session> DebugSession<'session> for DwarfDebugSession<'data> {
         self.files()
     }
 
-    fn source_by_path(&self, path: &str) -> Result<Option<SourceCode<'_>>, Self::Error> {
+    fn source_by_path(&self, path: &str) -> Result<Option<SourceFileDescriptor<'_>>, Self::Error> {
         self.source_by_path(path)
     }
 }

--- a/symbolic-debuginfo/src/object.rs
+++ b/symbolic-debuginfo/src/object.rs
@@ -484,7 +484,10 @@ impl<'d> ObjectDebugSession<'d> {
 
     /// Looks up a file's source by its full canonicalized path.
     /// Returns either source contents, if it was embedded, or a source link.
-    pub fn source_by_path(&self, path: &str) -> Result<Option<SourceCode<'_>>, ObjectError> {
+    pub fn source_by_path(
+        &self,
+        path: &str,
+    ) -> Result<Option<SourceFileDescriptor<'_>>, ObjectError> {
         match *self {
             ObjectDebugSession::Breakpad(ref s) => {
                 s.source_by_path(path).map_err(ObjectError::transparent)
@@ -518,7 +521,7 @@ impl<'session> DebugSession<'session> for ObjectDebugSession<'_> {
         self.files()
     }
 
-    fn source_by_path(&self, path: &str) -> Result<Option<SourceCode<'_>>, Self::Error> {
+    fn source_by_path(&self, path: &str) -> Result<Option<SourceFileDescriptor<'_>>, Self::Error> {
         self.source_by_path(path)
     }
 }

--- a/symbolic-debuginfo/src/pdb.rs
+++ b/symbolic-debuginfo/src/pdb.rs
@@ -24,6 +24,7 @@ use symbolic_common::{
 
 use crate::base::*;
 use crate::function_stack::FunctionStack;
+use crate::sourcebundle::SourceFileDescriptor;
 use crate::Parse;
 
 type Pdb<'data> = pdb::PDB<'data, Cursor<&'data [u8]>>;
@@ -638,7 +639,10 @@ impl<'d> PdbDebugSession<'d> {
     }
 
     /// See [DebugSession::source_by_path] for more information.
-    pub fn source_by_path(&self, _path: &str) -> Result<Option<SourceCode<'_>>, PdbError> {
+    pub fn source_by_path(
+        &self,
+        _path: &str,
+    ) -> Result<Option<SourceFileDescriptor<'_>>, PdbError> {
         Ok(None)
     }
 }
@@ -656,7 +660,7 @@ impl<'session> DebugSession<'session> for PdbDebugSession<'_> {
         self.files()
     }
 
-    fn source_by_path(&self, path: &str) -> Result<Option<SourceCode<'_>>, Self::Error> {
+    fn source_by_path(&self, path: &str) -> Result<Option<SourceFileDescriptor<'_>>, Self::Error> {
         self.source_by_path(path)
     }
 }

--- a/symbolic-debuginfo/src/sourcebundle.rs
+++ b/symbolic-debuginfo/src/sourcebundle.rs
@@ -282,7 +282,7 @@ impl SourceFileInfo {
     pub fn add_header(&mut self, header: String, value: String) {
         let mut header = header;
         if !header.chars().all(|x| x.is_ascii_lowercase()) {
-            header = header.to_ascii_uppercase();
+            header = header.to_ascii_lowercase();
         }
         self.headers.insert(header, value);
     }

--- a/symbolic-debuginfo/src/sourcebundle.rs
+++ b/symbolic-debuginfo/src/sourcebundle.rs
@@ -54,7 +54,7 @@ use std::sync::Arc;
 use lazycell::LazyCell;
 use parking_lot::Mutex;
 use regex::Regex;
-use serde::{de, Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
 use zip::{write::FileOptions, ZipWriter};
 
@@ -192,9 +192,9 @@ pub struct SourceFileInfo {
 /// Helper to ensure that header keys are normalized to lowercase
 fn deserialize_headers<'de, D>(deserializer: D) -> Result<BTreeMap<String, String>, D::Error>
 where
-    D: de::Deserializer<'de>,
+    D: Deserializer<'de>,
 {
-    let rv: BTreeMap<String, String> = de::Deserialize::deserialize(deserializer)?;
+    let rv: BTreeMap<String, String> = Deserialize::deserialize(deserializer)?;
     if rv.is_empty()
         || rv
             .keys()

--- a/symbolic-debuginfo/src/sourcebundle.rs
+++ b/symbolic-debuginfo/src/sourcebundle.rs
@@ -258,7 +258,7 @@ impl SourceFileInfo {
 
     /// Retrieves the specified header, if it exists.
     pub fn header(&self, header: &str) -> Option<&str> {
-        if header.chars().any(|x| x.is_ascii_uppercase()) {
+        if !header.chars().any(|x| x.is_ascii_uppercase()) {
             self.headers.get(header).map(String::as_str)
         } else {
             self.headers.iter().find_map(|(k, v)| {

--- a/symbolic-debuginfo/src/sourcebundle.rs
+++ b/symbolic-debuginfo/src/sourcebundle.rs
@@ -1159,7 +1159,7 @@ where
     where
         O: ObjectLike<'data, 'object, Error = E>,
         E: std::error::Error + Send + Sync + 'static,
-        F: FnMut(&FileEntry, &Option<SourceCode<'_>>) -> bool,
+        F: FnMut(&FileEntry, &Option<SourceFileDescriptor<'_>>) -> bool,
     {
         let mut files_handled = BTreeSet::new();
         let mut referenced_files = BTreeSet::new();

--- a/symbolic-debuginfo/src/sourcebundle.rs
+++ b/symbolic-debuginfo/src/sourcebundle.rs
@@ -855,22 +855,18 @@ impl<'data> SourceBundleDebugSession<'data> {
         Ok(Some(source_content))
     }
 
-    /// File info by zip path.
-    fn file_info_by_zip_path(&self, zip_path: &str) -> Option<&SourceFileInfo> {
-        self.manifest.files.get(zip_path)
-    }
-
-    fn lookup_source(
+    /// Looks up a source file descriptor.
+    fn get_source_file_descriptor(
         &self,
         key: FileKey,
     ) -> Result<Option<SourceFileDescriptor<'_>>, SourceBundleError> {
         let zip_path = match self.indexed_files().get(&key) {
-            Some(zip_path) => zip_path,
+            Some(zip_path) => zip_path.as_str(),
             None => return Ok(None),
         };
 
         let content = self.source_by_zip_path(zip_path)?;
-        let info = self.file_info_by_zip_path(zip_path);
+        let info = self.manifest.files.get(zip_path);
         Ok(content.map(|opt| SourceFileDescriptor::new_embedded(Cow::Owned(opt), info)))
     }
 
@@ -879,7 +875,7 @@ impl<'data> SourceBundleDebugSession<'data> {
         &self,
         path: &str,
     ) -> Result<Option<SourceFileDescriptor<'_>>, SourceBundleError> {
-        self.lookup_source(FileKey::Path(path.into()))
+        self.get_source_file_descriptor(FileKey::Path(path.into()))
     }
 
     /// Like [`source_by_path`](Self::source_by_path) but looks up by URL.
@@ -887,7 +883,7 @@ impl<'data> SourceBundleDebugSession<'data> {
         &self,
         url: &str,
     ) -> Result<Option<SourceFileDescriptor<'_>>, SourceBundleError> {
-        self.lookup_source(FileKey::Url(url.into()))
+        self.get_source_file_descriptor(FileKey::Url(url.into()))
     }
 
     /// Looks up some source by debug ID and file type.
@@ -908,7 +904,7 @@ impl<'data> SourceBundleDebugSession<'data> {
         debug_id: DebugId,
         ty: SourceFileType,
     ) -> Result<Option<SourceFileDescriptor<'_>>, SourceBundleError> {
-        self.lookup_source(FileKey::DebugId(debug_id, ty))
+        self.get_source_file_descriptor(FileKey::DebugId(debug_id, ty))
     }
 }
 

--- a/symbolic-debuginfo/src/sourcebundle.rs
+++ b/symbolic-debuginfo/src/sourcebundle.rs
@@ -195,7 +195,11 @@ where
     D: de::Deserializer<'de>,
 {
     let rv: BTreeMap<String, String> = de::Deserialize::deserialize(deserializer)?;
-    if rv.is_empty() || rv.keys().all(|x| x.chars().all(|c| c.is_ascii_lowercase())) {
+    if rv.is_empty()
+        || rv
+            .keys()
+            .all(|x| !x.chars().any(|c| c.is_ascii_uppercase()))
+    {
         Ok(rv)
     } else {
         Ok(rv
@@ -254,7 +258,7 @@ impl SourceFileInfo {
 
     /// Retrieves the specified header, if it exists.
     pub fn header(&self, header: &str) -> Option<&str> {
-        if header.chars().all(|x| x.is_ascii_lowercase()) {
+        if header.chars().any(|x| x.is_ascii_uppercase()) {
             self.headers.get(header).map(String::as_str)
         } else {
             self.headers.iter().find_map(|(k, v)| {
@@ -281,7 +285,7 @@ impl SourceFileInfo {
     /// - `sourcemap` (and `x-sourcemap`): see [`source_mapping_url`](Self::source_mapping_url)
     pub fn add_header(&mut self, header: String, value: String) {
         let mut header = header;
-        if !header.chars().all(|x| x.is_ascii_lowercase()) {
+        if !header.chars().any(|x| x.is_ascii_uppercase()) {
             header = header.to_ascii_lowercase();
         }
         self.headers.insert(header, value);
@@ -381,6 +385,7 @@ struct SourceBundleManifest {
     pub files: BTreeMap<String, SourceFileInfo>,
 
     /// Arbitrary attributes to include in the bundle.
+    #[serde(flatten)]
     pub attributes: BTreeMap<String, String>,
 }
 

--- a/symbolic-debuginfo/src/sourcebundle.rs
+++ b/symbolic-debuginfo/src/sourcebundle.rs
@@ -428,11 +428,7 @@ impl<'a> SourceFileDescriptor<'a> {
 fn discover_sourcemaps_location(contents: &str) -> Option<&str> {
     for line in contents.lines().rev() {
         if line.starts_with("//# sourceMappingURL=") || line.starts_with("//@ sourceMappingURL=") {
-            let possible_sourcemap = line[21..].trim();
-            if possible_sourcemap.starts_with("data:application/json") {
-                return None;
-            }
-            return Some(possible_sourcemap);
+            return Some(line[21..].trim());
         }
     }
     None

--- a/symbolic-debuginfo/src/sourcebundle.rs
+++ b/symbolic-debuginfo/src/sourcebundle.rs
@@ -285,7 +285,7 @@ impl SourceFileInfo {
     /// - `sourcemap` (and `x-sourcemap`): see [`source_mapping_url`](Self::source_mapping_url)
     pub fn add_header(&mut self, header: String, value: String) {
         let mut header = header;
-        if !header.chars().any(|x| x.is_ascii_uppercase()) {
+        if header.chars().any(|x| x.is_ascii_uppercase()) {
             header = header.to_ascii_lowercase();
         }
         self.headers.insert(header, value);

--- a/symbolic-debuginfo/src/sourcebundle.rs
+++ b/symbolic-debuginfo/src/sourcebundle.rs
@@ -270,7 +270,7 @@ impl SourceFileInfo {
     /// Adds a custom attribute following header conventions.
     ///
     /// Header keys are converted to lowercase before writing as this is
-    /// the canonical format for headers however the file format does
+    /// the canonical format for headers. However, the file format does
     /// support headers to be case insensitive and they will be lower cased
     /// upon reading.
     ///

--- a/symbolic-debuginfo/tests/test_objects.rs
+++ b/symbolic-debuginfo/tests/test_objects.rs
@@ -805,7 +805,7 @@ fn test_ppdb_source_links() -> Result<(), Error> {
         if let Some(text) = source.contents() {
             assert!(known_embedded_sources.contains(&file.name_str().as_ref()));
             assert!(!text.is_empty());
-        } else if let Some(url) = source.remote_url() {
+        } else if let Some(url) = source.url() {
             // testing this is simple because there's just one prefix rule in this PPDB.
             let expected = file
                 .path_str()

--- a/symbolic-debuginfo/tests/test_objects.rs
+++ b/symbolic-debuginfo/tests/test_objects.rs
@@ -2,7 +2,7 @@ use std::{env, ffi::CString, fmt, io::BufWriter};
 
 use symbolic_common::ByteView;
 use symbolic_debuginfo::{
-    elf::ElfObject, pe::PeObject, FileEntry, Function, LineInfo, Object, SourceCode, SymbolMap,
+    elf::ElfObject, pe::PeObject, FileEntry, Function, LineInfo, Object, SymbolMap,
 };
 use symbolic_testutils::fixture;
 
@@ -776,10 +776,8 @@ fn test_ppdb_source_by_path() -> Result<(), Error> {
                 "C:\\dev\\sentry-dotnet\\samples\\Sentry.Samples.Console.Basic\\Program.cs",
             )
             .unwrap();
-        match source.unwrap() {
-            SourceCode::Content(text) => assert_eq!(text.len(), 204),
-            _ => panic!(),
-        }
+        let source = source.unwrap();
+        assert_eq!(source.contents().unwrap().len(), 204);
     }
 
     Ok(())
@@ -803,20 +801,19 @@ fn test_ppdb_source_links() -> Result<(), Error> {
     for file in session.files() {
         let file = file.unwrap();
 
-        match session.source_by_path(&file.path_str()).unwrap().unwrap() {
-            SourceCode::Content(text) => {
-                assert!(known_embedded_sources.contains(&file.name_str().as_ref()));
-                assert!(!text.is_empty());
-            }
-            SourceCode::Url(url) => {
-                // testing this is simple because there's just one prefix rule in this PPDB.
-                let expected = file
-                    .path_str()
-                    .replace(src_prefix, url_prefix)
-                    .replace('\\', "/");
-                assert_eq!(url, expected);
-            }
-            _ => panic!(),
+        let source = session.source_by_path(&file.path_str()).unwrap().unwrap();
+        if let Some(text) = source.contents() {
+            assert!(known_embedded_sources.contains(&file.name_str().as_ref()));
+            assert!(!text.is_empty());
+        } else if let Some(url) = source.remote_url() {
+            // testing this is simple because there's just one prefix rule in this PPDB.
+            let expected = file
+                .path_str()
+                .replace(src_prefix, url_prefix)
+                .replace('\\', "/");
+            assert_eq!(url, expected);
+        } else {
+            unreachable!();
         }
     }
 


### PR DESCRIPTION
This adds a new header `debug-id` to files stored in a source bundle that is used as artifact bundle. The goal of this is to enable the lookup of JavaScript files by debug ID. As we are not using much of the `DebugSession` abstraction for this yet, i chose not to add this to the trait but just the particular implementation of a session for source bundles. Lookup requires knowledge of the file type and only returns contents, no meta information.

```rust
let sess = bundle.debug_session().unwrap();
let f = sess
    .source_by_debug_id(
        "5e618b9f-54a9-4389-b196-519819dd7c47".parse().unwrap(),
        SourceFileType::MinifiedSource,
    )
    .unwrap()
    .expect("should exist");
```

# Manifest Format Changes

The manifest gains a new well known key in the `headers` dictionary called `debug-id` which so far is exclusively used to refer to debug IDs of source maps and minified source files. However it's intentionally kept generic in case there is further use of this in the future. For instance it might be valuable for discovering debug files for `.wasm` files on the internet via HTTP header.

```json
{
  "files": {
    "foo.min.js": {
      "type":"minified_sourec",
      "url": "https://mycdn.invalid/foo/foo.min.js",
      "headers": {
        "sourcemap": "foo.min.map",
        "debug-id": "eb6e60f1-65ff-4f6f-adff-f1bbeded627b"
      }
    }
  },
  "debug_id": "06f93af5-832b-3bbc-6dfd-27a46912605a"
}
```

Additionally the use of `debug_id` in the toplevel manifest is now also used to refer to the artifact bundle for JavaScript. This means that in the JavaScript case we have multiple IDs at play:

* toplevel `debug_id`: refers to the artifact bundle (source bundle) of a particular upload / release
* per file `debug_id`: refers to the particular debug ID of an individual minified source and it's corresponding source map

This also changes the implementation to always lowercase headers before writing and after reading for simplified handling.

# Source Maps vs Indexed RAM Bundles

Because we have different `SourceFileType`s for normal source maps and indexed RAM bundles they require separate handling for the caller. This is probably sensible as they are nothing alike but it's a bit odd.

# Artifact vs Source Bundle

This commit also documents that a source bundle and an artifact bundle are really the same thing, with some minor differences about how we refer to it depending on if it's use to hold sources for a debug file, or if it holds release like artifacts for JavaScript processing.

# Other API Changes

This also adds missing functionality to the `SourceBundleDebugSession` to make this actually useful for JavaScript processing:

* `source_by_url` is added to look up a source by URL. Open question here is if this can just be the same as `source_by_path`? It's odd that we have two ways to key this really.
* `source_by_debug_id` is the canonical way now to look up sources by debug ID + kind
* `SourceFileDescriptor` is added to better describe what a source is for. The descriptor has all the API necessary to retrieve information from source files (contents and meta data) that is relevant for symbolication and unminification:
  * `ty` returns the `SourceFileType`. This was previously impossible to read after setting.
  * `contents` returns the contents if available, otherwise `url` should be used for fetching.
  * `url` doubles as a way to either refer to a source link or the canonical URL of the source file. There is no reason why these need to be separate methods as they are referring to the same thing anyways.
  * `path` is just the path that was used to look up the source for native source bundle companions
  * `debug_id` returns the parsed `DebugId` for source maps and minified sources in bundles that have debug IDs
  * `source_mapping_url` returns either the `sourcemap` or `x-sourcemap` reference in the manifest of the bundle. If neither can be found, it falls back to parsing the embedded contents. This makes it convenient enough to use though one could make an argument that the parsing logic should go elsewhere.