### PR TITLE
feat: Add support for embedded debug IDs in minified files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Added debug IDs to source bundle JavaScript files and source maps. ([#762](https://github.com/getsentry/symbolic/pull/762))
+- Add support for embedded debug IDs in minified files ([#765](https://github.com/getsentry/symbolic/pull/765))
 
 **Breaking changes**:
 

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["tests/**/*"]
 all-features = true
 
 [features]
-default = ["breakpad", "elf", "macho", "ms", "ppdb", "sourcebundle", "wasm"]
+default = ["breakpad", "elf", "macho", "ms", "ppdb", "sourcebundle", "js", "wasm"]
 # Breakpad text format parsing and processing
 breakpad = ["nom", "nom-supreme", "regex"]
 # DWARF processing.
@@ -70,8 +70,11 @@ sourcebundle = [
     "regex",
     "serde_json",
     "zip",
-    "debugid/serde"
+    "js",
+    "debugid/serde",
 ]
+# JavaScript stuff
+js = []
 # WASM processing
 wasm = ["bitvec", "dwarf", "wasmparser"]
 

--- a/symbolic-debuginfo/src/js.rs
+++ b/symbolic-debuginfo/src/js.rs
@@ -1,0 +1,40 @@
+//! Utilities specifically for working with JavaScript specific debug info.
+//!
+//! This for the most part only contains utility functions to parse references
+//! out of minified JavaScript files and source maps.  For actually working
+//! with source maps this module is insufficient.
+
+use debugid::DebugId;
+use serde::Deserialize;
+
+/// Parses a sourceMappingURL comment in a file to discover a sourcemap reference.
+pub fn discover_sourcemaps_location(contents: &str) -> Option<&str> {
+    for line in contents.lines().rev() {
+        if line.starts_with("//# sourceMappingURL=") || line.starts_with("//@ sourceMappingURL=") {
+            return Some(line[21..].trim());
+        }
+    }
+    None
+}
+
+/// Quickly reads the embedded `debug_id` key from a source map.
+pub fn discover_sourcemap_embedded_debug_id(contents: &str) -> Option<DebugId> {
+    #[derive(Deserialize)]
+    struct DebugIdInSourceMap {
+        debug_id: Option<DebugId>,
+    }
+
+    serde_json::from_str(contents)
+        .ok()
+        .and_then(|x: DebugIdInSourceMap| x.debug_id)
+}
+
+/// Parses a `debugId` comment in a file to discover a sourcemap's debug ID.
+pub fn discover_debug_id(contents: &str) -> Option<DebugId> {
+    for line in contents.lines().rev() {
+        if let Some(rest) = line.strip_prefix("//# debugId=") {
+            return rest.trim().parse().ok();
+        }
+    }
+    None
+}

--- a/symbolic-debuginfo/src/lib.rs
+++ b/symbolic-debuginfo/src/lib.rs
@@ -67,6 +67,8 @@ pub mod pe;
 pub mod ppdb;
 #[cfg(feature = "sourcebundle")]
 pub mod sourcebundle;
+#[cfg(feature = "js")]
+pub mod js;
 #[cfg(feature = "wasm")]
 pub mod wasm;
 

--- a/symbolic-debuginfo/src/lib.rs
+++ b/symbolic-debuginfo/src/lib.rs
@@ -57,6 +57,8 @@ pub mod elf;
 pub mod function_builder;
 #[cfg(feature = "ms")]
 pub(crate) mod function_stack;
+#[cfg(feature = "js")]
+pub mod js;
 #[cfg(feature = "macho")]
 pub mod macho;
 #[cfg(feature = "ms")]
@@ -67,8 +69,6 @@ pub mod pe;
 pub mod ppdb;
 #[cfg(feature = "sourcebundle")]
 pub mod sourcebundle;
-#[cfg(feature = "js")]
-pub mod js;
 #[cfg(feature = "wasm")]
 pub mod wasm;
 


### PR DESCRIPTION
This adds support for parsing `debugId` references in the source file. It also provides utilities for parsing the comments separately so that code does not need to be written another time in other places.

Followup to #762

Refs https://github.com/getsentry/sentry-cli/pull/1469