### PR TITLE
ref: Make `SourceBundleDebugSession`: `Send`, `Sync` and `AsSelf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Replace internal usage of `LazyCell` by `OnceCell` and make `SourceBundleDebugSession`: `Send`, `Sync` and `AsSelf`. ([#767](https://github.com/getsentry/symbolic/pull/767))
+
 ## 12.0.0
 
 **Features**:

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -25,7 +25,7 @@ default = ["breakpad", "elf", "macho", "ms", "ppdb", "sourcebundle", "js", "wasm
 # Breakpad text format parsing and processing
 breakpad = ["nom", "nom-supreme", "regex"]
 # DWARF processing.
-dwarf = ["gimli", "lazycell"]
+dwarf = ["gimli", "once_cell"]
 # ELF reading
 elf = [
     "dwarf",
@@ -53,7 +53,7 @@ ms = [
     "goblin/pe32",
     "goblin/pe64",
     "goblin/std",
-    "lazycell",
+    "once_cell",
     "parking_lot",
     "pdb-addr2line",
     "scroll",
@@ -65,7 +65,7 @@ ppdb = [
 # Source bundle creation
 sourcebundle = [
     "lazy_static",
-    "lazycell",
+    "once_cell",
     "parking_lot",
     "regex",
     "serde_json",
@@ -94,7 +94,7 @@ gimli = { version = "0.27.0", optional = true, default-features = false, feature
 ] }
 goblin = { version = "0.6.0", optional = true, default-features = false }
 lazy_static = { version = "1.4.0", optional = true }
-lazycell = { version = "1.2.1", optional = true }
+once_cell = { version = "1.17.1", optional = true }
 nom = { version = "7.0.0", optional = true }
 nom-supreme = { version = "0.8.0", optional = true }
 parking_lot = { version = "0.12.0", optional = true }


### PR DESCRIPTION
This replaces all usages of `LazyCell` (which is not thread safe) with `OnceCell`, which is and will also be available as `std::sync::OnceLock` in the future.