### PR TITLE
fix: Completely skip over hidden sequence points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Skip hidden sequence points when creating PortablePDB cache. ([#769](https://github.com/getsentry/symbolic/pull/769))
+
 ## 12.1.0
 
 **Features**:

--- a/symbolic-ppdb/src/cache/writer.rs
+++ b/symbolic-ppdb/src/cache/writer.rs
@@ -43,11 +43,9 @@ impl PortablePdbCacheConverter {
             let sequence_points = sequence_points?;
 
             for sp in sequence_points.iter() {
-                let line = if sp.is_hidden() {
+                if sp.is_hidden() {
                     continue;
-                } else {
-                    sp.start_line
-                };
+                }
                 let range = raw::Range {
                     func_idx,
                     il_offset: sp.il_offset,
@@ -55,7 +53,10 @@ impl PortablePdbCacheConverter {
 
                 let doc = portable_pdb.get_document(sp.document_id as usize)?;
                 let file_idx = self.insert_file(&doc.name, doc.lang);
-                let source_location = raw::SourceLocation { line, file_idx };
+                let source_location = raw::SourceLocation {
+                    line: sp.start_line,
+                    file_idx,
+                };
 
                 self.ranges.insert(range, source_location);
             }

--- a/symbolic-ppdb/src/cache/writer.rs
+++ b/symbolic-ppdb/src/cache/writer.rs
@@ -43,6 +43,11 @@ impl PortablePdbCacheConverter {
             let sequence_points = sequence_points?;
 
             for sp in sequence_points.iter() {
+                let line = if sp.is_hidden() {
+                    continue;
+                } else {
+                    sp.start_line
+                };
                 let range = raw::Range {
                     func_idx,
                     il_offset: sp.il_offset,
@@ -50,10 +55,7 @@ impl PortablePdbCacheConverter {
 
                 let doc = portable_pdb.get_document(sp.document_id as usize)?;
                 let file_idx = self.insert_file(&doc.name, doc.lang);
-                let source_location = raw::SourceLocation {
-                    line: if sp.is_hidden() { 0 } else { sp.start_line },
-                    file_idx,
-                };
+                let source_location = raw::SourceLocation { line, file_idx };
 
                 self.ranges.insert(range, source_location);
             }


### PR DESCRIPTION
It is a bit unclear how to really treat these hidden sequence points.
However just setting the line to `0` means we do find a source location (with line `0`) on lookup, and then later on we apply the wrong source context lines.

By ignoring these, we do get the correct source line (and thus source context) for the linked customer issue.

If just skipping these is really the way we want to go:

fixes https://github.com/getsentry/symbolic/issues/768
fixes https://github.com/getsentry/team-stacktrace-private/issues/28