### PR TITLE
Bump dependencies to latest versions

### DIFF
--- a/symbolic-cabi/Cargo.toml
+++ b/symbolic-cabi/Cargo.toml
@@ -21,6 +21,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 proguard = { version = "5.0.0", features = ["uuid"] }
-sourcemap = "6.0.2"
+sourcemap = "6.2.3"
 symbolic = { version = "12.1.1", path = "../symbolic", features = ["cfi", "debuginfo", "sourcemapcache", "symcache"] }
-tempfile = "3.1.0"
+tempfile = "3.4.0"

--- a/symbolic-cfi/Cargo.toml
+++ b/symbolic-cfi/Cargo.toml
@@ -17,9 +17,9 @@ edition = "2021"
 [dependencies]
 symbolic-common = { version = "12.1.1", path = "../symbolic-common" }
 symbolic-debuginfo = { version = "12.1.1", path = "../symbolic-debuginfo" }
-thiserror = "1.0.20"
+thiserror = "1.0.39"
 
 [dev-dependencies]
-insta = { version = "1.18.0", features = ["yaml"] }
+insta = { version = "1.28.0", features = ["yaml"] }
 symbolic-testutils = { path = "../symbolic-testutils" }
-similar-asserts = "1.0.0"
+similar-asserts = "1.4.2"

--- a/symbolic-common/Cargo.toml
+++ b/symbolic-common/Cargo.toml
@@ -20,20 +20,17 @@ edition = "2021"
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+serde = ["dep:serde", "debugid/serde"]
+
 [dependencies]
 debugid = "0.8.0"
-memmap2 = "0.5.0"
-stable_deref_trait = "1.1.1"
-serde_ = { package = "serde", version = "1.0.88", optional = true, features = ["derive"] }
-uuid = "1.0.0"
+memmap2 = "0.5.10"
+stable_deref_trait = "1.2.0"
+serde = {version = "1.0.154", optional = true, features = ["derive"] }
+uuid = "1.3.0"
 
 [dev-dependencies]
 symbolic-testutils = { path = "../symbolic-testutils" }
-tempfile = "3.1.0"
-similar-asserts = "1.0.0"
-
-[features]
-serde = ["serde_", "debugid/serde"]
-
-[badges]
-travis-ci = { repository = "getsentry/symbolic", branch = "master" }
+tempfile = "3.4.0"
+similar-asserts = "1.4.2"

--- a/symbolic-common/src/types.rs
+++ b/symbolic-common/src/types.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::str;
 
 #[cfg(feature = "serde")]
-use serde_::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 /// Represents a family of CPUs.
 ///
@@ -566,11 +566,7 @@ impl str::FromStr for Language {
 ///
 /// By default, the mangling of a [`Name`] is not known, but an explicit mangling state can be set
 /// for Names that are guaranteed to be unmangled.
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(crate = "serde_")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Default)]
 pub enum NameMangling {
     /// The [`Name`] is definitely mangled.
@@ -618,11 +614,7 @@ pub enum NameMangling {
 ///
 /// [`language`]: struct.Name.html#method.language
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(crate = "serde_")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Name<'a> {
     string: Cow<'a, str>,
     lang: Language,
@@ -820,23 +812,23 @@ mod derive_serde {
     /// appropriately.
     macro_rules! impl_str_serde {
         ($type:ty) => {
-            impl ::serde_::ser::Serialize for $type {
+            impl ::serde::ser::Serialize for $type {
                 fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
                 where
-                    S: ::serde_::ser::Serializer,
+                    S: ::serde::ser::Serializer,
                 {
                     serializer.serialize_str(self.name())
                 }
             }
 
-            impl<'de> ::serde_::de::Deserialize<'de> for $type {
+            impl<'de> ::serde::de::Deserialize<'de> for $type {
                 fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
                 where
-                    D: ::serde_::de::Deserializer<'de>,
+                    D: ::serde::de::Deserializer<'de>,
                 {
                     <::std::borrow::Cow<str>>::deserialize(deserializer)?
                         .parse()
-                        .map_err(::serde_::de::Error::custom)
+                        .map_err(::serde::de::Error::custom)
                 }
             }
         };

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -79,45 +79,38 @@ js = []
 wasm = ["bitvec", "dwarf", "wasmparser"]
 
 [dependencies]
-bitvec = { version = "1.0.0", optional = true, features = ["alloc"] }
-dmsort = "1.0.1"
+bitvec = { version = "1.0.1", optional = true, features = ["alloc"] }
+dmsort = "1.0.2"
 debugid = { version = "0.8.0" }
-elementtree = { version = "1.2.2", optional = true }
-elsa = { version = "1.4.0", optional = true }
+elementtree = { version = "1.2.3", optional = true }
+elsa = { version = "1.8.0", optional = true }
 fallible-iterator = "0.2.0"
-flate2 = { version = "1.0.13", optional = true, default-features = false, features = [
-    "rust_backend",
-] }
-gimli = { version = "0.27.0", optional = true, default-features = false, features = [
-    "read",
-    "std",
-] }
-goblin = { version = "0.6.0", optional = true, default-features = false }
+flate2 = { version = "1.0.25", optional = true, default-features = false, features = ["rust_backend"] }
+gimli = { version = "0.27.2", optional = true, default-features = false, features = ["read", "std"] }
+goblin = { version = "0.6.1", optional = true, default-features = false }
 lazy_static = { version = "1.4.0", optional = true }
 once_cell = { version = "1.17.1", optional = true }
-nom = { version = "7.0.0", optional = true }
+nom = { version = "7.1.3", optional = true }
 nom-supreme = { version = "0.8.0", optional = true }
-parking_lot = { version = "0.12.0", optional = true }
-pdb-addr2line = { version = "0.10.2", optional = true }
-regex = { version = "1.3.5", optional = true }
+parking_lot = { version = "0.12.1", optional = true }
+pdb-addr2line = { version = "0.10.4", optional = true }
+regex = { version = "1.7.1", optional = true }
 # keep this in sync with whatever version `goblin` uses
-scroll = { version = "0.11", optional = true }
-serde = { version = "1.0.94", features = ["derive"] }
-serde_json = { version = "1.0.40", optional = true }
-smallvec = { version = "1.2.0", optional = true }
+scroll = { version = "0.11.0", optional = true }
+serde = { version = "1.0.154", features = ["derive"] }
+serde_json = { version = "1.0.94", optional = true }
+smallvec = { version = "1.10.0", optional = true }
 symbolic-common = { version = "12.1.1", path = "../symbolic-common" }
 symbolic-ppdb = { version = "12.1.1", path = "../symbolic-ppdb", optional = true }
-thiserror = "1.0.20"
-wasmparser = { version = "0.95.0", optional = true }
-zip = { version = "0.6.2", optional = true, default-features = false, features = [
-    "deflate",
-] }
+thiserror = "1.0.39"
+wasmparser = { version = "0.102.0", optional = true }
+zip = { version = "0.6.4", optional = true, default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }
-insta = { version = "1.18.0", features = ["yaml"] }
-tempfile = "3.1.0"
-similar-asserts = "1.0.0"
+insta = { version = "1.28.0", features = ["yaml"] }
+tempfile = "3.4.0"
+similar-asserts = "1.4.2"
 symbolic-testutils = { path = "../symbolic-testutils" }
 
 [[bench]]

--- a/symbolic-demangle/Cargo.toml
+++ b/symbolic-demangle/Cargo.toml
@@ -33,14 +33,11 @@ swift = ["cc"]
 [dependencies]
 cpp_demangle = { version = "0.4.0", optional = true }
 msvc-demangler = { version = "0.9.0", optional = true }
-rustc-demangle = { version = "0.1.16", optional = true }
+rustc-demangle = { version = "0.1.21", optional = true }
 symbolic-common = { version = "12.1.1", path = "../symbolic-common" }
 
 [build-dependencies]
-cc = { version = "1.0.50", optional = true }
-
-[badges]
-travis-ci = { repository = "getsentry/symbolic", branch = "master" }
+cc = { version = "1.0.79", optional = true }
 
 [dev-dependencies]
-similar-asserts = "1.0.0"
+similar-asserts = "1.4.2"

--- a/symbolic-il2cpp/Cargo.toml
+++ b/symbolic-il2cpp/Cargo.toml
@@ -12,7 +12,7 @@ A library for parsing il2cpp line mappings.
 edition = "2021"
 
 [dependencies]
-indexmap = "1.8.0"
-serde_json = "1.0.79"
+indexmap = "1.9.2"
+serde_json = "1.0.94"
 symbolic-common = { version = "12.1.1", path = "../symbolic-common" }
 symbolic-debuginfo = { version = "12.1.1", path = "../symbolic-debuginfo" }

--- a/symbolic-ppdb/Cargo.toml
+++ b/symbolic-ppdb/Cargo.toml
@@ -20,13 +20,13 @@ exclude = ["tests/**/*"]
 all-features = true
 
 [dependencies]
-indexmap = "1.9.1"
+indexmap = "1.9.2"
 symbolic-common = { version = "12.1.1", path = "../symbolic-common" }
 watto = { version = "0.1.0", features = ["writer", "strings"] }
-thiserror = "1.0.31"
-uuid = "1.0.0"
-flate2 = { version ="1.0.13", default-features = false, features = [ "rust_backend" ] }
-serde_json = { version = "1.0.40" }
+thiserror = "1.0.39"
+uuid = "1.3.0"
+flate2 = { version = "1.0.25", default-features = false, features = ["rust_backend"] }
+serde_json = { version = "1.0.94" }
 
 [dev-dependencies]
 symbolic-debuginfo = { path = "../symbolic-debuginfo" }

--- a/symbolic-sourcemapcache/Cargo.toml
+++ b/symbolic-sourcemapcache/Cargo.toml
@@ -13,12 +13,12 @@ edition = "2021"
 
 [dependencies]
 js-source-scopes = "0.3.1"
-thiserror = "1.0.31"
-sourcemap = "6.1.0"
+thiserror = "1.0.39"
+sourcemap = "6.2.3"
 symbolic-common = { version = "12.1.1", path = "../symbolic-common" }
-tracing = "0.1.36"
+tracing = "0.1.37"
 watto = { version = "0.1.0", features = ["writer", "strings"] }
-itertools = "0.10.3"
+itertools = "0.10.5"
 
 [dev-dependencies]
 symbolic-testutils = { path = "../symbolic-testutils" }

--- a/symbolic-symcache/Cargo.toml
+++ b/symbolic-symcache/Cargo.toml
@@ -26,16 +26,16 @@ all-features = true
 symbolic-common = { version = "12.1.1", path = "../symbolic-common" }
 symbolic-debuginfo = { version = "12.1.1", path = "../symbolic-debuginfo" }
 symbolic-il2cpp = { version = "12.1.1", path = "../symbolic-il2cpp", optional = true }
-thiserror = "1.0.20"
-indexmap = "1.7.0"
-tracing = "0.1.35"
+thiserror = "1.0.39"
+indexmap = "1.9.2"
+tracing = "0.1.37"
 watto = { version = "0.1.0", features = ["writer", "strings"] }
 
 [dev-dependencies]
-insta = { version = "1.18.0", features = ["yaml"] }
+insta = { version = "1.28.0", features = ["yaml"] }
 criterion = "0.4.0"
 symbolic-testutils = { path = "../symbolic-testutils" }
-similar-asserts = "1.0.0"
+similar-asserts = "1.4.2"
 
 [features]
 bench = []

--- a/symbolic-unreal/Cargo.toml
+++ b/symbolic-unreal/Cargo.toml
@@ -23,23 +23,23 @@ exclude = [
 all-features = true
 
 [features]
-serde = ["serde_", "chrono/serde"]
+serde = ["dep:serde", "chrono/serde"]
 
 [dependencies]
 anylog = "0.6.3"
-bytes = "1.1.0"
+bytes = "1.4.0"
 # this is still used for compatibility with `anylog`
-chrono = "0.4.7"
-elementtree = "1.2.2"
-flate2 = { version = "1.0.13", features = ["rust_backend"], default-features = false }
+chrono = "0.4.23"
+elementtree = "1.2.3"
+flate2 = { version = "1.0.25", features = ["rust_backend"], default-features = false }
 lazy_static = "1.4.0"
-regex = "1.3.5"
-scroll = { version = "0.11", features = ["derive"] }
-serde_ = { package = "serde", version = "1.0.94", optional = true, features = ["derive"] }
-thiserror = "1.0.20"
-time = { version = "0.3.5", features = ["formatting"] }
+regex = "1.7.1"
+scroll = { version = "0.11.0", features = ["derive"] }
+serde = { version = "1.0.154", optional = true, features = ["derive"] }
+thiserror = "1.0.39"
+time = { version = "0.3.20", features = ["formatting"] }
 
 [dev-dependencies]
-insta = { version = "1.18.0", features = ["yaml"] }
+insta = { version = "1.28.0", features = ["yaml"] }
 symbolic-testutils = { path = "../symbolic-testutils" }
-similar-asserts = "1.0.0"
+similar-asserts = "1.4.2"

--- a/symbolic-unreal/src/context.rs
+++ b/symbolic-unreal/src/context.rs
@@ -14,8 +14,7 @@ use crate::error::Unreal4Error;
 ///
 /// [Source](https://github.com/EpicGames/UnrealEngine/blob/b70f31f6645d764bcb55829228918a6e3b571e0b/Engine/Source/Runtime/Core/Private/GenericPlatform/GenericPlatformCrashContext.cpp#L274)
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde_::Serialize))]
-#[cfg_attr(feature = "serde", serde(crate = "serde_"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Unreal4ContextRuntimeProperties {
     /// CrashGUID
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
@@ -266,8 +265,7 @@ impl Unreal4ContextRuntimeProperties {
 /// [Source](https://github.com/EpicGames/UnrealEngine/blob/b70f31f6645d764bcb55829228918a6e3b571e0b/Engine/Source/Runtime/Core/Private/GenericPlatform/GenericPlatformCrashContext.cpp#L451-L455)
 /// [Windows](https://github.com/EpicGames/UnrealEngine/blob/b70f31f6645d764bcb55829228918a6e3b571e0b/Engine/Source/Runtime/Core/Private/Windows/WindowsPlatformCrashContext.cpp#L39-L44)
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde_::Serialize))]
-#[cfg_attr(feature = "serde", serde(crate = "serde_"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Unreal4ContextPlatformProperties {
     /// Whether the crash happened on a Windows device.
     pub is_windows: Option<bool>,
@@ -307,8 +305,7 @@ impl Unreal4ContextPlatformProperties {
 ///
 /// [Source](https://github.com/EpicGames/UnrealEngine/blob/b70f31f6645d764bcb55829228918a6e3b571e0b/Engine/Source/Runtime/Core/Private/GenericPlatform/GenericPlatformCrashContext.cpp)
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde_::Serialize))]
-#[cfg_attr(feature = "serde", serde(crate = "serde_"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Unreal4Context {
     /// RuntimeProperties context element.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]

--- a/symbolic-unreal/src/logs.rs
+++ b/symbolic-unreal/src/logs.rs
@@ -21,11 +21,11 @@ lazy_static! {
 }
 
 #[cfg(feature = "serde")]
-fn serialize_timestamp<S: serde_::Serializer>(
+fn serialize_timestamp<S: serde::Serializer>(
     timestamp: &Option<time::OffsetDateTime>,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
-    use serde_::ser::Error;
+    use serde::ser::Error;
     match timestamp {
         Some(timestamp) => serializer.serialize_str(&match timestamp.format(&Rfc3339) {
             Ok(s) => s,
@@ -36,8 +36,7 @@ fn serialize_timestamp<S: serde_::Serializer>(
 }
 
 /// A log entry from an Unreal Engine 4 crash.
-#[cfg_attr(feature = "serde", derive(serde_::Serialize))]
-#[cfg_attr(feature = "serde", serde(crate = "serde_"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Unreal4LogEntry {
     /// The timestamp of the message, when available.
     #[cfg_attr(


### PR DESCRIPTION
It is pretty much impossible to tell what the "real" minimum version of a dependency is, so bump them all to the very latest.

Also updates `wasmparser`, which is always a pain as it has frequent undocumented API changes :-(

#skip-changelog

fixes https://github.com/getsentry/symbolic/issues/770