### PR TITLE
Fix the problem that some symbols are not parsed

### DIFF
--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -347,7 +347,12 @@ impl<'d> DwarfLineProgram<'d> {
             let from = match seq.rows.binary_search_by_key(&range.begin, |x| x.address) {
                 Ok(idx) => idx,
                 Err(0) => continue,
-                Err(next_idx) => next_idx - 1,
+                Err(next_idx) => {
+                    if next_idx == seq.rows.len() {
+                        continue;
+                    }
+                    next_idx - 1
+                }
             };
 
             let len = seq.rows[from..]


### PR DESCRIPTION
debug_line example:
0x0000000102704a68      0     13      3   0             0 
0x0000000102704a6c    313     12      3   0             0 
0x0000000102704a78      0     12      3   0             0 
0x0000000102704a84    314      1      3   0             0  is_stmt
0x0000000108cc1bfc    314      1      3   0             0  is_stmt end_sequence
0x0000000102704e40     53      0      3   0             0  is_stmt
0x0000000102704e4c     54      6      3   0             0  is_stmt prologue_end
0x0000000102704e58      0      6      3   0             0 
0x0000000102704e5c     54      6      3   0             0 
0x0000000102704e68      0      6      3   0             0 
0x0000000102704e6c     54      5      3   0             0 
0x0000000102704e70      0      5      3   0             0 
0x0000000102704e78     54      5      3   0             0 
0x0000000102704e7c     54      5      3   0             0  end_sequence
0x000000010274c3c0    389      0      3   0             0  is_stmt
0x000000010274c3cc    390      6      3   0             0  is_stmt prologue_end
0x000000010274c3d8      0      6      3   0             0 
0x000000010274c3dc    390      6      3   0             0 
0x000000010274c3e8      0      6      3   0             0 
0x000000010274c3ec    390      5      3   0             0 
0x000000010274c3f0      0      5      3   0             0 
0x000000010274c3f8    390      5      3   0             0 
0x000000010274c3fc    390      5      3   0             0  end_sequence
0x00000001072b37b0     49      0      3   0             0  is_stmt
0x00000001072b37bc     50      6      3   0             0  is_stmt prologue_end

pc start with 0x0000000107 will hit the seq  with the range 0x0000000102704a68 0x0000000108cc1bfc. the symbols for these pc will not to be resolved