### PR TITLE
fix(sourcemap): Improve scope name resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- sourcemapcache: Improved scope name resolution. ([#786](https://github.com/getsentry/symbolic/pull/786))
+
 ## 12.1.3
 
 **Fixes**:

--- a/symbolic-sourcemapcache/src/writer.rs
+++ b/symbolic-sourcemapcache/src/writer.rs
@@ -196,9 +196,6 @@ impl SourceMapCacheWriter {
                 };
 
                 let name = token.get_name();
-                if token.get_name_id() == 8638 {
-                    println!("({min_line}, {min_col})");
-                }
                 let name_idx = match name {
                     Some(name) => string_table.insert(name) as u32,
                     None => raw::NO_NAME_SENTINEL,

--- a/symbolic-sourcemapcache/src/writer.rs
+++ b/symbolic-sourcemapcache/src/writer.rs
@@ -234,7 +234,16 @@ impl SourceMapCacheWriter {
         let sp = ctx.offset_to_position(range.end - 1)?;
         let token = sourcemap.lookup_token(sp.line, sp.column)?;
 
+        // Validate that the token really is exactly at the scope's end
         if token.get_dst() != (sp.line, sp.column) {
+            return None;
+        }
+
+        let sp_past_end = ctx.offset_to_position(range.end);
+        let token_past_end = sp_past_end.and_then(|sp| sourcemap.lookup_token(sp.line, sp.column));
+
+        // Validate that the token one past the scope's end (if it exists) is different
+        if token_past_end == Some(token) {
             return None;
         }
 


### PR DESCRIPTION
We have seen cases in Flutter where a scope name cannot be resolved, but the scope's closing brace has the correct name attached. Therefore, if we can't resolve a scope name the straightforward way, we try to grab the name off the scope's last token.