### PR TITLE
Optimze SourceBundle/DebugSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Optimze SourceBundle/DebugSession ([#787](https://github.com/getsentry/symbolic/pull/787))
+
 ## 12.1.3
 
 **Fixes**:


### PR DESCRIPTION
This gives each `SourceBundleDebugSession` its own `archive`, so multiple sessions do not contend on the same lock. Also creates the manifest index eagerly and shares that across debug sessions. While previously the complete `SourceBundle` was cached in memory and shared, each `DebugSession` would still create its own index on each access. Another driveby improvement is to provide a consuming `SourceFileDescriptor::into_contents` to avoid a clone.