### PR TITLE
meta: Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
-## 12.1.4
+## Unreleased
 
 **Fixes**:
 
 - sourcemapcache: Improved scope name resolution. ([#786](https://github.com/getsentry/symbolic/pull/786))
+
+## 12.1.4
+
+**Fixes**:
+
 - Optimize SourceBundle/DebugSession ([#787](https://github.com/getsentry/symbolic/pull/787))
 
 ## 12.1.3


### PR DESCRIPTION
The changelog is wrong, #786 was not included in 12.1.4.

#skip-changelog