### PR TITLE
Remove the bitvec crate.

### DIFF
--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -76,10 +76,9 @@ sourcebundle = [
 # JavaScript stuff
 js = []
 # WASM processing
-wasm = ["bitvec", "dwarf", "wasmparser"]
+wasm = ["dwarf", "wasmparser"]
 
 [dependencies]
-bitvec = { version = "1.0.1", optional = true, features = ["alloc"] }
 dmsort = "1.0.2"
 debugid = { version = "0.8.0" }
 elementtree = { version = "1.2.3", optional = true }


### PR DESCRIPTION
It is used only in one place, and an in-crate definition is simple enough.

We are using `symbolic` and are auditing our third-party crates. To reduce the audit surface of `symbolic`, this removes `bitvec` and replaces it with an implementation that should be as performant. `bitvec` is a huge crate, so it is preferable to remove it since it is barely used.

If this is not desirable, we can also patch `bitvec` with an API-equivalent interface on our side, but that is an uglier solution and may be more burdensome in the future.