### PR TITLE
chore(deps): Bump minidump to 0.16.0

### DIFF
--- a/examples/minidump_stackwalk/Cargo.toml
+++ b/examples/minidump_stackwalk/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 [dependencies]
 async-trait = "0.1.53"
 clap = "3.1.0"
-minidump = "0.14.0"
-minidump-processor = "0.14.0"
+minidump = "0.16.0"
+minidump-processor = "0.16.0"
 symbolic = { path = "../../symbolic", features = ["symcache", "demangle", "cfi"] }
 thiserror = "1.0.31"
 tokio = {version = "1.18.1", features = ["macros", "rt"] }

--- a/examples/minidump_stackwalk/src/main.rs
+++ b/examples/minidump_stackwalk/src/main.rs
@@ -457,11 +457,9 @@ impl fmt::Display for Report<'_> {
         if let Some(ref assertion) = self.process_state.assertion {
             writeln!(f, "Assertion:     {assertion}")?;
         }
-        if let Some(crash_reason) = self.process_state.crash_reason {
-            writeln!(f, "Crash reason:  {crash_reason}")?;
-        }
-        if let Some(crash_address) = self.process_state.crash_address {
-            writeln!(f, "Crash address: 0x{crash_address:x}")?;
+        if let Some(ref exception_info) = self.process_state.exception_info {
+            writeln!(f, "Crash reason:  {}", exception_info.reason)?;
+            writeln!(f, "Crash address: {}", exception_info.address)?;
         }
         if let Ok(duration) = self.process_state.time.duration_since(UNIX_EPOCH) {
             writeln!(f, "Crash time:    {}", duration.as_secs())?;


### PR DESCRIPTION
This gets rid of the unmaintained `encoding` dependency.