### PR TITLE
chore(deps): Bump proguard to `5.0.2`

### DIFF
--- a/symbolic-cabi/Cargo.toml
+++ b/symbolic-cabi/Cargo.toml
@@ -20,7 +20,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-proguard = { version = "5.0.1", features = ["uuid"] }
+proguard = { version = "5.0.2", features = ["uuid"] }
 sourcemap = "6.2.3"
 symbolic = { version = "12.1.5", path = "../symbolic", features = ["cfi", "debuginfo", "sourcemapcache", "symcache"] }
 tempfile = "3.4.0"

--- a/symbolic-sourcemapcache/Cargo.toml
+++ b/symbolic-sourcemapcache/Cargo.toml
@@ -12,13 +12,13 @@ A fast lookup cache for JavaScript Source Maps.
 edition = "2021"
 
 [dependencies]
-js-source-scopes = "0.3.1"
-thiserror = "1.0.39"
+itertools = "0.10.5"
+js-source-scopes = "0.3.2"
 sourcemap = "6.2.3"
 symbolic-common = { version = "12.1.5", path = "../symbolic-common" }
+thiserror = "1.0.39"
 tracing = "0.1.37"
 watto = { version = "0.1.0", features = ["writer", "strings"] }
-itertools = "0.10.5"
 
 [dev-dependencies]
 symbolic-testutils = { path = "../symbolic-testutils" }


### PR DESCRIPTION
`5.0.2` of https://github.com/getsentry/rust-proguard contains a fix for wrong line numbers when using callbacks like `setOnMenuItemClickListener`.