### PR TITLE
Remove `cargo update` from version-bump script

### DIFF
--- a/scripts/bump-version
+++ b/scripts/bump-version
@@ -17,4 +17,3 @@ echo "Bumping version: ${NEW_VERSION}"
 TOML_FILES="$(git ls-files '*Cargo.toml')"
 perl -pi -e "s/^version = .*\$/version = \"$NEW_VERSION\"/" $TOML_FILES
 perl -pi -e "s/^(symbolic.*version = )\"[^\"]*\"/\\1\"$NEW_VERSION\"/" $TOML_FILES
-cargo update -p symbolic --precise "${NEW_VERSION}"


### PR DESCRIPTION
Looks like `minidump-processor` is now using symbolic as well. And we cannot bump the version of its symbolic dependency because its an out-of-workspace package. `cargo update` in that case would require the version to already exist in the registry.

Just remove the `cargo update`. We do not check in our lockfile so whatever updates it would do would never be committed anyway.

#skip-changelog