### PR TITLE
(Super tiny PR) Fix wrong link

### DIFF
--- a/symbolic-debuginfo/src/lib.rs
+++ b/symbolic-debuginfo/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! # Background
 //!
-//! The functionality of `symbolic::debuginfo` is conceptionally similar to the [`object`] crate.
+//! The functionality of `symbolic::debuginfo` is conceptionally similar to the [`object crate`].
 //! However, there are key differences that warranted a separate implementation:
 //!
 //!  - `object` has a stronger focus on executable formats, while `symbolic` focusses on debugging
@@ -31,7 +31,7 @@
 //! [`Archive`]: enum.Archive.html
 //! [`ObjectLike`]: trait.ObjectLike.html
 //! [`DebugSession`]: trait.DebugSession.html
-//! [`object`]: https://docs.rs/object
+//! [`object crate`]: https://docs.rs/object
 
 #![warn(missing_docs)]
 


### PR DESCRIPTION
At https://docs.rs/symbolic/latest/symbolic/debuginfo/index.html, if you click "object crate", it goes to the wrong page.

![image](https://github.com/getsentry/symbolic/assets/5236035/e9873108-d20e-4d40-a5a3-c5cd08f9e4d8)

#skip-changelog