### PR TITLE
ref: Move sourcelinks to symbolic-common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**
+
+- Add sourcelink functionality to `symbolic-common` ([#803](https://github.com/getsentry/symbolic/pull/803))
+
 ## 12.2.0
 
 **Features**

--- a/symbolic-cabi/src/sourcemap.rs
+++ b/symbolic-cabi/src/sourcemap.rs
@@ -195,7 +195,7 @@ ffi_fn! {
                 // and the upstream python code does a `- 1` here:
                 // https://github.com/getsentry/sentry/blob/fdabccac7576c80674c2fed556d4c5407657dc4c/src/sentry/lang/javascript/processor.py#L584-L586
                 smh.lookup_token(line, col + 1).map(|token| {
-                    let mut rv = make_token_match(token);
+                    let rv = make_token_match(token);
                     if let Some(name) = smh.get_original_function_name(col + 1).map(str::to_owned) {
                         (*rv).function_name = SymbolicStr::from_string(name);
                     }
@@ -203,7 +203,7 @@ ffi_fn! {
                 })
             }
             _ => source_map.inner.lookup_token(line, col).map(|token| {
-                let mut rv = make_token_match(token);
+                let  rv = make_token_match(token);
                 if let Some(name) = source_view
                     .get_original_function_name(token, (*minified_name).as_str())
                     .map(str::to_owned) {

--- a/symbolic-common/Cargo.toml
+++ b/symbolic-common/Cargo.toml
@@ -21,14 +21,13 @@ edition = "2021"
 all-features = true
 
 [features]
-serde = ["debugid/serde"]
+serde = ["dep:serde", "debugid/serde"]
 
 [dependencies]
 debugid = "0.8.0"
 memmap2 = "0.5.10"
 stable_deref_trait = "1.2.0"
-serde = { version = "1.0.154", features = ["derive"] }
-serde_json = { version = "1.0.94" }
+serde = { version = "1.0.154", optional = true, features = ["derive"] }
 uuid = "1.3.0"
 
 [dev-dependencies]

--- a/symbolic-common/Cargo.toml
+++ b/symbolic-common/Cargo.toml
@@ -21,13 +21,14 @@ edition = "2021"
 all-features = true
 
 [features]
-serde = ["dep:serde", "debugid/serde"]
+serde = ["debugid/serde"]
 
 [dependencies]
 debugid = "0.8.0"
 memmap2 = "0.5.10"
 stable_deref_trait = "1.2.0"
-serde = {version = "1.0.154", optional = true, features = ["derive"] }
+serde = { version = "1.0.154", features = ["derive"] }
+serde_json = { version = "1.0.94" }
 uuid = "1.3.0"
 
 [dev-dependencies]

--- a/symbolic-common/src/lib.rs
+++ b/symbolic-common/src/lib.rs
@@ -26,12 +26,14 @@ mod byteview;
 mod cell;
 mod heuristics;
 mod path;
+mod sourcelinks;
 mod types;
 
 pub use crate::byteview::*;
 pub use crate::cell::*;
 pub use crate::heuristics::*;
 pub use crate::path::*;
+pub use crate::sourcelinks::*;
 pub use crate::types::*;
 
 pub use debugid::*;

--- a/symbolic-common/src/sourcelinks.rs
+++ b/symbolic-common/src/sourcelinks.rs
@@ -87,7 +87,7 @@ impl PartialOrd for Pattern {
 ///
 /// # Example
 /// ```
-/// use crate ::SourceLinkMappings;
+/// use symbolic_common::SourceLinkMappings;
 /// let mappings: SourceLinkMappings = serde_json::from_str(r#"
 ///     "C:\\src\\*":                   "http://MyDefaultDomain.com/src/*",
 ///     "C:\\src\\fOO\\*":              "http://MyFooDomain.com/src/*",

--- a/symbolic-common/src/sourcelinks.rs
+++ b/symbolic-common/src/sourcelinks.rs
@@ -108,7 +108,6 @@ impl SourceLinkMappings {
                             .get(value.len()..)
                             .unwrap_or_default()
                             .replace('\\', "/");
-                        dbg!(&replacement);
                         return Some(target.replace('*', &replacement));
                     }
                 }

--- a/symbolic-common/src/sourcelinks.rs
+++ b/symbolic-common/src/sourcelinks.rs
@@ -4,6 +4,16 @@ use std::collections::BTreeMap;
 use serde::de::Visitor;
 use serde::{Deserialize, Serialize};
 
+/// A pattern for matching source paths.
+///
+/// A pattern either matches a string exactly (`Exact`)
+/// or it matches any string starting with a certain prefix (`Prefix`).
+///
+/// Patterns are ordered as follows:
+/// 1. Exact patterns come before prefixes
+/// 2. Exact patterns are ordered lexicographically
+/// 3. Prefix patterns are ordered inversely by length, i.e.,
+///    longer before shorter, and lexicographically among equally long strings.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Pattern {
     Exact(String),
@@ -75,7 +85,18 @@ impl PartialOrd for Pattern {
 
 /// A structure mapping source file paths to remote locations.
 ///
-/// Patterns have the form
+/// # Example
+/// ```
+/// use crate ::SourceLinkMappings;
+/// let mappings: SourceLinkMappings = serde_json::from_str(r#"
+///     "C:\\src\\*":                   "http://MyDefaultDomain.com/src/*",
+///     "C:\\src\\fOO\\*":              "http://MyFooDomain.com/src/*",
+///     "C:\\src\\foo\\specific.txt":   "http://MySpecificFoodDomain.com/src/specific.txt",
+///     "C:\\src\\bar\\*":              "http://MyBarDomain.com/src/*",
+/// "#).unwrap();
+/// let resolved = mappings.resolve("c:\\src\\bAr\\foo\\FiLe.txt").unwrap();
+/// assert_eq!(resolved, "http://MyBarDomain.com/src/foo/FiLe.txt");
+/// ````
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct SourceLinkMappings {
     #[serde(flatten)]

--- a/symbolic-common/src/sourcelinks.rs
+++ b/symbolic-common/src/sourcelinks.rs
@@ -88,12 +88,12 @@ impl PartialOrd for Pattern {
 /// # Example
 /// ```
 /// use symbolic_common::SourceLinkMappings;
-/// let mappings: SourceLinkMappings = serde_json::from_str(r#"
+/// let mappings: SourceLinkMappings = serde_json::from_str(r#"{
 ///     "C:\\src\\*":                   "http://MyDefaultDomain.com/src/*",
 ///     "C:\\src\\fOO\\*":              "http://MyFooDomain.com/src/*",
 ///     "C:\\src\\foo\\specific.txt":   "http://MySpecificFoodDomain.com/src/specific.txt",
-///     "C:\\src\\bar\\*":              "http://MyBarDomain.com/src/*",
-/// "#).unwrap();
+///     "C:\\src\\bar\\*":              "http://MyBarDomain.com/src/*"
+/// }"#).unwrap();
 /// let resolved = mappings.resolve("c:\\src\\bAr\\foo\\FiLe.txt").unwrap();
 /// assert_eq!(resolved, "http://MyBarDomain.com/src/foo/FiLe.txt");
 /// ````

--- a/symbolic-ppdb/Cargo.toml
+++ b/symbolic-ppdb/Cargo.toml
@@ -26,7 +26,6 @@ watto = { version = "0.1.0", features = ["writer", "strings"] }
 thiserror = "1.0.39"
 uuid = "1.3.0"
 flate2 = { version = "1.0.25", default-features = false, features = ["rust_backend"] }
-serde_json = { version = "1.0.94" }
 
 [dev-dependencies]
 symbolic-debuginfo = { path = "../symbolic-debuginfo" }

--- a/symbolic-ppdb/Cargo.toml
+++ b/symbolic-ppdb/Cargo.toml
@@ -26,6 +26,8 @@ watto = { version = "0.1.0", features = ["writer", "strings"] }
 thiserror = "1.0.39"
 uuid = "1.3.0"
 flate2 = { version = "1.0.25", default-features = false, features = ["rust_backend"] }
+serde_json = "1.0.102"
+serde = "1.0.171"
 
 [dev-dependencies]
 symbolic-debuginfo = { path = "../symbolic-debuginfo" }

--- a/symbolic-ppdb/src/format/mod.rs
+++ b/symbolic-ppdb/src/format/mod.rs
@@ -1,7 +1,6 @@
 mod metadata;
 mod raw;
 mod sequence_points;
-mod sourcelinks;
 mod streams;
 mod utils;
 
@@ -11,13 +10,12 @@ use flate2::read::DeflateDecoder;
 use thiserror::Error;
 use watto::Pod;
 
-use symbolic_common::{DebugId, Language, Uuid};
+use symbolic_common::{DebugId, Language, SourceLinkMappings, Uuid};
 
 use metadata::{
     CustomDebugInformation, CustomDebugInformationIterator, CustomDebugInformationTag,
     MetadataStream, Table, TableType,
 };
-use sourcelinks::SourceLinkMappings;
 use streams::{BlobStream, GuidStream, PdbStream, StringStream, UsStream};
 
 /// The kind of a [`FormatError`].
@@ -301,7 +299,8 @@ impl<'data> PortablePdb<'data> {
                 source_link_mappings.push(result.get_blob(cdi.blob)?);
             }
         }
-        result.source_link_mappings = SourceLinkMappings::new(source_link_mappings)?;
+        result.source_link_mappings = SourceLinkMappings::new(source_link_mappings)
+            .map_err(|e| FormatError::new(FormatErrorKind::InvalidSourceLinkJson, e))?;
 
         Ok(result)
     }

--- a/symbolic-ppdb/src/format/mod.rs
+++ b/symbolic-ppdb/src/format/mod.rs
@@ -299,8 +299,9 @@ impl<'data> PortablePdb<'data> {
                 source_link_mappings.push(result.get_blob(cdi.blob)?);
             }
         }
-        result.source_link_mappings = SourceLinkMappings::new(source_link_mappings)
-            .map_err(|e| FormatError::new(FormatErrorKind::InvalidSourceLinkJson, e))?;
+        result.source_link_mappings =
+            SourceLinkMappings::parse_from_documents(&source_link_mappings)
+                .map_err(|e| FormatError::new(FormatErrorKind::InvalidSourceLinkJson, e))?;
 
         Ok(result)
     }

--- a/symbolic-ppdb/src/format/sourcelinks.rs
+++ b/symbolic-ppdb/src/format/sourcelinks.rs
@@ -1,0 +1,196 @@
+use std::cmp::Ordering;
+
+use crate::{FormatError, FormatErrorKind};
+
+/// See [Source Link PPDB docs](https://github.com/dotnet/designs/blob/main/accepted/2020/diagnostics/source-link.md#source-link-json-schema).
+#[derive(Default, Clone)]
+pub(crate) struct SourceLinkMappings {
+    rules: Vec<Rule>,
+}
+
+#[derive(Clone)]
+struct Rule {
+    pattern: Pattern,
+    url: String,
+}
+
+#[derive(Clone)]
+enum Pattern {
+    Exact(String),
+    Prefix(String),
+}
+
+impl SourceLinkMappings {
+    pub fn new(jsons: Vec<&[u8]>) -> Result<Self, FormatError> {
+        let mut result = Self { rules: Vec::new() };
+        for json in jsons {
+            result.add_mappings(json)?;
+        }
+        result.sort();
+        Ok(result)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    fn add_mappings(&mut self, json: &[u8]) -> Result<(), FormatError> {
+        use serde_json::*;
+        let json: Value = serde_json::from_slice(json)
+            .map_err(|e| FormatError::new(FormatErrorKind::InvalidSourceLinkJson, e))?;
+
+        let docs = json
+            .get("documents")
+            .and_then(|v| v.as_object())
+            .ok_or_else(Self::err)?;
+
+        self.rules.reserve(docs.len());
+        for (key, url) in docs.iter() {
+            /*
+            Each document is defined by a file path and a URL. Original source file paths are compared
+            case-insensitively to documents and the resulting URL is used to download source. The document
+            may contain an asterisk to represent a wildcard in order to match anything in the asterisk's
+            location. The rules for the asterisk are as follows:
+                1. The only acceptable wildcard is one and only one '*', which if present will be replaced by a relative path.
+                2. If the file path does not contain a *, the URL cannot contain a * and if the file path contains a * the URL must contain a *.
+                3. If the file path contains a *, it must be the final character.
+                4. If the URL contains a *, it may be anywhere in the URL.
+            */
+            let key = key.to_lowercase();
+            let url = url.as_str().ok_or_else(Self::err)?.into();
+            let pattern = if let Some(prefix) = key.strip_suffix('*') {
+                Pattern::Prefix(prefix.into())
+            } else {
+                Pattern::Exact(key)
+            };
+            self.rules.push(Rule { pattern, url });
+        }
+        Ok(())
+    }
+
+    fn err() -> FormatError {
+        FormatError {
+            kind: FormatErrorKind::InvalidSourceLinkJson,
+            source: None,
+        }
+    }
+
+    /// Sort internal rules. This must be called before [Self::resolve].
+    fn sort(&mut self) {
+        // Put Exact matches first, then sort by the Prefix length, longest to shortest.
+        self.rules.sort_unstable_by(|a, b| match &a.pattern {
+            Pattern::Exact(_) => Ordering::Less,
+            Pattern::Prefix(a) => match &b.pattern {
+                Pattern::Exact(_) => Ordering::Greater,
+                Pattern::Prefix(b) => b.len().cmp(&a.len()),
+            },
+        });
+    }
+
+    /// Resolve the path to a URL.
+    pub fn resolve(&self, path: &str) -> Option<String> {
+        // Note: this is currently quite simple, just pick the first match. If we needed to improve
+        // performance in the future because we encounter PDBs with too many items, we can do a
+        // prefix binary search, for example.
+        let path_lower = path.to_lowercase();
+        for rule in &self.rules {
+            match &rule.pattern {
+                Pattern::Exact(value) => {
+                    if value == &path_lower {
+                        return Some(rule.url.clone());
+                    }
+                }
+                Pattern::Prefix(value) => {
+                    if path_lower.starts_with(value) {
+                        let replacement = path
+                            .get(value.len()..)
+                            .unwrap_or_default()
+                            .replace('\\', "/");
+                        return Some(rule.url.replace('*', &replacement));
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_invalid_json() {
+        let mut mappings = SourceLinkMappings::default();
+        assert!(mappings.add_mappings(b"").is_err());
+        assert!(mappings.add_mappings(b"foo").is_err());
+        assert!(mappings
+            .add_mappings(b"{\"docs\": {\"k\": \"v\"}}")
+            .is_err());
+        assert!(mappings
+            .add_mappings(b"{\"documents\": [\"k\", \"v\"]}")
+            .is_err());
+        assert_eq!(mappings.rules.len(), 0);
+    }
+
+    #[test]
+    fn test_mapping() {
+        let mappings = SourceLinkMappings::new(
+            vec![br#"
+                {
+                    "documents": {
+                        "C:\\src\\*":                   "http://MyDefaultDomain.com/src/*",
+                        "C:\\src\\fOO\\*":              "http://MyFooDomain.com/src/*",
+                        "C:\\src\\foo\\specific.txt":   "http://MySpecificFoodDomain.com/src/specific.txt",
+                        "C:\\src\\bar\\*":              "http://MyBarDomain.com/src/*"
+                    }
+                }
+                "#, br#"
+                {
+                    "documents": {
+                        "C:\\src\\file.txt": "https://example.com/file.txt"
+                    }
+                }
+                "#, br#"
+                {
+                    "documents": {
+                        "/home/user/src/*": "https://linux.com/*"
+                    }
+                }
+                "#]
+        ).unwrap();
+
+        assert_eq!(mappings.rules.len(), 6);
+
+        // In this example:
+        //   All files under directory bar will map to a relative URL beginning with http://MyBarDomain.com/src/.
+        //   All files under directory foo will map to a relative URL beginning with http://MyFooDomain.com/src/ EXCEPT foo/specific.txt which will map to http://MySpecificFoodDomain.com/src/specific.txt.
+        //   All other files anywhere under the src directory will map to a relative url beginning with http://MyDefaultDomain.com/src/.
+        assert!(mappings.resolve("c:\\other\\path").is_none());
+        assert!(mappings.resolve("/home/path").is_none());
+        assert_eq!(
+            mappings.resolve("c:\\src\\bAr\\foo\\FiLe.txt").unwrap(),
+            "http://MyBarDomain.com/src/foo/FiLe.txt"
+        );
+        assert_eq!(
+            mappings.resolve("c:\\src\\foo\\FiLe.txt").unwrap(),
+            "http://MyFooDomain.com/src/FiLe.txt"
+        );
+        assert_eq!(
+            mappings.resolve("c:\\src\\foo\\SpEcIfIc.txt").unwrap(),
+            "http://MySpecificFoodDomain.com/src/specific.txt"
+        );
+        assert_eq!(
+            mappings.resolve("c:\\src\\other\\path").unwrap(),
+            "http://MyDefaultDomain.com/src/other/path"
+        );
+        assert_eq!(
+            mappings.resolve("c:\\src\\other\\path").unwrap(),
+            "http://MyDefaultDomain.com/src/other/path"
+        );
+        assert_eq!(
+            mappings.resolve("/home/user/src/Path/TO/file.txt").unwrap(),
+            "https://linux.com/Path/TO/file.txt"
+        );
+    }
+}


### PR DESCRIPTION
In preparation of using sourcelinks in sourcebundles, this extracts the sourcelink functionality from `symbolic-ppdb` and moves it to `symbolic-common`. It also refactors the implementation based on `serde`.

The JSON representation of a `SourceLinkMappings` struct looks like this:

```
{
    "C:\\src\\*":                   "http://MyDefaultDomain.com/src/*",
    "C:\\src\\fOO\\*":              "http://MyFooDomain.com/src/*",
    "C:\\src\\foo\\specific.txt":   "http://MySpecificFoodDomain.com/src/specific.txt",
    "C:\\src\\bar\\*":              "http://MyBarDomain.com/src/*",
    "C:\\src\\file.txt": "https://example.com/file.txt",
    "/home/user/src/*": "https://linux.com/*"
}
```

One downside of this is that it makes the `serde` dependency of `symbolic-common` non-optional. I don't know how big a deal this really is, but it may be that this code might more appropriately live in a different place.