### PR TITLE
fix: Nightly clippy lints

### DIFF
--- a/examples/minidump_stackwalk/src/main.rs
+++ b/examples/minidump_stackwalk/src/main.rs
@@ -366,7 +366,7 @@ impl<'a> minidump_processor::SymbolProvider for LocalSymbolProvider<'a> {
             .map(|(id, sym)| {
                 let stats = SymbolStats {
                     symbol_url: None,
-                    loaded_symbols: matches!(sym, Ok(_)),
+                    loaded_symbols: sym.is_ok(),
                     corrupt_symbols: matches!(sym, Err(SymbolError::Corrupt)),
                 };
 

--- a/symbolic-common/src/sourcelinks.rs
+++ b/symbolic-common/src/sourcelinks.rs
@@ -135,7 +135,7 @@ mod tests {
             ("/home/user/src/*", "https://linux.com/*"),
         ];
 
-        let mappings = SourceLinkMappings::new(mappings.into_iter());
+        let mappings = SourceLinkMappings::new(mappings);
 
         assert_eq!(mappings.mappings.len(), 6);
 

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -2104,14 +2104,14 @@ mod tests {
         let string = b"MODULE Linux x86_64 492E2DD23CC306CA9C494EEF1533A3810 crash";
         let record = BreakpadModuleRecord::parse(string)?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r#"
        ⋮BreakpadModuleRecord {
        ⋮    os: "Linux",
        ⋮    arch: "x86_64",
        ⋮    id: "492E2DD23CC306CA9C494EEF1533A3810",
        ⋮    name: "crash",
        ⋮}
-        "###);
+        "#);
 
         Ok(())
     }
@@ -2122,14 +2122,14 @@ mod tests {
         let string = b"MODULE Linux x86_64 6216C672A8D33EC9CF4A1BAB8B29D00E libdispatch.so";
         let record = BreakpadModuleRecord::parse(string)?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r#"
        ⋮BreakpadModuleRecord {
        ⋮    os: "Linux",
        ⋮    arch: "x86_64",
        ⋮    id: "6216C672A8D33EC9CF4A1BAB8B29D00E",
        ⋮    name: "libdispatch.so",
        ⋮}
-        "###);
+        "#);
 
         Ok(())
     }
@@ -2139,12 +2139,12 @@ mod tests {
         let string = b"FILE 37 /usr/include/libkern/i386/_OSByteOrder.h";
         let record = BreakpadFileRecord::parse(string)?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r#"
        ⋮BreakpadFileRecord {
        ⋮    id: 37,
        ⋮    name: "/usr/include/libkern/i386/_OSByteOrder.h",
        ⋮}
-        "###);
+        "#);
 
         Ok(())
     }
@@ -2154,12 +2154,12 @@ mod tests {
         let string = b"FILE 38 /usr/local/src/filename with spaces.c";
         let record = BreakpadFileRecord::parse(string)?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r#"
        ⋮BreakpadFileRecord {
        ⋮    id: 38,
        ⋮    name: "/usr/local/src/filename with spaces.c",
        ⋮}
-        "###);
+        "#);
 
         Ok(())
     }
@@ -2169,12 +2169,12 @@ mod tests {
         let string = b"INLINE_ORIGIN 3529 LZ4F_initStream";
         let record = BreakpadInlineOriginRecord::parse(string)?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r#"
         BreakpadInlineOriginRecord {
             id: 3529,
             name: "LZ4F_initStream",
         }
-        "###);
+        "#);
 
         Ok(())
     }
@@ -2185,12 +2185,12 @@ mod tests {
             b"INLINE_ORIGIN 3576 unsigned int mozilla::AddToHash<char, 0>(unsigned int, char)";
         let record = BreakpadInlineOriginRecord::parse(string)?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r#"
         BreakpadInlineOriginRecord {
             id: 3576,
             name: "unsigned int mozilla::AddToHash<char, 0>(unsigned int, char)",
         }
-        "###);
+        "#);
 
         Ok(())
     }
@@ -2201,7 +2201,7 @@ mod tests {
         let string = b"FUNC 1730 1a 0 <name omitted>";
         let record = BreakpadFuncRecord::parse(string, Lines::default())?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r#"
        ⋮BreakpadFuncRecord {
        ⋮    multiple: false,
        ⋮    address: 5936,
@@ -2209,7 +2209,7 @@ mod tests {
        ⋮    parameter_size: 0,
        ⋮    name: "<name omitted>",
        ⋮}
-        "###);
+        "#);
 
         Ok(())
     }
@@ -2219,7 +2219,7 @@ mod tests {
         let string = b"FUNC m 1730 1a 0 <name omitted>";
         let record = BreakpadFuncRecord::parse(string, Lines::default())?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r#"
        ⋮BreakpadFuncRecord {
        ⋮    multiple: true,
        ⋮    address: 5936,
@@ -2227,7 +2227,7 @@ mod tests {
        ⋮    parameter_size: 0,
        ⋮    name: "<name omitted>",
        ⋮}
-        "###);
+        "#);
 
         Ok(())
     }
@@ -2237,7 +2237,7 @@ mod tests {
         let string = b"FUNC 0 f 0";
         let record = BreakpadFuncRecord::parse(string, Lines::default())?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r#"
        ⋮BreakpadFuncRecord {
        ⋮    multiple: false,
        ⋮    address: 0,
@@ -2245,7 +2245,7 @@ mod tests {
        ⋮    parameter_size: 0,
        ⋮    name: "<unknown>",
        ⋮}
-        "###);
+        "#);
 
         Ok(())
     }
@@ -2308,14 +2308,14 @@ mod tests {
         let string = b"PUBLIC 5180 0 __clang_call_terminate";
         let record = BreakpadPublicRecord::parse(string)?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r#"
        ⋮BreakpadPublicRecord {
        ⋮    multiple: false,
        ⋮    address: 20864,
        ⋮    parameter_size: 0,
        ⋮    name: "__clang_call_terminate",
        ⋮}
-        "###);
+        "#);
 
         Ok(())
     }
@@ -2325,14 +2325,14 @@ mod tests {
         let string = b"PUBLIC m 5180 0 __clang_call_terminate";
         let record = BreakpadPublicRecord::parse(string)?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r#"
        ⋮BreakpadPublicRecord {
        ⋮    multiple: true,
        ⋮    address: 20864,
        ⋮    parameter_size: 0,
        ⋮    name: "__clang_call_terminate",
        ⋮}
-        "###);
+        "#);
 
         Ok(())
     }
@@ -2342,14 +2342,14 @@ mod tests {
         let string = b"PUBLIC 5180 0";
         let record = BreakpadPublicRecord::parse(string)?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r#"
        ⋮BreakpadPublicRecord {
        ⋮    multiple: false,
        ⋮    address: 20864,
        ⋮    parameter_size: 0,
        ⋮    name: "<unknown>",
        ⋮}
-        "###);
+        "#);
 
         Ok(())
     }
@@ -2416,7 +2416,7 @@ mod tests {
         let string = b"STACK CFI INIT 1880 2d .cfa: $rsp 8 + .ra: .cfa -8 + ^";
         let record = BreakpadStackRecord::parse(string)?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r#"
         Cfi(
             BreakpadStackCfiRecord {
                 start: 6272,
@@ -2431,7 +2431,7 @@ mod tests {
                 ),
             },
         )
-        "###);
+        "#);
 
         Ok(())
     }
@@ -2442,7 +2442,7 @@ mod tests {
             b"STACK WIN 4 371a c 0 0 0 0 0 0 1 $T0 .raSearch = $eip $T0 ^ = $esp $T0 4 + =";
         let record = BreakpadStackRecord::parse(string)?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r#"
         Win(
             BreakpadStackWinRecord {
                 ty: FrameData,
@@ -2460,7 +2460,7 @@ mod tests {
                 ),
             },
         )
-        "###);
+        "#);
 
         Ok(())
     }
@@ -2496,7 +2496,7 @@ mod tests {
                 ";
         let record = BreakpadStackRecord::parse(string)?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r#"
         Win(
             BreakpadStackWinRecord {
                 ty: FrameData,
@@ -2514,7 +2514,7 @@ mod tests {
                 ),
             },
         )
-        "###);
+        "#);
         Ok(())
     }
 

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -283,7 +283,7 @@ impl<'d> DwarfLineProgram<'d> {
                         } else {
                             address
                         },
-                        rows: sequence_rows.drain(..).collect(),
+                        rows: std::mem::take(&mut sequence_rows),
                     });
                 }
                 prev_address = 0;

--- a/symbolic-debuginfo/src/pdb.rs
+++ b/symbolic-debuginfo/src/pdb.rs
@@ -1,14 +1,14 @@
 //! Support for Program Database, the debug companion format on Windows.
 
 use std::borrow::Cow;
+use std::cell::RefCell;
 use std::collections::btree_map::BTreeMap;
 use std::error::Error;
 use std::fmt;
 use std::io::Cursor;
-use std::sync::Arc;
+use std::rc::Rc;
 
 use elsa::FrozenMap;
-use parking_lot::RwLock;
 use pdb_addr2line::pdb::{
     AddressMap, FallibleIterator, ImageSectionHeader, InlineSiteSymbol, LineProgram, MachineType,
     Module, ModuleInfo, PdbInternalSectionOffset, ProcedureSymbol, RawString, SeparatedCodeSymbol,
@@ -117,8 +117,8 @@ impl From<pdb_addr2line::Error> for PdbError {
 ///
 /// This object is a sole debug companion to [`PeObject`](../pdb/struct.PdbObject.html).
 pub struct PdbObject<'data> {
-    pdb: Arc<RwLock<Pdb<'data>>>,
-    debug_info: Arc<pdb::DebugInformation<'data>>,
+    pdb: Rc<RefCell<Pdb<'data>>>,
+    debug_info: Rc<pdb::DebugInformation<'data>>,
     pdb_info: pdb::PDBInformation<'data>,
     public_syms: pdb::SymbolTable<'data>,
     executable_sections: ExecutableSections,
@@ -149,8 +149,8 @@ impl<'data> PdbObject<'data> {
         let sections = pdb.sections()?;
 
         Ok(PdbObject {
-            pdb: Arc::new(RwLock::new(pdb)),
-            debug_info: Arc::new(dbi),
+            pdb: Rc::new(RefCell::new(pdb)),
+            debug_info: Rc::new(dbi),
             pdb_info: pdbi,
             public_syms: pubi,
             data,
@@ -227,7 +227,7 @@ impl<'data> PdbObject<'data> {
     pub fn symbols(&self) -> PdbSymbolIterator<'data, '_> {
         PdbSymbolIterator {
             symbols: self.public_syms.iter(),
-            address_map: self.pdb.write().address_map().ok(),
+            address_map: self.pdb.borrow_mut().address_map().ok(),
             executable_sections: &self.executable_sections,
         }
     }
@@ -276,7 +276,7 @@ impl<'data> PdbObject<'data> {
     }
 
     #[doc(hidden)]
-    pub fn inner(&self) -> &RwLock<Pdb<'data>> {
+    pub fn inner(&self) -> &RefCell<Pdb<'data>> {
         &self.pdb
     }
 }
@@ -470,12 +470,12 @@ impl<'data, 'object> Iterator for PdbSymbolIterator<'data, 'object> {
 }
 
 struct PdbStreams<'d> {
-    debug_info: Arc<pdb::DebugInformation<'d>>,
+    debug_info: Rc<pdb::DebugInformation<'d>>,
     type_info: pdb::TypeInformation<'d>,
     id_info: pdb::IdInformation<'d>,
     string_table: Option<pdb::StringTable<'d>>,
 
-    pdb: Arc<RwLock<Pdb<'d>>>,
+    pdb: Rc<RefCell<Pdb<'d>>>,
 
     /// ModuleInfo objects are stored on this object (outside PdbDebugInfo) so that the
     /// PdbDebugInfo can store a TypeFormatter, which has a lifetime dependency on its
@@ -487,7 +487,7 @@ struct PdbStreams<'d> {
 
 impl<'d> PdbStreams<'d> {
     fn from_pdb(pdb: &PdbObject<'d>) -> Result<Self, PdbError> {
-        let mut p = pdb.pdb.write();
+        let mut p = pdb.pdb.borrow_mut();
 
         // PDB::string_table errors if the named stream for the string table is not present.
         // However, this occurs in certain PDBs and does not automatically indicate an error.
@@ -518,7 +518,7 @@ impl<'d> pdb_addr2line::ModuleProvider<'d> for PdbStreams<'d> {
             return Ok(Some(module_info));
         }
 
-        let mut pdb = self.pdb.write();
+        let mut pdb = self.pdb.borrow_mut();
         Ok(pdb.module_info(module)?.map(|module_info| {
             self.module_infos
                 .insert(module_index, Box::new(module_info))
@@ -543,7 +543,7 @@ impl<'d> PdbDebugInfo<'d> {
 
         // Avoid deadlocks by only covering the two access to the address map. For
         // instance, `pdb.symbol_map()` requires a mutable borrow of the PDB as well.
-        let mut p = pdb.pdb.write();
+        let mut p = pdb.pdb.borrow_mut();
         let address_map = p.address_map()?;
 
         drop(p);

--- a/symbolic-debuginfo/src/sourcebundle.rs
+++ b/symbolic-debuginfo/src/sourcebundle.rs
@@ -78,7 +78,7 @@ static MANIFEST_PATH: &str = "manifest.json";
 static FILES_PATH: &str = "files";
 
 lazy_static::lazy_static! {
-    static ref SANE_PATH_RE: Regex = Regex::new(r#":?[/\\]+"#).unwrap();
+    static ref SANE_PATH_RE: Regex = Regex::new(r":?[/\\]+").unwrap();
 }
 
 /// The error type for [`SourceBundleError`].

--- a/symbolic-debuginfo/tests/test_objects.rs
+++ b/symbolic-debuginfo/tests/test_objects.rs
@@ -127,7 +127,7 @@ fn test_breakpad() -> Result<(), Error> {
     let view = ByteView::open(fixture("windows/crash.sym"))?;
     let object = Object::parse(&view)?;
 
-    insta::assert_debug_snapshot!(object, @r###"
+    insta::assert_debug_snapshot!(object, @r#"
    ⋮Breakpad(
    ⋮    BreakpadObject {
    ⋮        code_id: Some(
@@ -145,7 +145,7 @@ fn test_breakpad() -> Result<(), Error> {
    ⋮        is_malformed: false,
    ⋮    },
    ⋮)
-    "###);
+    "#);
 
     Ok(())
 }
@@ -208,7 +208,7 @@ fn test_elf_executable() -> Result<(), Error> {
     let view = ByteView::open(fixture("linux/crash"))?;
     let object = Object::parse(&view)?;
 
-    insta::assert_debug_snapshot!(object, @r###"
+    insta::assert_debug_snapshot!(object, @r#"
    ⋮Elf(
    ⋮    ElfObject {
    ⋮        code_id: Some(
@@ -227,7 +227,7 @@ fn test_elf_executable() -> Result<(), Error> {
    ⋮        is_malformed: false,
    ⋮    },
    ⋮)
-    "###);
+    "#);
 
     Ok(())
 }
@@ -237,7 +237,7 @@ fn test_elf_debug() -> Result<(), Error> {
     let view = ByteView::open(fixture("linux/crash.debug"))?;
     let object = Object::parse(&view)?;
 
-    insta::assert_debug_snapshot!(object, @r###"
+    insta::assert_debug_snapshot!(object, @r#"
    ⋮Elf(
    ⋮    ElfObject {
    ⋮        code_id: Some(
@@ -256,7 +256,7 @@ fn test_elf_debug() -> Result<(), Error> {
    ⋮        is_malformed: false,
    ⋮    },
    ⋮)
-    "###);
+    "#);
 
     Ok(())
 }
@@ -357,7 +357,7 @@ fn test_mach_executable() -> Result<(), Error> {
     let view = ByteView::open(fixture("macos/crash"))?;
     let object = Object::parse(&view)?;
 
-    insta::assert_debug_snapshot!(object, @r###"
+    insta::assert_debug_snapshot!(object, @r#"
    ⋮MachO(
    ⋮    MachObject {
    ⋮        code_id: Some(
@@ -376,7 +376,7 @@ fn test_mach_executable() -> Result<(), Error> {
    ⋮        is_malformed: false,
    ⋮    },
    ⋮)
-    "###);
+    "#);
 
     Ok(())
 }
@@ -386,7 +386,7 @@ fn test_mach_dsym() -> Result<(), Error> {
     let view = ByteView::open(fixture("macos/crash.dSYM/Contents/Resources/DWARF/crash"))?;
     let object = Object::parse(&view)?;
 
-    insta::assert_debug_snapshot!(object, @r###"
+    insta::assert_debug_snapshot!(object, @r#"
    ⋮MachO(
    ⋮    MachObject {
    ⋮        code_id: Some(
@@ -405,7 +405,7 @@ fn test_mach_dsym() -> Result<(), Error> {
    ⋮        is_malformed: false,
    ⋮    },
    ⋮)
-    "###);
+    "#);
 
     Ok(())
 }
@@ -452,7 +452,7 @@ fn test_pe_32() -> Result<(), Error> {
     let view = ByteView::open(fixture("windows/crash.exe"))?;
     let object = Object::parse(&view)?;
 
-    insta::assert_debug_snapshot!(object, @r###"
+    insta::assert_debug_snapshot!(object, @r#"
    ⋮Pe(
    ⋮    PeObject {
    ⋮        code_id: Some(
@@ -474,7 +474,7 @@ fn test_pe_32() -> Result<(), Error> {
    ⋮        is_malformed: false,
    ⋮    },
    ⋮)
-    "###);
+    "#);
 
     Ok(())
 }
@@ -484,7 +484,7 @@ fn test_pe_64() -> Result<(), Error> {
     let view = ByteView::open(fixture("windows/CrashWithException.exe"))?;
     let object = Object::parse(&view)?;
 
-    insta::assert_debug_snapshot!(object, @r###"
+    insta::assert_debug_snapshot!(object, @r#"
    ⋮Pe(
    ⋮    PeObject {
    ⋮        code_id: Some(
@@ -506,7 +506,7 @@ fn test_pe_64() -> Result<(), Error> {
    ⋮        is_malformed: false,
    ⋮    },
    ⋮)
-    "###);
+    "#);
 
     Ok(())
 }
@@ -582,7 +582,7 @@ fn test_pdb() -> Result<(), Error> {
     let view = ByteView::open(fixture("windows/crash.pdb"))?;
     let object = Object::parse(&view)?;
 
-    insta::assert_debug_snapshot!(object, @r###"
+    insta::assert_debug_snapshot!(object, @r#"
    ⋮Pdb(
    ⋮    PdbObject {
    ⋮        debug_id: DebugId {
@@ -597,7 +597,7 @@ fn test_pdb() -> Result<(), Error> {
    ⋮        is_malformed: false,
    ⋮    },
    ⋮)
-    "###);
+    "#);
 
     Ok(())
 }
@@ -670,7 +670,7 @@ fn test_ppdb() -> Result<(), Error> {
     let view = ByteView::open(fixture("windows/portable.pdb"))?;
     let object = Object::parse(&view)?;
 
-    insta::assert_debug_snapshot!(object, @r###"
+    insta::assert_debug_snapshot!(object, @r#"
     ⋮PortablePdb(
     ⋮    PortablePdbObject {
     ⋮        portable_pdb: PortablePdb {
@@ -694,7 +694,7 @@ fn test_ppdb() -> Result<(), Error> {
     ⋮        },
     ⋮    },
     ⋮)
-    "###);
+    "#);
 
     Ok(())
 }
@@ -795,10 +795,8 @@ fn test_ppdb_source_links() -> Result<(), Error> {
     let object = Object::parse(&view)?;
     let session = object.debug_session()?;
 
-    let known_embedded_sources = vec![
-        ".NETStandard,Version=v2.0.AssemblyAttributes.cs",
-        "ppdb-sourcelink-sample.AssemblyInfo.cs",
-    ];
+    let known_embedded_sources = [".NETStandard,Version=v2.0.AssemblyAttributes.cs",
+        "ppdb-sourcelink-sample.AssemblyInfo.cs"];
 
     // Testing this is simple because there's just one prefix rule in this PPDB.
     let src_prefix = "C:\\dev\\symbolic\\";

--- a/symbolic-symcache/tests/test_cache.rs
+++ b/symbolic-symcache/tests/test_cache.rs
@@ -8,7 +8,7 @@ type Error = Box<dyn std::error::Error>;
 fn test_load_header_linux() -> Result<(), Error> {
     let buffer = ByteView::open(fixture("symcache/current/linux.symc"))?;
     let symcache = SymCache::parse(&buffer)?;
-    insta::assert_debug_snapshot!(symcache, @r###"
+    insta::assert_debug_snapshot!(symcache, @r#"
     SymCache {
         version: 7,
         debug_id: DebugId {
@@ -22,7 +22,7 @@ fn test_load_header_linux() -> Result<(), Error> {
         ranges: 6762,
         string_bytes: 52180,
     }
-    "###);
+    "#);
     Ok(())
 }
 
@@ -38,7 +38,7 @@ fn test_load_functions_linux() -> Result<(), Error> {
 fn test_load_header_macos() -> Result<(), Error> {
     let buffer = ByteView::open(fixture("symcache/current/macos.symc"))?;
     let symcache = SymCache::parse(&buffer)?;
-    insta::assert_debug_snapshot!(symcache, @r###"
+    insta::assert_debug_snapshot!(symcache, @r#"
     SymCache {
         version: 7,
         debug_id: DebugId {
@@ -52,7 +52,7 @@ fn test_load_header_macos() -> Result<(), Error> {
         ranges: 4591,
         string_bytes: 42829,
     }
-    "###);
+    "#);
     Ok(())
 }
 

--- a/symbolic-symcache/tests/test_writer.rs
+++ b/symbolic-symcache/tests/test_writer.rs
@@ -23,7 +23,7 @@ fn test_write_header_linux() -> Result<(), Error> {
     }
 
     let symcache = SymCache::parse(&buffer)?;
-    insta::assert_debug_snapshot!(symcache, @r###"
+    insta::assert_debug_snapshot!(symcache, @r#"
     SymCache {
         version: 8,
         debug_id: DebugId {
@@ -37,7 +37,7 @@ fn test_write_header_linux() -> Result<(), Error> {
         ranges: 6828,
         string_bytes: 49877,
     }
-    "###);
+    "#);
 
     Ok(())
 }
@@ -67,7 +67,7 @@ fn test_write_header_macos() -> Result<(), Error> {
     converter.process_object(&object)?;
     converter.serialize(&mut Cursor::new(&mut buffer))?;
     let symcache = SymCache::parse(&buffer)?;
-    insta::assert_debug_snapshot!(symcache, @r###"
+    insta::assert_debug_snapshot!(symcache, @r#"
     SymCache {
         version: 8,
         debug_id: DebugId {
@@ -81,7 +81,7 @@ fn test_write_header_macos() -> Result<(), Error> {
         ranges: 5782,
         string_bytes: 40958,
     }
-    "###);
+    "#);
 
     Ok(())
 }

--- a/symbolic-unreal/src/context.rs
+++ b/symbolic-unreal/src/context.rs
@@ -524,10 +524,10 @@ test_unreal_runtime_properties!(epic_account_id, "EpicAccountId", "epic acc id")
 test_unreal_runtime_properties!(
     legacy_call_stack,
     "CallStack",
-    r#"YetAnother!AActor::IsPendingKillPending()
+    r"YetAnother!AActor::IsPendingKillPending()
 YetAnother!__scrt_common_main_seh() [f:\dd\vctools\crt\vcstartup\src\startup\exe_common.inl:288]
 kernel32
-ntdll"#
+ntdll"
 );
 test_unreal_runtime_properties!(portable_call_stack, "PCallStack", "YetAnother 0x0000000025ca0000 + 703394 YetAnother 0x0000000025ca0000 + 281f2ee YetAnother 0x0000000025ca0000 + 2a26dd3 YetAnother 0x0000000025ca0000 + 2a4f984 YetAnother 0x0000000025ca0000 + 355e77e YetAnother 0x0000000025ca0000 + 3576186 YetAnother 0x0000000025ca0000 + 8acc56 YetAnother 0x0000000025ca0000 + 8acf00 YetAnother 0x0000000025ca0000 + 35c121d YetAnother 0x0000000025ca0000 + 35cfb58 YetAnother 0x0000000025ca0000 + 2eb082f YetAnother 0x0000000025ca0000 + 2eb984f YetAnother 0x0000000025ca0000 + 2d1cd39 YetAnother 0x0000000025ca0000 + 325258 YetAnother 0x0000000025ca0000 + 334e4c YetAnother 0x0000000025ca0000 + 334eaa YetAnother 0x0000000025ca0000 + 3429e6 YetAnother 0x0000000025ca0000 + 44e73c6 KERNEL32 0x000000000fd40000 + 13034 ntdll 0x0000000010060000 + 71471");
 test_unreal_runtime_properties!(
@@ -587,8 +587,8 @@ test_unreal_runtime_properties!(
 test_unreal_runtime_properties!(
     modules,
     "Modules",
-    r#"\\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-\\Mac\Home\Desktop\WindowsNoEditor\Engine\Binaries\ThirdParty\Vorbis\Win64\VS2015\libvorbis_64.dll"#
+    r"\\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+\\Mac\Home\Desktop\WindowsNoEditor\Engine\Binaries\ThirdParty\Vorbis\Win64\VS2015\libvorbis_64.dll"
 );
 
 test_unreal_platform_properties!(is_windows, "PlatformIsRunningWindows", true);


### PR DESCRIPTION
Most of these fixes are straightforward, except for the ones in `pdb.rs`. There, `clippy` complains that the `PdbObject` struct contains fields of non-`Send`/`Sync` types (`Pdb`, `pdb::DebugInfo`) wrapped in `Arc`. This is pointless; if the type isn't `Send`/`Sync` there is no advantage to wrapping it in `Arc` over `Rc` because you can't use it across threads anyway.

Strictly speaking, this is a breaking change—there's a public method whose signature changes. But it's marked as hidden, so arguably this shouldn't count as breaking?
```
impl<'data> PdbObject<'data> {
    #[doc(hidden)]
    pub fn inner(&self) -> &RefCell<Pdb<'data>> {
        &self.pdb
    }
}
```