### PR TITLE
fix(sourcebundles): Don't write empty sourcelinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**
+
+- sourcebundles: Don't write empty `source_links` maps ([#809](https://github.com/getsentry/symbolic/pull/813))
+
 ## 12.4.0
 
 **Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Fixes**
 
-- sourcebundles: Don't write empty `source_links` maps ([#809](https://github.com/getsentry/symbolic/pull/813))
+- sourcebundles: Don't write empty `source_links` maps ([#813](https://github.com/getsentry/symbolic/pull/813))
 
 ## 12.4.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "debuginfo_debug"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -497,7 +497,7 @@ checksum = "f0bc8fbe9441c17c9f46f75dfe27fa1ddb6c68a461ccaed0481419219d4f10d3"
 
 [[package]]
 name = "dump_cfi"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "dump_sources"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "clap",
  "symbolic",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "minidump_stackwalk"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "object_debug"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "clap",
  "symbolic",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "sourcemapcache_debug"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "symbolic-cfi",
  "symbolic-common",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-cabi"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "proguard",
  "sourcemap",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-cfi"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "insta",
  "similar-asserts",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "debugid",
  "memmap2",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "criterion",
  "debugid",
@@ -2202,7 +2202,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "indexmap 2.0.0",
  "serde_json",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-ppdb"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "flate2",
  "indexmap 1.9.3",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-sourcemapcache"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "itertools",
  "js-source-scopes",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "criterion",
  "indexmap 2.0.0",
@@ -2271,11 +2271,11 @@ dependencies = [
 
 [[package]]
 name = "symbolic-testutils"
-version = "12.3.0"
+version = "12.4.0"
 
 [[package]]
 name = "symbolic-unreal"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "anylog",
  "bytes",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "symcache_debug"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2577,7 +2577,7 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unreal_engine_crash"
-version = "12.3.0"
+version = "12.4.0"
 dependencies = [
  "clap",
  "symbolic",

--- a/symbolic-debuginfo/src/sourcebundle.rs
+++ b/symbolic-debuginfo/src/sourcebundle.rs
@@ -517,7 +517,7 @@ struct SourceBundleManifest {
     #[serde(default)]
     pub files: BTreeMap<String, SourceFileInfo>,
 
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub source_links: BTreeMap<String, String>,
 
     /// Arbitrary attributes to include in the bundle.


### PR DESCRIPTION
Sourcebundle manifests written after the introduction of source links would always contain a `source_links: {}` field, which would cause earlier `symbolic` versions to throw an error when trying to read the manifest (because `source_links` is interpreted as a key in the `attributes` map, whose values are supposed to be strings).

This fixes the problem by not writing empty source link maps (which is all that we are seeing in the wild) at all.