### PR TITLE
fix empty parameters list issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 **Fixes**
 
+- Fix empty parameters list issue ([#821](https://github.com/getsentry/symbolic/pull/821))
+
 ## 12.6.0
 
 ### Various fixes & improvements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "debuginfo_debug"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -543,7 +543,7 @@ checksum = "f0bc8fbe9441c17c9f46f75dfe27fa1ddb6c68a461ccaed0481419219d4f10d3"
 
 [[package]]
 name = "dump_cfi"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "dump_sources"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "clap",
  "symbolic",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "minidump_stackwalk"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "object_debug"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "clap",
  "symbolic",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "sourcemapcache_debug"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "symbolic-cfi",
  "symbolic-common",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-cabi"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "proguard",
  "sourcemap",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-cfi"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "insta",
  "similar-asserts",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "debugid",
  "memmap2 0.8.0",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "criterion",
  "debugid",
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "indexmap",
  "serde_json",
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-ppdb"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "flate2",
  "indexmap",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-sourcemapcache"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "itertools 0.11.0",
  "js-source-scopes",
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "criterion",
  "indexmap",
@@ -2231,11 +2231,11 @@ dependencies = [
 
 [[package]]
 name = "symbolic-testutils"
-version = "12.5.0"
+version = "12.6.0"
 
 [[package]]
 name = "symbolic-unreal"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "anylog",
  "bytes",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "symcache_debug"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2511,7 +2511,7 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unreal_engine_crash"
-version = "12.5.0"
+version = "12.6.0"
 dependencies = [
  "clap",
  "symbolic",

--- a/py/symbolic/proguard.py
+++ b/py/symbolic/proguard.py
@@ -81,7 +81,7 @@ class ProguardMapper(RustObject):
         return output if len(output[0]) > 0 and len(output[1]) > 0 else None
 
     def remap_frame(
-        self, klass: str, method: str, line: int, parameters: str = ""
+        self, klass: str, method: str, line: int, parameters: str = "", use_parameters: bool = False
     ) -> list[JavaStackFrame]:
         """Remaps the stackframe, given its class, method and line."""
         result = self._methodcall(
@@ -90,6 +90,7 @@ class ProguardMapper(RustObject):
             encode_str(method),
             line,
             encode_str(parameters),
+            use_parameters,
         )
 
         frames = []

--- a/py/symbolic/proguard.py
+++ b/py/symbolic/proguard.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Tuple
+from typing import Optional, Tuple
 
 import uuid as uuid_mod
 
@@ -85,8 +85,7 @@ class ProguardMapper(RustObject):
         klass: str,
         method: str,
         line: int,
-        parameters: str = "",
-        use_parameters: bool = False,
+        parameters: Optional[str] = None,
     ) -> list[JavaStackFrame]:
         """Remaps the stackframe, given its class, method and line."""
         result = self._methodcall(
@@ -94,8 +93,8 @@ class ProguardMapper(RustObject):
             encode_str(klass),
             encode_str(method),
             line,
-            encode_str(parameters),
-            use_parameters,
+            encode_str("" if parameters is None else parameters),
+            parameters is not None,
         )
 
         frames = []

--- a/py/symbolic/proguard.py
+++ b/py/symbolic/proguard.py
@@ -81,7 +81,12 @@ class ProguardMapper(RustObject):
         return output if len(output[0]) > 0 and len(output[1]) > 0 else None
 
     def remap_frame(
-        self, klass: str, method: str, line: int, parameters: str = "", use_parameters: bool = False
+        self,
+        klass: str,
+        method: str,
+        line: int,
+        parameters: str = "",
+        use_parameters: bool = False,
     ) -> list[JavaStackFrame]:
         """Remaps the stackframe, given its class, method and line."""
         result = self._methodcall(

--- a/symbolic-cabi/include/symbolic.h
+++ b/symbolic-cabi/include/symbolic.h
@@ -514,7 +514,8 @@ struct SymbolicProguardRemapResult symbolic_proguardmapper_remap_frame(const str
                                                                        const struct SymbolicStr *class_,
                                                                        const struct SymbolicStr *method,
                                                                        uintptr_t line,
-                                                                       const struct SymbolicStr *parameters);
+                                                                       const struct SymbolicStr *parameters,
+                                                                       bool use_parameters);
 
 /**
  * Remaps a class name.

--- a/symbolic-cabi/src/proguard.rs
+++ b/symbolic-cabi/src/proguard.rs
@@ -82,9 +82,10 @@ ffi_fn! {
         method: *const SymbolicStr,
         line: usize,
         parameters: *const SymbolicStr,
+        use_parameters: bool,
     ) -> Result<SymbolicProguardRemapResult> {
         let mapper = &SymbolicProguardMapper::as_rust(mapper).inner.get().mapper;
-        let frame = if (*parameters).len > 0 {
+        let frame = if use_parameters {
             StackFrame::with_parameters((*class).as_str(), (*method).as_str(), (*parameters).as_str())
         } else {
             StackFrame::new((*class).as_str(), (*method).as_str(), line)


### PR DESCRIPTION
Use a specific boolean flag to decide whether to deobfuscate based on parameters list or line numbers.

Empty parameters list should not be used to make this discrimination, but at the same Time `Option<T>` type is not FFI safe therefore we cannot use it for the Rust bindings.