### PR TITLE
enhance: make mapping by params initialization optional (android deobfuscation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+**Internal**
+
+**Fixes**
+
+**Features**
+
+- Make mapping by params initialization optional ([#823](https://github.com/getsentry/symbolic/pull/823))
+
 ## 12.7.1
 
 **Internal**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 **Internal**
 
 **Fixes**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "debuginfo_debug"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -543,7 +543,7 @@ checksum = "f0bc8fbe9441c17c9f46f75dfe27fa1ddb6c68a461ccaed0481419219d4f10d3"
 
 [[package]]
 name = "dump_cfi"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "dump_sources"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "clap",
  "symbolic",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "minidump_stackwalk"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "object_debug"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "clap",
  "symbolic",
@@ -1450,9 +1450,9 @@ dependencies = [
 
 [[package]]
 name = "proguard"
-version = "5.3.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a4fc2794b6ee3ae207c36fb970a591e590dc6e1d36444f1de135529b285d88"
+checksum = "02edf5746919e655cfec7b1accbfc889d76b80e5cf72ba4a4da8024b2c2ee1a6"
 dependencies = [
  "lazy_static",
  "uuid",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "sourcemapcache_debug"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "symbolic-cfi",
  "symbolic-common",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-cabi"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "proguard",
  "sourcemap",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-cfi"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "insta",
  "similar-asserts",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "debugid",
  "memmap2 0.9.0",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "criterion",
  "debugid",
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "indexmap",
  "serde_json",
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-ppdb"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "flate2",
  "indexmap",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-sourcemapcache"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "itertools 0.12.0",
  "js-source-scopes",
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "criterion",
  "indexmap",
@@ -2231,11 +2231,11 @@ dependencies = [
 
 [[package]]
 name = "symbolic-testutils"
-version = "12.7.0"
+version = "12.7.1"
 
 [[package]]
 name = "symbolic-unreal"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "anylog",
  "bytes",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "symcache_debug"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2511,7 +2511,7 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unreal_engine_crash"
-version = "12.7.0"
+version = "12.7.1"
 dependencies = [
  "clap",
  "symbolic",

--- a/py/symbolic/proguard.py
+++ b/py/symbolic/proguard.py
@@ -39,10 +39,14 @@ class ProguardMapper(RustObject):
     __dealloc_func__ = lib.symbolic_proguardmapper_free
 
     @classmethod
-    def open(cls, path: str) -> ProguardMapper:
+    def open(cls, path: str, initialize_param_mapping: bool = False) -> ProguardMapper:
         """Constructs a mapping file from a path."""
         return cls._from_objptr(
-            rustcall(lib.symbolic_proguardmapper_open, encode_path(path))
+            rustcall(
+                lib.symbolic_proguardmapper_open,
+                encode_path(path),
+                initialize_param_mapping,
+            )
         )
 
     @property

--- a/symbolic-cabi/Cargo.toml
+++ b/symbolic-cabi/Cargo.toml
@@ -20,7 +20,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-proguard = { version = "5.3.0", features = ["uuid"] }
+proguard = { version = "5.4.0", features = ["uuid"] }
 sourcemap = "7.0.0"
 symbolic = { version = "12.7.1", path = "../symbolic", features = ["cfi", "debuginfo", "sourcemapcache", "symcache"] }
 tempfile = "3.4.0"

--- a/symbolic-cabi/include/symbolic.h
+++ b/symbolic-cabi/include/symbolic.h
@@ -500,7 +500,8 @@ struct SymbolicStr symbolic_normalize_debug_id(const struct SymbolicStr *debug_i
 /**
  * Creates a proguard mapping view from a path.
  */
-struct SymbolicProguardMapper *symbolic_proguardmapper_open(const char *path);
+struct SymbolicProguardMapper *symbolic_proguardmapper_open(const char *path,
+                                                            bool initialize_param_mapping);
 
 /**
  * Frees a proguard mapping view.

--- a/symbolic-cabi/src/proguard.rs
+++ b/symbolic-cabi/src/proguard.rs
@@ -52,13 +52,18 @@ impl ForeignObject for SymbolicProguardMapper {
 ffi_fn! {
     /// Creates a proguard mapping view from a path.
     unsafe fn symbolic_proguardmapper_open(
-        path: *const c_char
+        path: *const c_char,
+        initialize_param_mapping: bool
     ) -> Result<*mut SymbolicProguardMapper> {
         let byteview = ByteView::open(CStr::from_ptr(path).to_str()?)?;
 
         let inner = SelfCell::new(byteview, |data| {
             let mapping = ProguardMapping::new(&*data);
-            let mapper = ProguardMapper::new(mapping.clone());
+            let mapper = if !initialize_param_mapping {
+                ProguardMapper::new(mapping.clone())
+            } else {
+                ProguardMapper::new_with_param_mapping(mapping.clone(), initialize_param_mapping)
+            };
             Inner { mapping, mapper }
         });
 


### PR DESCRIPTION
This follow the changes in https://github.com/getsentry/rust-proguard/pull/34

This will allow us to make `mappings_by_params` initialization optional so that we don't incur in unnecessary memory increase in those part of sentry services where deobfuscation based on parameters list instead of line numbers is not necessary.