### PR TITLE
Do not assume that the debug file string is as long as the array in which it is stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+**Internal**
+
+**Fixes**
+
+- Fix an issue when extracting the name of the debug file from a PE object ([#825](https://github.com/getsentry/symbolic/pull/825))
+
+**Features**
+
 ## 12.8.0
 
 **Internal**

--- a/symbolic-debuginfo/src/pe.rs
+++ b/symbolic-debuginfo/src/pe.rs
@@ -154,8 +154,12 @@ impl<'data> PeObject<'data> {
             .debug_data
             .as_ref()
             .and_then(|debug_data| debug_data.codeview_pdb70_debug_info.as_ref())
-            .map(|debug_info| {
-                String::from_utf8_lossy(&debug_info.filename[..debug_info.filename.len() - 1])
+            .and_then(|debug_info| {
+                debug_info
+                    .filename
+                    .iter()
+                    .position(|&c| c == 0)
+                    .map(|nul_byte| String::from_utf8_lossy(&debug_info.filename[..nul_byte]))
             })
     }
 


### PR DESCRIPTION
This fixes issue #824