### PR TITLE
chore: update tokio to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 **Internal**
 
+- Update tokio to latest version ([#833](https://github.com/getsentry/symbolic/pull/833))
+
 **Fixes**
 
 - sourcebundles: Only valid UTF-8 files can be written into sourcebundles ([#816](https://github.com/getsentry/symbolic/pull/816))

--- a/examples/minidump_stackwalk/Cargo.toml
+++ b/examples/minidump_stackwalk/Cargo.toml
@@ -15,7 +15,7 @@ minidump-processor = "0.21.0"
 minidump-unwind = "0.21.0"
 symbolic = { path = "../../symbolic", features = ["symcache", "demangle", "cfi"] }
 thiserror = "1.0.31"
-tokio = {version = "1.18.1", features = ["macros", "rt"] }
+tokio = { version = "1.36.0", features = ["macros", "rt"] }
 tracing = "0.1.34"
 tracing-subscriber = "0.3.11"
 walkdir = "2.3.1"


### PR DESCRIPTION
Fixes https://github.com/getsentry/symbolic/issues/832