### PR TITLE
Avoid infinite recursion on indirect self-references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Internal**
 
 - Update tokio to latest version ([#833](https://github.com/getsentry/symbolic/pull/833))
+- Fix infinite recursion caused by indirect self-references when resolving function names ([#836](https://github.com/getsentry/symbolic/pull/836))
 
 **Fixes**
 

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -455,13 +455,10 @@ impl<'d, 'a> UnitRef<'d, 'a> {
             return self.resolve_reference(attr, |ref_unit, ref_entry| {
                 // Self-references may have a layer of indircetion. Avoid infinite recursion
                 // in this scenario.
-                match prior_offset {
-                    Some(prior) => {
-                        if self.offset() == ref_unit.offset() && prior == ref_entry.offset() {
-                            return Ok(None);
-                        }
+                if let Some(prior) = prior_offset {
+                    if self.offset() == ref_unit.offset() && prior == ref_entry.offset() {
+                        return Ok(None);
                     }
-                    None => {}
                 }
 
                 if self.offset() != ref_unit.offset() || entry.offset() != ref_entry.offset() {

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -457,7 +457,7 @@ impl<'d, 'a> UnitRef<'d, 'a> {
                 // in this scenario.
                 match prior_offset {
                     Some(prior) => {
-                        if prior == ref_entry.offset() {
+                        if self.offset() == ref_unit.offset() && prior == ref_entry.offset() {
                             return Ok(None);
                         }
                     }

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -419,6 +419,7 @@ impl<'d, 'a> UnitRef<'d, 'a> {
         entry: &Die<'d, '_>,
         language: Language,
         bcsymbolmap: Option<&'d BcSymbolMap<'d>>,
+        prior_offset: Option<UnitOffset>,
     ) -> Result<Option<Name<'d>>, DwarfError> {
         let mut attrs = entry.attrs();
         let mut fallback_name = None;
@@ -452,8 +453,24 @@ impl<'d, 'a> UnitRef<'d, 'a> {
 
         if let Some(attr) = reference_target {
             return self.resolve_reference(attr, |ref_unit, ref_entry| {
+                // Self-references may have a layer of indircetion. Avoid infinite recursion
+                // in this scenario.
+                match prior_offset {
+                    Some(prior) => {
+                        if prior == ref_entry.offset() {
+                            return Ok(None);
+                        }
+                    }
+                    None => {}
+                }
+
                 if self.offset() != ref_unit.offset() || entry.offset() != ref_entry.offset() {
-                    ref_unit.resolve_function_name(ref_entry, language, bcsymbolmap)
+                    ref_unit.resolve_function_name(
+                        ref_entry,
+                        language,
+                        bcsymbolmap,
+                        Some(entry.offset()),
+                    )
                 } else {
                     Ok(None)
                 }
@@ -714,7 +731,7 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
     /// Resolves the name of a function from DWARF debug information.
     fn resolve_dwarf_name(&self, entry: &Die<'d, '_>) -> Option<Name<'d>> {
         self.inner
-            .resolve_function_name(entry, self.language, self.bcsymbolmap)
+            .resolve_function_name(entry, self.language, self.bcsymbolmap, None)
             .ok()
             .flatten()
     }


### PR DESCRIPTION
**Background**

If there is an indirect self-reference, infinite recursion can occur.

**Changes**
* keep track if the prior entry is the same as the next entry to go to and skip function name resolution

**Test Plan**
* tested against a symbol file where this was occurring and it no longer crashes