### PR TITLE
Revert workspace inheritance for workspace deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "breakpad-symbols"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14722511e9c032b38689b0e952a633826850873adb10de56ec775b217a519366"
+checksum = "b37cb0d96cbe2c0cb6c4fc8856dc38b87d61abaa220c818f162bee332d3f4193"
 dependencies = [
  "async-trait",
  "cachemap2",
@@ -1089,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "minidump"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cb8353fdcd59c0caaf7525cb83b29ee02e6eac4c85d5a7944a9773d0f33f2e"
+checksum = "8d385b740c6b991e6eff48f26e2c6978c9e9e9e2e935f4967bcdf4c2d1d18828"
 dependencies = [
  "debugid",
  "encoding_rs",
@@ -1109,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "minidump-common"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb6eaf88cc770fa58e6ae721cf2e40c2ca6a4c942ae8c7aa324d680bd3c6717"
+checksum = "5c4d14bcca0fd3ed165a03000480aaa364c6860c34e900cb2dafdf3b95340e77"
 dependencies = [
  "bitflags 2.5.0",
  "debugid",
@@ -1124,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "minidump-processor"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bc8e39bb830c2e92ff0f3af8166f3fbc3ad2dc0c843c66de3b918b71190a6c"
+checksum = "7869a9256743611832cdf02d01ee5e2d67055a47727b21a01d47a79839876ca4"
 dependencies = [
  "async-trait",
  "breakpad-symbols",
@@ -1145,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "minidump-unwind"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2096876dbb3d5a0bbc5c42a913d44e935cb7f6139dcf9eda043ae1ce702ab529"
+checksum = "1f4fb17e3a2508326b9547166051a979d439d883bcd1058b48a2d1181a0b37cf"
 dependencies = [
  "async-trait",
  "breakpad-symbols",
@@ -2053,9 +2053,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.113.5"
+version = "0.113.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa77fca9412729a3fe634e55c354f6c70c7983f127411ce8684e4c7edf32ed3"
+checksum = "0ae3fb68e165bb093ea05fe68dfbc5d378c8b41515a5160f733d7b45bfb9d96e"
 dependencies = [
  "bitflags 2.5.0",
  "is-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,17 +52,6 @@ similar-asserts = "1.4.2"
 smallvec = "1.10.0"
 sourcemap = "8.0.1"
 stable_deref_trait = "1.2.0"
-symbolic = { version = "12.8.0", path = "symbolic" }
-symbolic-cfi = { version = "12.8.0", path = "symbolic-cfi" }
-symbolic-common = { version = "12.8.0", path = "symbolic-common" }
-symbolic-debuginfo = { version = "12.8.0", path = "symbolic-debuginfo" }
-symbolic-demangle = { version = "12.8.0", path = "symbolic-demangle" }
-symbolic-il2cpp = { version = "12.8.0", path = "symbolic-il2cpp" }
-symbolic-ppdb = { version = "12.8.0", path = "symbolic-ppdb" }
-symbolic-sourcemapcache = { version = "12.8.0", path = "symbolic-sourcemapcache" }
-symbolic-symcache = { version = "12.8.0", path = "symbolic-symcache" }
-symbolic-testutils = { path = "symbolic-testutils" }
-symbolic-unreal = { version = "12.8.0", path = "symbolic-unreal" }
 tempfile = "3.4.0"
 thiserror = "1.0.39"
 time = { version = "0.3.20", features = ["formatting"] }

--- a/examples/addr2line/Cargo.toml
+++ b/examples/addr2line/Cargo.toml
@@ -10,4 +10,4 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-symbolic = { workspace = true, features = ["demangle"] }
+symbolic = { version = "12.8.0", path = "../../symbolic", features = ["demangle"] }

--- a/examples/debuginfo_debug/Cargo.toml
+++ b/examples/debuginfo_debug/Cargo.toml
@@ -10,4 +10,6 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-symbolic = { workspace = true, features = ["demangle"] }
+symbolic = { version = "12.8.0", path = "../../symbolic", features = [
+    "demangle",
+] }

--- a/examples/dump_cfi/Cargo.toml
+++ b/examples/dump_cfi/Cargo.toml
@@ -10,4 +10,4 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-symbolic = { workspace = true, features = ["cfi"] }
+symbolic = { version = "12.8.0", path = "../../symbolic", features = ["cfi"] }

--- a/examples/dump_sources/Cargo.toml
+++ b/examples/dump_sources/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 
 [dependencies]
 clap = { workspace = true }
-symbolic = { workspace = true }
+symbolic = { version = "12.8.0", path = "../../symbolic" }

--- a/examples/minidump_stackwalk/Cargo.toml
+++ b/examples/minidump_stackwalk/Cargo.toml
@@ -13,7 +13,11 @@ clap = { workspace = true }
 minidump = { workspace = true }
 minidump-processor = { workspace = true }
 minidump-unwind = { workspace = true }
-symbolic = { workspace = true, features = ["symcache", "demangle", "cfi"] }
+symbolic = { version = "12.8.0", path = "../../symbolic", features = [
+    "symcache",
+    "demangle",
+    "cfi",
+] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
 tracing = { workspace = true }

--- a/examples/object_debug/Cargo.toml
+++ b/examples/object_debug/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 
 [dependencies]
 clap = { workspace = true }
-symbolic = { workspace = true }
+symbolic = { version = "12.8.0", path = "../../symbolic" }

--- a/examples/sourcemapcache_debug/Cargo.toml
+++ b/examples/sourcemapcache_debug/Cargo.toml
@@ -8,5 +8,7 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-symbolic = { workspace = true, features = ["sourcemapcache"] }
-tracing-subscriber = {  workspace = true, features = ["env-filter"] }
+symbolic = { version = "12.8.0", path = "../../symbolic", features = [
+    "sourcemapcache",
+] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/examples/symcache_debug/Cargo.toml
+++ b/examples/symcache_debug/Cargo.toml
@@ -10,4 +10,8 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-symbolic = { workspace = true, features = ["symcache", "demangle", "il2cpp"] }
+symbolic = { version = "12.8.0", path = "../../symbolic", features = [
+    "symcache",
+    "demangle",
+    "il2cpp",
+] }

--- a/examples/unreal_engine_crash/Cargo.toml
+++ b/examples/unreal_engine_crash/Cargo.toml
@@ -9,4 +9,6 @@ publish = false
 
 [dependencies]
 clap = { workspace = true }
-symbolic = { workspace = true, features = ["unreal"] }
+symbolic = { version = "12.8.0", path = "../../symbolic", features = [
+    "unreal",
+] }

--- a/symbolic-cabi/Cargo.toml
+++ b/symbolic-cabi/Cargo.toml
@@ -22,5 +22,10 @@ crate-type = ["cdylib"]
 [dependencies]
 proguard = { workspace = true, features = ["uuid"] }
 sourcemap = { workspace = true }
-symbolic = { workspace = true, features = ["cfi", "debuginfo", "sourcemapcache", "symcache"] }
+symbolic = { version = "12.8.0", path = "../symbolic", features = [
+    "cfi",
+    "debuginfo",
+    "sourcemapcache",
+    "symcache",
+] }
 tempfile = { workspace = true }

--- a/symbolic-cfi/Cargo.toml
+++ b/symbolic-cfi/Cargo.toml
@@ -15,11 +15,11 @@ A library to process call frame information
 edition = "2021"
 
 [dependencies]
-symbolic-common = { workspace = true }
-symbolic-debuginfo = { workspace = true }
+symbolic-common = { version = "12.8.0", path = "../symbolic-common" }
+symbolic-debuginfo = { version = "12.8.0", path = "../symbolic-debuginfo" }
 thiserror = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
-symbolic-testutils = { workspace = true }
 similar-asserts = { workspace = true }
+symbolic-testutils = { path = "../symbolic-testutils" }

--- a/symbolic-common/Cargo.toml
+++ b/symbolic-common/Cargo.toml
@@ -30,6 +30,6 @@ serde = { workspace = true, optional = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
-symbolic-testutils = { workspace = true }
+symbolic-testutils = { path = "../symbolic-testutils" }
 tempfile = { workspace = true }
 similar-asserts = { workspace = true }

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -106,8 +106,8 @@ scroll = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 smallvec = { workspace = true, optional = true }
-symbolic-common = { workspace = true }
-symbolic-ppdb = { workspace = true, optional = true }
+symbolic-common = { version = "12.8.0", path = "../symbolic-common" }
+symbolic-ppdb = { version = "12.8.0", path = "../symbolic-ppdb", optional = true }
 thiserror = { workspace = true }
 wasmparser = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }
@@ -118,7 +118,7 @@ criterion = { workspace = true }
 insta = { workspace = true }
 tempfile = { workspace = true }
 similar-asserts = { workspace = true }
-symbolic-testutils = { workspace = true }
+symbolic-testutils = { path = "../symbolic-testutils" }
 
 [[bench]]
 name = "breakpad_parser"

--- a/symbolic-demangle/Cargo.toml
+++ b/symbolic-demangle/Cargo.toml
@@ -16,9 +16,7 @@ A library to demangle symbols from various languages and compilers.
 build = "build.rs"
 edition = "2021"
 
-exclude = [
-    "tests/**/*",
-]
+exclude = ["tests/**/*"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -34,7 +32,7 @@ swift = ["cc"]
 cpp_demangle = { workspace = true, optional = true }
 msvc-demangler = { workspace = true, optional = true }
 rustc-demangle = { workspace = true, optional = true }
-symbolic-common = { workspace = true }
+symbolic-common = { version = "12.8.0", path = "../symbolic-common" }
 
 [build-dependencies]
 cc = { workspace = true, optional = true }

--- a/symbolic-il2cpp/Cargo.toml
+++ b/symbolic-il2cpp/Cargo.toml
@@ -14,5 +14,5 @@ edition = "2021"
 [dependencies]
 indexmap = { workspace = true }
 serde_json = { workspace = true }
-symbolic-common = { workspace = true }
-symbolic-debuginfo = { workspace = true }
+symbolic-common = { version = "12.8.0", path = "../symbolic-common" }
+symbolic-debuginfo = { version = "12.8.0", path = "../symbolic-debuginfo" }

--- a/symbolic-ppdb/Cargo.toml
+++ b/symbolic-ppdb/Cargo.toml
@@ -4,7 +4,7 @@ version = "12.8.0"
 license = "MIT"
 authors = [
     "Sebastian Zivota <sebastian.zivota@sentry.io>",
-    "Arpad Borsos <arpad.borsos@sentry.io>"
+    "Arpad Borsos <arpad.borsos@sentry.io>",
 ]
 documentation = "https://docs.rs/symbolic-ppdb"
 homepage = "https://github.com/getsentry/symbolic"
@@ -20,15 +20,15 @@ exclude = ["tests/**/*"]
 all-features = true
 
 [dependencies]
+flate2 = { workspace = true }
 indexmap = { workspace = true }
-symbolic-common = { workspace = true }
-watto = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+symbolic-common = { version = "12.8.0", path = "../symbolic-common" }
 thiserror = { workspace = true }
 uuid = { workspace = true }
-flate2 = { workspace = true }
-serde_json = { workspace = true }
-serde = { workspace = true }
+watto = { workspace = true }
 
 [dev-dependencies]
-symbolic-debuginfo = { workspace = true }
-symbolic-testutils = { workspace = true }
+symbolic-debuginfo = { path = "../symbolic-debuginfo" }
+symbolic-testutils = { path = "../symbolic-testutils" }

--- a/symbolic-sourcemapcache/Cargo.toml
+++ b/symbolic-sourcemapcache/Cargo.toml
@@ -15,10 +15,10 @@ edition = "2021"
 itertools = { workspace = true }
 js-source-scopes = { workspace = true }
 sourcemap = { workspace = true }
-symbolic-common = { workspace = true }
+symbolic-common = { version = "12.8.0", path = "../symbolic-common" }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 watto = { workspace = true }
 
 [dev-dependencies]
-symbolic-testutils = { workspace = true }
+symbolic-testutils = { path = "../symbolic-testutils" }

--- a/symbolic-symcache/Cargo.toml
+++ b/symbolic-symcache/Cargo.toml
@@ -15,26 +15,24 @@ stack frames in debugging information.
 """
 edition = "2021"
 
-exclude = [
-    "tests/**/*",
-]
+exclude = ["tests/**/*"]
 
 [package.metadata.docs.rs]
 all-features = true
 
 [dependencies]
-symbolic-common = { workspace = true }
-symbolic-debuginfo = { workspace = true }
-symbolic-il2cpp = { workspace = true, optional = true }
-thiserror = { workspace = true }
 indexmap = { workspace = true }
+symbolic-common = { version = "12.8.0", path = "../symbolic-common" }
+symbolic-debuginfo = { version = "12.8.0", path = "../symbolic-debuginfo" }
+symbolic-il2cpp = { version = "12.8.0", path = "../symbolic-il2cpp", optional = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 watto = { workspace = true }
 
 [dev-dependencies]
-insta = { workspace = true }
 criterion = { workspace = true }
-symbolic-testutils = { workspace = true }
+insta = { workspace = true }
+symbolic-testutils = { path = "../symbolic-testutils" }
 
 [features]
 bench = []

--- a/symbolic-unreal/Cargo.toml
+++ b/symbolic-unreal/Cargo.toml
@@ -15,9 +15,7 @@ Parsing and processing utilities for Unreal Engine 4 crash files.
 """
 edition = "2021"
 
-exclude = [
-    "tests/**/*",
-]
+exclude = ["tests/**/*"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -40,5 +38,5 @@ time = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
-symbolic-testutils = { workspace = true }
 similar-asserts = { workspace = true }
+symbolic-testutils = { path = "../symbolic-testutils" }

--- a/symbolic/Cargo.toml
+++ b/symbolic/Cargo.toml
@@ -34,12 +34,12 @@ unreal = ["symbolic-unreal"]
 unreal-serde = ["unreal", "common-serde", "symbolic-unreal/serde"]
 
 [dependencies]
-symbolic-cfi = { workspace = true, optional = true }
-symbolic-common = { workspace = true }
-symbolic-debuginfo = { workspace = true, optional = true }
-symbolic-demangle = { workspace = true, optional = true }
-symbolic-il2cpp = { workspace = true, optional = true }
-symbolic-ppdb = { workspace = true, optional = true }
-symbolic-sourcemapcache = { workspace = true, optional = true }
-symbolic-symcache = { workspace = true, optional = true }
-symbolic-unreal = { workspace = true, optional = true }
+symbolic-cfi = { version = "12.8.0", path = "../symbolic-cfi", optional = true }
+symbolic-common = { version = "12.8.0", path = "../symbolic-common" }
+symbolic-debuginfo = { version = "12.8.0", path = "../symbolic-debuginfo", optional = true }
+symbolic-demangle = { version = "12.8.0", path = "../symbolic-demangle", optional = true }
+symbolic-il2cpp = { version = "12.8.0", path = "../symbolic-il2cpp", optional = true }
+symbolic-ppdb = { version = "12.8.0", path = "../symbolic-ppdb", optional = true }
+symbolic-sourcemapcache = { version = "12.8.0", path = "../symbolic-sourcemapcache", optional = true }
+symbolic-symcache = { version = "12.8.0", path = "../symbolic-symcache", optional = true }
+symbolic-unreal = { version = "12.8.0", path = "../symbolic-unreal", optional = true }


### PR DESCRIPTION
A recent publish with craft failed because it claims "Circular dependency detected!". This is most likely caused by the recent change to using workspace dependency inheritance, and lack thereof within craft.

So just revert this change, to hopefully make craft happy.

#skip-changelog