### PR TITLE
Downgrade and pin `zip` to fix SourceBundles with >64k files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Downgrade and pin `zip` to fix SourceBundles with >64k files ([#846](https://github.com/getsentry/symbolic/pull/846))
+
 ## 12.9.1
 
 **Features**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,9 +2976,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.1.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098d5d7737fb0b70814faa73c17df84f047d38dd31d13bbf2ec3fb354b5abf45"
+checksum = "1dd56a4d5921bc2f99947ac5b3abe5f510b1be7376fdc5e9fce4a23c6a93e87c"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,8 @@ uuid = "1.3.0"
 walkdir = "2.3.1"
 wasmparser = "0.209.1"
 watto = { version = "0.1.0", features = ["writer", "strings"] }
-zip = { version = "2.1.2", default-features = false, features = ["deflate"] }
+# We are currently pinning a known good version prior to https://github.com/zip-rs/zip2/issues/189
+zip = { version = "=2.1.1", default-features = false, features = ["deflate"] }
 zstd = { version = "0.13.1" }
 
 


### PR DESCRIPTION
The recent symbolicator update started emitting errors related to this. After a short debugging sessions, I pinned down the problem to a regression in `zip` which broke archives with >64k files.

See https://github.com/zip-rs/zip2/issues/189 which is also linked from the `Cargo.toml`.