### PR TITLE
Updated wasmparser dependency to 0.214.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**
 
 - Support for DWARFv5 embedded source code extension ([#849](https://github.com/getsentry/symbolic/pull/849))
+- Updated wasmparser dependency to 0.214.0.
 
 ## 12.9.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Features**
 
 - Support for DWARFv5 embedded source code extension ([#849](https://github.com/getsentry/symbolic/pull/849))
-- Updated wasmparser dependency to 0.214.0.
+- Updated wasmparser dependency to 0.214.0 ([#849](https://github.com/getsentry/symbolic/pull/853))
 
 ## 12.9.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,9 +2709,9 @@ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasmparser"
-version = "0.209.1"
+version = "0.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07035cc9a9b41e62d3bb3a3815a66ab87c993c06fe1cf6b2a3f2a18499d937db"
+checksum = "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
 dependencies = [
  "ahash",
  "bitflags 2.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ tracing = "0.1.34"
 tracing-subscriber = "0.3.11"
 uuid = "1.3.0"
 walkdir = "2.3.1"
-wasmparser = "0.209.1"
+wasmparser = "0.214.0"
 watto = { version = "0.1.0", features = ["writer", "strings"] }
 # We are currently pinning a known good version prior to https://github.com/zip-rs/zip2/issues/189
 zip = { version = "=2.1.1", default-features = false, features = ["deflate"] }

--- a/symbolic-debuginfo/src/wasm/parser.rs
+++ b/symbolic-debuginfo/src/wasm/parser.rs
@@ -3,7 +3,7 @@
 use super::WasmError;
 use crate::base::{ObjectKind, Symbol};
 use wasmparser::{
-    BinaryReader, CompositeType, FuncValidatorAllocations, NameSectionReader, Payload, TypeRef,
+    BinaryReader, CompositeInnerType, FuncValidatorAllocations, NameSectionReader, Payload, TypeRef,
     Validator, WasmFeatures,
 };
 
@@ -83,8 +83,8 @@ impl<'data> super::WasmObject<'data> {
                     for (i, ty) in tsr.into_iter().enumerate() {
                         let mut types = ty?.into_types();
                         let ty_is_func = matches!(
-                            types.next().map(|s| s.composite_type),
-                            Some(CompositeType::Func(_))
+                            types.next().map(|s| s.composite_type.inner),
+                            Some(CompositeInnerType::Func(_))
                         );
                         if types.next().is_none() && ty_is_func {
                             func_sigs.set(i, true);

--- a/symbolic-debuginfo/src/wasm/parser.rs
+++ b/symbolic-debuginfo/src/wasm/parser.rs
@@ -3,8 +3,8 @@
 use super::WasmError;
 use crate::base::{ObjectKind, Symbol};
 use wasmparser::{
-    BinaryReader, CompositeInnerType, FuncValidatorAllocations, NameSectionReader, Payload, TypeRef,
-    Validator, WasmFeatures,
+    BinaryReader, CompositeInnerType, FuncValidatorAllocations, NameSectionReader, Payload,
+    TypeRef, Validator, WasmFeatures,
 };
 
 #[derive(Default)]


### PR DESCRIPTION
The main reason for the upgrade is to improve these two reports:
* https://github.com/getsentry/symbolic/issues/848
  * https://github.com/bytecodealliance/wasm-tools/pull/1650
* https://github.com/getsentry/symbolic/issues/850
  * https://github.com/bytecodealliance/wasm-tools/pull/1661
