### PR TITLE
Revert "all-repos: update actions/upload-artifact to v4"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           # consumed by cargo and setup.py to obtain the target dir
           CARGO_BUILD_TARGET: ${{ matrix.target }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3.1.1
         with:
           name: ${{ github.sha }}
           path: py/dist/*
@@ -63,7 +63,7 @@ jobs:
         name: Build in Docker (x86_64)
         run: make wheel-manylinux IMAGE=quay.io/pypa/"$MANYLINUX_VERSION"_x86_64
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3.1.1
         with:
           name: ${{ github.sha }}
           path: py/dist/*
@@ -81,7 +81,7 @@ jobs:
 
       - run: make sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3.1.1
         with:
           name: ${{ github.sha }}
           path: py/dist/*


### PR DESCRIPTION
Reverts getsentry/symbolic#858. `upload-artifacts` v4 is causing our release builds to fail as it is incompatible with our release build process.

We needed to [revert this change in Sentry CLI](https://github.com/getsentry/sentry-cli/pull/2119) for the same reason.

#skip-changelog