### PR TITLE
ref(debuginfo): Replace dmsort with std sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+
+- Removed `dmsort` dependency and replaced uses with stable std sorts. ([#869](https://github.com/getsentry/symbolic/pull/869))
+
 ## 12.11.0
 
 - Add callback to `symbolic::debuginfo::sourcebundle::SourceBundleWriter` which handles files skipped while writing to the source bundle. ([#864](https://github.com/getsentry/symbolic/pull/864))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,12 +593,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dmsort"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0bc8fbe9441c17c9f46f75dfe27fa1ddb6c68a461ccaed0481419219d4f10d3"
-
-[[package]]
 name = "dump_cfi"
 version = "12.11.0"
 dependencies = [
@@ -2207,7 +2201,6 @@ version = "12.11.0"
 dependencies = [
  "criterion",
  "debugid",
- "dmsort",
  "elementtree",
  "elsa",
  "fallible-iterator 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ clap = "4.4.5"
 cpp_demangle = "0.4.1"
 criterion = { version = "0.5.1", features = ["html_reports"] }
 debugid = "0.8.0"
-dmsort = "1.0.2"
 elementtree = "1.2.3"
 elsa = "1.8.0"
 fallible-iterator = "0.3.0"

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -87,7 +87,6 @@ js = []
 wasm = ["dwarf", "wasmparser"]
 
 [dependencies]
-dmsort = { workspace = true }
 debugid = { workspace = true }
 elementtree = { workspace = true, optional = true }
 elsa = { workspace = true, optional = true }

--- a/symbolic-debuginfo/src/base.rs
+++ b/symbolic-debuginfo/src/base.rs
@@ -413,7 +413,7 @@ impl<'d> From<Vec<Symbol<'d>>> for SymbolMap<'d> {
             //
             // Inlined functions will generally not appear in this list, unless they _also_ have an
             // explicit function body, in which case they will have a unique address, again.
-            symbols.sort_unstable_by_key(Self::key);
+            symbols.sort_by_key(Self::key);
 
             // Compute sizes of consecutive symbols if the size has not been provided by the symbol
             // iterator. In the same go, drop all but the first symbols at any given address. We do

--- a/symbolic-debuginfo/src/base.rs
+++ b/symbolic-debuginfo/src/base.rs
@@ -413,7 +413,7 @@ impl<'d> From<Vec<Symbol<'d>>> for SymbolMap<'d> {
             //
             // Inlined functions will generally not appear in this list, unless they _also_ have an
             // explicit function body, in which case they will have a unique address, again.
-            dmsort::sort_by_key(&mut symbols, Self::key);
+            symbols.sort_unstable_by_key(Self::key);
 
             // Compute sizes of consecutive symbols if the size has not been provided by the symbol
             // iterator. In the same go, drop all but the first symbols at any given address. We do

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -330,7 +330,7 @@ impl<'d> DwarfLineProgram<'d> {
         }
 
         // Sequences are not guaranteed to be in order.
-        dmsort::sort_by_key(&mut sequences, |x| x.start);
+        sequences.sort_unstable_by_key(|x| x.start);
 
         DwarfLineProgram {
             header: state_machine.header().clone(),

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -330,7 +330,7 @@ impl<'d> DwarfLineProgram<'d> {
         }
 
         // Sequences are not guaranteed to be in order.
-        sequences.sort_unstable_by_key(|x| x.start);
+        sequences.sort_by_key(|x| x.start);
 
         DwarfLineProgram {
             header: state_machine.header().clone(),

--- a/symbolic-debuginfo/tests/snapshots/test_objects__elf_symbols.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__elf_symbols.snap
@@ -1,7 +1,5 @@
 ---
-created: "2019-02-27T13:05:25.490529Z"
-creator: insta@0.6.3
-source: debuginfo/tests/test_objects.rs
+source: symbolic-debuginfo/tests/test_objects.rs
 expression: SymbolsDebug(&symbols)
 ---
             1558 _init
@@ -41,7 +39,7 @@ expression: SymbolsDebug(&symbols)
             3660 _ZN15google_breakpad30SetFirstChanceExceptionHandlerEPFbiPvS0_E
             3670 _ZN15google_breakpad16ExceptionHandlerC1ERKNS_18MinidumpDescriptorEPFbPvEPFbS3_S4_bES4_bi
             3a10 _ZN15google_breakpad16ExceptionHandler13WriteMinidumpERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFbRKNS_18MinidumpDescriptorEPvbESC_
-            3cb0 _ZNSt6vectorIPN15google_breakpad16ExceptionHandlerESaIS2_EE19_M_emplace_back_auxIIS2_EEEvDpOT_
+            3cb0 _ZNSt6vectorIPN15google_breakpad16ExceptionHandlerESaIS2_EE19_M_emplace_back_auxIJS2_EEEvDpOT_
             3da0 _ZN15google_breakpad18MinidumpDescriptorC1ERKS0_
             3f20 _ZN15google_breakpad18MinidumpDescriptor10UpdatePathEv
             42f0 _ZN15google_breakpad18MinidumpDescriptoraSERKS0_
@@ -71,9 +69,9 @@ expression: SymbolsDebug(&symbols)
             94a0 _ZNK15google_breakpad17LinuxPtraceDumper12IsPostMortemEv
             94b0 _ZN15google_breakpad17LinuxPtraceDumper15CopyFromProcessEPviPKvm
             9640 _ZN15google_breakpad17LinuxPtraceDumper13ThreadsResumeEv
-            9700 _ZNK15google_breakpad17LinuxPtraceDumper13BuildProcPathEPciPKc
+            9700 _ZNK15google_breakpad17LinuxPtraceDumper13BuildProcPathEPciPKc.localalias.19
             97c0 _ZN15google_breakpad17LinuxPtraceDumper16EnumerateThreadsEv
-            9e50 _ZN15google_breakpad17LinuxPtraceDumperC1Ei
+            9e50 _ZN15google_breakpad17LinuxPtraceDumperC2Ei
             9e80 _ZN15google_breakpad17LinuxPtraceDumper15ReadRegisterSetEPNS_10ThreadInfoEi
             9f70 _ZN15google_breakpad17LinuxPtraceDumper13ReadRegistersEPNS_10ThreadInfoEi
             a050 _ZN15google_breakpad17LinuxPtraceDumper20GetThreadInfoByIndexEmPNS_10ThreadInfoE
@@ -94,7 +92,7 @@ expression: SymbolsDebug(&symbols)
             f3c0 _ZN15google_breakpad13WriteMinidumpEiliPKvmRKNSt7__cxx114listINS_12MappingEntryESaIS4_EEERKNS3_INS_9AppMemoryESaIS9_EEEbmb
             f400 _ZN15google_breakpad17ProcCpuInfoReader12GetNextFieldEPPKc
             f660 _ZNSt6vectorIcN15google_breakpad16PageStdAllocatorIcEEE6resizeEm
-            f8c0 _ZNSt6vectorI18MDMemoryDescriptorN15google_breakpad16PageStdAllocatorIS0_EEE19_M_emplace_back_auxIIRKS0_EEEvDpOT_
+            f8c0 _ZNSt6vectorI18MDMemoryDescriptorN15google_breakpad16PageStdAllocatorIS0_EEE19_M_emplace_back_auxIJRKS0_EEEvDpOT_
             fb10 _ZN15google_breakpad10TypedMDRVAI8MDStringE20CopyIndexAfterObjectEjPKvm.isra.7.part.8
             fb40 _ZN15google_breakpad18MinidumpFileWriterC1Ev
             fb60 _ZN15google_breakpad18MinidumpFileWriter4OpenEPKc
@@ -120,8 +118,8 @@ expression: SymbolsDebug(&symbols)
            11220 _ZN15google_breakpad8ElfClassEPKv
            11230 _ZN15google_breakpad14FindElfSectionEPKvPKcjPS1_Pm
            116a0 _ZN15google_breakpad15FindElfSegmentsEPKvjPNS_15wasteful_vectorINS_10ElfSegmentEEE
-           11990 _ZNSt6vectorIN15google_breakpad10ElfSegmentENS0_16PageStdAllocatorIS1_EEE19_M_emplace_back_auxIIRKS1_EEEvDpOT_
-           11be0 _ZN15google_breakpad6FileIDC2EPKc
+           11990 _ZNSt6vectorIN15google_breakpad10ElfSegmentENS0_16PageStdAllocatorIS1_EEE19_M_emplace_back_auxIJRKS1_EEEvDpOT_
+           11be0 _ZN15google_breakpad6FileIDC1EPKc
            11cc0 _ZN15google_breakpad6FileID29ConvertIdentifierToUUIDStringB5cxx11ERKNS_15wasteful_vectorIhEE
            11e70 _ZN15google_breakpad6FileID25ConvertIdentifierToStringB5cxx11ERKNS_15wasteful_vectorIhEE
            11fb0 _ZN15google_breakpad6FileID31ElfFileIdentifierFromMappedFileEPKvRNS_15wasteful_vectorIhEE
@@ -148,9 +146,9 @@ expression: SymbolsDebug(&symbols)
            13220 _ZN15google_breakpad16MemoryMappedFile5UnmapEv
            13270 _ZN15google_breakpad16MemoryMappedFileD2Ev
            13280 _ZN15google_breakpad16MemoryMappedFile3MapEPKcm
-           13430 _ZN15google_breakpad16MemoryMappedFileC1EPKcm
+           13430 _ZN15google_breakpad16MemoryMappedFileC2EPKcm
            13450 _ZN15google_breakpad12SafeReadLinkEPKcPcm
-           13490 _ZN15google_breakpad12_GLOBAL__N_125CrashGenerationClientImplD1Ev
+           13490 _ZN15google_breakpad12_GLOBAL__N_125CrashGenerationClientImplD2Ev
            134a0 _ZN15google_breakpad12_GLOBAL__N_125CrashGenerationClientImpl11RequestDumpEPKvm
            136c0 _ZN15google_breakpad12_GLOBAL__N_125CrashGenerationClientImplD0Ev
            136d0 _ZN15google_breakpad21CrashGenerationClient9TryCreateEi
@@ -171,4 +169,3 @@ expression: SymbolsDebug(&symbols)
            14c30 __libc_csu_init
            14ca0 __libc_csu_fini
            14ca4 _fini
-

--- a/symbolic-debuginfo/tests/snapshots/test_objects__elf_symbols.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__elf_symbols.snap
@@ -37,10 +37,10 @@ expression: SymbolsDebug(&symbols)
             33a0 _ZN15google_breakpad16ExceptionHandler19UnregisterAppMemoryEPv
             3400 _ZN15google_breakpad16ExceptionHandler21WriteMinidumpForChildEiiRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFbRKNS_18MinidumpDescriptorEPvbESC_
             3660 _ZN15google_breakpad30SetFirstChanceExceptionHandlerEPFbiPvS0_E
-            3670 _ZN15google_breakpad16ExceptionHandlerC2ERKNS_18MinidumpDescriptorEPFbPvEPFbS3_S4_bES4_bi
+            3670 _ZN15google_breakpad16ExceptionHandlerC1ERKNS_18MinidumpDescriptorEPFbPvEPFbS3_S4_bES4_bi
             3a10 _ZN15google_breakpad16ExceptionHandler13WriteMinidumpERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFbRKNS_18MinidumpDescriptorEPvbESC_
-            3cb0 _ZNSt6vectorIPN15google_breakpad16ExceptionHandlerESaIS2_EE19_M_emplace_back_auxIJS2_EEEvDpOT_
-            3da0 _ZN15google_breakpad18MinidumpDescriptorC1ERKS0_
+            3cb0 _ZNSt6vectorIPN15google_breakpad16ExceptionHandlerESaIS2_EE19_M_emplace_back_auxIIS2_EEEvDpOT_
+            3da0 _ZN15google_breakpad18MinidumpDescriptorC2ERKS0_
             3f20 _ZN15google_breakpad18MinidumpDescriptor10UpdatePathEv
             42f0 _ZN15google_breakpad18MinidumpDescriptoraSERKS0_
             43c0 _ZN6logger5writeEPKcm
@@ -49,7 +49,7 @@ expression: SymbolsDebug(&symbols)
             71f0 _ZN15google_breakpad11LinuxDumper8LateInitEv
             7200 _ZN15google_breakpad11LinuxDumper17EnumerateMappingsEv
             7ac0 _ZN15google_breakpad11LinuxDumperC2EiPKc
-            8300 _ZN15google_breakpad11LinuxDumperD1Ev
+            8300 _ZN15google_breakpad11LinuxDumperD2Ev
             8370 _ZN15google_breakpad11LinuxDumperD0Ev
             8390 _ZNK15google_breakpad11LinuxDumper20GetCrashSignalStringEv
             8590 _ZNK15google_breakpad11LinuxDumper22GetMappingAbsolutePathERKNS_11MappingInfoEPc
@@ -69,14 +69,14 @@ expression: SymbolsDebug(&symbols)
             94a0 _ZNK15google_breakpad17LinuxPtraceDumper12IsPostMortemEv
             94b0 _ZN15google_breakpad17LinuxPtraceDumper15CopyFromProcessEPviPKvm
             9640 _ZN15google_breakpad17LinuxPtraceDumper13ThreadsResumeEv
-            9700 _ZNK15google_breakpad17LinuxPtraceDumper13BuildProcPathEPciPKc
+            9700 _ZNK15google_breakpad17LinuxPtraceDumper13BuildProcPathEPciPKc.localalias.19
             97c0 _ZN15google_breakpad17LinuxPtraceDumper16EnumerateThreadsEv
             9e50 _ZN15google_breakpad17LinuxPtraceDumperC1Ei
             9e80 _ZN15google_breakpad17LinuxPtraceDumper15ReadRegisterSetEPNS_10ThreadInfoEi
             9f70 _ZN15google_breakpad17LinuxPtraceDumper13ReadRegistersEPNS_10ThreadInfoEi
             a050 _ZN15google_breakpad17LinuxPtraceDumper20GetThreadInfoByIndexEmPNS_10ThreadInfoE
             a690 _ZN15google_breakpad17LinuxPtraceDumper14ThreadsSuspendEv
-            a8f0 _ZN15google_breakpad17LinuxPtraceDumperD1Ev
+            a8f0 _ZN15google_breakpad17LinuxPtraceDumperD2Ev
             a910 _ZN15google_breakpad17LinuxPtraceDumperD0Ev
             a930 _ZNSt6vectorIiN15google_breakpad16PageStdAllocatorIiEEE17_M_default_appendEm
             abc0 _ZN12_GLOBAL__N_114MinidumpWriter21WriteThreadListStreamEP14MDRawDirectory.constprop.105
@@ -92,7 +92,7 @@ expression: SymbolsDebug(&symbols)
             f3c0 _ZN15google_breakpad13WriteMinidumpEiliPKvmRKNSt7__cxx114listINS_12MappingEntryESaIS4_EEERKNS3_INS_9AppMemoryESaIS9_EEEbmb
             f400 _ZN15google_breakpad17ProcCpuInfoReader12GetNextFieldEPPKc
             f660 _ZNSt6vectorIcN15google_breakpad16PageStdAllocatorIcEEE6resizeEm
-            f8c0 _ZNSt6vectorI18MDMemoryDescriptorN15google_breakpad16PageStdAllocatorIS0_EEE19_M_emplace_back_auxIJRKS0_EEEvDpOT_
+            f8c0 _ZNSt6vectorI18MDMemoryDescriptorN15google_breakpad16PageStdAllocatorIS0_EEE19_M_emplace_back_auxIIRKS0_EEEvDpOT_
             fb10 _ZN15google_breakpad10TypedMDRVAI8MDStringE20CopyIndexAfterObjectEjPKvm.isra.7.part.8
             fb40 _ZN15google_breakpad18MinidumpFileWriterC1Ev
             fb60 _ZN15google_breakpad18MinidumpFileWriter4OpenEPKc
@@ -118,8 +118,8 @@ expression: SymbolsDebug(&symbols)
            11220 _ZN15google_breakpad8ElfClassEPKv
            11230 _ZN15google_breakpad14FindElfSectionEPKvPKcjPS1_Pm
            116a0 _ZN15google_breakpad15FindElfSegmentsEPKvjPNS_15wasteful_vectorINS_10ElfSegmentEEE
-           11990 _ZNSt6vectorIN15google_breakpad10ElfSegmentENS0_16PageStdAllocatorIS1_EEE19_M_emplace_back_auxIIRKS1_EEEvDpOT_
-           11be0 _ZN15google_breakpad6FileIDC1EPKc
+           11990 _ZNSt6vectorIN15google_breakpad10ElfSegmentENS0_16PageStdAllocatorIS1_EEE19_M_emplace_back_auxIJRKS1_EEEvDpOT_
+           11be0 _ZN15google_breakpad6FileIDC2EPKc
            11cc0 _ZN15google_breakpad6FileID29ConvertIdentifierToUUIDStringB5cxx11ERKNS_15wasteful_vectorIhEE
            11e70 _ZN15google_breakpad6FileID25ConvertIdentifierToStringB5cxx11ERKNS_15wasteful_vectorIhEE
            11fb0 _ZN15google_breakpad6FileID31ElfFileIdentifierFromMappedFileEPKvRNS_15wasteful_vectorIhEE
@@ -142,9 +142,9 @@ expression: SymbolsDebug(&symbols)
            130e0 my_strlcpy
            13120 my_strlcat
            13160 my_isspace
-           13210 _ZN15google_breakpad16MemoryMappedFileC1Ev
+           13210 _ZN15google_breakpad16MemoryMappedFileC2Ev
            13220 _ZN15google_breakpad16MemoryMappedFile5UnmapEv
-           13270 _ZN15google_breakpad16MemoryMappedFileD2Ev
+           13270 _ZN15google_breakpad16MemoryMappedFileD1Ev
            13280 _ZN15google_breakpad16MemoryMappedFile3MapEPKcm
            13430 _ZN15google_breakpad16MemoryMappedFileC2EPKcm
            13450 _ZN15google_breakpad12SafeReadLinkEPKcPcm

--- a/symbolic-debuginfo/tests/snapshots/test_objects__elf_symbols.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__elf_symbols.snap
@@ -37,7 +37,7 @@ expression: SymbolsDebug(&symbols)
             33a0 _ZN15google_breakpad16ExceptionHandler19UnregisterAppMemoryEPv
             3400 _ZN15google_breakpad16ExceptionHandler21WriteMinidumpForChildEiiRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFbRKNS_18MinidumpDescriptorEPvbESC_
             3660 _ZN15google_breakpad30SetFirstChanceExceptionHandlerEPFbiPvS0_E
-            3670 _ZN15google_breakpad16ExceptionHandlerC1ERKNS_18MinidumpDescriptorEPFbPvEPFbS3_S4_bES4_bi
+            3670 _ZN15google_breakpad16ExceptionHandlerC2ERKNS_18MinidumpDescriptorEPFbPvEPFbS3_S4_bES4_bi
             3a10 _ZN15google_breakpad16ExceptionHandler13WriteMinidumpERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFbRKNS_18MinidumpDescriptorEPvbESC_
             3cb0 _ZNSt6vectorIPN15google_breakpad16ExceptionHandlerESaIS2_EE19_M_emplace_back_auxIJS2_EEEvDpOT_
             3da0 _ZN15google_breakpad18MinidumpDescriptorC1ERKS0_
@@ -48,8 +48,8 @@ expression: SymbolsDebug(&symbols)
             6e10 _ZNSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEE15_M_range_insertIPKhEEvN9__gnu_cxx17__normal_iteratorIPhS3_EET_SB_St20forward_iterator_tag
             71f0 _ZN15google_breakpad11LinuxDumper8LateInitEv
             7200 _ZN15google_breakpad11LinuxDumper17EnumerateMappingsEv
-            7ac0 _ZN15google_breakpad11LinuxDumperC1EiPKc
-            8300 _ZN15google_breakpad11LinuxDumperD2Ev
+            7ac0 _ZN15google_breakpad11LinuxDumperC2EiPKc
+            8300 _ZN15google_breakpad11LinuxDumperD1Ev
             8370 _ZN15google_breakpad11LinuxDumperD0Ev
             8390 _ZNK15google_breakpad11LinuxDumper20GetCrashSignalStringEv
             8590 _ZNK15google_breakpad11LinuxDumper22GetMappingAbsolutePathERKNS_11MappingInfoEPc
@@ -69,9 +69,9 @@ expression: SymbolsDebug(&symbols)
             94a0 _ZNK15google_breakpad17LinuxPtraceDumper12IsPostMortemEv
             94b0 _ZN15google_breakpad17LinuxPtraceDumper15CopyFromProcessEPviPKvm
             9640 _ZN15google_breakpad17LinuxPtraceDumper13ThreadsResumeEv
-            9700 _ZNK15google_breakpad17LinuxPtraceDumper13BuildProcPathEPciPKc.localalias.19
+            9700 _ZNK15google_breakpad17LinuxPtraceDumper13BuildProcPathEPciPKc
             97c0 _ZN15google_breakpad17LinuxPtraceDumper16EnumerateThreadsEv
-            9e50 _ZN15google_breakpad17LinuxPtraceDumperC2Ei
+            9e50 _ZN15google_breakpad17LinuxPtraceDumperC1Ei
             9e80 _ZN15google_breakpad17LinuxPtraceDumper15ReadRegisterSetEPNS_10ThreadInfoEi
             9f70 _ZN15google_breakpad17LinuxPtraceDumper13ReadRegistersEPNS_10ThreadInfoEi
             a050 _ZN15google_breakpad17LinuxPtraceDumper20GetThreadInfoByIndexEmPNS_10ThreadInfoE
@@ -118,7 +118,7 @@ expression: SymbolsDebug(&symbols)
            11220 _ZN15google_breakpad8ElfClassEPKv
            11230 _ZN15google_breakpad14FindElfSectionEPKvPKcjPS1_Pm
            116a0 _ZN15google_breakpad15FindElfSegmentsEPKvjPNS_15wasteful_vectorINS_10ElfSegmentEEE
-           11990 _ZNSt6vectorIN15google_breakpad10ElfSegmentENS0_16PageStdAllocatorIS1_EEE19_M_emplace_back_auxIJRKS1_EEEvDpOT_
+           11990 _ZNSt6vectorIN15google_breakpad10ElfSegmentENS0_16PageStdAllocatorIS1_EEE19_M_emplace_back_auxIIRKS1_EEEvDpOT_
            11be0 _ZN15google_breakpad6FileIDC1EPKc
            11cc0 _ZN15google_breakpad6FileID29ConvertIdentifierToUUIDStringB5cxx11ERKNS_15wasteful_vectorIhEE
            11e70 _ZN15google_breakpad6FileID25ConvertIdentifierToStringB5cxx11ERKNS_15wasteful_vectorIhEE
@@ -142,7 +142,7 @@ expression: SymbolsDebug(&symbols)
            130e0 my_strlcpy
            13120 my_strlcat
            13160 my_isspace
-           13210 _ZN15google_breakpad16MemoryMappedFileC2Ev
+           13210 _ZN15google_breakpad16MemoryMappedFileC1Ev
            13220 _ZN15google_breakpad16MemoryMappedFile5UnmapEv
            13270 _ZN15google_breakpad16MemoryMappedFileD2Ev
            13280 _ZN15google_breakpad16MemoryMappedFile3MapEPKcm

--- a/symbolic-debuginfo/tests/snapshots/test_objects__pdb_symbols.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__pdb_symbols.snap
@@ -48,7 +48,7 @@ expression: SymbolsDebug(&symbols)
             2e72 ??0bad_array_new_length@std@@QAE@XZ
             2e8a ??0exception@std@@QAE@ABV01@@Z
             2eb6 ??1bad_alloc@std@@UAE@XZ
-            2ec7 ??_Eexception@std@@UAEPAXI@Z
+            2ec7 ??_Gexception@std@@UAEPAXI@Z
             2ef4 ?__scrt_throw_std_bad_alloc@@YAXXZ
             2f11 ?__scrt_throw_std_bad_array_new_length@@YAXXZ
             2f2e ?what@exception@std@@UBEPBDXZ
@@ -65,9 +65,9 @@ expression: SymbolsDebug(&symbols)
             3253 __get_startup_argv_mode
             3257 __get_startup_file_mode
             325d ?__scrt_initialize_type_info@@YAXXZ
-            3269 ___vcrt_uninitialize
+            3269 __should_initialize_environment
             326c __initialize_default_precision
-            328d @_guard_check_icall_nop@4
+            328d __initialize_denormal_control
             328e ___local_stdio_scanf_options
             3294 ___scrt_initialize_default_local_stdio_options
             32b1 ___scrt_is_user_matherr_present
@@ -122,4 +122,3 @@ expression: SymbolsDebug(&symbols)
             37e6 _terminate
             37ec _IsProcessorFeaturePresent@4
             37f2 _memcpy
-

--- a/symbolic-debuginfo/tests/snapshots/test_objects__pdb_symbols.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__pdb_symbols.snap
@@ -61,13 +61,13 @@ expression: SymbolsDebug(&symbols)
             3166 __onexit
             31a1 _atexit
             3205 ___security_init_cookie
-            3250 __matherr
+            3250 __get_startup_commit_mode
             3253 __get_startup_argv_mode
             3257 __get_startup_file_mode
             325d ?__scrt_initialize_type_info@@YAXXZ
             3269 __should_initialize_environment
             326c __initialize_default_precision
-            328d __initialize_denormal_control
+            328d @_guard_check_icall_nop@4
             328e ___local_stdio_scanf_options
             3294 ___scrt_initialize_default_local_stdio_options
             32b1 ___scrt_is_user_matherr_present

--- a/symbolic-symcache/tests/snapshots/test_writer__functions_linux.snap
+++ b/symbolic-symcache/tests/snapshots/test_writer__functions_linux.snap
@@ -1,7 +1,6 @@
 ---
 source: symbolic-symcache/tests/test_writer.rs
 expression: FunctionsDebug(&symcache)
-
 ---
             1558 _init
             1900 _ZN15google_breakpad13PageAllocator7FreeAllEv.isra.6
@@ -40,7 +39,7 @@ expression: FunctionsDebug(&symcache)
             3660 _ZN15google_breakpad30SetFirstChanceExceptionHandlerEPFbiPvS0_E
             3670 _ZN15google_breakpad16ExceptionHandlerC1ERKNS_18MinidumpDescriptorEPFbPvEPFbS3_S4_bES4_bi
             3a10 _ZN15google_breakpad16ExceptionHandler13WriteMinidumpERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFbRKNS_18MinidumpDescriptorEPvbESC_
-            3cb0 _ZNSt6vectorIPN15google_breakpad16ExceptionHandlerESaIS2_EE19_M_emplace_back_auxIIS2_EEEvDpOT_
+            3cb0 _ZNSt6vectorIPN15google_breakpad16ExceptionHandlerESaIS2_EE19_M_emplace_back_auxIJS2_EEEvDpOT_
             3da0 _ZN15google_breakpad18MinidumpDescriptorC1ERKS0_
             3f20 _ZN15google_breakpad18MinidumpDescriptor10UpdatePathEv
             42f0 _ZN15google_breakpad18MinidumpDescriptoraSERKS0_
@@ -70,9 +69,9 @@ expression: FunctionsDebug(&symcache)
             94a0 _ZNK15google_breakpad17LinuxPtraceDumper12IsPostMortemEv
             94b0 _ZN15google_breakpad17LinuxPtraceDumper15CopyFromProcessEPviPKvm
             9640 _ZN15google_breakpad17LinuxPtraceDumper13ThreadsResumeEv
-            9700 _ZNK15google_breakpad17LinuxPtraceDumper13BuildProcPathEPciPKc
+            9700 _ZNK15google_breakpad17LinuxPtraceDumper13BuildProcPathEPciPKc.localalias.19
             97c0 _ZN15google_breakpad17LinuxPtraceDumper16EnumerateThreadsEv
-            9e50 _ZN15google_breakpad17LinuxPtraceDumperC1Ei
+            9e50 _ZN15google_breakpad17LinuxPtraceDumperC2Ei
             9e80 _ZN15google_breakpad17LinuxPtraceDumper15ReadRegisterSetEPNS_10ThreadInfoEi
             9f70 _ZN15google_breakpad17LinuxPtraceDumper13ReadRegistersEPNS_10ThreadInfoEi
             a050 _ZN15google_breakpad17LinuxPtraceDumper20GetThreadInfoByIndexEmPNS_10ThreadInfoE
@@ -93,7 +92,7 @@ expression: FunctionsDebug(&symcache)
             f3c0 _ZN15google_breakpad13WriteMinidumpEiliPKvmRKNSt7__cxx114listINS_12MappingEntryESaIS4_EEERKNS3_INS_9AppMemoryESaIS9_EEEbmb
             f400 _ZN15google_breakpad17ProcCpuInfoReader12GetNextFieldEPPKc
             f660 _ZNSt6vectorIcN15google_breakpad16PageStdAllocatorIcEEE6resizeEm
-            f8c0 _ZNSt6vectorI18MDMemoryDescriptorN15google_breakpad16PageStdAllocatorIS0_EEE19_M_emplace_back_auxIIRKS0_EEEvDpOT_
+            f8c0 _ZNSt6vectorI18MDMemoryDescriptorN15google_breakpad16PageStdAllocatorIS0_EEE19_M_emplace_back_auxIJRKS0_EEEvDpOT_
             fb10 _ZN15google_breakpad10TypedMDRVAI8MDStringE20CopyIndexAfterObjectEjPKvm.isra.7.part.8
             fb40 _ZN15google_breakpad18MinidumpFileWriterC1Ev
             fb60 _ZN15google_breakpad18MinidumpFileWriter4OpenEPKc
@@ -119,8 +118,8 @@ expression: FunctionsDebug(&symcache)
            11220 _ZN15google_breakpad8ElfClassEPKv
            11230 _ZN15google_breakpad14FindElfSectionEPKvPKcjPS1_Pm
            116a0 _ZN15google_breakpad15FindElfSegmentsEPKvjPNS_15wasteful_vectorINS_10ElfSegmentEEE
-           11990 _ZNSt6vectorIN15google_breakpad10ElfSegmentENS0_16PageStdAllocatorIS1_EEE19_M_emplace_back_auxIIRKS1_EEEvDpOT_
-           11be0 _ZN15google_breakpad6FileIDC2EPKc
+           11990 _ZNSt6vectorIN15google_breakpad10ElfSegmentENS0_16PageStdAllocatorIS1_EEE19_M_emplace_back_auxIJRKS1_EEEvDpOT_
+           11be0 _ZN15google_breakpad6FileIDC1EPKc
            11cc0 _ZN15google_breakpad6FileID29ConvertIdentifierToUUIDStringB5cxx11ERKNS_15wasteful_vectorIhEE
            11e70 _ZN15google_breakpad6FileID25ConvertIdentifierToStringB5cxx11ERKNS_15wasteful_vectorIhEE
            11fb0 _ZN15google_breakpad6FileID31ElfFileIdentifierFromMappedFileEPKvRNS_15wasteful_vectorIhEE
@@ -147,9 +146,9 @@ expression: FunctionsDebug(&symcache)
            13220 _ZN15google_breakpad16MemoryMappedFile5UnmapEv
            13270 _ZN15google_breakpad16MemoryMappedFileD2Ev
            13280 _ZN15google_breakpad16MemoryMappedFile3MapEPKcm
-           13430 _ZN15google_breakpad16MemoryMappedFileC1EPKcm
+           13430 _ZN15google_breakpad16MemoryMappedFileC2EPKcm
            13450 _ZN15google_breakpad12SafeReadLinkEPKcPcm
-           13490 _ZN15google_breakpad12_GLOBAL__N_125CrashGenerationClientImplD1Ev
+           13490 _ZN15google_breakpad12_GLOBAL__N_125CrashGenerationClientImplD2Ev
            134a0 _ZN15google_breakpad12_GLOBAL__N_125CrashGenerationClientImpl11RequestDumpEPKvm
            136c0 _ZN15google_breakpad12_GLOBAL__N_125CrashGenerationClientImplD0Ev
            136d0 _ZN15google_breakpad21CrashGenerationClient9TryCreateEi
@@ -170,4 +169,3 @@ expression: FunctionsDebug(&symcache)
            14c30 __libc_csu_init
            14ca0 __libc_csu_fini
            14ca4 _fini
-

--- a/symbolic-symcache/tests/snapshots/test_writer__functions_linux.snap
+++ b/symbolic-symcache/tests/snapshots/test_writer__functions_linux.snap
@@ -39,8 +39,8 @@ expression: FunctionsDebug(&symcache)
             3660 _ZN15google_breakpad30SetFirstChanceExceptionHandlerEPFbiPvS0_E
             3670 _ZN15google_breakpad16ExceptionHandlerC1ERKNS_18MinidumpDescriptorEPFbPvEPFbS3_S4_bES4_bi
             3a10 _ZN15google_breakpad16ExceptionHandler13WriteMinidumpERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPFbRKNS_18MinidumpDescriptorEPvbESC_
-            3cb0 _ZNSt6vectorIPN15google_breakpad16ExceptionHandlerESaIS2_EE19_M_emplace_back_auxIJS2_EEEvDpOT_
-            3da0 _ZN15google_breakpad18MinidumpDescriptorC1ERKS0_
+            3cb0 _ZNSt6vectorIPN15google_breakpad16ExceptionHandlerESaIS2_EE19_M_emplace_back_auxIIS2_EEEvDpOT_
+            3da0 _ZN15google_breakpad18MinidumpDescriptorC2ERKS0_
             3f20 _ZN15google_breakpad18MinidumpDescriptor10UpdatePathEv
             42f0 _ZN15google_breakpad18MinidumpDescriptoraSERKS0_
             43c0 _ZN6logger5writeEPKcm
@@ -48,7 +48,7 @@ expression: FunctionsDebug(&symcache)
             6e10 _ZNSt6vectorIhN15google_breakpad16PageStdAllocatorIhEEE15_M_range_insertIPKhEEvN9__gnu_cxx17__normal_iteratorIPhS3_EET_SB_St20forward_iterator_tag
             71f0 _ZN15google_breakpad11LinuxDumper8LateInitEv
             7200 _ZN15google_breakpad11LinuxDumper17EnumerateMappingsEv
-            7ac0 _ZN15google_breakpad11LinuxDumperC1EiPKc
+            7ac0 _ZN15google_breakpad11LinuxDumperC2EiPKc
             8300 _ZN15google_breakpad11LinuxDumperD2Ev
             8370 _ZN15google_breakpad11LinuxDumperD0Ev
             8390 _ZNK15google_breakpad11LinuxDumper20GetCrashSignalStringEv
@@ -71,12 +71,12 @@ expression: FunctionsDebug(&symcache)
             9640 _ZN15google_breakpad17LinuxPtraceDumper13ThreadsResumeEv
             9700 _ZNK15google_breakpad17LinuxPtraceDumper13BuildProcPathEPciPKc.localalias.19
             97c0 _ZN15google_breakpad17LinuxPtraceDumper16EnumerateThreadsEv
-            9e50 _ZN15google_breakpad17LinuxPtraceDumperC2Ei
+            9e50 _ZN15google_breakpad17LinuxPtraceDumperC1Ei
             9e80 _ZN15google_breakpad17LinuxPtraceDumper15ReadRegisterSetEPNS_10ThreadInfoEi
             9f70 _ZN15google_breakpad17LinuxPtraceDumper13ReadRegistersEPNS_10ThreadInfoEi
             a050 _ZN15google_breakpad17LinuxPtraceDumper20GetThreadInfoByIndexEmPNS_10ThreadInfoE
             a690 _ZN15google_breakpad17LinuxPtraceDumper14ThreadsSuspendEv
-            a8f0 _ZN15google_breakpad17LinuxPtraceDumperD1Ev
+            a8f0 _ZN15google_breakpad17LinuxPtraceDumperD2Ev
             a910 _ZN15google_breakpad17LinuxPtraceDumperD0Ev
             a930 _ZNSt6vectorIiN15google_breakpad16PageStdAllocatorIiEEE17_M_default_appendEm
             abc0 _ZN12_GLOBAL__N_114MinidumpWriter21WriteThreadListStreamEP14MDRawDirectory.constprop.105
@@ -92,7 +92,7 @@ expression: FunctionsDebug(&symcache)
             f3c0 _ZN15google_breakpad13WriteMinidumpEiliPKvmRKNSt7__cxx114listINS_12MappingEntryESaIS4_EEERKNS3_INS_9AppMemoryESaIS9_EEEbmb
             f400 _ZN15google_breakpad17ProcCpuInfoReader12GetNextFieldEPPKc
             f660 _ZNSt6vectorIcN15google_breakpad16PageStdAllocatorIcEEE6resizeEm
-            f8c0 _ZNSt6vectorI18MDMemoryDescriptorN15google_breakpad16PageStdAllocatorIS0_EEE19_M_emplace_back_auxIJRKS0_EEEvDpOT_
+            f8c0 _ZNSt6vectorI18MDMemoryDescriptorN15google_breakpad16PageStdAllocatorIS0_EEE19_M_emplace_back_auxIIRKS0_EEEvDpOT_
             fb10 _ZN15google_breakpad10TypedMDRVAI8MDStringE20CopyIndexAfterObjectEjPKvm.isra.7.part.8
             fb40 _ZN15google_breakpad18MinidumpFileWriterC1Ev
             fb60 _ZN15google_breakpad18MinidumpFileWriter4OpenEPKc
@@ -119,7 +119,7 @@ expression: FunctionsDebug(&symcache)
            11230 _ZN15google_breakpad14FindElfSectionEPKvPKcjPS1_Pm
            116a0 _ZN15google_breakpad15FindElfSegmentsEPKvjPNS_15wasteful_vectorINS_10ElfSegmentEEE
            11990 _ZNSt6vectorIN15google_breakpad10ElfSegmentENS0_16PageStdAllocatorIS1_EEE19_M_emplace_back_auxIJRKS1_EEEvDpOT_
-           11be0 _ZN15google_breakpad6FileIDC1EPKc
+           11be0 _ZN15google_breakpad6FileIDC2EPKc
            11cc0 _ZN15google_breakpad6FileID29ConvertIdentifierToUUIDStringB5cxx11ERKNS_15wasteful_vectorIhEE
            11e70 _ZN15google_breakpad6FileID25ConvertIdentifierToStringB5cxx11ERKNS_15wasteful_vectorIhEE
            11fb0 _ZN15google_breakpad6FileID31ElfFileIdentifierFromMappedFileEPKvRNS_15wasteful_vectorIhEE
@@ -144,7 +144,7 @@ expression: FunctionsDebug(&symcache)
            13160 my_isspace
            13210 _ZN15google_breakpad16MemoryMappedFileC2Ev
            13220 _ZN15google_breakpad16MemoryMappedFile5UnmapEv
-           13270 _ZN15google_breakpad16MemoryMappedFileD2Ev
+           13270 _ZN15google_breakpad16MemoryMappedFileD1Ev
            13280 _ZN15google_breakpad16MemoryMappedFile3MapEPKcm
            13430 _ZN15google_breakpad16MemoryMappedFileC2EPKcm
            13450 _ZN15google_breakpad12SafeReadLinkEPKcPcm


### PR DESCRIPTION
We're using an unstable sorting algorithm (dmsort) to sort symbols upon collection. It behaves differently under Rust 1.81 than 1.80, so some snapshots change.