### PR TITLE
feat(js): Read debug IDs from debugId field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Unreleased
+
+**Features**:
+- feat(js): Sourcemap debug IDs can now be read from the `"debugId"` field in addition to
+  `"debug_id"` ([#870](https://github.com/getsentry/symbolic/pull/870)).
+
 ## 12.12.0
 
 ### Various fixes & improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 ## 12.12.0
 
-### Various fixes & improvements
-
 **Fixes**
 - Unship "Support for DWARFv5 embedded source code extension ([#849](https://github.com/getsentry/symbolic/pull/849))".
   Unfortunately the check for whether an elf file contains embedded sources is prohibitively expensive in terms of memory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# Unreleased
+## Unreleased
 
 **Features**:
 - feat(js): Sourcemap debug IDs can now be read from the `"debugId"` field in addition to

--- a/symbolic-debuginfo/src/js.rs
+++ b/symbolic-debuginfo/src/js.rs
@@ -29,9 +29,12 @@ pub fn discover_sourcemaps_location(contents: &str) -> Option<&str> {
 }
 
 /// Quickly reads the embedded `debug_id` key from a source map.
+///
+/// Both `debug_id` and `debugId` are supported as field names.
 pub fn discover_sourcemap_embedded_debug_id(contents: &str) -> Option<DebugId> {
     #[derive(Deserialize)]
     struct DebugIdInSourceMap {
+        #[serde(alias = "debugId")]
         debug_id: Option<DebugId>,
     }
 
@@ -48,4 +51,43 @@ pub fn discover_debug_id(contents: &str) -> Option<DebugId> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use debugid::DebugId;
+
+    use crate::js::discover_sourcemap_embedded_debug_id;
+
+    #[test]
+    fn test_debugid_snake_case() {
+        let input = r#"{
+         "version":3,
+         "sources":["coolstuff.js"],
+         "names":["x","alert"],
+         "mappings":"AAAA,GAAIA,GAAI,EACR,IAAIA,GAAK,EAAG,CACVC,MAAM",
+         "debug_id":"00000000-0000-0000-0000-000000000000"
+     }"#;
+
+        assert_eq!(
+            discover_sourcemap_embedded_debug_id(input),
+            Some(DebugId::default())
+        );
+    }
+
+    #[test]
+    fn test_debugid_camel_case() {
+        let input = r#"{
+         "version":3,
+         "sources":["coolstuff.js"],
+         "names":["x","alert"],
+         "mappings":"AAAA,GAAIA,GAAI,EACR,IAAIA,GAAK,EAAG,CACVC,MAAM",
+         "debugId":"00000000-0000-0000-0000-000000000000"
+     }"#;
+
+        assert_eq!(
+            discover_sourcemap_embedded_debug_id(input),
+            Some(DebugId::default())
+        );
+    }
 }


### PR DESCRIPTION
Companion PR to https://github.com/getsentry/rust-sourcemap/pull/97. This adjusts `discover_sourcemap_embedded_debug_id` so that it finds debug IDs at both `"debug_id"` and `"debugId"`.

#skip-changelog because Danger is acting up.