### PR TITLE
fix(js): Resolve conflict between "debugId" and "debug_id"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**
+- js: Fixed an error when reading debug IDs from sourcemaps with
+  both `"debugId"` and `"debug_id"` keys ([#877](https://github.com/getsentry/symbolic/pull/877)).
+
 ## 12.12.1
 
 **Features**:


### PR DESCRIPTION
Companion PR to https://github.com/getsentry/rust-sourcemap/pull/100.

Using a alias causes deserialization to fail when
both keys are set. Therefore we now read both fields and implement the logic explicitly.