### PR TITLE
fix(symcache): Use saturating addition in writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**
+- symcache: Fixed a bug related to to inlinee resolution during symcache conversion. ([#883](https://github.com/getsentry/symbolic/pull/883))
+
 ## 12.12.3
 
 **Fixes**

--- a/symbolic-symcache/src/writer.rs
+++ b/symbolic-symcache/src/writer.rs
@@ -188,8 +188,9 @@ impl<'a> SymCacheConverter<'a> {
         let mut inlinee_ranges = Vec::new();
         for inlinee in &function.inlinees {
             for line in &inlinee.lines {
-                let start = line.address as u32;
-                let end = start.saturating_add(line.size.unwrap_or(1) as u32);
+                let start = line.address.try_into().unwrap_or(u32::MAX);
+                let end =
+                    start.saturating_add(line.size.unwrap_or(1).try_into().unwrap_or(u32::MAX));
                 inlinee_ranges.push(start..end);
             }
         }
@@ -213,8 +214,9 @@ impl<'a> SymCacheConverter<'a> {
 
         // Iterate over the line records.
         while let Some(line) = next_line.take() {
-            let line_range_start = line.address as u32;
-            let line_range_end = line_range_start.saturating_add(line.size.unwrap_or(1) as u32);
+            let line_range_start = line.address.try_into().unwrap_or(u32::MAX);
+            let line_range_end = line_range_start
+                .saturating_add(line.size.unwrap_or(1).try_into().unwrap_or(u32::MAX));
 
             // Find the call location for this line.
             while next_call_location.is_some() && next_call_location.unwrap().0 <= line_range_start


### PR DESCRIPTION
Addition wraps in release mode. For large line size values, this resulted in ranges whose end was before their start, which caused us to skip a function's inlinees in some cases.

Instead of using bare addition on `u64` and casting to `u32` at the end, we now use saturating addition on `u32` directly.