### PR TITLE
fix(demangle): Suppresses c++ warnings on older GCCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Fixed a compilation issue with older GCC compilers. ([#886](https://github.com/getsentry/symbolic/pull/886))
+
+
 ## 12.13.0
 
-- Update libswift demangle to v6.0.3 ([#885](https://github.com/getsentry/symbolic/pull/885))
+- Update libswift demangle to v6.0.3. ([#885](https://github.com/getsentry/symbolic/pull/885))
 
 ## 12.12.4
 

--- a/symbolic-demangle/build.rs
+++ b/symbolic-demangle/build.rs
@@ -18,7 +18,7 @@ fn main() {
                 "vendor/swift/lib/Demangling/Remangler.cpp",
             ])
             .flag_if_supported("-std=c++17")
-            .flag_if_supported("-mmacosx-version-min=11.0.0")
+            .flag_if_supported("-fpermissive")
             .flag_if_supported("-Wno-changes-meaning")
             .flag("-DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1")
             .flag("-DSWIFT_STDLIB_HAS_TYPE_PRINTING=1")


### PR DESCRIPTION
Older GCC versions do not have `-Wno-changes-meaning` as a separate warning, but it is part of the permissive category.

Also removes the mac os min, it's not actually required as I thought before it was.