### PR TITLE
fix(demangle): Unbreak GitHub Action Windows builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,21 @@
 
 ## Unreleased
 
-- Fix new clippy lints ([#889](https://github.com/getsentry/symbolic/pull/889))
-- Run `cargo update` ([#888](https://github.com/getsentry/symbolic/pull/888))
+**Fixes**
+
+- Fixed GHA-based Windows builds ([#891](https://github.com/getsentry/symbolic/pull/891)).
 
 ## 12.13.1
+
+**Fixes**
 
 - Fixed a compilation issue with older GCC compilers. ([#886](https://github.com/getsentry/symbolic/pull/886))
 
 ## 12.13.0
 
-- Update libswift demangle to v6.0.3. ([#885](https://github.com/getsentry/symbolic/pull/885))
+**Features**
+
+- Updated libswift demangle to v6.0.3. ([#885](https://github.com/getsentry/symbolic/pull/885))
 
 ## 12.12.4
 
@@ -34,7 +39,7 @@
 
 ## 12.12.1
 
-**Features**:
+**Features**
 
 - feat(js): Sourcemap debug IDs can now be read from the `"debugId"` field in addition to
   `"debug_id"` ([#870](https://github.com/getsentry/symbolic/pull/870)).

--- a/symbolic-demangle/build.rs
+++ b/symbolic-demangle/build.rs
@@ -18,6 +18,7 @@ fn main() {
                 "vendor/swift/lib/Demangling/Remangler.cpp",
             ])
             .flag_if_supported("-std=c++17")
+            .flag_if_supported("/std:c++17")
             .flag_if_supported("-fpermissive")
             .flag_if_supported("-Wno-changes-meaning")
             .flag("-DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1")


### PR DESCRIPTION
The `12.13.0` release and pull request #885 specifically broke GitHub Action based Windows builds. The reason seems to be that the Swift library upgrade now relies on C++17 features and the GitHub Actions Windows image uses MSVC 2022, which requires an explicit opt-in to those. The provided `-std=c++17` works on GCC and similar, but does not have any effect on MSVC.
To fix the build, add the flag that MSVC understands for opting in to the new standard.