### PR TITLE
build: Fix Rust 1.85 clippy lints

### DIFF
--- a/symbolic-common/src/path.rs
+++ b/symbolic-common/src/path.rs
@@ -54,7 +54,7 @@ fn is_windows_driveletter<P: AsRef<[u8]>>(path: P) -> bool {
 
     if let (Some(drive_letter), Some(b':')) = (path.first(), path.get(1)) {
         if drive_letter.is_ascii_alphabetic() {
-            return path.get(2).map_or(true, is_windows_separator);
+            return path.get(2).is_none_or(is_windows_separator);
         }
     }
 

--- a/symbolic-debuginfo/src/macho/compact.rs
+++ b/symbolic-debuginfo/src/macho/compact.rs
@@ -2504,7 +2504,7 @@ mod test {
             let opcode = Opcode(
                 X86_MODE_RBP_FRAME
                     | pack_x86_rbp_registers(registers)
-                    | (stack_size as u32) << stack_size_offset,
+                    | ((stack_size as u32) << stack_size_offset),
             );
             let expected = vec![
                 CompactCfiOp::RegisterIs {
@@ -2536,7 +2536,7 @@ mod test {
             let opcode = Opcode(
                 X86_MODE_RBP_FRAME
                     | pack_x86_rbp_registers(registers)
-                    | (stack_size as u32) << stack_size_offset,
+                    | ((stack_size as u32) << stack_size_offset),
             );
             let expected = vec![
                 CompactCfiOp::RegisterIs {
@@ -2573,7 +2573,7 @@ mod test {
             let opcode = Opcode(
                 X86_MODE_RBP_FRAME
                     | pack_x86_rbp_registers(registers)
-                    | (stack_size as u32) << stack_size_offset,
+                    | ((stack_size as u32) << stack_size_offset),
             );
             let expected = vec![
                 CompactCfiOp::RegisterIs {
@@ -2630,7 +2630,7 @@ mod test {
             let opcode = Opcode(
                 X86_MODE_RBP_FRAME
                     | pack_x86_rbp_registers(registers)
-                    | (stack_size as u32) << stack_size_offset,
+                    | ((stack_size as u32) << stack_size_offset),
             );
             let expected = vec![
                 CompactCfiOp::RegisterIs {
@@ -2894,7 +2894,7 @@ mod test {
             let opcode = Opcode(
                 X86_MODE_RBP_FRAME
                     | pack_x86_rbp_registers(registers)
-                    | (stack_size as u32) << stack_size_offset,
+                    | ((stack_size as u32) << stack_size_offset),
             );
             let expected = vec![
                 CompactCfiOp::RegisterIs {
@@ -2926,7 +2926,7 @@ mod test {
             let opcode = Opcode(
                 X86_MODE_RBP_FRAME
                     | pack_x86_rbp_registers(registers)
-                    | (stack_size as u32) << stack_size_offset,
+                    | ((stack_size as u32) << stack_size_offset),
             );
             let expected = vec![
                 CompactCfiOp::RegisterIs {
@@ -2963,7 +2963,7 @@ mod test {
             let opcode = Opcode(
                 X86_MODE_RBP_FRAME
                     | pack_x86_rbp_registers(registers)
-                    | (stack_size as u32) << stack_size_offset,
+                    | ((stack_size as u32) << stack_size_offset),
             );
             let expected = vec![
                 CompactCfiOp::RegisterIs {
@@ -3020,7 +3020,7 @@ mod test {
             let opcode = Opcode(
                 X86_MODE_RBP_FRAME
                     | pack_x86_rbp_registers(registers)
-                    | (stack_size as u32) << stack_size_offset,
+                    | ((stack_size as u32) << stack_size_offset),
             );
             let expected = vec![
                 CompactCfiOp::RegisterIs {

--- a/symbolic-debuginfo/src/wasm/parser.rs
+++ b/symbolic-debuginfo/src/wasm/parser.rs
@@ -43,7 +43,7 @@ impl BitVec {
         } else {
             let vec_index = index / u64::BITS as usize;
             let item_bit = index % u64::BITS as usize;
-            Some(self.data[vec_index] & 1 << item_bit != 0)
+            Some(self.data[vec_index] & (1 << item_bit) != 0)
         }
     }
 }

--- a/symbolic-ppdb/src/format/metadata.rs
+++ b/symbolic-ppdb/src/format/metadata.rs
@@ -354,7 +354,7 @@ impl<'data> MetadataStream<'data> {
             contents: <&[u8]>::default(),
         }; 64];
         for (i, table) in tables.iter_mut().enumerate() {
-            if (header.valid_tables >> i & 1) == 0 {
+            if ((header.valid_tables >> i) & 1) == 0 {
                 continue;
             }
 

--- a/symbolic-ppdb/src/format/streams.rs
+++ b/symbolic-ppdb/src/format/streams.rs
@@ -48,7 +48,7 @@ impl<'data> PdbStream<'data> {
 
         let mut referenced_table_sizes = [0; 64];
         for (i, table) in referenced_table_sizes.iter_mut().enumerate() {
-            if (header.referenced_tables >> i & 1) == 0 {
+            if ((header.referenced_tables >> i) & 1) == 0 {
                 continue;
             }
 


### PR DESCRIPTION
Just a `cargo clippy --fix`

#skip-changelog