### PR TITLE
build: pin MSRV to 1.73 and clarify policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**
+
+- Restore support for older Rust versions and clarify MSRV policy. ([#902](https://github.com/getsentry/symbolic/pull/902))
+
 ## 12.14.0
 
 **Features**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 resolver = "2"
 members = ["symbolic*", "examples/*"]
 
+[workspace.package]
+edition = "2021"
+rust-version = "1.73"
+
 [workspace.dependencies]
 anyhow = "1.0.32"
 anylog = "0.6.4"

--- a/README.md
+++ b/README.md
@@ -158,6 +158,13 @@ To run these examples, use the `run` script. For example:
 ./run minidump_stackwalk mini.dmp /path/to/files
 ```
 
+## Supported Rust Versions
+
+Symbolic tries to not break MSRV compatibility but makes no guarantees about the Rust version.
+Although you can expect Rust version compatibility of **at least 6 months**.
+
+The current MSRV is 1.73.
+
 ## License
 
 Symbolic is licensed under the MIT license. It uses some Apache2 licensed code

--- a/symbolic-cfi/Cargo.toml
+++ b/symbolic-cfi/Cargo.toml
@@ -12,7 +12,8 @@ repository = "https://github.com/getsentry/symbolic"
 description = """
 A library to process call frame information
 """
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 symbolic-common = { version = "12.14.0", path = "../symbolic-common" }

--- a/symbolic-common/Cargo.toml
+++ b/symbolic-common/Cargo.toml
@@ -14,7 +14,8 @@ description = """
 Common types and utilities for symbolic, a library to symbolicate and process
 stack traces from native applications, minidumps or minified JavaScript.
 """
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/symbolic-common/src/path.rs
+++ b/symbolic-common/src/path.rs
@@ -54,7 +54,7 @@ fn is_windows_driveletter<P: AsRef<[u8]>>(path: P) -> bool {
 
     if let (Some(drive_letter), Some(b':')) = (path.first(), path.get(1)) {
         if drive_letter.is_ascii_alphabetic() {
-            return path.get(2).is_none_or(is_windows_separator);
+            return path.get(2).map_or(true, is_windows_separator);
         }
     }
 

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -13,7 +13,8 @@ description = """
 A library to inspect and load DWARF debugging information from binaries, such
 as Mach-O or ELF.
 """
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 exclude = ["tests/**/*"]
 

--- a/symbolic-demangle/Cargo.toml
+++ b/symbolic-demangle/Cargo.toml
@@ -14,7 +14,8 @@ description = """
 A library to demangle symbols from various languages and compilers.
 """
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 exclude = ["tests/**/*"]
 

--- a/symbolic-il2cpp/Cargo.toml
+++ b/symbolic-il2cpp/Cargo.toml
@@ -9,7 +9,8 @@ repository = "https://github.com/getsentry/symbolic"
 description = """
 A library for parsing il2cpp line mappings.
 """
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 indexmap = { workspace = true }

--- a/symbolic-ppdb/Cargo.toml
+++ b/symbolic-ppdb/Cargo.toml
@@ -12,7 +12,8 @@ repository = "https://github.com/getsentry/symbolic"
 description = """
 A library for parsing and performing lookups on Portable PDB files.
 """
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 exclude = ["tests/**/*"]
 

--- a/symbolic-symcache/Cargo.toml
+++ b/symbolic-symcache/Cargo.toml
@@ -13,7 +13,8 @@ description = """
 An optimized cache file for fast and memory efficient lookup of symbols and
 stack frames in debugging information.
 """
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 exclude = ["tests/**/*"]
 

--- a/symbolic-symcache/src/lookup.rs
+++ b/symbolic-symcache/src/lookup.rs
@@ -228,9 +228,11 @@ impl<'data> Iterator for Functions<'data> {
             }
         }
 
-        function.inspect(|_f| {
+        if function.is_some() {
             self.function_idx += 1;
-        })
+        }
+
+        function
     }
 }
 
@@ -265,9 +267,11 @@ impl<'data> Iterator for Files<'data> {
     type Item = File<'data>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.cache.get_file(self.file_idx).inspect(|_f| {
+        let file = self.cache.get_file(self.file_idx);
+        if file.is_some() {
             self.file_idx += 1;
-        })
+        }
+        file
     }
 }
 

--- a/symbolic-unreal/Cargo.toml
+++ b/symbolic-unreal/Cargo.toml
@@ -13,7 +13,8 @@ repository = "https://github.com/getsentry/symbolic"
 description = """
 Parsing and processing utilities for Unreal Engine 4 crash files.
 """
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 exclude = ["tests/**/*"]
 

--- a/symbolic/Cargo.toml
+++ b/symbolic/Cargo.toml
@@ -14,7 +14,8 @@ description = """
 A library to symbolicate and process stack traces from native applications,
 minidumps, Unreal Engine 4 or minified JavaScript.
 """
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Fixes: #901

Request was for MSRV 1.75 but we can support 1.73 without any more changes.