### PR TITLE
feat(minidump-stackwalk): Allow specifying multiple sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Allow specifying multiple symbol sources in minidump-stackwalk utility. ([#903](https://github.com/getsentry/symbolic/pull/903))
+
 ## 12.14.1
 
 **Fixes**


### PR DESCRIPTION
Currently using this to debug a minidump where I want some debug info loaded from the binary but others from system libraries.

The patch makes it possible to specify multiple sources.