### PR TITLE
fix(minidump-stackwalk): Do not hallucinate frames when stackwalking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Allow specifying multiple symbol sources in minidump-stackwalk utility. ([#903](https://github.com/getsentry/symbolic/pull/903))
+- Do not hallucinate frames when stack walking in minidump-stackwalk utility. ([#904](https://github.com/getsentry/symbolic/pull/904))
 
 ## 12.14.1
 

--- a/examples/minidump_stackwalk/src/main.rs
+++ b/examples/minidump_stackwalk/src/main.rs
@@ -326,7 +326,7 @@ impl minidump_unwind::SymbolProvider for LocalSymbolProvider<'_> {
             // find the instruction. In which case this is most likely not a real
             // frame.
             //
-            // The minidump stackwalker skips alls frames without a name and continues
+            // The minidump stackwalker skips all frames without a name and continues
             // the search, but it assumes there is a correct frame if the lookup
             // fails. To not hallucinate frames, we return `Ok(())` here (a frame without a name).
             return Ok(());


### PR DESCRIPTION
The instruction definitely belongs to this module, but we cannot
find the instruction. In which case this is most likely not a real
frame.

The minidump stackwalker skips alls frames without a name and continues
the search, but it assumes there is a correct frame if the lookup
fails. To not hallucinate frames, we return `Ok(())` here (a frame without a name).

Rust minidump code here: https://github.com/rust-minidump/rust-minidump/blob/32e01a0e54d987025aa64486ebc4154f7f6b16d2/minidump-unwind/src/lib.rs#L865-L877

Relates to: https://github.com/getsentry/sentry/issues/85336

With the change:

```
  0  CrashApp.pdb!DoCrash(int, int) [CrashApp\CrashingProgram.cpp : 17]
      rax = 0x0000000000000000      rdx = 0x0000000000000003
      rcx = 0x00007ff7f3ad711d      rbx = 0x0000000000000000
      rsi = 0x0000000000000003      rdi = 0x0000000000000005
      rbp = 0x0000003b349fe8d0      rsp = 0x0000003b349fe8b0
       r8 = 0x0000000000000000       r9 = 0x000001810bc1c3d0
      r10 = 0x000001810e6e0000      r11 = 0x0000000000000000
      r12 = 0x0000003b349fefe0      r13 = 0x0000003b349ff218
      r14 = 0x000001810d862d20      r15 = 0x000001810bbb9390
      rip = 0x00007ff7f3a9fc36
     Found by: given as instruction pointer in context
  1  CrashApp.pdb!NativeAdd(int, int) [CrashApp\CrashingProgram.cpp : 23]
      rbx = 0x0000000000000000      rdi = 0x0000000000000005
      rbp = 0x0000003b349fea10      rsp = 0x0000003b349fe9f0
      r12 = 0x0000003b349fefe0      r13 = 0x0000003b349ff218
      r14 = 0x000001810d862d20      r15 = 0x000001810bbb9390
      rip = 0x00007ff7f3aa5624
     Found by: call frame info
  2  0x1810e69de87
      rbx = 0x0000000000000000      rdi = 0x0000000000000005
      rbp = 0x0000003b349feb70      rsp = 0x0000003b349feaf0
      r12 = 0x0000003b349fefe0      r13 = 0x0000003b349ff218
      r14 = 0x000001810d862d20      r15 = 0x000001810bbb9390
      rip = 0x000001810e69de88
     Found by: call frame info
  3  C:\build\output\Unity-Technologies\mono\msvc\build\boehm\x64\bin\Release\mono-2.0-bdwgc.pdb!mono_create_ftnptr(_MonoDomain*, void*) [C:\build\output\Unity-Technologies\mono\mono\metadata\object.c : 9364]
     Found by: inlined into next frame
  4  C:\build\output\Unity-Technologies\mono\msvc\build\boehm\x64\bin\Release\mono-2.0-bdwgc.pdb!mono_jit_compile_method_with_opt(_MonoMethod*, unsigned int, int, _MonoError*) [C:\build\output\Unity-Technologies\mono\mono\mini\mini-runtime.c : 2612]
      rsp = 0x0000003b349febc0      rip = 0x00007ffad2014472
     Found by: stack scanning
```

Without the change, notice two additional frames:

```
Thread 0 (crashed)
  0  CrashApp.pdb!DoCrash(int, int) [CrashApp\CrashingProgram.cpp : 17]
      rax = 0x0000000000000000      rdx = 0x0000000000000003
      rcx = 0x00007ff7f3ad711d      rbx = 0x0000000000000000
      rsi = 0x0000000000000003      rdi = 0x0000000000000005
      rbp = 0x0000003b349fe8d0      rsp = 0x0000003b349fe8b0
       r8 = 0x0000000000000000       r9 = 0x000001810bc1c3d0
      r10 = 0x000001810e6e0000      r11 = 0x0000000000000000
      r12 = 0x0000003b349fefe0      r13 = 0x0000003b349ff218
      r14 = 0x000001810d862d20      r15 = 0x000001810bbb9390
      rip = 0x00007ff7f3a9fc36
     Found by: given as instruction pointer in context
  1  CrashApp.pdb!NativeAdd(int, int) [CrashApp\CrashingProgram.cpp : 23]
      rbx = 0x0000000000000000      rdi = 0x0000000000000005
      rbp = 0x0000003b349fea10      rsp = 0x0000003b349fe9f0
      r12 = 0x0000003b349fefe0      r13 = 0x0000003b349ff218
      r14 = 0x000001810d862d20      r15 = 0x000001810bbb9390
      rip = 0x00007ff7f3aa5624
     Found by: call frame info
  2  0x1810e69de87
      rbx = 0x0000000000000000      rdi = 0x0000000000000005
      rbp = 0x0000003b349feb70      rsp = 0x0000003b349feaf0
      r12 = 0x0000003b349fefe0      r13 = 0x0000003b349ff218
      r14 = 0x000001810d862d20      r15 = 0x000001810bbb9390
      rip = 0x000001810e69de88
     Found by: call frame info
  3  C:\build\output\Unity-Technologies\mono\msvc\build\boehm\x64\bin\Release\mono-2.0-bdwgc.pdb + 0x7454d7
      rbp = 0x0000003b349feb70      rsp = 0x0000003b349feb30
      rip = 0x00007ffad24d54d8
     Found by: stack scanning
  4  C:\build\output\Unity-Technologies\mono\msvc\build\boehm\x64\bin\Release\mono-2.0-bdwgc.pdb + 0x74542f
      rsp = 0x0000003b349feb38      rip = 0x00007ffad24d5430
     Found by: stack scanning
  5  C:\build\output\Unity-Technologies\mono\msvc\build\boehm\x64\bin\Release\mono-2.0-bdwgc.pdb!mono_create_ftnptr(_MonoDomain*, void*) [C:\build\output\Unity-Technologies\mono\mono\metadata\object.c : 9364]
     Found by: inlined into next frame
  6  C:\build\output\Unity-Technologies\mono\msvc\build\boehm\x64\bin\Release\mono-2.0-bdwgc.pdb!mono_jit_compile_method_with_opt(_MonoMethod*, unsigned int, int, _MonoError*) [C:\build\output\Unity-Technologies\mono\mono\mini\mini-runtime.c : 2612]
      rsp = 0x0000003b349febc0      rip = 0x00007ffad2014472
     Found by: stack scanning
```

Note, all following frames are wrong, but at least with the change the hallucinated frames `0x7454d7` and `0x74542f` are gone.