### PR TITLE
feat(unreal-engine-crash): Add extraction command to cli utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Allow specifying multiple symbol sources in minidump-stackwalk utility. ([#903](https://github.com/getsentry/symbolic/pull/903))
 - Do not hallucinate frames when stack walking in minidump-stackwalk utility. ([#904](https://github.com/getsentry/symbolic/pull/904))
+- Add a subcommand to extract individual files from a unreal crash report to the `unreal_engine_crash` utility. ([#907](https://github.com/getsentry/symbolic/pull/907))
 
 ## 12.14.1
 

--- a/examples/unreal_engine_crash/src/main.rs
+++ b/examples/unreal_engine_crash/src/main.rs
@@ -1,20 +1,12 @@
 use std::fs::File;
-use std::io::Read;
+use std::io::{BufWriter, Read, Write};
 use std::{cmp, path::PathBuf};
 
 use clap::{value_parser, Arg, ArgMatches, Command};
 
 use symbolic::unreal::{Unreal4Crash, Unreal4FileType};
 
-fn execute(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let crash_file_path = matches.get_one::<PathBuf>("crash_file_path").unwrap();
-
-    let mut file = File::open(crash_file_path)?;
-    let mut file_content = Vec::new();
-    file.read_to_end(&mut file_content)?;
-
-    let ue4_crash = Unreal4Crash::parse(&file_content)?;
-
+fn print_debug(ue4_crash: Unreal4Crash) -> Result<(), Box<dyn std::error::Error>> {
     match ue4_crash.file_by_type(Unreal4FileType::Minidump) {
         Some(m) => println!("Minidump size: {} bytes.", m.data().len()),
         None => println!("No minidump found in the Unreal Crash provided."),
@@ -40,7 +32,26 @@ fn execute(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn main() {
+fn extract(
+    ue4_crash: Unreal4Crash,
+    matches: &ArgMatches,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let filename = matches.get_one::<String>("filename").unwrap();
+
+    let Some(file) = ue4_crash.files().find(|file| file.name() == filename) else {
+        return Err(format!("No file named '{filename}' in crash report").into());
+    };
+
+    let mut output: Box<dyn Write> = match matches.get_one::<PathBuf>("output_path") {
+        Some(output) => Box::new(BufWriter::new(File::create(output)?)),
+        None => Box::new(std::io::stdout()),
+    };
+    output.write_all(file.data())?;
+
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let matches = Command::new("unreal-engine-crash")
         .about("Unpack an Unreal Engine crash report")
         .arg(
@@ -50,10 +61,38 @@ fn main() {
                 .value_parser(value_parser!(PathBuf))
                 .help("Path to the crash file"),
         )
+        .subcommand(
+            Command::new("extract")
+                .about("extract a single file from the crash file")
+                .arg(
+                    Arg::new("output_path")
+                        .short('o')
+                        .long("output")
+                        .value_parser(value_parser!(PathBuf))
+                        .help(
+                            "Path to write the file to, if missing contents are written to stdout",
+                        ),
+                )
+                .arg(
+                    Arg::new("filename")
+                        .required(true)
+                        .value_name("filename")
+                        .help("filename to extract"),
+                ),
+        )
         .get_matches();
 
-    match execute(&matches) {
-        Ok(()) => (),
-        Err(e) => println!("Error: {e}"),
+    let crash = {
+        let crash_file_path = matches.get_one::<PathBuf>("crash_file_path").unwrap();
+        let mut file = File::open(crash_file_path)?;
+        let mut file_content = Vec::new();
+        file.read_to_end(&mut file_content)?;
+        Unreal4Crash::parse(&file_content)?
     };
+
+    match matches.subcommand() {
+        Some(("extract", matches)) => extract(crash, matches),
+        None => print_debug(crash),
+        _ => unreachable!(),
+    }
 }


### PR DESCRIPTION
Make it possible to extract individual files from an unreal crash report via the commandline utility.