### PR TITLE
ref: split changelog in sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## Unreleased
 
+**Features**
+
 - Allow specifying multiple symbol sources in minidump-stackwalk utility. ([#903](https://github.com/getsentry/symbolic/pull/903))
-- Do not hallucinate frames when stack walking in minidump-stackwalk utility. ([#904](https://github.com/getsentry/symbolic/pull/904))
 - Add a subcommand to extract individual files from a unreal crash report to the `unreal_engine_crash` utility. ([#907](https://github.com/getsentry/symbolic/pull/907))
+
+**Fixes**
+
+- Do not hallucinate frames when stack walking in minidump-stackwalk utility. ([#904](https://github.com/getsentry/symbolic/pull/904))
+
+**Improvements**
+
 - Add normalization for paths in `FileKey`. ([#908](https://github.com/getsentry/symbolic/pull/908))
 
 ## 12.14.1


### PR DESCRIPTION
Splits the changes into appropriate sections to give more context what the change does.

#skip-changelog