### PR TITLE
fix(craft): update craft to find .tar.gz archives

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -21,4 +21,4 @@ requireNames:
   - /^symbolic-.*-py2.py3-none-macosx_11_0_arm64.whl$/
   - /^symbolic-.*-py2.py3-none-manylinux_2_28_aarch64.whl$/
   - /^symbolic-.*-py2.py3-none-manylinux_2_28_x86_64.whl$/
-  - /^symbolic-.*.zip$/
+  - /^symbolic-.*.tar.gz$/


### PR DESCRIPTION
In the previous PR we removed the `--format=zip` parameter from the Makefile but forgot to update the `.craft.yml` which led to another failed publish run because it failed to find the artifact.

This PR fixes the regex so that it finds the new source artifact.

Old PR: https://github.com/getsentry/symbolic/pull/910
Failed publish: https://github.com/getsentry/publish/actions/runs/14380071441/job/40321532143

#skip-changelog