### PR TITLE
fix(swift): Remove unnecessary assert in swift demangler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**
+
+- demangle: Fixed a crash/abort when providing bad input to the swift demangler. ([#917](https://github.com/getsentry/symbolic/pull/917))
+
 ## 12.15.4
 
 **Fixes**

--- a/symbolic-demangle/vendor/swift/1-arguments.patch
+++ b/symbolic-demangle/vendor/swift/1-arguments.patch
@@ -43,3 +43,14 @@ index 6c309bbf..5b251e8d 100644
        return;
  
      if (isAsync)
+diff --git a/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp b/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp
+index 6c309bbf..5b251e8d 100644
+--- a/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp
++++ b/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp
+@@ -3423,7 +3423,6 @@ NodePointer Demangler::demangleSpecAttributes(Node::Kind SpecKind) {
+
+   int PassID = (int)nextChar() - '0';
+   if (PassID < 0 || PassID >= MAX_SPECIALIZATION_PASS) {
+-    assert(false && "unexpected pass id");
+     return nullptr;
+   }

--- a/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp
+++ b/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp
@@ -3423,7 +3423,6 @@ NodePointer Demangler::demangleSpecAttributes(Node::Kind SpecKind) {
 
   int PassID = (int)nextChar() - '0';
   if (PassID < 0 || PassID >= MAX_SPECIALIZATION_PASS) {
-    assert(false && "unexpected pass id");
     return nullptr;
   }
 


### PR DESCRIPTION
Fixes: #912

Smaller version of #913 which attempts to update the entire swift demangler, but runs into other issues. 

Removing the assert is fine, as upstream ended up removing it as well. This is the minimal fix to stop crashing on bad inputs. Eventually we'll want to update the swift sources.

Removed Upstream: https://github.com/swiftlang/swift/blob/ace5c20b12ef404ef4f169a5484c2ae8b981cfc3/lib/Demangling/Demangler.cpp#L3544-L3547