### PR TITLE
test(swift): Add regression test for swift demangler crash

### DIFF
--- a/symbolic-demangle/tests/test_swift.rs
+++ b/symbolic-demangle/tests/test_swift.rs
@@ -147,6 +147,9 @@ fn test_demangle_swift_short() {
 
         // Swift 5.2
         "$s7ranking22propertyVersusFunctionyyAA1P_p_xtAaCRzlFyAaC_pcAaC_pcfu_" => "implicit closure #1 (P) in propertyVersusFunction<A>(P, A)",
+
+        // Causes an abort with the Swift 6.0.3 demangler.
+        "$sTB" => "$sTB",
     });
 }
 


### PR DESCRIPTION
Forgot to add it to #917, just a regression test, to catch the abort.

#skip-changelog