### PR TITLE
Expose SourceMapView.get_source_contents function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**
+
+- python bindings: Expose SourceMapView.get_source_contents function. ([#921](https://github.com/getsentry/symbolic/pull/921))
+
 ## 12.15.5
 
 **Fixes**

--- a/py/symbolic/sourcemap.py
+++ b/py/symbolic/sourcemap.py
@@ -172,6 +172,11 @@ class SourceMapView(RustObject):
         name = self._methodcall(lib.symbolic_sourcemapview_get_source_name, idx)
         return decode_str(name, free=True) or None
 
+    def get_source_contents(self, idx: int) -> str | None:
+        """Returns the contents of the source at the given index."""
+        name = self._methodcall(lib.symbolic_sourcemapview_get_source_contents, idx)
+        return decode_str(name, free=True) or None
+
     def iter_sources(self) -> Generator[tuple[int, str | None], None, None]:
         """Iterates over the sources in the file."""
         for src_id in range(self.source_count):

--- a/symbolic-cabi/include/symbolic.h
+++ b/symbolic-cabi/include/symbolic.h
@@ -615,15 +615,21 @@ const struct SymbolicSourceView *symbolic_sourcemapview_get_sourceview(const str
                                                                        uint32_t index);
 
 /**
+ * Return the number of sources.
+ */
+uint32_t symbolic_sourcemapview_get_source_count(const struct SymbolicSourceMapView *source_map);
+
+/**
  * Return the source name for an index.
  */
 struct SymbolicStr symbolic_sourcemapview_get_source_name(const struct SymbolicSourceMapView *source_map,
                                                           uint32_t index);
 
 /**
- * Return the number of sources.
+ * Return the source contents for an index.
  */
-uint32_t symbolic_sourcemapview_get_source_count(const struct SymbolicSourceMapView *source_map);
+struct SymbolicStr symbolic_sourcemapview_get_source_contents(const struct SymbolicSourceMapView *source_map,
+                                                          uint32_t index);
 
 /**
  * Returns a specific token.

--- a/symbolic-cabi/src/sourcemap.rs
+++ b/symbolic-cabi/src/sourcemap.rs
@@ -228,6 +228,15 @@ ffi_fn! {
 }
 
 ffi_fn! {
+    /// Return the number of sources.
+    unsafe fn symbolic_sourcemapview_get_source_count(
+        source_map: *const SymbolicSourceMapView
+    ) -> Result<u32> {
+        Ok(SymbolicSourceMapView::as_rust(source_map).inner.get_source_count())
+    }
+}
+
+ffi_fn! {
     /// Return the source name for an index.
     unsafe fn symbolic_sourcemapview_get_source_name(
         source_map: *const SymbolicSourceMapView,
@@ -240,11 +249,14 @@ ffi_fn! {
 }
 
 ffi_fn! {
-    /// Return the number of sources.
-    unsafe fn symbolic_sourcemapview_get_source_count(
-        source_map: *const SymbolicSourceMapView
-    ) -> Result<u32> {
-        Ok(SymbolicSourceMapView::as_rust(source_map).inner.get_source_count())
+    /// Return the source contents for an index.
+    unsafe fn symbolic_sourcemapview_get_source_contents(
+        source_map: *const SymbolicSourceMapView,
+        index: u32
+    ) -> Result<SymbolicStr> {
+        let view = SymbolicSourceMapView::as_rust(source_map);
+        let contents_opt = view.inner.get_source_contents(index);
+        Ok(contents_opt.unwrap_or("").into())
     }
 }
 


### PR DESCRIPTION
Currently only a few functions of the underlying lib (https://github.com/getsentry/rust-sourcemap) are exposed. 

In particular, there's currently no way to get the source code contents, but just the names can currently be retrieved.

This change adds support to expose the fn SourceMap::get_source_contents : https://github.com/getsentry/rust-sourcemap/blob/24a07e376a634c7823ada1b55326454ba7fc921d/src/types.rs#L787-L792