### PR TITLE
fix(sourcemapcache): Don't return unmapped source locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - python bindings: Expose SourceMapView.get_source_contents function. ([#921](https://github.com/getsentry/symbolic/pull/921))
 
+**Fixes**
+
+- sourcemapcache: Don't return unmapped source locations. ([#922](https://github.com/getsentry/symbolic/pull/922))
+
 ## 12.15.5
 
 **Fixes**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,11 +201,12 @@ dependencies = [
 
 [[package]]
 name = "base64-simd"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781dd20c3aff0bd194fe7d2a977dd92f21c173891f3a03b677359e5fa457e5d5"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
 dependencies = [
- "simd-abstraction",
+ "outref",
+ "vsimd",
 ]
 
 [[package]]
@@ -869,7 +870,7 @@ dependencies = [
  "new_debug_unreachable",
  "once_cell",
  "phf",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "triomphe",
 ]
 
@@ -1500,9 +1501,9 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "outref"
-version = "0.1.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "overload"
@@ -1929,24 +1930,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
 
 [[package]]
 name = "rustix"
@@ -2028,24 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -2131,15 +2102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-abstraction"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
-dependencies = [
- "outref",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2216,17 +2178,16 @@ dependencies = [
 
 [[package]]
 name = "sourcemap"
-version = "9.1.2"
+version = "9.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c4ea7042fd1a155ad95335b5d505ab00d5124ea0332a06c8390d200bb1a76a"
+checksum = "e22afbcb92ce02d23815b9795523c005cb9d3c214f8b7a66318541c240ea7935"
 dependencies = [
  "base64-simd",
  "bitvec",
  "data-encoding",
  "debugid",
  "if_chain",
- "rustc-hash 1.1.0",
- "rustc_version",
+ "rustc-hash",
  "serde",
  "serde_json",
  "unicode-id-start",
@@ -2309,7 +2270,7 @@ dependencies = [
  "allocator-api2",
  "bumpalo",
  "ptr_meta",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "triomphe",
 ]
 
@@ -2321,7 +2282,7 @@ checksum = "9d7077ba879f95406459bc0c81f3141c529b34580bc64d7ab7bd15e7118a0391"
 dependencies = [
  "hstr",
  "once_cell",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
 ]
 
@@ -2339,7 +2300,7 @@ dependencies = [
  "new_debug_unreachable",
  "num-bigint",
  "once_cell",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "siphasher 0.3.11",
  "swc_allocator",
@@ -2380,7 +2341,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "phf",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "smallvec",
  "smartstring",
@@ -2959,6 +2920,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3047,7 +3014,7 @@ dependencies = [
  "bitflags 2.7.0",
  "hashbrown 0.14.5",
  "indexmap",
- "semver 1.0.24",
+ "semver",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ serde = { version = "1.0.171", features = ["derive"] }
 serde_json = "1.0.102"
 similar-asserts = "1.4.2"
 smallvec = "1.10.0"
-sourcemap = "9.1.2"
+sourcemap = "9.2.2"
 stable_deref_trait = "1.2.0"
 tempfile = "3.4.0"
 thiserror = "1.0.39"

--- a/symbolic-sourcemapcache/src/lookup.rs
+++ b/symbolic-sourcemapcache/src/lookup.rs
@@ -173,11 +173,16 @@ impl<'data> SourceMapCache<'data> {
     pub fn lookup(&self, sp: SourcePosition) -> Option<SourceLocation> {
         let idx = match self.min_source_positions.binary_search(&sp.into()) {
             Ok(idx) => idx,
-            Err(0) => 0,
+            Err(0) => return None,
             Err(idx) => idx - 1,
         };
 
         let sl = self.orig_source_locations.get(idx)?;
+
+        // If file, line, and column are all absent (== `u32::MAX`), this location is simply unmapped.
+        if sl.file_idx == raw::NO_FILE_SENTINEL && sl.line == u32::MAX && sl.column == u32::MAX {
+            return None;
+        }
 
         let line = sl.line;
         let column = sl.column;

--- a/symbolic-sourcemapcache/src/lookup.rs
+++ b/symbolic-sourcemapcache/src/lookup.rs
@@ -381,4 +381,43 @@ mod tests {
         assert_eq!(file.line(3), Some("c\n"));
         assert_eq!(file.line(4), Some(""));
     }
+
+    #[test]
+    fn unmapped_token() {
+        let minified = r#""foo"; /*added by bundler*/ "bar";"#;
+        let sourcemap = r#"{"version":3,"file":"test.min.js","sources":["test.js"],"sourcesContent":["\"foo\":\n\"baz\";"],"names":[],"mappings":"AAAA,M,sBACA"}"#;
+
+        let mut buf = vec![];
+        SourceMapCacheWriter::new(minified, sourcemap)
+            .unwrap()
+            .serialize(&mut buf)
+            .unwrap();
+
+        let cache = SourceMapCache::parse(&buf).unwrap();
+
+        // "foo";
+        let foo = cache.lookup(SourcePosition { line: 0, column: 4 }).unwrap();
+        assert_eq!(foo.file_name().unwrap(), "test.js");
+        assert_eq!(foo.line, 0);
+        assert_eq!(foo.column, 0);
+
+        // comment
+        // this should be unmapped
+        assert!(dbg!(cache.lookup(SourcePosition {
+            line: 0,
+            column: 17
+        }))
+        .is_none());
+
+        // "bar";
+        let bar = cache
+            .lookup(SourcePosition {
+                line: 0,
+                column: 30,
+            })
+            .unwrap();
+        assert_eq!(bar.file_name().unwrap(), "test.js");
+        assert_eq!(bar.line, 1);
+        assert_eq!(bar.column, 0);
+    }
 }


### PR DESCRIPTION
This doesn't do anything without https://github.com/getsentry/rust-sourcemap/pull/129, but is sound even without it.