### PR TITLE
semgrep: exclude example and test directories

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,4 @@
+:include .gitignore
+
+examples/
+**/tests/


### PR DESCRIPTION
A lot of `symbolic`'s findings are in these example and test directories. Using this ignore file will auto-ignore findings here and reduce the noise.