### PR TITLE
chore: Update the docs and code to be complient with current supported MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["symbolic*", "examples/*"]
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.73"
+rust-version = "1.82"
 
 [workspace.dependencies]
 anyhow = "1.0.32"
@@ -21,12 +21,12 @@ elementtree = "1.2.3"
 elsa = "1.8.0"
 fallible-iterator = "0.3.0"
 flate2 = { version = "1.0.25", default-features = false, features = [
-    "rust_backend",
+  "rust_backend",
 ] }
 gimli = { version = "0.31.0", default-features = false, features = [
-    "read",
-    "std",
-    "fallible-iterator",
+  "read",
+  "std",
+  "fallible-iterator",
 ] }
 goblin = { version = "0.8.0", default-features = false }
 indexmap = "2.0.0"

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ To run these examples, use the `run` script. For example:
 Symbolic tries to not break MSRV compatibility but makes no guarantees about the Rust version.
 Although you can expect Rust version compatibility of **at least 6 months**.
 
-The current MSRV is 1.73.
+The current MSRV is 1.82.
 
 ## License
 

--- a/symbolic-cfi/tests/snapshots/test_cfi__cfi_elf.snap
+++ b/symbolic-cfi/tests/snapshots/test_cfi__cfi_elf.snap
@@ -1,7 +1,5 @@
 ---
-created: "2019-07-05T18:52:40.332785Z"
-creator: insta@0.8.1
-source: minidump/tests/test_cfi.rs
+source: symbolic-cfi/tests/test_cfi.rs
 expression: cfi
 ---
 STACK CFI INIT 1dc0 2a .cfa: $rsp 8 +
@@ -1502,4 +1500,3 @@ STACK CFI 14c90 .cfa: $rsp 24 +
 STACK CFI 14c92 .cfa: $rsp 16 +
 STACK CFI 14c94 .cfa: $rsp 8 +
 STACK CFI INIT 14ca0 2 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-

--- a/symbolic-cfi/tests/snapshots/test_cfi__cfi_macho.snap
+++ b/symbolic-cfi/tests/snapshots/test_cfi__cfi_macho.snap
@@ -1,7 +1,6 @@
 ---
-source: symbolic-minidump/tests/test_cfi.rs
+source: symbolic-cfi/tests/test_cfi.rs
 expression: cfi
-
 ---
 STACK CFI INIT d20 1a .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT d40 1a .cfa: $rsp 8 + .ra: .cfa -8 + ^
@@ -302,4 +301,3 @@ STACK CFI INIT db50 41 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI db51 .cfa: $rsp 16 +
 STACK CFI INIT dba0 d0 .cfa: $rsp 320 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
 STACK CFI INIT dc70 34 .cfa: $rsp 16 + .ra: .cfa -8 + ^ $rbx: .cfa -16 + ^
-

--- a/symbolic-cfi/tests/snapshots/test_cfi__cfi_pdb_windows.snap
+++ b/symbolic-cfi/tests/snapshots/test_cfi__cfi_pdb_windows.snap
@@ -1,7 +1,5 @@
 ---
-created: "2019-04-03T18:49:08.328347Z"
-creator: insta@0.7.4
-source: minidump/tests/test_cfi.rs
+source: symbolic-cfi/tests/test_cfi.rs
 expression: cfi
 ---
 STACK WIN 4 1000 114 11 0 8 0 0 0 1 $T0 .raSearch = $eip $T0 ^ = $esp $T0 4 + =
@@ -156,4 +154,3 @@ STACK WIN 4 358f 187 0 0 0 4 24 0 1 $T0 $ebp = $eip $T0 4 + ^ = $ebp $T0 ^ = $es
 STACK WIN 4 35b7 ef 0 0 0 8 24 0 1 $T0 $ebp = $eip $T0 4 + ^ = $ebp $T0 ^ = $esp $T0 8 + =  $20 $T0 40 - ^ =  $23 $T0 44 - ^ =
 STACK WIN 4 35b8 ed 0 0 0 c 24 0 1 $T0 $ebp = $eip $T0 4 + ^ = $ebp $T0 ^ = $esp $T0 8 + =  $20 $T0 40 - ^ =  $23 $T0 44 - ^ =  $24 $T0 48 - ^ =
 STACK WIN 4 371a c 0 0 0 0 0 0 1 $T0 .raSearch = $eip $T0 ^ = $esp $T0 4 + =
-

--- a/symbolic-cfi/tests/snapshots/test_cfi__cfi_pe_windows.snap
+++ b/symbolic-cfi/tests/snapshots/test_cfi__cfi_pe_windows.snap
@@ -1,6 +1,5 @@
 ---
 source: symbolic-cfi/tests/test_cfi.rs
-assertion_line: 105
 expression: cfi
 ---
 STACK CFI INIT 1010 55 .cfa: $rsp 80 + $rbx: .cfa 16 - ^ $rsi: .cfa 24 - ^ $rdi: .cfa 32 - ^ .ra: .cfa 8 - ^
@@ -44,4 +43,3 @@ STACK CFI INIT 1de8 1b9 .cfa: $rsp 48 + $rsi: .cfa 16 - ^ $rdi: .cfa 24 - ^ $r14
 STACK CFI INIT 2090 2 .cfa: $rsp 8 + .ra: .cfa 8 - ^
 STACK CFI INIT 20ac 1e .cfa: $rsp 48 + $rbp: .cfa 16 - ^ .ra: .cfa 8 - ^
 STACK CFI INIT 20ca 18 .cfa: $rsp 16 + $rbp: .cfa 16 - ^ .ra: .cfa 8 - ^
-

--- a/symbolic-cfi/tests/snapshots/test_cfi__cfi_sym_linux.snap
+++ b/symbolic-cfi/tests/snapshots/test_cfi__cfi_sym_linux.snap
@@ -1,7 +1,5 @@
 ---
-created: "2019-02-20T15:42:11.809248Z"
-creator: insta@0.6.3
-source: minidump/tests/test_cfi.rs
+source: symbolic-cfi/tests/test_cfi.rs
 expression: cfi
 ---
 STACK CFI INIT 1dc0 2a .cfa: $rsp 8 + .ra: .cfa -8 + ^
@@ -1502,4 +1500,3 @@ STACK CFI 14c90 .cfa: $rsp 24 +
 STACK CFI 14c92 .cfa: $rsp 16 +
 STACK CFI 14c94 .cfa: $rsp 8 +
 STACK CFI INIT 14ca0 2 .cfa: $rsp 8 + .ra: .cfa -8 + ^
-

--- a/symbolic-cfi/tests/snapshots/test_cfi__cfi_sym_macos.snap
+++ b/symbolic-cfi/tests/snapshots/test_cfi__cfi_sym_macos.snap
@@ -1,7 +1,5 @@
 ---
-created: "2019-02-20T15:42:11.796554Z"
-creator: insta@0.6.3
-source: minidump/tests/test_cfi.rs
+source: symbolic-cfi/tests/test_cfi.rs
 expression: cfi
 ---
 STACK CFI INIT d20 1a .cfa: $rsp 8 + .ra: .cfa -8 + ^
@@ -217,4 +215,3 @@ STACK CFI INIT db30 a .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT db40 a .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI INIT db50 41 .cfa: $rsp 8 + .ra: .cfa -8 + ^
 STACK CFI db51 .cfa: $rsp 16 +
-

--- a/symbolic-cfi/tests/snapshots/test_cfi__cfi_sym_windows.snap
+++ b/symbolic-cfi/tests/snapshots/test_cfi__cfi_sym_windows.snap
@@ -1,7 +1,5 @@
 ---
-created: "2019-02-20T15:42:11.796623Z"
-creator: insta@0.6.3
-source: minidump/tests/test_cfi.rs
+source: symbolic-cfi/tests/test_cfi.rs
 expression: cfi
 ---
 STACK WIN 4 1000 114 11 0 8 0 0 0 1 $T0 .raSearch = $eip $T0 ^ = $esp $T0 4 + =
@@ -158,4 +156,3 @@ STACK WIN 4 35b8 ed 0 0 0 c 24 0 1 $T0 $ebp = $eip $T0 4 + ^ = $ebp $T0 ^ = $esp
 STACK WIN 4 371a c 0 0 0 0 0 0 1 $T0 .raSearch = $eip $T0 ^ = $esp $T0 4 + =
 STACK WIN 0 2dc4 14 0 0 0 0 0 0 0 0
 STACK WIN 0 30fc 13 0 0 0 0 0 0 0 0
-

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -2104,12 +2104,12 @@ mod tests {
         let record = BreakpadModuleRecord::parse(string)?;
 
         insta::assert_debug_snapshot!(record, @r#"
-       ⋮BreakpadModuleRecord {
-       ⋮    os: "Linux",
-       ⋮    arch: "x86_64",
-       ⋮    id: "492E2DD23CC306CA9C494EEF1533A3810",
-       ⋮    name: "crash",
-       ⋮}
+        BreakpadModuleRecord {
+            os: "Linux",
+            arch: "x86_64",
+            id: "492E2DD23CC306CA9C494EEF1533A3810",
+            name: "crash",
+        }
         "#);
 
         Ok(())
@@ -2122,12 +2122,12 @@ mod tests {
         let record = BreakpadModuleRecord::parse(string)?;
 
         insta::assert_debug_snapshot!(record, @r#"
-       ⋮BreakpadModuleRecord {
-       ⋮    os: "Linux",
-       ⋮    arch: "x86_64",
-       ⋮    id: "6216C672A8D33EC9CF4A1BAB8B29D00E",
-       ⋮    name: "libdispatch.so",
-       ⋮}
+        BreakpadModuleRecord {
+            os: "Linux",
+            arch: "x86_64",
+            id: "6216C672A8D33EC9CF4A1BAB8B29D00E",
+            name: "libdispatch.so",
+        }
         "#);
 
         Ok(())
@@ -2139,10 +2139,10 @@ mod tests {
         let record = BreakpadFileRecord::parse(string)?;
 
         insta::assert_debug_snapshot!(record, @r#"
-       ⋮BreakpadFileRecord {
-       ⋮    id: 37,
-       ⋮    name: "/usr/include/libkern/i386/_OSByteOrder.h",
-       ⋮}
+        BreakpadFileRecord {
+            id: 37,
+            name: "/usr/include/libkern/i386/_OSByteOrder.h",
+        }
         "#);
 
         Ok(())
@@ -2154,10 +2154,10 @@ mod tests {
         let record = BreakpadFileRecord::parse(string)?;
 
         insta::assert_debug_snapshot!(record, @r#"
-       ⋮BreakpadFileRecord {
-       ⋮    id: 38,
-       ⋮    name: "/usr/local/src/filename with spaces.c",
-       ⋮}
+        BreakpadFileRecord {
+            id: 38,
+            name: "/usr/local/src/filename with spaces.c",
+        }
         "#);
 
         Ok(())
@@ -2201,13 +2201,13 @@ mod tests {
         let record = BreakpadFuncRecord::parse(string, Lines::default())?;
 
         insta::assert_debug_snapshot!(record, @r#"
-       ⋮BreakpadFuncRecord {
-       ⋮    multiple: false,
-       ⋮    address: 5936,
-       ⋮    size: 26,
-       ⋮    parameter_size: 0,
-       ⋮    name: "<name omitted>",
-       ⋮}
+        BreakpadFuncRecord {
+            multiple: false,
+            address: 5936,
+            size: 26,
+            parameter_size: 0,
+            name: "<name omitted>",
+        }
         "#);
 
         Ok(())
@@ -2219,13 +2219,13 @@ mod tests {
         let record = BreakpadFuncRecord::parse(string, Lines::default())?;
 
         insta::assert_debug_snapshot!(record, @r#"
-       ⋮BreakpadFuncRecord {
-       ⋮    multiple: true,
-       ⋮    address: 5936,
-       ⋮    size: 26,
-       ⋮    parameter_size: 0,
-       ⋮    name: "<name omitted>",
-       ⋮}
+        BreakpadFuncRecord {
+            multiple: true,
+            address: 5936,
+            size: 26,
+            parameter_size: 0,
+            name: "<name omitted>",
+        }
         "#);
 
         Ok(())
@@ -2237,13 +2237,13 @@ mod tests {
         let record = BreakpadFuncRecord::parse(string, Lines::default())?;
 
         insta::assert_debug_snapshot!(record, @r#"
-       ⋮BreakpadFuncRecord {
-       ⋮    multiple: false,
-       ⋮    address: 0,
-       ⋮    size: 15,
-       ⋮    parameter_size: 0,
-       ⋮    name: "<unknown>",
-       ⋮}
+        BreakpadFuncRecord {
+            multiple: false,
+            address: 0,
+            size: 15,
+            parameter_size: 0,
+            name: "<unknown>",
+        }
         "#);
 
         Ok(())
@@ -2254,14 +2254,14 @@ mod tests {
         let string = b"1730 6 93 20";
         let record = BreakpadLineRecord::parse(string)?;
 
-        insta::assert_debug_snapshot!(record, @r###"
-       ⋮BreakpadLineRecord {
-       ⋮    address: 5936,
-       ⋮    size: 6,
-       ⋮    line: 93,
-       ⋮    file_id: 20,
-       ⋮}
-        "###);
+        insta::assert_debug_snapshot!(record, @r"
+        BreakpadLineRecord {
+            address: 5936,
+            size: 6,
+            line: 93,
+            file_id: 20,
+        }
+        ");
 
         Ok(())
     }
@@ -2271,14 +2271,14 @@ mod tests {
         let string = b"e0fd10 5 -376 2225";
         let record = BreakpadLineRecord::parse(string)?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r"
         BreakpadLineRecord {
             address: 14744848,
             size: 5,
             line: 0,
             file_id: 2225,
         }
-        "###);
+        ");
 
         Ok(())
     }
@@ -2290,14 +2290,14 @@ mod tests {
         let record = BreakpadLineRecord::parse(string)?;
 
         insta::assert_debug_snapshot!(
-            record, @r###"
+            record, @r"
         BreakpadLineRecord {
             address: 4096,
             size: 28,
             line: 2972,
             file_id: 2,
         }
-        "###);
+        ");
 
         Ok(())
     }
@@ -2308,12 +2308,12 @@ mod tests {
         let record = BreakpadPublicRecord::parse(string)?;
 
         insta::assert_debug_snapshot!(record, @r#"
-       ⋮BreakpadPublicRecord {
-       ⋮    multiple: false,
-       ⋮    address: 20864,
-       ⋮    parameter_size: 0,
-       ⋮    name: "__clang_call_terminate",
-       ⋮}
+        BreakpadPublicRecord {
+            multiple: false,
+            address: 20864,
+            parameter_size: 0,
+            name: "__clang_call_terminate",
+        }
         "#);
 
         Ok(())
@@ -2325,12 +2325,12 @@ mod tests {
         let record = BreakpadPublicRecord::parse(string)?;
 
         insta::assert_debug_snapshot!(record, @r#"
-       ⋮BreakpadPublicRecord {
-       ⋮    multiple: true,
-       ⋮    address: 20864,
-       ⋮    parameter_size: 0,
-       ⋮    name: "__clang_call_terminate",
-       ⋮}
+        BreakpadPublicRecord {
+            multiple: true,
+            address: 20864,
+            parameter_size: 0,
+            name: "__clang_call_terminate",
+        }
         "#);
 
         Ok(())
@@ -2342,12 +2342,12 @@ mod tests {
         let record = BreakpadPublicRecord::parse(string)?;
 
         insta::assert_debug_snapshot!(record, @r#"
-       ⋮BreakpadPublicRecord {
-       ⋮    multiple: false,
-       ⋮    address: 20864,
-       ⋮    parameter_size: 0,
-       ⋮    name: "<unknown>",
-       ⋮}
+        BreakpadPublicRecord {
+            multiple: false,
+            address: 20864,
+            parameter_size: 0,
+            name: "<unknown>",
+        }
         "#);
 
         Ok(())
@@ -2358,7 +2358,7 @@ mod tests {
         let string = b"INLINE 0 3082 52 1410 49200 10";
         let record = BreakpadInlineRecord::parse(string)?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r"
         BreakpadInlineRecord {
             inline_depth: 0,
             call_site_line: 3082,
@@ -2371,7 +2371,7 @@ mod tests {
                 },
             ],
         }
-        "###);
+        ");
 
         Ok(())
     }
@@ -2381,7 +2381,7 @@ mod tests {
         let string = b"INLINE 6 642 8 207 8b110 18 8b154 18";
         let record = BreakpadInlineRecord::parse(string)?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r"
         BreakpadInlineRecord {
             inline_depth: 6,
             call_site_line: 642,
@@ -2398,7 +2398,7 @@ mod tests {
                 },
             ],
         }
-        "###);
+        ");
 
         Ok(())
     }
@@ -2469,7 +2469,7 @@ mod tests {
         let string = b"STACK WIN 3 8a10b ec b 0 c c 4 0 0 1";
         let record = BreakpadStackWinRecord::parse(string)?;
 
-        insta::assert_debug_snapshot!(record, @r###"
+        insta::assert_debug_snapshot!(record, @r"
         BreakpadStackWinRecord {
             ty: Standard,
             code_start: 565515,
@@ -2483,7 +2483,7 @@ mod tests {
             uses_base_pointer: true,
             program_string: None,
         }
-        "###);
+        ");
 
         Ok(())
     }

--- a/symbolic-debuginfo/tests/snapshots/test_objects__breakpad_files.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__breakpad_files.snap
@@ -1,7 +1,5 @@
 ---
-created: "2019-06-28T08:09:53.890090Z"
-creator: insta@0.8.1
-source: debuginfo/tests/test_objects.rs
+source: symbolic-debuginfo/tests/test_objects.rs
 expression: "FilesDebug(&files[..10])"
 ---
 c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include\system_error
@@ -14,4 +12,3 @@ c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.1
 c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include\xstring
 c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include\cstdlib
 c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include\xmemory0
-

--- a/symbolic-debuginfo/tests/snapshots/test_objects__breakpad_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__breakpad_functions.snap
@@ -1,10 +1,7 @@
 ---
-created: "2019-02-20T15:25:10.239080Z"
-creator: insta@0.6.3
-source: debuginfo/tests/test_objects.rs
+source: symbolic-debuginfo/tests/test_objects.rs
 expression: "FunctionsDebug(&functions[..10], 0)"
 ---
-
 > 0x1000: google_breakpad::CrashGenerationClient::RequestDump(_EXCEPTION_POINTERS *,MDRawAssertionInfo *) (0x114)
   0x1000: crash_generation_client.cc:323 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\crash_generation)
   0x1011: crash_generation_client.cc:324 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\crash_generation)
@@ -132,4 +129,3 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x1727: exception_handler.cc:289 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\handler)
   0x1741: exception_handler.cc:291 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\handler)
   0x174c: exception_handler.cc:293 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\handler)
-

--- a/symbolic-debuginfo/tests/snapshots/test_objects__breakpad_functions_mac_with_inlines.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__breakpad_functions_mac_with_inlines.snap
@@ -1,9 +1,7 @@
 ---
 source: symbolic-debuginfo/tests/test_objects.rs
-assertion_line: 150
 expression: "FunctionsDebug(&functions[..10], 0)"
 ---
-
 > 0xd20: google_breakpad::MinidumpFileWriter::MinidumpFileWriter() (0x1a)
   0xd20: minidump_file_writer.cc:93 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
   0xd26: minidump_file_writer.cc:94 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
@@ -163,4 +161,3 @@ expression: "FunctionsDebug(&functions[..10], 0)"
 
 > 0x1140: google_breakpad::MinidumpFileWriter::WriteString(wchar_t const*, unsigned int, MDLocationDescriptor*) (0x5)
   0x1140: minidump_file_writer.cc:245 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)
-

--- a/symbolic-debuginfo/tests/snapshots/test_objects__breakpad_symbols.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__breakpad_symbols.snap
@@ -1,8 +1,6 @@
 ---
-created: "2019-02-20T11:25:23.767168Z"
-creator: insta@0.6.3
-source: debuginfo/tests/test_objects.rs
-expression: SymbolDebug(&symbols)
+source: symbolic-debuginfo/tests/test_objects.rs
+expression: SymbolsDebug(&symbols)
 ---
             3726 __CxxFrameHandler3
             372c __std_exception_copy
@@ -39,4 +37,3 @@ expression: SymbolDebug(&symbols)
             37e6 terminate
             37ec IsProcessorFeaturePresent
             37f2 memcpy
-

--- a/symbolic-debuginfo/tests/snapshots/test_objects__elf_files.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__elf_files.snap
@@ -1,7 +1,5 @@
 ---
-created: "2019-06-28T08:34:30.750035Z"
-creator: insta@0.8.1
-source: debuginfo/tests/test_objects.rs
+source: symbolic-debuginfo/tests/test_objects.rs
 expression: "FilesDebug(&files[..10])"
 ---
 /work/linux/main.cpp
@@ -14,4 +12,3 @@ expression: "FilesDebug(&files[..10])"
 /usr/lib/gcc/x86_64-linux-gnu/5/include/stddef.h
 /usr/include/x86_64-linux-gnu/bits/types.h
 /usr/include/stdio.h
-

--- a/symbolic-debuginfo/tests/snapshots/test_objects__elf_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__elf_functions.snap
@@ -2,7 +2,6 @@
 source: symbolic-debuginfo/tests/test_objects.rs
 expression: "FunctionsDebug(&functions[..10], 0)"
 ---
-
 > 0x1ec0: _ZN12_GLOBAL__N_18callbackERKN15google_breakpad18MinidumpDescriptorEPvb (0x3b)
   0x1ec0: main.cpp:9 (../linux)
   0x1ec2: main.cpp:8 (../linux)
@@ -965,4 +964,3 @@ expression: "FunctionsDebug(&functions[..10], 0)"
 
   > 0x2dae: InstallDefaultHandler (0xc)
     0x2dae: exception_handler.cc:199 (../deps/breakpad/src/client/linux/handler)
-

--- a/symbolic-debuginfo/tests/snapshots/test_objects__mach_files.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__mach_files.snap
@@ -1,7 +1,5 @@
 ---
-created: "2019-06-28T08:34:30.763613Z"
-creator: insta@0.8.1
-source: debuginfo/tests/test_objects.rs
+source: symbolic-debuginfo/tests/test_objects.rs
 expression: "FilesDebug(&files[..10])"
 ---
 /Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client/minidump_file_writer.h
@@ -14,4 +12,3 @@ expression: "FilesDebug(&files[..10])"
 /usr/include/_types/_uint16_t.h
 /usr/include/sys/_types.h
 /usr/include/sys/_types/_off_t.h
-

--- a/symbolic-debuginfo/tests/snapshots/test_objects__mach_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__mach_functions.snap
@@ -1,9 +1,7 @@
 ---
 source: symbolic-debuginfo/tests/test_objects.rs
-assertion_line: 396
 expression: "FunctionsDebug(&functions[..10], 0)"
 ---
-
 > 0xd20: _ZN15google_breakpad18MinidumpFileWriterC2Ev (0x1a)
   0xd20: minidump_file_writer.cc:93 (../deps/breakpad/src/client)
   0xd26: minidump_file_writer.cc:94 (../deps/breakpad/src/client)
@@ -188,4 +186,3 @@ expression: "FunctionsDebug(&functions[..10], 0)"
 
 > 0x1140: _ZN15google_breakpad18MinidumpFileWriter11WriteStringEPKwjP20MDLocationDescriptor (0x5)
   0x1140: minidump_file_writer.cc:245 (../deps/breakpad/src/client)
-

--- a/symbolic-debuginfo/tests/snapshots/test_objects__mach_symbols.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__mach_symbols.snap
@@ -1,8 +1,6 @@
 ---
-created: "2019-02-20T12:28:37.426989Z"
-creator: insta@0.6.3
-source: debuginfo/tests/test_objects.rs
-expression: SymbolDebug(&symbols)
+source: symbolic-debuginfo/tests/test_objects.rs
+expression: SymbolsDebug(&symbols)
 ---
                0 _mh_execute_header
              d20 _ZN15google_breakpad18MinidumpFileWriterC2Ev
@@ -199,4 +197,3 @@ expression: SymbolDebug(&symbols)
             db50 _ZN15google_breakpad14MachPortSender11SendMessageERNS_15MachSendMessageEj
             dba0 main
             dc70 _ZN12_GLOBAL__N_18callbackEPKcS1_Pvb
-

--- a/symbolic-debuginfo/tests/snapshots/test_objects__pdb_files.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__pdb_files.snap
@@ -1,7 +1,5 @@
 ---
-created: "2019-06-28T08:20:37.446264Z"
-creator: insta@0.8.1
-source: debuginfo/tests/test_objects.rs
+source: symbolic-debuginfo/tests/test_objects.rs
 expression: "FilesDebug(&files[..10])"
 ---
 c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include\system_error
@@ -14,4 +12,3 @@ c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.1
 c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include\xstring
 c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include\cstdlib
 c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include\xmemory0
-

--- a/symbolic-debuginfo/tests/snapshots/test_objects__pdb_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__pdb_functions.snap
@@ -1,9 +1,7 @@
 ---
 source: symbolic-debuginfo/tests/test_objects.rs
-assertion_line: 524
 expression: "FunctionsDebug(&functions[..10], 0)"
 ---
-
 > 0x1120: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::~basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >() (0x54)
   0x1120: xstring:2424 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
   0x1123: xstring:2425 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)
@@ -469,4 +467,3 @@ expression: "FunctionsDebug(&functions[..10], 0)"
 > 0x2690: google_breakpad::scoped_ptr<google_breakpad::CrashGenerationClient>::~scoped_ptr<google_breakpad::CrashGenerationClient>() (0xd)
   0x2690: scoped_ptr.h:98 (c:\projects\breakpad-tools\deps\breakpad\src\common)
   0x269c: scoped_ptr.h:99 (c:\projects\breakpad-tools\deps\breakpad\src\common)
-

--- a/symbolic-debuginfo/tests/snapshots/test_objects__pe_dwarf_files.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__pe_dwarf_files.snap
@@ -12,4 +12,3 @@ expression: "FilesDebug(&files[..10])"
 /mxe/usr/x86_64-w64-mingw32.static/include/stdlib.h
 /mxe/usr/x86_64-w64-mingw32.static/include/errhandlingapi.h
 /mxe/usr/x86_64-w64-mingw32.static/include/processthreadsapi.h
-

--- a/symbolic-debuginfo/tests/snapshots/test_objects__pe_dwarf_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__pe_dwarf_functions.snap
@@ -2,7 +2,6 @@
 source: symbolic-debuginfo/tests/test_objects.rs
 expression: "FunctionsDebug(&functions[..10], 0)"
 ---
-
 > 0x14f0: atexit (0x14)
   0x14f0: crtexe.c:418 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
   0x14f4: crtexe.c:419 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
@@ -220,4 +219,3 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x165a: gccmain.c:60 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
   0x1660: gccmain.c:57 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
   0x166a: gccmain.c:58 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
-

--- a/symbolic-debuginfo/tests/snapshots/test_objects__ppdb_files.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__ppdb_files.snap
@@ -1,10 +1,8 @@
 ---
 source: symbolic-debuginfo/tests/test_objects.rs
-assertion_line: 656
 expression: FilesDebug(&files)
 ---
 /Users/swatinem/Coding/sentry-dotnet/samples/foo/Program.cs
 /Users/swatinem/Coding/sentry-dotnet/samples/foo/obj/Debug/net6.0/foo.GlobalUsings.g.cs
 /Users/swatinem/Coding/sentry-dotnet/samples/foo/obj/Debug/net6.0/.NETCoreApp,Version=v6.0.AssemblyAttributes.cs
 /Users/swatinem/Coding/sentry-dotnet/samples/foo/obj/Debug/net6.0/foo.AssemblyInfo.cs
-

--- a/symbolic-debuginfo/tests/snapshots/test_objects__wasm_symbols.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__wasm_symbols.snap
@@ -1,7 +1,5 @@
 ---
 source: symbolic-debuginfo/tests/test_objects.rs
 expression: SymbolsDebug(&symbols)
-
 ---
               8b internal_func
-

--- a/symbolic-debuginfo/tests/test_objects.rs
+++ b/symbolic-debuginfo/tests/test_objects.rs
@@ -128,23 +128,23 @@ fn test_breakpad() -> Result<(), Error> {
     let object = Object::parse(&view)?;
 
     insta::assert_debug_snapshot!(object, @r#"
-   ⋮Breakpad(
-   ⋮    BreakpadObject {
-   ⋮        code_id: Some(
-   ⋮            CodeId(5ab380779000),
-   ⋮        ),
-   ⋮        debug_id: DebugId {
-   ⋮            uuid: "3249d99d-0c40-4931-8610-f4e4fb0b6936",
-   ⋮            appendix: 1,
-   ⋮        },
-   ⋮        arch: X86,
-   ⋮        name: "crash.pdb",
-   ⋮        has_symbols: true,
-   ⋮        has_debug_info: true,
-   ⋮        has_unwind_info: true,
-   ⋮        is_malformed: false,
-   ⋮    },
-   ⋮)
+    Breakpad(
+        BreakpadObject {
+            code_id: Some(
+                CodeId(5ab380779000),
+            ),
+            debug_id: DebugId {
+                uuid: "3249d99d-0c40-4931-8610-f4e4fb0b6936",
+                appendix: 1,
+            },
+            arch: X86,
+            name: "crash.pdb",
+            has_symbols: true,
+            has_debug_info: true,
+            has_unwind_info: true,
+            is_malformed: false,
+        },
+    )
     "#);
 
     Ok(())
@@ -209,24 +209,24 @@ fn test_elf_executable() -> Result<(), Error> {
     let object = Object::parse(&view)?;
 
     insta::assert_debug_snapshot!(object, @r#"
-   ⋮Elf(
-   ⋮    ElfObject {
-   ⋮        code_id: Some(
-   ⋮            CodeId(f1c3bcc0279865fe3058404b2831d9e64135386c),
-   ⋮        ),
-   ⋮        debug_id: DebugId {
-   ⋮            uuid: "c0bcc3f1-9827-fe65-3058-404b2831d9e6",
-   ⋮            appendix: 0,
-   ⋮        },
-   ⋮        arch: Amd64,
-   ⋮        kind: Executable,
-   ⋮        load_address: 0x400000,
-   ⋮        has_symbols: true,
-   ⋮        has_debug_info: false,
-   ⋮        has_unwind_info: true,
-   ⋮        is_malformed: false,
-   ⋮    },
-   ⋮)
+    Elf(
+        ElfObject {
+            code_id: Some(
+                CodeId(f1c3bcc0279865fe3058404b2831d9e64135386c),
+            ),
+            debug_id: DebugId {
+                uuid: "c0bcc3f1-9827-fe65-3058-404b2831d9e6",
+                appendix: 0,
+            },
+            arch: Amd64,
+            kind: Executable,
+            load_address: 0x400000,
+            has_symbols: true,
+            has_debug_info: false,
+            has_unwind_info: true,
+            is_malformed: false,
+        },
+    )
     "#);
 
     Ok(())
@@ -238,24 +238,24 @@ fn test_elf_debug() -> Result<(), Error> {
     let object = Object::parse(&view)?;
 
     insta::assert_debug_snapshot!(object, @r#"
-   ⋮Elf(
-   ⋮    ElfObject {
-   ⋮        code_id: Some(
-   ⋮            CodeId(f1c3bcc0279865fe3058404b2831d9e64135386c),
-   ⋮        ),
-   ⋮        debug_id: DebugId {
-   ⋮            uuid: "c0bcc3f1-9827-fe65-3058-404b2831d9e6",
-   ⋮            appendix: 0,
-   ⋮        },
-   ⋮        arch: Amd64,
-   ⋮        kind: Debug,
-   ⋮        load_address: 0x400000,
-   ⋮        has_symbols: true,
-   ⋮        has_debug_info: true,
-   ⋮        has_unwind_info: false,
-   ⋮        is_malformed: false,
-   ⋮    },
-   ⋮)
+    Elf(
+        ElfObject {
+            code_id: Some(
+                CodeId(f1c3bcc0279865fe3058404b2831d9e64135386c),
+            ),
+            debug_id: DebugId {
+                uuid: "c0bcc3f1-9827-fe65-3058-404b2831d9e6",
+                appendix: 0,
+            },
+            arch: Amd64,
+            kind: Debug,
+            load_address: 0x400000,
+            has_symbols: true,
+            has_debug_info: true,
+            has_unwind_info: false,
+            is_malformed: false,
+        },
+    )
     "#);
 
     Ok(())
@@ -388,24 +388,24 @@ fn test_mach_executable() -> Result<(), Error> {
     let object = Object::parse(&view)?;
 
     insta::assert_debug_snapshot!(object, @r#"
-   ⋮MachO(
-   ⋮    MachObject {
-   ⋮        code_id: Some(
-   ⋮            CodeId(67e9247c814e392ba027dbde6748fcbf),
-   ⋮        ),
-   ⋮        debug_id: DebugId {
-   ⋮            uuid: "67e9247c-814e-392b-a027-dbde6748fcbf",
-   ⋮            appendix: 0,
-   ⋮        },
-   ⋮        arch: Amd64,
-   ⋮        kind: Executable,
-   ⋮        load_address: 0x100000000,
-   ⋮        has_symbols: true,
-   ⋮        has_debug_info: false,
-   ⋮        has_unwind_info: true,
-   ⋮        is_malformed: false,
-   ⋮    },
-   ⋮)
+    MachO(
+        MachObject {
+            code_id: Some(
+                CodeId(67e9247c814e392ba027dbde6748fcbf),
+            ),
+            debug_id: DebugId {
+                uuid: "67e9247c-814e-392b-a027-dbde6748fcbf",
+                appendix: 0,
+            },
+            arch: Amd64,
+            kind: Executable,
+            load_address: 0x100000000,
+            has_symbols: true,
+            has_debug_info: false,
+            has_unwind_info: true,
+            is_malformed: false,
+        },
+    )
     "#);
 
     Ok(())
@@ -417,24 +417,24 @@ fn test_mach_dsym() -> Result<(), Error> {
     let object = Object::parse(&view)?;
 
     insta::assert_debug_snapshot!(object, @r#"
-   ⋮MachO(
-   ⋮    MachObject {
-   ⋮        code_id: Some(
-   ⋮            CodeId(67e9247c814e392ba027dbde6748fcbf),
-   ⋮        ),
-   ⋮        debug_id: DebugId {
-   ⋮            uuid: "67e9247c-814e-392b-a027-dbde6748fcbf",
-   ⋮            appendix: 0,
-   ⋮        },
-   ⋮        arch: Amd64,
-   ⋮        kind: Debug,
-   ⋮        load_address: 0x100000000,
-   ⋮        has_symbols: true,
-   ⋮        has_debug_info: true,
-   ⋮        has_unwind_info: false,
-   ⋮        is_malformed: false,
-   ⋮    },
-   ⋮)
+    MachO(
+        MachObject {
+            code_id: Some(
+                CodeId(67e9247c814e392ba027dbde6748fcbf),
+            ),
+            debug_id: DebugId {
+                uuid: "67e9247c-814e-392b-a027-dbde6748fcbf",
+                appendix: 0,
+            },
+            arch: Amd64,
+            kind: Debug,
+            load_address: 0x100000000,
+            has_symbols: true,
+            has_debug_info: true,
+            has_unwind_info: false,
+            is_malformed: false,
+        },
+    )
     "#);
 
     Ok(())
@@ -483,27 +483,27 @@ fn test_pe_32() -> Result<(), Error> {
     let object = Object::parse(&view)?;
 
     insta::assert_debug_snapshot!(object, @r#"
-   ⋮Pe(
-   ⋮    PeObject {
-   ⋮        code_id: Some(
-   ⋮            CodeId(5ab380779000),
-   ⋮        ),
-   ⋮        debug_id: DebugId {
-   ⋮            uuid: "3249d99d-0c40-4931-8610-f4e4fb0b6936",
-   ⋮            appendix: 1,
-   ⋮        },
-   ⋮        debug_file_name: Some(
-   ⋮            "C:\\projects\\breakpad-tools\\windows\\Release\\crash.pdb",
-   ⋮        ),
-   ⋮        arch: X86,
-   ⋮        kind: Executable,
-   ⋮        load_address: 0x400000,
-   ⋮        has_symbols: false,
-   ⋮        has_debug_info: false,
-   ⋮        has_unwind_info: false,
-   ⋮        is_malformed: false,
-   ⋮    },
-   ⋮)
+    Pe(
+        PeObject {
+            code_id: Some(
+                CodeId(5ab380779000),
+            ),
+            debug_id: DebugId {
+                uuid: "3249d99d-0c40-4931-8610-f4e4fb0b6936",
+                appendix: 1,
+            },
+            debug_file_name: Some(
+                "C:\\projects\\breakpad-tools\\windows\\Release\\crash.pdb",
+            ),
+            arch: X86,
+            kind: Executable,
+            load_address: 0x400000,
+            has_symbols: false,
+            has_debug_info: false,
+            has_unwind_info: false,
+            is_malformed: false,
+        },
+    )
     "#);
 
     Ok(())
@@ -515,27 +515,27 @@ fn test_pe_64() -> Result<(), Error> {
     let object = Object::parse(&view)?;
 
     insta::assert_debug_snapshot!(object, @r#"
-   ⋮Pe(
-   ⋮    PeObject {
-   ⋮        code_id: Some(
-   ⋮            CodeId(5c9e09599000),
-   ⋮        ),
-   ⋮        debug_id: DebugId {
-   ⋮            uuid: "f535c5fb-2ae8-4bb8-aa20-6c30be566c5a",
-   ⋮            appendix: 1,
-   ⋮        },
-   ⋮        debug_file_name: Some(
-   ⋮            "C:\\Users\\sentry\\source\\repos\\CrashWithException\\x64\\Release\\CrashWithException.pdb",
-   ⋮        ),
-   ⋮        arch: Amd64,
-   ⋮        kind: Executable,
-   ⋮        load_address: 0x140000000,
-   ⋮        has_symbols: false,
-   ⋮        has_debug_info: false,
-   ⋮        has_unwind_info: true,
-   ⋮        is_malformed: false,
-   ⋮    },
-   ⋮)
+    Pe(
+        PeObject {
+            code_id: Some(
+                CodeId(5c9e09599000),
+            ),
+            debug_id: DebugId {
+                uuid: "f535c5fb-2ae8-4bb8-aa20-6c30be566c5a",
+                appendix: 1,
+            },
+            debug_file_name: Some(
+                "C:\\Users\\sentry\\source\\repos\\CrashWithException\\x64\\Release\\CrashWithException.pdb",
+            ),
+            arch: Amd64,
+            kind: Executable,
+            load_address: 0x140000000,
+            has_symbols: false,
+            has_debug_info: false,
+            has_unwind_info: true,
+            is_malformed: false,
+        },
+    )
     "#);
 
     Ok(())
@@ -613,20 +613,20 @@ fn test_pdb() -> Result<(), Error> {
     let object = Object::parse(&view)?;
 
     insta::assert_debug_snapshot!(object, @r#"
-   ⋮Pdb(
-   ⋮    PdbObject {
-   ⋮        debug_id: DebugId {
-   ⋮            uuid: "3249d99d-0c40-4931-8610-f4e4fb0b6936",
-   ⋮            appendix: 1,
-   ⋮        },
-   ⋮        arch: X86,
-   ⋮        load_address: 0x0,
-   ⋮        has_symbols: true,
-   ⋮        has_debug_info: true,
-   ⋮        has_unwind_info: true,
-   ⋮        is_malformed: false,
-   ⋮    },
-   ⋮)
+    Pdb(
+        PdbObject {
+            debug_id: DebugId {
+                uuid: "3249d99d-0c40-4931-8610-f4e4fb0b6936",
+                appendix: 1,
+            },
+            arch: X86,
+            load_address: 0x0,
+            has_symbols: true,
+            has_debug_info: true,
+            has_unwind_info: true,
+            is_malformed: false,
+        },
+    )
     "#);
 
     Ok(())
@@ -701,29 +701,29 @@ fn test_ppdb() -> Result<(), Error> {
     let object = Object::parse(&view)?;
 
     insta::assert_debug_snapshot!(object, @r#"
-    ⋮PortablePdb(
-    ⋮    PortablePdbObject {
-    ⋮        portable_pdb: PortablePdb {
-    ⋮            header: Header {
-    ⋮                signature: 1112167234,
-    ⋮                major_version: 1,
-    ⋮                minor_version: 1,
-    ⋮                version_length: 12,
-    ⋮            },
-    ⋮            version_string: "PDB v1.0",
-    ⋮            header2: HeaderPart2 {
-    ⋮                flags: 0,
-    ⋮                streams: 6,
-    ⋮            },
-    ⋮            has_pdb_stream: true,
-    ⋮            has_table_stream: true,
-    ⋮            has_string_stream: true,
-    ⋮            has_us_stream: true,
-    ⋮            has_blob_stream: true,
-    ⋮            has_guid_stream: true,
-    ⋮        },
-    ⋮    },
-    ⋮)
+    PortablePdb(
+        PortablePdbObject {
+            portable_pdb: PortablePdb {
+                header: Header {
+                    signature: 1112167234,
+                    major_version: 1,
+                    minor_version: 1,
+                    version_length: 12,
+                },
+                version_string: "PDB v1.0",
+                header2: HeaderPart2 {
+                    flags: 0,
+                    streams: 6,
+                },
+                has_pdb_stream: true,
+                has_table_stream: true,
+                has_string_stream: true,
+                has_us_stream: true,
+                has_blob_stream: true,
+                has_guid_stream: true,
+            },
+        },
+    )
     "#);
 
     Ok(())

--- a/symbolic-symcache/tests/snapshots/test_cache__functions_linux.snap
+++ b/symbolic-symcache/tests/snapshots/test_cache__functions_linux.snap
@@ -1,7 +1,6 @@
 ---
 source: symbolic-symcache/tests/test_cache.rs
 expression: FunctionsDebug(&symcache)
-
 ---
             1558 _init
             1900 _ZN15google_breakpad13PageAllocator7FreeAllEv.isra.6
@@ -170,4 +169,3 @@ expression: FunctionsDebug(&symcache)
            14c30 __libc_csu_init
            14ca0 __libc_csu_fini
            14ca4 _fini
-

--- a/symbolic-symcache/tests/snapshots/test_cache__functions_macos.snap
+++ b/symbolic-symcache/tests/snapshots/test_cache__functions_macos.snap
@@ -1,7 +1,6 @@
 ---
 source: symbolic-symcache/tests/test_cache.rs
 expression: FunctionsDebug(&symcache)
-
 ---
                0 _mh_execute_header
              d20 _ZN15google_breakpad18MinidumpFileWriterC2Ev
@@ -198,4 +197,3 @@ expression: FunctionsDebug(&symcache)
             db50 _ZN15google_breakpad14MachPortSender11SendMessageERNS_15MachSendMessageEj
             dba0 main
             dc70 _ZN12_GLOBAL__N_18callbackEPKcS1_Pvb
-

--- a/symbolic-symcache/tests/snapshots/test_cache__lookup.snap
+++ b/symbolic-symcache/tests/snapshots/test_cache__lookup.snap
@@ -1,7 +1,6 @@
 ---
 source: symbolic-symcache/tests/test_cache.rs
 expression: result
-
 ---
 [
     (

--- a/symbolic-symcache/tests/snapshots/test_writer__functions_macos.snap
+++ b/symbolic-symcache/tests/snapshots/test_writer__functions_macos.snap
@@ -1,7 +1,6 @@
 ---
 source: symbolic-symcache/tests/test_writer.rs
 expression: FunctionsDebug(&symcache)
-
 ---
                0 _mh_execute_header
              d20 _ZN15google_breakpad18MinidumpFileWriterC2Ev
@@ -198,4 +197,3 @@ expression: FunctionsDebug(&symcache)
             db50 _ZN15google_breakpad14MachPortSender11SendMessageERNS_15MachSendMessageEj
             dba0 main
             dc70 _ZN12_GLOBAL__N_18callbackEPKcS1_Pvb
-

--- a/symbolic-symcache/tests/snapshots/test_writer__overlapping_funcs.snap
+++ b/symbolic-symcache/tests/snapshots/test_writer__overlapping_funcs.snap
@@ -1,7 +1,6 @@
 ---
 source: symbolic-symcache/tests/test_writer.rs
 expression: FunctionsDebug(&symcache)
-
 ---
                0 _mh_execute_header
             3f50 main
@@ -9,4 +8,3 @@ expression: FunctionsDebug(&symcache)
             3f90 unique_i_swear
             3fa0 spin
             3fb0 unique_i_swear
-

--- a/symbolic-symcache/tests/test_writer.rs
+++ b/symbolic-symcache/tests/test_writer.rs
@@ -23,7 +23,7 @@ fn test_write_header_linux() -> Result<(), Error> {
     }
 
     let symcache = SymCache::parse(&buffer)?;
-    insta::assert_debug_snapshot!(symcache, @r###"
+    insta::assert_debug_snapshot!(symcache, @r#"
     SymCache {
         version: 8,
         debug_id: DebugId {
@@ -37,7 +37,7 @@ fn test_write_header_linux() -> Result<(), Error> {
         ranges: 6975,
         string_bytes: 49877,
     }
-    "###);
+    "#);
 
     Ok(())
 }
@@ -67,7 +67,7 @@ fn test_write_header_macos() -> Result<(), Error> {
     converter.process_object(&object)?;
     converter.serialize(&mut Cursor::new(&mut buffer))?;
     let symcache = SymCache::parse(&buffer)?;
-    insta::assert_debug_snapshot!(symcache, @r###"
+    insta::assert_debug_snapshot!(symcache, @r#"
     SymCache {
         version: 8,
         debug_id: DebugId {
@@ -81,7 +81,7 @@ fn test_write_header_macos() -> Result<(), Error> {
         ranges: 5965,
         string_bytes: 40958,
     }
-    "###);
+    "#);
 
     Ok(())
 }


### PR DESCRIPTION
* Bump MSRV to 1.82 in the docs to actual latest MSRV that code compiles with.
* Update the insta snapshot to fix the warning when tests are running.