### PR TITLE
build: switch to python3.11 for releases builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - python bindings: Expose SourceMapView.get_source_contents function. ([#921](https://github.com/getsentry/symbolic/pull/921))
 - Change the MSRV version to 1.82. ([#927](https://github.com/getsentry/symbolic/pull/927))
+- build: switch to python3.11 for releases builds([#929](https://github.com/getsentry/symbolic/pull/929))
 
 **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - python bindings: Expose SourceMapView.get_source_contents function. ([#921](https://github.com/getsentry/symbolic/pull/921))
 - Change the MSRV version to 1.82. ([#927](https://github.com/getsentry/symbolic/pull/927))
-- build: switch to python3.11 for releases builds([#929](https://github.com/getsentry/symbolic/pull/929))
+- build: switch to Python3.11 for releases builds. ([#929](https://github.com/getsentry/symbolic/pull/929))
 
 **Fixes**
 

--- a/py/manylinux.sh
+++ b/py/manylinux.sh
@@ -4,8 +4,13 @@ set -e
 # Install dependencies needed by our wheel
 yum -y -q -e 0 install gcc libffi-devel
 
-# upgrade wheel
+# Upgrade wheel
 /opt/python/cp311-cp311/bin/pip install --upgrade wheel
+# Milksnake 0.1.6 relies on CFFI.
+# Python 3.11 has some known compatibility issues with older versions of CFFI,
+# leading to errors during usage of milksnake.
+# Upgrade CFFI to latest and fresh version
+/opt/python/cp311-cp311/bin/pip install --upgrade cffi
 
 # Install Rust
 curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/py/manylinux.sh
+++ b/py/manylinux.sh
@@ -5,21 +5,21 @@ set -e
 yum -y -q -e 0 install gcc libffi-devel
 
 # upgrade wheel
-/opt/python/cp36-cp36m/bin/pip install --upgrade wheel
+/opt/python/cp311-cp311/bin/pip install --upgrade wheel
 
 # Install Rust
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 export PATH=~/.cargo/bin:$PATH
 
-cat > ~/.cargo/config <<EOF
+cat >~/.cargo/config <<EOF
 [net]
 git-fetch-with-cli = true
 EOF
 
-/opt/python/cp36-cp36m/bin/python setup.py bdist_wheel
+/opt/python/cp311-cp311/bin/python setup.py bdist_wheel
 
 # Audit wheels
 for wheel in dist/*-linux_*.whl; do
-  auditwheel repair "$wheel" -w dist/
-  rm "$wheel"
+	auditwheel repair "$wheel" -w dist/
+	rm "$wheel"
 done

--- a/py/manylinux.sh
+++ b/py/manylinux.sh
@@ -6,11 +6,6 @@ yum -y -q -e 0 install gcc libffi-devel
 
 # Upgrade wheel
 /opt/python/cp311-cp311/bin/pip install --upgrade wheel
-# Milksnake 0.1.6 relies on CFFI.
-# Python 3.11 has some known compatibility issues with older versions of CFFI,
-# leading to errors during usage of milksnake.
-# Upgrade CFFI to latest and fresh version
-/opt/python/cp311-cp311/bin/pip install --upgrade cffi
 
 # Install Rust
 curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/py/setup.py
+++ b/py/setup.py
@@ -111,7 +111,12 @@ setup(
     zip_safe=False,
     platforms="any",
     install_requires=["milksnake>=0.1.2"],
-    setup_requires=["milksnake>=0.1.2"],
+    # Specify transitive dependencies manually that are required for the build because
+    # they are not resolved properly since upgrading to python 3.11 in manylinux.
+    # milksnake -> cffi -> pycparser
+    # milksnake specifies cffi>=1.6.0 as dependency while cffi does not specify a
+    # minimum version for pycparser
+    setup_requires=["milksnake>=0.1.2", "cffi>=1.6.0", "pycparser"],
     python_requires=">=3.8",
     milksnake_tasks=[build_native],
     cmdclass={"sdist": CustomSDist},


### PR DESCRIPTION
Python 3.6 was removed from the image, and is not longer available. 
Switching to Python 3.11 for build releases. 