### PR TITLE
fix(symcache): Correctly insert functions without line records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**
+
+- symcache: Fixed a bug in symcache generation for functions without line records. ([#930](https://github.com/getsentry/symbolic/pull/930))
+
 ## 12.16.0
 
 **Features**


### PR DESCRIPTION
https://github.com/getsentry/symbolic/pull/897 introduced a bug where functions without line records wouldn't correctly overwrite the previous function's end marker. This PR fixes the bug and factors the logic out into a function.

Closes INGEST-472.