### PR TITLE
fix(sourcemapcache): Tokens only extend to the end of the line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**
+
+- sourcemapcache: Tokens are now considered to only extend to the end of the line
+  (as intended). This means that some lookups that would previously (incorrectly)
+  have returned unminified source positions now return nothing. ([#932](https://github.com/getsentry/symbolic/pull/932))
+
 ## 12.16.1
 
 **Fixes**

--- a/symbolic-sourcemapcache/src/lookup.rs
+++ b/symbolic-sourcemapcache/src/lookup.rs
@@ -177,6 +177,13 @@ impl<'data> SourceMapCache<'data> {
             Err(idx) => idx - 1,
         };
 
+        // If the token has a lower minified line number,
+        // it actually belongs to the previous line. That means it should
+        // not match.
+        if self.min_source_positions.get(idx)?.line < sp.line {
+            return None;
+        }
+
         let sl = self.orig_source_locations.get(idx)?;
 
         // If file, line, and column are all absent (== `u32::MAX`), this location is simply unmapped.

--- a/symbolic-sourcemapcache/tests/integration.rs
+++ b/symbolic-sourcemapcache/tests/integration.rs
@@ -38,6 +38,9 @@ fn resolves_inlined_function() {
     assert_eq!(sl.line(), 1);
     assert_eq!(sl.column(), 8);
     assert_eq!(sl.scope(), ScopeLookupResult::AnonymousScope);
+
+    // There are no mappings for line 1 in the sourcemap.
+    assert!(cache.lookup(SourcePosition::new(1, 17)).is_none());
 }
 
 #[test]


### PR DESCRIPTION
Previously, when looking up a line and column, we would always return the token at or immediately before that position, even if it belonged to an earlier minified line. This is
1. wrong—tokens are only meant to extend to the end of a line.
2. inconsistent—this means that an unmapped line before any mapped line
   would return no mapping, but an unmapped line after a mapped line
   would.