### PR TITLE
ci(changelog): Allow skipping changelog with label

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -2,7 +2,7 @@ name: Danger
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited, ready_for_review]
+    types: [opened, synchronize, reopened, edited, ready_for_review, labeled, unlabeled]
 
 jobs:
   danger:


### PR DESCRIPTION
As of https://github.com/getsentry/github-workflows/pull/94 the `danger` workflow supports skipping the changelog check with a `skip-changelog` label. To make this work the `danger` job needs to run when a PR is labeled or unlabeled.