### PR TITLE
fix: Revert "release: 12.6.2"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 12.6.2
+## Unreleased
 
 **Fixes**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "debuginfo_debug"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "dump_cfi"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "dump_sources"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "clap",
  "symbolic",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "minidump_stackwalk"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "object_debug"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "clap",
  "symbolic",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "sourcemapcache_debug"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "symbolic-cfi",
  "symbolic-common",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-cabi"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "proguard",
  "sourcemap",
@@ -2427,7 +2427,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-cfi"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "insta",
  "similar-asserts",
@@ -2439,7 +2439,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "debugid",
  "memmap2",
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-debuginfo"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "criterion",
  "debugid",
@@ -2489,7 +2489,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "cc",
  "cpp_demangle",
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-il2cpp"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "indexmap",
  "serde_json",
@@ -2511,7 +2511,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-ppdb"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "flate2",
  "indexmap",
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-sourcemapcache"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "itertools 0.13.0",
  "js-source-scopes",
@@ -2541,7 +2541,7 @@ dependencies = [
 
 [[package]]
 name = "symbolic-symcache"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "criterion",
  "indexmap",
@@ -2557,11 +2557,11 @@ dependencies = [
 
 [[package]]
 name = "symbolic-testutils"
-version = "12.6.2"
+version = "12.16.1"
 
 [[package]]
 name = "symbolic-unreal"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "anylog",
  "bytes",
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "symcache_debug"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2863,7 +2863,7 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unreal_engine_crash"
-version = "12.6.2"
+version = "12.16.1"
 dependencies = [
  "clap",
  "symbolic",

--- a/examples/addr2line/Cargo.toml
+++ b/examples/addr2line/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "addr2line"
-version = "12.6.2"
+version = "12.16.1"
 authors = ["Jan Michael Auer <mail@jauer.org>"]
 edition = "2021"
 publish = false
@@ -10,4 +10,4 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-symbolic = { version = "12.6.2", path = "../../symbolic", features = ["demangle"] }
+symbolic = { version = "12.16.1", path = "../../symbolic", features = ["demangle"] }

--- a/examples/debuginfo_debug/Cargo.toml
+++ b/examples/debuginfo_debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "debuginfo_debug"
-version = "12.6.2"
+version = "12.16.1"
 authors = ["Markus Stange <mstange.moz@gmail.com>"]
 edition = "2021"
 publish = false
@@ -10,6 +10,6 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-symbolic = { version = "12.6.2", path = "../../symbolic", features = [
+symbolic = { version = "12.16.1", path = "../../symbolic", features = [
     "demangle",
 ] }

--- a/examples/dump_cfi/Cargo.toml
+++ b/examples/dump_cfi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dump_cfi"
-version = "12.6.2"
+version = "12.16.1"
 authors = ["Jan Michael Auer <mail@jauer.org>"]
 edition = "2021"
 publish = false
@@ -10,4 +10,4 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-symbolic = { version = "12.6.2", path = "../../symbolic", features = ["cfi"] }
+symbolic = { version = "12.16.1", path = "../../symbolic", features = ["cfi"] }

--- a/examples/dump_sources/Cargo.toml
+++ b/examples/dump_sources/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dump_sources"
-version = "12.6.2"
+version = "12.16.1"
 authors = ["Jan Michael Auer <mail@jauer.org>"]
 edition = "2021"
 publish = false
@@ -9,4 +9,4 @@ publish = false
 
 [dependencies]
 clap = { workspace = true }
-symbolic = { version = "12.6.2", path = "../../symbolic" }
+symbolic = { version = "12.16.1", path = "../../symbolic" }

--- a/examples/minidump_stackwalk/Cargo.toml
+++ b/examples/minidump_stackwalk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minidump_stackwalk"
-version = "12.6.2"
+version = "12.16.1"
 authors = ["Jan Michael Auer <mail@jauer.org>"]
 edition = "2021"
 publish = false
@@ -13,7 +13,7 @@ clap = { workspace = true }
 minidump = { workspace = true }
 minidump-processor = { workspace = true }
 minidump-unwind = { workspace = true }
-symbolic = { version = "12.6.2", path = "../../symbolic", features = [
+symbolic = { version = "12.16.1", path = "../../symbolic", features = [
     "symcache",
     "demangle",
     "cfi",

--- a/examples/object_debug/Cargo.toml
+++ b/examples/object_debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "object_debug"
-version = "12.6.2"
+version = "12.16.1"
 authors = ["Jan Michael Auer <mail@jauer.org>"]
 edition = "2021"
 publish = false
@@ -9,4 +9,4 @@ publish = false
 
 [dependencies]
 clap = { workspace = true }
-symbolic = { version = "12.6.2", path = "../../symbolic" }
+symbolic = { version = "12.16.1", path = "../../symbolic" }

--- a/examples/sourcemapcache_debug/Cargo.toml
+++ b/examples/sourcemapcache_debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourcemapcache_debug"
-version = "12.6.2"
+version = "12.16.1"
 authors = ["Sentry <hello@sentry.io>"]
 edition = "2021"
 publish = false
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-symbolic = { version = "12.6.2", path = "../../symbolic", features = [
+symbolic = { version = "12.16.1", path = "../../symbolic", features = [
     "sourcemapcache",
 ] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/examples/symcache_debug/Cargo.toml
+++ b/examples/symcache_debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symcache_debug"
-version = "12.6.2"
+version = "12.16.1"
 authors = ["Jan Michael Auer <mail@jauer.org>"]
 edition = "2021"
 publish = false
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-symbolic = { version = "12.6.2", path = "../../symbolic", features = [
+symbolic = { version = "12.16.1", path = "../../symbolic", features = [
     "symcache",
     "demangle",
     "il2cpp",

--- a/examples/unreal_engine_crash/Cargo.toml
+++ b/examples/unreal_engine_crash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unreal_engine_crash"
-version = "12.6.2"
+version = "12.16.1"
 authors = ["Jan Michael Auer <mail@jauer.org>"]
 edition = "2021"
 publish = false
@@ -9,6 +9,6 @@ publish = false
 
 [dependencies]
 clap = { workspace = true }
-symbolic = { version = "12.6.2", path = "../../symbolic", features = [
+symbolic = { version = "12.16.1", path = "../../symbolic", features = [
     "unreal",
 ] }

--- a/symbolic-cabi/Cargo.toml
+++ b/symbolic-cabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-cabi"
-version = "12.6.2"
+version = "12.16.1"
 license = "MIT"
 authors = [
     "Armin Ronacher <armin.ronacher@active-4.com>",
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 [dependencies]
 proguard = { workspace = true, features = ["uuid"] }
 sourcemap = { workspace = true }
-symbolic = { version = "12.6.2", path = "../symbolic", features = [
+symbolic = { version = "12.16.1", path = "../symbolic", features = [
     "cfi",
     "debuginfo",
     "sourcemapcache",

--- a/symbolic-cfi/Cargo.toml
+++ b/symbolic-cfi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-cfi"
-version = "12.6.2"
+version = "12.16.1"
 license = "MIT"
 authors = [
     "Armin Ronacher <armin.ronacher@active-4.com>",
@@ -16,8 +16,8 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-symbolic-common = { version = "12.6.2", path = "../symbolic-common" }
-symbolic-debuginfo = { version = "12.6.2", path = "../symbolic-debuginfo" }
+symbolic-common = { version = "12.16.1", path = "../symbolic-common" }
+symbolic-debuginfo = { version = "12.16.1", path = "../symbolic-debuginfo" }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/symbolic-common/Cargo.toml
+++ b/symbolic-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-common"
-version = "12.6.2"
+version = "12.16.1"
 license = "MIT"
 authors = [
     "Armin Ronacher <armin.ronacher@active-4.com>",

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-debuginfo"
-version = "12.6.2"
+version = "12.16.1"
 license = "MIT"
 authors = [
     "Armin Ronacher <armin.ronacher@active-4.com>",
@@ -106,8 +106,8 @@ scroll = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 smallvec = { workspace = true, optional = true }
-symbolic-common = { version = "12.6.2", path = "../symbolic-common" }
-symbolic-ppdb = { version = "12.6.2", path = "../symbolic-ppdb", optional = true }
+symbolic-common = { version = "12.16.1", path = "../symbolic-common" }
+symbolic-ppdb = { version = "12.16.1", path = "../symbolic-ppdb", optional = true }
 thiserror = { workspace = true }
 wasmparser = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }

--- a/symbolic-debuginfo/fuzz/Cargo.toml
+++ b/symbolic-debuginfo/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-debuginfo-fuzz"
-version = "12.6.2"
+version = "12.16.1"
 authors = ["Automatically generated"]
 publish = false
 edition = "2021"

--- a/symbolic-demangle/Cargo.toml
+++ b/symbolic-demangle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-demangle"
-version = "12.6.2"
+version = "12.16.1"
 license = "MIT"
 authors = [
     "Armin Ronacher <armin.ronacher@active-4.com>",
@@ -33,7 +33,7 @@ swift = ["cc"]
 cpp_demangle = { workspace = true, optional = true }
 msvc-demangler = { workspace = true, optional = true }
 rustc-demangle = { workspace = true, optional = true }
-symbolic-common = { version = "12.6.2", path = "../symbolic-common" }
+symbolic-common = { version = "12.16.1", path = "../symbolic-common" }
 
 [build-dependencies]
 cc = { workspace = true, optional = true }

--- a/symbolic-il2cpp/Cargo.toml
+++ b/symbolic-il2cpp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-il2cpp"
-version = "12.6.2"
+version = "12.16.1"
 license = "MIT"
 authors = ["Sentry <hello@sentry.io>"]
 documentation = "https://docs.rs/symbolic-il2cpp"
@@ -15,5 +15,5 @@ rust-version.workspace = true
 [dependencies]
 indexmap = { workspace = true }
 serde_json = { workspace = true }
-symbolic-common = { version = "12.6.2", path = "../symbolic-common" }
-symbolic-debuginfo = { version = "12.6.2", path = "../symbolic-debuginfo" }
+symbolic-common = { version = "12.16.1", path = "../symbolic-common" }
+symbolic-debuginfo = { version = "12.16.1", path = "../symbolic-debuginfo" }

--- a/symbolic-ppdb/Cargo.toml
+++ b/symbolic-ppdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-ppdb"
-version = "12.6.2"
+version = "12.16.1"
 license = "MIT"
 authors = [
     "Sebastian Zivota <sebastian.zivota@sentry.io>",
@@ -25,7 +25,7 @@ flate2 = { workspace = true }
 indexmap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-symbolic-common = { version = "12.6.2", path = "../symbolic-common" }
+symbolic-common = { version = "12.16.1", path = "../symbolic-common" }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 watto = { workspace = true }

--- a/symbolic-ppdb/fuzz/Cargo.toml
+++ b/symbolic-ppdb/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-ppdb-fuzz"
-version = "12.6.2"
+version = "12.16.1"
 authors = ["Automatically generated"]
 publish = false
 edition = "2021"

--- a/symbolic-sourcemapcache/Cargo.toml
+++ b/symbolic-sourcemapcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-sourcemapcache"
-version = "12.6.2"
+version = "12.16.1"
 license = "MIT"
 authors = ["Sentry <hello@sentry.io>"]
 documentation = "https://docs.rs/symbolic-sourcemapcache"
@@ -15,7 +15,7 @@ edition = "2021"
 itertools = { workspace = true }
 js-source-scopes = { workspace = true }
 sourcemap = { workspace = true }
-symbolic-common = { version = "12.6.2", path = "../symbolic-common" }
+symbolic-common = { version = "12.16.1", path = "../symbolic-common" }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 watto = { workspace = true }

--- a/symbolic-symcache/Cargo.toml
+++ b/symbolic-symcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-symcache"
-version = "12.6.2"
+version = "12.16.1"
 license = "MIT"
 authors = [
     "Armin Ronacher <armin.ronacher@active-4.com>",
@@ -23,9 +23,9 @@ all-features = true
 
 [dependencies]
 indexmap = { workspace = true }
-symbolic-common = { version = "12.6.2", path = "../symbolic-common" }
-symbolic-debuginfo = { version = "12.6.2", path = "../symbolic-debuginfo" }
-symbolic-il2cpp = { version = "12.6.2", path = "../symbolic-il2cpp", optional = true }
+symbolic-common = { version = "12.16.1", path = "../symbolic-common" }
+symbolic-debuginfo = { version = "12.16.1", path = "../symbolic-debuginfo" }
+symbolic-il2cpp = { version = "12.16.1", path = "../symbolic-il2cpp", optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 watto = { workspace = true }

--- a/symbolic-testutils/Cargo.toml
+++ b/symbolic-testutils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-testutils"
-version = "12.6.2"
+version = "12.16.1"
 license = "MIT"
 edition = "2021"
 publish = false

--- a/symbolic-unreal/Cargo.toml
+++ b/symbolic-unreal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-unreal"
-version = "12.6.2"
+version = "12.16.1"
 license = "MIT"
 authors = [
     "Armin Ronacher <armin.ronacher@active-4.com>",

--- a/symbolic/Cargo.toml
+++ b/symbolic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic"
-version = "12.6.2"
+version = "12.16.1"
 license = "MIT"
 authors = [
     "Armin Ronacher <armin.ronacher@active-4.com>",
@@ -35,12 +35,12 @@ unreal = ["symbolic-unreal"]
 unreal-serde = ["unreal", "common-serde", "symbolic-unreal/serde"]
 
 [dependencies]
-symbolic-cfi = { version = "12.6.2", path = "../symbolic-cfi", optional = true }
-symbolic-common = { version = "12.6.2", path = "../symbolic-common" }
-symbolic-debuginfo = { version = "12.6.2", path = "../symbolic-debuginfo", optional = true }
-symbolic-demangle = { version = "12.6.2", path = "../symbolic-demangle", optional = true }
-symbolic-il2cpp = { version = "12.6.2", path = "../symbolic-il2cpp", optional = true }
-symbolic-ppdb = { version = "12.6.2", path = "../symbolic-ppdb", optional = true }
-symbolic-sourcemapcache = { version = "12.6.2", path = "../symbolic-sourcemapcache", optional = true }
-symbolic-symcache = { version = "12.6.2", path = "../symbolic-symcache", optional = true }
-symbolic-unreal = { version = "12.6.2", path = "../symbolic-unreal", optional = true }
+symbolic-cfi = { version = "12.16.1", path = "../symbolic-cfi", optional = true }
+symbolic-common = { version = "12.16.1", path = "../symbolic-common" }
+symbolic-debuginfo = { version = "12.16.1", path = "../symbolic-debuginfo", optional = true }
+symbolic-demangle = { version = "12.16.1", path = "../symbolic-demangle", optional = true }
+symbolic-il2cpp = { version = "12.16.1", path = "../symbolic-il2cpp", optional = true }
+symbolic-ppdb = { version = "12.16.1", path = "../symbolic-ppdb", optional = true }
+symbolic-sourcemapcache = { version = "12.16.1", path = "../symbolic-sourcemapcache", optional = true }
+symbolic-symcache = { version = "12.16.1", path = "../symbolic-symcache", optional = true }
+symbolic-unreal = { version = "12.16.1", path = "../symbolic-unreal", optional = true }


### PR DESCRIPTION
This reverts commits e68fbb70e7902a5e74ef17ae14b910c5353188fd and 9fe2438868ddf991a187930928bcfc9f17e4c668.

I mistakenly released master as `12.6.2` instead of `12.16.2`.