### PR TITLE
fix(dwarf): Allow -2 as a tombstone address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- feat(elf): Added support for dynamic symbols when DYNAMIC segment is missing ([#935](https://github.com/getsentry/symbolic/pull/935))
+- feat(elf): Added support for dynamic symbols when DYNAMIC segment is missing. ([#935](https://github.com/getsentry/symbolic/pull/935))
+- fix(dwarf): -2 is now an allowed tombstone address in some DWARF sections.
+  For details, see https://github.com/gimli-rs/gimli/pull/791. ([#937](https://github.com/getsentry/symbolic/pull/937)).
 
 ## 12.16.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli",
+ "gimli 0.31.1",
 ]
 
 [[package]]
@@ -799,6 +799,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator 0.3.0",
  "stable_deref_trait",
@@ -2461,7 +2467,7 @@ dependencies = [
  "elsa",
  "fallible-iterator 0.3.0",
  "flate2",
- "gimli",
+ "gimli 0.32.3",
  "goblin",
  "insta",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ fallible-iterator = "0.3.0"
 flate2 = { version = "1.0.25", default-features = false, features = [
   "rust_backend",
 ] }
-gimli = { version = "0.31.0", default-features = false, features = [
+gimli = { version = "0.32.3", default-features = false, features = [
   "read",
   "std",
   "fallible-iterator",

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -1097,6 +1097,8 @@ struct DwarfSections<'data> {
     debug_str_offsets: DwarfSectionData<'data, gimli::read::DebugStrOffsets<Slice<'data>>>,
     debug_ranges: DwarfSectionData<'data, gimli::read::DebugRanges<Slice<'data>>>,
     debug_rnglists: DwarfSectionData<'data, gimli::read::DebugRngLists<Slice<'data>>>,
+    debug_macinfo: DwarfSectionData<'data, gimli::read::DebugMacinfo<Slice<'data>>>,
+    debug_macro: DwarfSectionData<'data, gimli::read::DebugMacro<Slice<'data>>>,
 }
 
 impl<'data> DwarfSections<'data> {
@@ -1116,6 +1118,8 @@ impl<'data> DwarfSections<'data> {
             debug_str_offsets: DwarfSectionData::load(dwarf),
             debug_ranges: DwarfSectionData::load(dwarf),
             debug_rnglists: DwarfSectionData::load(dwarf),
+            debug_macinfo: DwarfSectionData::load(dwarf),
+            debug_macro: DwarfSectionData::load(dwarf),
         }
     }
 }
@@ -1156,6 +1160,8 @@ impl<'d> DwarfInfo<'d> {
             debug_str: sections.debug_str.to_gimli(),
             debug_str_offsets: sections.debug_str_offsets.to_gimli(),
             debug_types: Default::default(),
+            debug_macinfo: sections.debug_macinfo.to_gimli(),
+            debug_macro: sections.debug_macro.to_gimli(),
             locations: Default::default(),
             ranges: RangeLists::new(
                 sections.debug_ranges.to_gimli(),


### PR DESCRIPTION
This updates the `gimli` dependency to give us access to https://github.com/gimli-rs/gimli/pull/791, in which the address -2 is allowed as a tombstone address in some DWARF files sections. This lets us extract debug info from some DWARF files that we couldn't handle before.

ref: INGEST-451