### PR TITLE
build: Pin manylinux version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
 
 env:
   MANYLINUX_VERSION: manylinux_2_28
+  # Pinned to 2025.08.15-1 since manylinux 2025.08.22 onward removes setuptools
+  MANYLINUX_PIN: 2025.08.15-1
 
 jobs:
   python-wheel-mac:
@@ -60,12 +62,12 @@ jobs:
 
       - if: matrix.build-arch == 'aarch64'
         name: Build in Docker (aarch64)
-        run: make wheel-manylinux-aarch64 IMAGE=messense/"$MANYLINUX_VERSION"-cross:aarch64-amd64
+        run: make wheel-manylinux-aarch64 IMAGE=messense/"$MANYLINUX_VERSION"-cross:aarch64-amd64:"$MANYLINUX_PIN"
 
       - if: matrix.build-arch == 'x86_64'
         name: Build in Docker (x86_64)
-        run: make wheel-manylinux IMAGE=quay.io/pypa/"$MANYLINUX_VERSION"_x86_64
 
+        run: make wheel-manylinux IMAGE=quay.io/pypa/"$MANYLINUX_VERSION"_x86_64:"$MANYLINUX_PIN"
       - uses: actions/upload-artifact@v4
         with:
           name: artifact-linux-${{ matrix.build-arch }}


### PR DESCRIPTION
Inspired by https://github.com/getsentry/relay/pull/5073. Building the image doesn't work with newer `manylinux` versions because they removed `setuptools`.