### PR TITLE
docs(sourcebundle): Fix incomplete sentence

### DIFF
--- a/symbolic-debuginfo/src/sourcebundle/mod.rs
+++ b/symbolic-debuginfo/src/sourcebundle/mod.rs
@@ -1079,7 +1079,7 @@ impl Display for SkippedFileInfo<'_> {
 /// [`add_file`] to add files and finally call [`finish`] to flush the archive to
 /// the underlying writer.
 ///
-/// Note that dropping the writer
+/// Note that dropping the writer without calling [`finish`] will result in an incomplete bundle.
 ///
 /// ```no_run
 /// # use std::fs::File;


### PR DESCRIPTION
The sentence, as written, is incomplete. I asked Cursor to infer what the rest of the sentence should be; this is what it proposed, giving the following justification:

> Looking at the implementation, I can see that:
>
> 1. The `SourceBundleWriter` has a `finish` method (line 1414) that:
>    - Takes `self` by value (consumes the writer)
>    - Writes the manifest
>    - Finalizes the underlying `ZipWriter`
>
> 2. There's **no `Drop` implementation** for `SourceBundleWriter`
>
> 3. The example code explicitly shows calling `bundle.finish()?;` to properly flush the bundle