### PR TITLE
build: Bump js-source-scopes to 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 **Improvements**
-- sourcemapcache: Bump `js-source-scopes` to 0.7.2. This improves name resolution via https://github.com/getsentry/js-source-scopes/pull/35.
+- sourcemapcache: Bump `js-source-scopes` to 0.7.2. This improves name resolution via https://github.com/getsentry/js-source-scopes/pull/35. ([#970](https://github.com/getsentry/symbolic/pull/970))
 
 ## 12.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+**Improvements**
+- sourcemapcache: Bump `js-source-scopes` to 0.7.2. This improves name resolution via https://github.com/getsentry/js-source-scopes/pull/35.
+
 ## 12.18.0
 
 **Improvements**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,9 +1145,9 @@ checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "js-source-scopes"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632e077b0fb37f6476d2fa0e15ee97afcfc2359a1a68b1990d4fa9f82324e3f0"
+checksum = "aad7db26c7e0013043d3f79f3a676305885c73c52a3b97e98d804ef5d6465514"
 dependencies = [
  "indexmap",
  "sourcemap",
@@ -2206,9 +2206,9 @@ dependencies = [
 
 [[package]]
 name = "sourcemap"
-version = "9.2.2"
+version = "9.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22afbcb92ce02d23815b9795523c005cb9d3c214f8b7a66318541c240ea7935"
+checksum = "314d62a489431668f719ada776ca1d49b924db951b7450f8974c9ae51ab05ad7"
 dependencies = [
  "base64-simd",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ goblin = { version = "0.8.0", default-features = false }
 indexmap = "2.0.0"
 insta = { version = "1.28.0", features = ["yaml"] }
 itertools = "0.14.0"
-js-source-scopes = "0.7.0"
+js-source-scopes = "0.7.2"
 memmap2 = "0.9.0"
 minidump = "0.26.1"
 minidump-processor = "0.26.1"


### PR DESCRIPTION
This improves name resolution in `symbolic-sourcemapcache` via https://github.com/getsentry/js-source-scopes/pull/35.