### PR TITLE
build: Downgrade cpp_demangle to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Downgrade `cpp_demangle` version to 0.4.1. Symbolicator is currently dependent on this. ([#972](https://github.com/getsentry/symbolic/pull/972))
+
 ## 12.18.1
 
 **Improvements**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,9 +456,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.5.1"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bytes = "1.4.0"
 cc = "1.0.79"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 clap = "4.4.5"
-cpp_demangle = "0.5.1"
+cpp_demangle = "0.4.1"
 criterion = { version = "0.8.1", features = ["html_reports"] }
 debugid = "0.8.0"
 elementtree = "1.2.3"


### PR DESCRIPTION
Symbolicator depends on a fork that hasn't been updated to 0.5.1 yet.