### PR TITLE
ref(js): Allow magic comments to appear anywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,9 +1243,9 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
@@ -2486,6 +2486,7 @@ dependencies = [
  "gimli 0.32.3",
  "goblin",
  "insta",
+ "memchr",
  "nom",
  "nom-supreme",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ indexmap = "2.0.0"
 insta = { version = "1.28.0", features = ["yaml"] }
 itertools = "0.14.0"
 js-source-scopes = "0.7.2"
+memchr = "2.8.0"
 memmap2 = "0.9.0"
 minidump = "0.26.1"
 minidump-processor = "0.26.1"

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -81,7 +81,7 @@ sourcebundle = [
     "debugid/serde",
 ]
 # JavaScript stuff
-js = []
+js = ["dep:memchr"]
 # WASM processing
 wasm = ["dwarf", "wasmparser"]
 
@@ -93,6 +93,7 @@ fallible-iterator = { workspace = true }
 flate2 = { workspace = true, optional = true }
 gimli = { workspace = true, optional = true }
 goblin = { workspace = true, optional = true }
+memchr = { workspace = true, optional = true }
 once_cell = { workspace = true, optional = true }
 nom = { workspace = true, optional = true }
 nom-supreme = { workspace = true, optional = true }

--- a/symbolic-debuginfo/src/js.rs
+++ b/symbolic-debuginfo/src/js.rs
@@ -12,20 +12,18 @@ use serde::Deserialize;
 ///
 /// Any query string or fragments the URL might contain will be stripped away.
 pub fn discover_sourcemaps_location(contents: &str) -> Option<&str> {
-    let finder = MagicCommentFinder::source_mapping_url().allow_deprecated_at_variant();
+    let url = MagicCommentFinder::source_mapping_url()
+        .allow_deprecated_at_variant()
+        .find(contents)?;
 
-    if let Some(url) = finder.find(contents) {
-        // The URL might contain a query string or fragment. Strip those away before recording the URL.
-        let without_query = url.split_once('?').map(|x| x.0).unwrap_or(url);
-        let without_fragment = without_query
-            .split_once('#')
-            .map(|x| x.0)
-            .unwrap_or(without_query);
+    // The URL might contain a query string or fragment. Strip those away before recording the URL.
+    let without_query = url.split_once('?').map(|x| x.0).unwrap_or(url);
+    let without_fragment = without_query
+        .split_once('#')
+        .map(|x| x.0)
+        .unwrap_or(without_query);
 
-        return Some(without_fragment);
-    }
-
-    None
+    Some(without_fragment)
 }
 
 /// Quickly reads the embedded `debug_id` key from a source map.
@@ -57,7 +55,7 @@ pub fn discover_debug_id(contents: &str) -> Option<DebugId> {
 
 /// A helper utility which allows searching for magic comments in JavaScript sources.
 ///
-/// The finder will optionally consider the `//#` variant as well as the deprecated `//@` variant.
+/// The finder will optionally consider the deprecated `//@` variant in addition to the official `//#` variant.
 ///
 /// Generally considered a magic comment is a comment following the pattern: `//[#@]\s<name>=\s*<value>\s*.*`
 struct MagicCommentFinder<'a> {

--- a/symbolic-debuginfo/src/js.rs
+++ b/symbolic-debuginfo/src/js.rs
@@ -109,11 +109,7 @@ impl<'a> MagicCommentFinder<'a> {
         // Trim whitespaces after the `=`.
         let value = value.trim_ascii_start();
         // Split until the next whitespace:
-        let value = value
-            .split(u8::is_ascii_whitespace)
-            .next()
-            // If there is no whitespace, assume until end.
-            .unwrap_or(value);
+        let value = value.split(u8::is_ascii_whitespace).next()?;
 
         // This should never fail, the input was a valid string, we only trimmed characters in the
         // ascii range.

--- a/symbolic-debuginfo/src/js.rs
+++ b/symbolic-debuginfo/src/js.rs
@@ -119,7 +119,7 @@ impl<'a> MagicCommentFinder<'a> {
 
         // This should never fail, the input was a valid string, we only trimmed characters in the
         // ascii range.
-        str::from_utf8(value).ok()
+        std::str::from_utf8(value).ok()
     }
 }
 

--- a/symbolic-debuginfo/src/js.rs
+++ b/symbolic-debuginfo/src/js.rs
@@ -5,26 +5,26 @@
 //! with source maps this module is insufficient.
 
 use debugid::DebugId;
+use memchr::memmem::FinderRev;
 use serde::Deserialize;
 
 /// Parses a sourceMappingURL comment in a file to discover a sourcemap reference.
 ///
 /// Any query string or fragments the URL might contain will be stripped away.
 pub fn discover_sourcemaps_location(contents: &str) -> Option<&str> {
-    for line in contents.lines().rev() {
-        if line.starts_with("//# sourceMappingURL=") || line.starts_with("//@ sourceMappingURL=") {
-            let url = line[21..].trim();
+    let finder = MagicCommentFinder::source_mapping_url().allow_deprecated_at_variant();
 
-            // The URL might contain a query string or fragment. Strip those away before recording the URL.
-            let without_query = url.split_once('?').map(|x| x.0).unwrap_or(url);
-            let without_fragment = without_query
-                .split_once('#')
-                .map(|x| x.0)
-                .unwrap_or(without_query);
+    if let Some(url) = finder.find(contents) {
+        // The URL might contain a query string or fragment. Strip those away before recording the URL.
+        let without_query = url.split_once('?').map(|x| x.0).unwrap_or(url);
+        let without_fragment = without_query
+            .split_once('#')
+            .map(|x| x.0)
+            .unwrap_or(without_query);
 
-            return Some(without_fragment);
-        }
+        return Some(without_fragment);
     }
+
     None
 }
 
@@ -50,19 +50,275 @@ pub fn discover_sourcemap_embedded_debug_id(contents: &str) -> Option<DebugId> {
 
 /// Parses a `debugId` comment in a file to discover a sourcemap's debug ID.
 pub fn discover_debug_id(contents: &str) -> Option<DebugId> {
-    for line in contents.lines().rev() {
-        if let Some(rest) = line.strip_prefix("//# debugId=") {
-            return rest.trim().parse().ok();
+    MagicCommentFinder::debug_id().find(contents).and_then(|s| s.parse().ok())
+}
+
+/// A helper utility which allows searching for magic comments in JavaScript sources.
+///
+/// The finder will optionally consider the `//#` variant as well as the deprecated `//@` variant.
+///
+/// Generally considered a magic comment is a comment following the pattern: `//[#@]\s<name>=\s*<value>\s*.*`
+struct MagicCommentFinder<'a> {
+    finder: FinderRev<'a>,
+    allow_at: bool,
+}
+
+impl<'a> MagicCommentFinder<'a> {
+    fn new(pattern: &'a str) -> Self {
+        Self {
+            finder: FinderRev::new(pattern),
+            allow_at: false,
         }
     }
-    None
+
+    /// Creates a new [`Self`] for `debugId`s,
+    pub fn debug_id() -> Self {
+        Self::new("debugId=")
+    }
+
+    /// Creates a new [`Self`] for `sourceMappingURL`s,
+    pub fn source_mapping_url() -> Self {
+        Self::new("sourceMappingURL=")
+    }
+
+    /// Also considers magic comments starting with `//@`.
+    pub fn allow_deprecated_at_variant(mut self) -> Self {
+        self.allow_at = true;
+        self
+    }
+
+    /// Finds the last occurrence of the magic comment in the supplied string.
+    ///
+    /// Returns the value of the magic comment.
+    pub fn find<'h>(&self, haystack: &'h str) -> Option<&'h str> {
+        let haystack = haystack.as_bytes();
+        let mut matches = self.finder.rfind_iter(haystack);
+
+        let value = loop {
+            let pos = matches.next()?;
+            let prefix = haystack.get(pos.checked_sub(4)?..pos)?;
+
+            // The match starts at needle, e.g. `sourceMappingURL=`, check if the characters
+            // before, are what we expect.
+            let is_match = (prefix == b"//# ") || (self.allow_at && prefix == b"//@ ");
+            if is_match {
+                break haystack.get(pos + self.finder.needle().len()..)?;
+            }
+        };
+
+        // Trim whitespaces after the `=`.
+        let value = value.trim_ascii_start();
+        // Split until the next whitespace:
+        let value = value
+            .split(u8::is_ascii_whitespace)
+            .next()
+            // If there is no whitespace, assume until end.
+            .unwrap_or(value);
+
+        // This should never fail, the input was a valid string, we only trimmed characters in the
+        // ascii range.
+        str::from_utf8(value).ok()
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use debugid::DebugId;
+    use super::*;
 
-    use crate::js::discover_sourcemap_embedded_debug_id;
+    macro_rules! test_sourcemaps_location {
+        ($name:ident, $input:expr, $expected:expr) => {
+            #[test]
+            fn $name() {
+                assert_eq!(discover_sourcemaps_location($input), $expected);
+            }
+        };
+    }
+
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_standalone_line,
+        "//# sourceMappingURL=foo.js.map\n",
+        Some("foo.js.map")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_no_trailing_newline,
+        "//# sourceMappingURL=foo.js.map",
+        Some("foo.js.map")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_after_code,
+        "var a=1;\n//# sourceMappingURL=foo.js.map\n",
+        Some("foo.js.map")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_after_code_no_newline,
+        "var a=1;\n//# sourceMappingURL=foo.js.map",
+        Some("foo.js.map")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_deprecated_at_variant,
+        "//@ sourceMappingURL=foo.js.map\n",
+        Some("foo.js.map")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_query_string_stripped,
+        "//# sourceMappingURL=foo.js.map?v=1&t=abc\n",
+        Some("foo.js.map")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_fragment_stripped,
+        "//# sourceMappingURL=foo.js.map#hash\n",
+        Some("foo.js.map")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_query_and_fragment_stripped,
+        "//# sourceMappingURL=foo.js.map?v=1#hash\n",
+        Some("foo.js.map")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_whitespace_after_eq,
+        "//# sourceMappingURL=  foo.js.map\n",
+        Some("foo.js.map")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_trailing_whitespace,
+        "//# sourceMappingURL=  foo.js.map  ",
+        Some("foo.js.map")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_trailing_tabs,
+        "//# sourceMappingURL=foo.js.map\t \t",
+        Some("foo.js.map")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_space_in_value,
+        "//# sourceMappingURL=foo bar.map",
+        Some("foo")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_trailing_junk,
+        "//# sourceMappingURL=foo.js.map junk",
+        Some("foo.js.map")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_trailing_comment,
+        "//# sourceMappingURL=foo.js.map //comment",
+        Some("foo.js.map")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_last_occurrence_wins,
+        "//# sourceMappingURL=first.js.map\n//# sourceMappingURL=second.js.map\n",
+        Some("second.js.map")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_none_when_missing,
+        "var a = 1;\n",
+        None
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_none_without_comment_prefix,
+        "sourceMappingURL=foo.js.map\n",
+        None
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_data_url,
+        "//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==\n",
+        Some("data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_relative_path,
+        "//# sourceMappingURL=../maps/foo.js.map\n",
+        Some("../maps/foo.js.map")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_absolute_url,
+        "//# sourceMappingURL=https://example.com/foo.js.map\n",
+        Some("https://example.com/foo.js.map")
+    );
+    test_sourcemaps_location!(
+        test_discover_sourcemaps_location_absolute_url_query_stripped,
+        "//# sourceMappingURL=https://example.com/foo.js.map?token=abc\n",
+        Some("https://example.com/foo.js.map")
+    );
+
+    macro_rules! test_debug_id {
+        ($name:ident, $input:expr, $expected:expr) => {
+            #[test]
+            fn $name() {
+                assert_eq!(discover_debug_id($input), $expected);
+            }
+        };
+    }
+
+    test_debug_id!(
+        test_discover_debug_id_standalone_line,
+        "//# debugId=00000000-0000-0000-0000-000000000000\n",
+        Some(DebugId::default())
+    );
+    test_debug_id!(
+        test_discover_debug_id_no_trailing_newline,
+        "//# debugId=00000000-0000-0000-0000-000000000000",
+        Some(DebugId::default())
+    );
+    test_debug_id!(
+        test_discover_debug_id_after_code,
+        "var a=1;\n//# debugId=00000000-0000-0000-0000-000000000000\n",
+        Some(DebugId::default())
+    );
+    test_debug_id!(
+        test_discover_debug_id_after_code_no_newline,
+        "var a=1;\n//# debugId=00000000-0000-0000-0000-000000000000",
+        Some(DebugId::default())
+    );
+    test_debug_id!(
+        test_discover_debug_id_whitespace_after_eq,
+        "//# debugId=  00000000-0000-0000-0000-000000000000\n",
+        Some(DebugId::default())
+    );
+    test_debug_id!(
+        test_discover_debug_id_trailing_whitespace,
+        "//# debugId=  00000000-0000-0000-0000-000000000000  ",
+        Some(DebugId::default())
+    );
+    test_debug_id!(
+        test_discover_debug_id_trailing_tabs,
+        "//# debugId=00000000-0000-0000-0000-000000000000\t \t",
+        Some(DebugId::default())
+    );
+    test_debug_id!(
+        test_discover_debug_id_trailing_junk,
+        "//# debugId=00000000-0000-0000-0000-000000000000 junk",
+        Some(DebugId::default())
+    );
+    test_debug_id!(
+        test_discover_debug_id_trailing_comment,
+        "//# debugId=00000000-0000-0000-0000-000000000000 //comment",
+        Some(DebugId::default())
+    );
+    test_debug_id!(
+        test_discover_debug_id_last_occurrence_wins,
+        "//# debugId=00000000-0000-0000-0000-000000000000\n//# debugId=11111111-1111-1111-1111-111111111111\n",
+        Some("11111111-1111-1111-1111-111111111111".parse().unwrap())
+    );
+    test_debug_id!(
+        test_discover_debug_id_none_when_missing,
+        "var a = 1;\n",
+        None
+    );
+    test_debug_id!(
+        test_discover_debug_id_none_without_comment_prefix,
+        "debugId=00000000-0000-0000-0000-000000000000\n",
+        None
+    );
+    test_debug_id!(
+        test_discover_debug_id_none_invalid_id,
+        "//# debugId=not-a-valid-id\n",
+        None
+    );
+    test_debug_id!(
+        test_discover_debug_id_at_magic_comment_not_allowed,
+        "//@ debugId=00000000-0000-0000-0000-000000000000\n",
+        None
+    );
 
     #[test]
     fn test_debugid_snake_case() {

--- a/symbolic-debuginfo/src/js.rs
+++ b/symbolic-debuginfo/src/js.rs
@@ -106,14 +106,15 @@ impl<'a> MagicCommentFinder<'a> {
             }
         };
 
-        // Trim whitespaces after the `=`.
-        let value = value.trim_ascii_start();
-        // Split until the next whitespace:
-        let value = value.split(u8::is_ascii_whitespace).next()?;
-
-        // This should never fail, the input was a valid string, we only trimmed characters in the
-        // ascii range.
-        std::str::from_utf8(value).ok()
+        value
+            // Trim whitespaces after the `=`.
+            .trim_ascii_start()
+            // Split until next whitespace, this will always yield at least one item.
+            .split(u8::is_ascii_whitespace)
+            .next()
+            // Utf-8 conversion should never fail, the input was a valid string,
+            // we only trimmed characters in the ascii range.
+            .and_then(|s| std::str::from_utf8(s).ok())
     }
 }
 

--- a/symbolic-debuginfo/src/js.rs
+++ b/symbolic-debuginfo/src/js.rs
@@ -50,7 +50,9 @@ pub fn discover_sourcemap_embedded_debug_id(contents: &str) -> Option<DebugId> {
 
 /// Parses a `debugId` comment in a file to discover a sourcemap's debug ID.
 pub fn discover_debug_id(contents: &str) -> Option<DebugId> {
-    MagicCommentFinder::debug_id().find(contents).and_then(|s| s.parse().ok())
+    MagicCommentFinder::debug_id()
+        .find(contents)
+        .and_then(|s| s.parse().ok())
 }
 
 /// A helper utility which allows searching for magic comments in JavaScript sources.


### PR DESCRIPTION
Updates the JS magic comment parsing to not only consider magic comments which are at the start of a line but anywhere in the source. The spec is not 100% clear of whether the magic comment must be at the beginning of a line, but major vendors have implementations allowing the comment to appear anywhere in the source.

The code will use the last occurrence of the magic comment in the JS source.

This will now also be more lenient with whitespaces, but consider the value of the magic comment to be separated by a whitespace. This follows the pattern defined in V8 `//[#@]\s<name>=\s*<value>\s*.*`: https://github.com/v8/v8/blob/4532c6bf8ac0838c9b3e85d6ae6078a1bc1dcb0c/src/parsing/scanner.cc#L279-L281

Fixes: #969

