### PR TITLE
ref(demangle): Add backward compat patch for swift demangler

### DIFF
--- a/symbolic-demangle/tests/test_swift.rs
+++ b/symbolic-demangle/tests/test_swift.rs
@@ -297,6 +297,7 @@ fn test_demangle_swift_no_args() {
 
         // Swift 6.0.3
         "$ss27withTaskCancellationHandler9operation8onCancel9isolationxxyYaKXE_yyYbXEScA_pSgYitYaKlFTwb" => "withTaskCancellationHandler<A>",
+        "$s11Supercharge2AXO7ElementPAAE8elements33_35EDDAA799FBB5B74D2F426690B0D99DLL3for2asSayqd__GSo28NSAccessibilityAttributeNamea_qd__mtSo7AXErrorVYKAcDRd__lFAC3AppC_AC6WindowCTgm5" => "specialized AX.Element.elements<A>",
 
         // Swift 6.1.0
         "$sTB" => "$sTB",

--- a/symbolic-demangle/vendor/swift/2-metatype-compat.patch
+++ b/symbolic-demangle/vendor/swift/2-metatype-compat.patch
@@ -1,0 +1,21 @@
+commit 444bc9275ef9876c9b8404e4c2e8982868376bb6
+Author: David Herberth <david.herberth@sentry.io>
+Date:   Mon May 18 19:07:06 2026 +0200
+
+    apply patch
+
+diff --git a/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp b/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp
+index 4f7bbbcb..d88fda74 100644
+--- a/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp
++++ b/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp
+@@ -3619,6 +3619,10 @@ NodePointer Demangler::addFuncSpecParamNumber(NodePointer Param,
+ }
+
+ NodePointer Demangler::demangleSpecAttributes(Node::Kind SpecKind) {
++  // Swift used 'm' for `MetatypeParamsRemoved`, with the 6.3 update it was removed.
++  // To keep old mangled strings compatible with `symbolic` we skip `m` here.
++  (void) nextIf('m');
++
+   bool isSerialized = nextIf('q');
+   bool asyncRemoved = nextIf('a');
+   bool representationChanged = nextIf('r');

--- a/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp
+++ b/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp
@@ -3619,6 +3619,10 @@ NodePointer Demangler::addFuncSpecParamNumber(NodePointer Param,
 }
 
 NodePointer Demangler::demangleSpecAttributes(Node::Kind SpecKind) {
+  // Swift used 'm' for `MetatypeParamsRemoved`, with the 6.3 update it was removed.
+  // To keep old mangled strings compatible with `symbolic` we skip `m` here.
+  (void) nextIf('m');
+
   bool isSerialized = nextIf('q');
   bool asyncRemoved = nextIf('a');
   bool representationChanged = nextIf('r');


### PR DESCRIPTION
Follow-up for the 6.3.1 upgrade in #980 restoring a removed test, which breaks with the upgrade.

With the upgrade support for `MetatypeParamsRemoved` was removed from the demangler, this was previously represented with a `m` in the mangled string. This patch skips the `m` marker to keep the correctly demangle the rest of the string.
This does break re-mangling of these strings, but symbolic does not expose any remangling functionality.

If this patch ever becomes a problem in the future, it may be removed, it's only required for compatibility with old compiler versions and we generally prefer staying compatible with recent compilers.