### PR TITLE
chore(ci): Pin macOS runner to macos-15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
             py-platform: macosx-11_0_arm64
 
     name: Python macOS ${{ matrix.py-platform }}
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-15, windows-latest]
 
     name: Rust Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-15]
 
     name: Python Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         # Should also run on ubuntu-latest but CI doesn't like this yet.
-        os: [macos-latest]
+        os: [macos-15]
 
     name: CABI tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
GitHub is migrating the `macos-latest` label to the macOS 26 runner image, rolling out between June 15 and July 15, 2026. Pin the test matrix to `macos-15` to stay on the current stable image.