### PR TITLE
feat(debuginfo): use C zstd on wasm too, drop ruzstd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,8 +107,10 @@ jobs:
       - run: rustup toolchain install stable --profile minimal --target wasm32-unknown-unknown --no-self-update
 
       # Node/npm are preinstalled on ubuntu runners (used for `npm pack`).
-      # Provides wasm-opt for size optimization (build-npm.sh skips it if absent).
+      # binaryen provides wasm-opt (required by build-npm.sh); clang/lld/llvm
+      # compile the C zstd library to wasm (zstd-sys's wasm-shim).
       - run: npm install -g binaryen@130.0.0
+      - run: sudo apt-get update && sudo apt-get install -y clang lld llvm
 
       # build-npm.sh installs the wasm-bindgen-cli version that matches the
       # locked wasm-bindgen crate, then builds + packs the tarball.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,23 @@ jobs:
 
       - run: cargo doc --workspace --all-features --document-private-items --no-deps
 
+  wasm-build:
+    name: WASM build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+
+      - run: rustup toolchain install stable --profile minimal --target wasm32-unknown-unknown --no-self-update
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      # The C `zstd` library is compiled to wasm by clang (zstd-sys's wasm-shim);
+      # llvm provides llvm-ar to archive the wasm objects. clang is normally
+      # preinstalled on the runner; install explicitly so the build is reproducible.
+      - run: sudo apt-get update && sudo apt-get install -y clang lld llvm
+
+      - run: cargo build -p symbolic-wasm --target wasm32-unknown-unknown
+
   test-rust:
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Changes**
+
+- `symbolic-debuginfo`: use the C `zstd` library on wasm32 too (via zstd-sys's wasm-shim), replacing the `ruzstd` decoder added in #989. One zstd implementation for all targets; `ruzstd` is no longer a dependency. Building for wasm now requires clang. ([#990](https://github.com/getsentry/symbolic/pull/990))
+
 ## 13.3.1
 
 **Changes**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,15 +1977,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruzstd"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
-dependencies = [
- "twox-hash",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,7 +2525,6 @@ dependencies = [
  "pdb-addr2line",
  "proptest",
  "regex",
- "ruzstd",
  "scroll 0.13.0",
  "serde",
  "serde_json",
@@ -2897,12 +2887,6 @@ dependencies = [
  "serde",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "twox-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typed-path"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ wasmparser = "0.243.0"
 watto = { version = "0.2.0", features = ["writer", "strings"] }
 zip = { version = "7.2.0", default-features = false, features = ["deflate"] }
 zstd = { version = "0.13.1" }
-ruzstd = { version = "0.8.3" }
 
 
 [profile.release]

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -110,9 +110,6 @@ thiserror = { workspace = true }
 wasmparser = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }
 
-# zstd-compressed ELF debug sections. The C `zstd` library also compiles to
-# wasm32 (zstd-sys ships a wasm-shim that maps malloc/memcpy/... onto Rust),
-# so a single dependency covers every target — no pure-Rust fallback needed.
 zstd = { workspace = true }
 
 [dev-dependencies]

--- a/symbolic-debuginfo/Cargo.toml
+++ b/symbolic-debuginfo/Cargo.toml
@@ -110,15 +110,10 @@ thiserror = { workspace = true }
 wasmparser = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }
 
-# zstd-compressed ELF debug sections are decompressed with the C `zstd` library
-# on native targets, and the pure-Rust `ruzstd` decoder on wasm32 (where the
-# `zstd` C library does not build). Selected by `cfg(target_arch)` rather than a
-# feature so `features = ["elf"]` keeps zstd support everywhere it can.
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# zstd-compressed ELF debug sections. The C `zstd` library also compiles to
+# wasm32 (zstd-sys ships a wasm-shim that maps malloc/memcpy/... onto Rust),
+# so a single dependency covers every target — no pure-Rust fallback needed.
 zstd = { workspace = true }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-ruzstd = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/symbolic-debuginfo/src/elf.rs
+++ b/symbolic-debuginfo/src/elf.rs
@@ -637,30 +637,7 @@ impl<'data> ElfObject<'data> {
                     .ok()?;
                 decompressed
             }
-            // The C `zstd` library on native targets.
-            #[cfg(not(target_arch = "wasm32"))]
             CompressionType::Zstd => zstd::bulk::decompress(compressed, size).ok()?,
-            // The pure-Rust `ruzstd` decoder on wasm32 (where `zstd` does not build).
-            #[cfg(target_arch = "wasm32")]
-            CompressionType::Zstd => {
-                use std::io::Read as _;
-                let decoder = ruzstd::decoding::StreamingDecoder::new(compressed).ok()?;
-                // Read at most `size` + 1 bytes: the declared decompressed size is
-                // bounded above (`max_decompressed_section_size`, checked above), and
-                // reading one extra byte lets us reject a stream that decompresses to
-                // more than `size` instead of silently truncating it. The result must
-                // be exactly `size`, matching `zstd::bulk::decompress` which errors on
-                // a size mismatch.
-                let mut decompressed = Vec::with_capacity(size);
-                decoder
-                    .take(size as u64 + 1)
-                    .read_to_end(&mut decompressed)
-                    .ok()?;
-                if decompressed.len() != size {
-                    return None;
-                }
-                decompressed
-            }
         };
 
         Some(decompressed)

--- a/symbolic-wasm/Cargo.toml
+++ b/symbolic-wasm/Cargo.toml
@@ -25,7 +25,7 @@ wasm-bindgen = { workspace = true }
 serde = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 # All formats. zstd-compressed ELF debug sections are handled by symbolic-debuginfo
-# itself (pure-Rust `ruzstd` on wasm32, selected via cfg(target_arch)).
+# itself (the C `zstd` library, which compiles to wasm32 via zstd-sys's shim).
 # The unified Archive/Object API requires breakpad+elf+macho+ms+sourcebundle+wasm
 # (dwarf is pulled transitively); ppdb+js are enabled for completeness.
 symbolic-debuginfo = { version = "13.3.1", path = "../symbolic-debuginfo", default-features = false, features = [


### PR DESCRIPTION
Follow-up to #989. Per the discussion about why we shipped two zstd implementations, it turns out we can use the **C `zstd` library on wasm too**, so we don't need the pure-Rust `ruzstd` fallback at all.

## How

`zstd-sys` ships a `wasm-shim/` whose headers `#define malloc`/`memcpy`/`qsort`/… to `rust_zstd_wasm_shim_*` functions implemented in Rust (`#[no_mangle]`, backed by Rust's allocator). Its `build.rs` auto-enables the shim for `wasm32-*` targets, so the C zstd compiles to `wasm32-unknown-unknown` with **no libc/sysroot** — it just needs **clang** (which has a native WebAssembly backend).

## What changes

- `symbolic-debuginfo`: one `zstd` dependency for **all** targets (no `[target.'cfg(...)']` split), and a single `zstd::bulk::decompress` arm in `elf.rs` (drops the wasm-only `ruzstd` arm and its manual size-mismatch guard).
- Drops the `ruzstd` dependency entirely.
- New `wasm-build` CI job compiles `symbolic-wasm` for `wasm32-unknown-unknown` (installs `clang`/`lld`/`llvm`) so the C-on-wasm path stays covered on PRs.

## Why

- **One implementation everywhere** — answers "why two decoders?". Native keeps full speed; wasm now also gets full C-zstd speed (`ruzstd` is significantly slower per its author), instead of trading correctness for a pure-Rust build.
- Simpler code: no `cfg(target_arch)` split, no `ruzstd` size-check workaround.

## Validation

- Builds: `symbolic-wasm` → `wasm32-unknown-unknown` compiles **and links** (clang 18 + the shim).
- Correctness on wasm: built `@sentry/symbolic` with C-zstd and ran `list_source_files` against `crash.debug-zstd` (zstd-compressed DWARF) → **152 sources, identical to the uncompressed fixture** — i.e. the wasm decompressed the zstd sections correctly. (`list_source_files` lands in #988; verified locally on that branch.)
- Native: `cargo test -p symbolic-debuginfo --all-features` (incl. the zstd fixtures) passes; `fmt` + `clippy` clean.

## Cost

- **clang** is required to build for wasm. It's preinstalled on GitHub `ubuntu-latest` runners (the new job also installs it explicitly to be safe); local contributors running `make npm` need it too.
- Bundle size: **~+3%** (`symbolic_bg.wasm` 2349 → 2428 KB raw, 902 → 926 KB gzip).