### PR TITLE
test(wasm): packaged-artifact smoke test (+ fix Object/global shadowing)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,23 +50,6 @@ jobs:
 
       - run: cargo doc --workspace --all-features --document-private-items --no-deps
 
-  wasm-build:
-    name: WASM build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-
-      - run: rustup toolchain install stable --profile minimal --target wasm32-unknown-unknown --no-self-update
-
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
-
-      # The C `zstd` library is compiled to wasm by clang (zstd-sys's wasm-shim);
-      # llvm provides llvm-ar to archive the wasm objects. clang is normally
-      # preinstalled on the runner; install explicitly so the build is reproducible.
-      - run: sudo apt-get update && sudo apt-get install -y clang lld llvm
-
-      - run: cargo build -p symbolic-wasm --target wasm32-unknown-unknown
-
   test-rust:
     strategy:
       fail-fast: false
@@ -141,10 +124,6 @@ jobs:
           cd symbolic-wasm
           wasm-pack test --node
 
-  # Builds the actual npm package and smoke-tests the *published* artifact
-  # (exports map, files[], initSync) via package-smoke.test.mjs. `wasm-pack test`
-  # above never loads the shipped `--target web` glue, so this is what catches
-  # packaging regressions.
   wasm-package:
     name: WASM package smoke test
     runs-on: ubuntu-latest
@@ -152,7 +131,6 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - run: rustup toolchain install stable --profile minimal --target wasm32-unknown-unknown --no-self-update
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
-      # binaryen provides wasm-opt; clang/lld/llvm compile the C zstd to wasm.
       - run: npm install -g binaryen@130.0.0
       - run: sudo apt-get update && sudo apt-get install -y clang lld llvm
       - run: make npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,22 @@ jobs:
           cd symbolic-wasm
           wasm-pack test --node
 
+  # Builds the actual npm package and smoke-tests the *published* artifact
+  # (exports map, files[], initSync) via package-smoke.test.mjs. `wasm-pack test`
+  # above never loads the shipped `--target web` glue, so this is what catches
+  # packaging regressions.
+  wasm-package:
+    name: WASM package smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - run: rustup toolchain install stable --profile minimal --target wasm32-unknown-unknown --no-self-update
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      # binaryen provides wasm-opt; clang/lld/llvm compile the C zstd to wasm.
+      - run: npm install -g binaryen@130.0.0
+      - run: sudo apt-get update && sudo apt-get install -y clang lld llvm
+      - run: make npm
+
   codecov:
     name: Code Coverage
     runs-on: ubuntu-latest

--- a/symbolic-wasm/build-npm.sh
+++ b/symbolic-wasm/build-npm.sh
@@ -10,7 +10,7 @@
 #   - Rust toolchain with the wasm32-unknown-unknown target
 #   - wasm-bindgen-cli matching the wasm-bindgen crate version
 #   - wasm-opt (binaryen) — for size optimization (required)
-#   - npm (for `npm pack`)
+#   - node + npm (for `npm pack` and the packaged-artifact smoke test)
 #
 # Usage: make npm   (or: bash symbolic-wasm/build-npm.sh)
 
@@ -62,9 +62,10 @@ fi
 echo "Optimizing with wasm-opt -Oz..."
 wasm-opt -Oz -o "$BG_WASM" "$BG_WASM"
 
-echo "Packing npm tarball..."
-cd "$NPM_DIR"
-npm pack
+echo "Packing npm tarball + smoke-testing the installed package..."
+# `npm test` (in $NPM_DIR) packs the tarball and runs the packaged-artifact
+# smoke test against the installed package (exports map, files[], initSync).
+npm test --prefix "$NPM_DIR"
 
 SIZE_KB=$(( $(wc -c < "$BG_WASM") / 1024 ))
 echo "Done. symbolic_bg.wasm: ${SIZE_KB} KB; tarball in $NPM_DIR"

--- a/symbolic-wasm/npm/package-smoke.test.mjs
+++ b/symbolic-wasm/npm/package-smoke.test.mjs
@@ -1,0 +1,45 @@
+// Packaged-artifact smoke test for @sentry/symbolic.
+//
+// Unlike `wasm-pack test` (which builds its own test glue and never loads what
+// we publish), this runs against the *installed* package: it resolves
+// `@sentry/symbolic` through the package `exports` map, loads the shipped
+// `--target web` glue + wasm via `initSync`, and exercises the public API the
+// way a real consumer would. It therefore catches packaging regressions
+// (bad `exports`, missing `files[]`, broken `initSync`) that behavior tests miss.
+//
+// Driven by smoke-test.mjs, which `npm pack`s + installs the tarball into a
+// throwaway project, copies this file next to it, and runs `node --test`.
+// `SMOKE_FIXTURE` points at a debug-info fixture in the repo.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { test } from "node:test";
+
+const require = createRequire(import.meta.url);
+
+// Bare import -> exercises the `.` export; resolve the wasm -> the
+// `./symbolic_bg.wasm` export + `files[]`.
+const symbolic = await import("@sentry/symbolic");
+const wasmPath = require.resolve("@sentry/symbolic/symbolic_bg.wasm");
+symbolic.initSync({ module: readFileSync(wasmPath) });
+
+const data = new Uint8Array(readFileSync(process.env.SMOKE_FIXTURE));
+
+test("the shipped package parses a debug file via the Archive API", () => {
+  const archive = new symbolic.Archive(data);
+  assert.equal(archive.fileFormat, "elf");
+  assert.equal(archive.objectCount, 1);
+
+  const objects = archive.objects();
+  assert.equal(objects.length, 1);
+
+  const [object] = objects;
+  assert.ok(object.debugId.length >= 32, `unexpected debugId: ${object.debugId}`);
+  assert.equal(object.arch, "x86_64");
+  assert.equal(object.hasDebugInfo, true);
+});
+
+test("Archive.peek detects the format without a full parse", () => {
+  assert.equal(symbolic.Archive.peek(data), "elf");
+});

--- a/symbolic-wasm/npm/package.json
+++ b/symbolic-wasm/npm/package.json
@@ -3,6 +3,9 @@
   "version": "13.3.1",
   "description": "WebAssembly bindings for symbolic — parse debug information files (Mach-O/dSYM, ELF, PE/PDB, Portable PDB, WebAssembly, Breakpad, source bundles).",
   "type": "module",
+  "scripts": {
+    "test": "node smoke-test.mjs"
+  },
   "main": "symbolic.js",
   "module": "symbolic.js",
   "types": "symbolic.d.ts",

--- a/symbolic-wasm/npm/smoke-test.mjs
+++ b/symbolic-wasm/npm/smoke-test.mjs
@@ -1,0 +1,52 @@
+// Orchestrates the packaged-artifact smoke test (package-smoke.test.mjs).
+//
+// Run via `npm test` from this directory (and by build-npm.sh / CI). Packs this
+// package, installs the tarball into a throwaway project exactly as a consumer
+// would, then runs the smoke test from inside it — so the `exports` map,
+// `files[]`, and `initSync` path are all exercised against the real published
+// artifact (things `wasm-pack test` never loads). Exits non-zero on failure.
+//
+// This file and package-smoke.test.mjs live in the package dir but are excluded
+// from `files[]`, so they are not published.
+
+import { execFileSync } from "node:child_process";
+import { cpSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = (rel) => fileURLToPath(new URL(rel, import.meta.url));
+const PKG_DIR = here(".");
+const FIXTURE = here("../../symbolic-testutils/fixtures/linux/crash.debug");
+
+const run = (cmd, args, opts) =>
+  execFileSync(cmd, args, { stdio: "inherit", ...opts });
+
+// 1. Pack this package (leaves the tarball here for the release upload too).
+const tarball = execFileSync("npm", ["pack", "--silent"], { cwd: PKG_DIR })
+  .toString()
+  .trim()
+  .split("\n")
+  .pop();
+console.log(`Packed ${tarball}; smoke-testing the installed package...`);
+
+// 2. Install it into a throwaway consumer project.
+const dir = mkdtempSync(join(tmpdir(), "symbolic-smoke-"));
+try {
+  run("npm", ["init", "-y"], { cwd: dir, stdio: "ignore" });
+  run("npm", ["install", "--no-audit", "--no-fund", join(PKG_DIR, tarball)], {
+    cwd: dir,
+    stdio: "ignore",
+  });
+
+  // 3. Run the smoke test from inside the consumer project so `@sentry/symbolic`
+  //    resolves to the installed package.
+  cpSync(here("./package-smoke.test.mjs"), join(dir, "package-smoke.test.mjs"));
+  run("node", ["--test", "package-smoke.test.mjs"], {
+    cwd: dir,
+    env: { ...process.env, SMOKE_FIXTURE: FIXTURE },
+  });
+  console.log("packaged-artifact smoke test passed");
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/symbolic-wasm/src/debuginfo/mod.rs
+++ b/symbolic-wasm/src/debuginfo/mod.rs
@@ -64,12 +64,16 @@ impl Archive {
 }
 
 /// A generic object file providing uniform access to various file formats.
-#[wasm_bindgen]
+///
+/// Exported to JS as `ObjectFile`: a class named `Object` would shadow the JS
+/// global `Object` inside the generated `--target web` glue (which uses
+/// `Object.create`/`Object.getPrototypeOf`), breaking `initSync` and `objects()`.
+#[wasm_bindgen(js_name = ObjectFile)]
 pub struct Object {
     inner: SelfCell<ByteView<'static>, di::Object<'static>>,
 }
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_class = ObjectFile)]
 impl Object {
     /// The object's debug identifier (the canonical `debug_id`).
     #[wasm_bindgen(getter, js_name = debugId)]


### PR DESCRIPTION
Follow-up to #992 (now on master). Adds the "does the published package actually work?" smoke-test layer we discussed, and fixes a ship-blocking bug it caught.

## The bug it caught (now live on master)

The class exported as `Object` shadows the JS global `Object` for the whole module, so the generated `--target web` glue breaks where it uses the global:
- `Object.create(Object.prototype)` — used by `archive.objects()`
- `Object.getPrototypeOf(module)` — used by `initSync`

So a real consumer doing `import * as symbolic from "@sentry/symbolic"; symbolic.initSync({ module })` gets `TypeError: Object.getPrototypeOf is not a function`. `wasm-pack test` (the `test-wasm` job) passes because it builds its own glue and never loads the shipped `--target web` artifact.

Fixed by exporting the class as **`ObjectFile`** via `#[wasm_bindgen(js_name = ObjectFile)]` (`objects(): ObjectFile[]`). The JS name is bikesheddable — anything that isn't a JS global works.

## The smoke test

`npm pack`s the package, installs the tarball into a throwaway project, and runs it through `node:test` as a real consumer would — bare `import "@sentry/symbolic"` (the `.` export), `require.resolve("@sentry/symbolic/symbolic_bg.wasm")` (the `./symbolic_bg.wasm` export + `files[]`), and `initSync` of the shipped glue.

- `symbolic-wasm/package-smoke.test.mjs` — the `node:test` assertions.
- `symbolic-wasm/smoke-test.mjs` — pack + install + run orchestrator.
- `build-npm.sh` — runs it after packing (so `make npm` covers it locally + in the release build).
- `ci.yml` — a `wasm-package` job runs `make npm` on PRs.

Complements `wasm-pack test --node` (behavior, node/browser) with the packaging layer it can't cover.

## Validation

`make npm` builds and the smoke test passes; without the rename it fails at `initSync`, which is the point.