### PR TITLE
feat(wasm): Expose `SourceBundleWriter`

### DIFF
--- a/symbolic-debuginfo/src/sourcebundle/mod.rs
+++ b/symbolic-debuginfo/src/sourcebundle/mod.rs
@@ -177,6 +177,24 @@ pub enum SourceFileType {
     IndexedRamBundle,
 }
 
+impl SourceFileType {
+    /// Returns the name of the source file type.
+    pub fn name(self) -> &'static str {
+        match self {
+            SourceFileType::Source => "source",
+            SourceFileType::MinifiedSource => "minified_source",
+            SourceFileType::SourceMap => "source_map",
+            SourceFileType::IndexedRamBundle => "indexed_ram_bundle",
+        }
+    }
+}
+
+impl fmt::Display for SourceFileType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
 /// Meta data information of a file in a [`SourceBundle`](struct.SourceBundle.html).
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct SourceFileInfo {

--- a/symbolic-wasm/Cargo.toml
+++ b/symbolic-wasm/Cargo.toml
@@ -8,9 +8,7 @@ authors = [
 homepage = "https://github.com/getsentry/symbolic"
 repository = "https://github.com/getsentry/symbolic"
 description = """
-WebAssembly bindings for symbolic-debuginfo, published to npm as
-@sentry/symbolic. Parses debug information files (Mach-O, ELF, PE/PDB,
-Portable PDB, WebAssembly, Breakpad, SourceBundle) in the browser or Node.
+WebAssembly bindings for symbolic, published to npm as @sentry/symbolic.
 """
 edition.workspace = true
 rust-version.workspace = true
@@ -35,6 +33,7 @@ symbolic-debuginfo = { version = "13.3.1", path = "../symbolic-debuginfo", defau
 
 serde = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
+js-sys = { workspace = true }
 thiserror = { workspace = true }
 wasm-bindgen = { workspace = true }
 
@@ -43,5 +42,4 @@ wasm-bindgen = { workspace = true }
 # this is not the workspace root package.
 
 [dev-dependencies]
-js-sys = { workspace = true }
 wasm-bindgen-test = { workspace = true }

--- a/symbolic-wasm/src/debuginfo/mod.rs
+++ b/symbolic-wasm/src/debuginfo/mod.rs
@@ -6,6 +6,8 @@ use wasm_bindgen::prelude::*;
 
 use crate::utils::{self, Error, Result};
 
+pub mod sourcebundle;
+
 /// A generic archive that can contain one or more object files.
 #[wasm_bindgen]
 pub struct Archive {
@@ -64,12 +66,12 @@ impl Archive {
 }
 
 /// A generic object file providing uniform access to various file formats.
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = ObjectFile)]
 pub struct Object {
     inner: SelfCell<ByteView<'static>, di::Object<'static>>,
 }
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_class = ObjectFile)]
 impl Object {
     /// The object's debug identifier (the canonical `debug_id`).
     #[wasm_bindgen(getter, js_name = debugId)]

--- a/symbolic-wasm/src/debuginfo/sourcebundle.rs
+++ b/symbolic-wasm/src/debuginfo/sourcebundle.rs
@@ -1,0 +1,183 @@
+use std::io::Cursor;
+
+use symbolic_debuginfo as di;
+use wasm_bindgen::prelude::*;
+
+use super::Object;
+use crate::utils::Result;
+
+/// A descriptor that provides information about a source file.
+///
+/// This descriptor is returned from `source_by_path` and friends.
+///
+/// This descriptor holds information that can be used to retrieve information
+/// about the source file.
+#[wasm_bindgen(getter_with_clone)]
+pub struct SourceFileDescriptor {
+    /// The type of the file the descriptor points to.
+    #[wasm_bindgen(js_name = "type")]
+    pub ty: String,
+    /// The contents of the source file as string, if it's available.
+    pub contents: Option<String>,
+    /// If available returns the URL of this source.
+    pub url: Option<String>,
+    /// If available returns the file path of this source.
+    pub path: Option<String>,
+    /// The debug ID of the file if available.
+    #[wasm_bindgen(js_name = debugId)]
+    pub debug_id: Option<String>,
+    /// The source mapping URL reference of the file.
+    #[wasm_bindgen(js_name = sourceMappingUrl)]
+    pub source_mapping_url: Option<String>,
+}
+
+impl<'a> From<&di::sourcebundle::SourceFileDescriptor<'a>> for SourceFileDescriptor {
+    fn from(source: &di::sourcebundle::SourceFileDescriptor<'a>) -> Self {
+        Self {
+            ty: source.ty().to_string(),
+            contents: source.contents().map(str::to_owned),
+            url: source.url().map(str::to_owned),
+            path: source.path().map(str::to_owned),
+            debug_id: source.debug_id().map(|debug_id| debug_id.to_string()),
+            source_mapping_url: source.source_mapping_url().map(str::to_owned),
+        }
+    }
+}
+
+/// A source file entry referenced by an object.
+#[wasm_bindgen]
+pub struct FileEntry {
+    // We only provide the API for `abs_path_str` for now, if we ever provide more,
+    // we may need to store the real `FileEntry` here.
+    abs_path_str: String,
+}
+
+#[wasm_bindgen]
+impl FileEntry {
+    /// Absolute path to the file, including the compilation directory.
+    #[wasm_bindgen(getter)]
+    pub fn abs_path_str(&self) -> String {
+        self.abs_path_str.clone()
+    }
+}
+
+impl<'a> From<&di::FileEntry<'a>> for FileEntry {
+    fn from(file: &di::FileEntry<'a>) -> Self {
+        Self {
+            abs_path_str: file.abs_path_str(),
+        }
+    }
+}
+
+#[wasm_bindgen]
+pub struct SourceBundleWriter {
+    inner: di::sourcebundle::SourceBundleWriter<Cursor<Vec<u8>>>,
+}
+
+#[wasm_bindgen]
+impl SourceBundleWriter {
+    /// Creates a bundle writer.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Result<Self> {
+        let writer = Cursor::new(Vec::new());
+
+        Ok(Self {
+            inner: di::sourcebundle::SourceBundleWriter::start(writer)?,
+        })
+    }
+
+    /// Returns whether the bundle contains any files.
+    #[wasm_bindgen(getter, js_name = isEmpty)]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// This controls if source files should be scanned for Il2cpp-specific source annotations,
+    /// and the referenced C# files should be bundled up as well.
+    #[wasm_bindgen(setter, js_name = collectIl2cppSources)]
+    pub fn collect_il2cpp_sources(&mut self, collect_il2cpp: bool) {
+        self.inner.collect_il2cpp_sources(collect_il2cpp);
+    }
+
+    /// Sets a meta data attribute of the bundle.
+    ///
+    /// Attributes are flushed to the bundle when it is finished. Thus, they can be retrieved or
+    /// changed at any time before flushing the writer.
+    ///
+    /// If the attribute was set before, the prior value is returned.
+    #[wasm_bindgen(js_name = setAttribute)]
+    pub fn set_attribute(&mut self, key: String, value: String) -> Option<String> {
+        self.inner.set_attribute(key, value)
+    }
+
+    /// Removes a meta data attribute of the bundle.
+    ///
+    /// If the attribute was set, the last value is returned.
+    #[wasm_bindgen(js_name = removeAttribute)]
+    pub fn remove_attribute(&mut self, key: &str) -> Option<String> {
+        self.inner.remove_attribute(key)
+    }
+
+    /// Returns the value of a meta data attribute.
+    pub fn attribute(&mut self, key: &str) -> Option<String> {
+        self.inner.attribute(key).map(str::to_owned)
+    }
+
+    /// Determines whether a file at the given path has been added already.
+    #[wasm_bindgen(js_name = hasFile)]
+    pub fn has_file(&self, path: &str) -> bool {
+        self.inner.has_file(path)
+    }
+
+    /// Writes a single object into the bundle.
+    ///
+    /// Loads source files by invoking the `provider` with the file path.
+    /// Before a file is written the `filter` is invoked which can return `false` to skip a file.
+    ///
+    /// This finishes the source bundle and returns its contents.
+    #[wasm_bindgen(js_name = writeObject)]
+    pub fn write_object(
+        self,
+        object: &Object,
+        object_name: &str,
+        filter: &js_sys::Function,
+        provider: &js_sys::Function,
+    ) -> Result<Option<Vec<u8>>> {
+        let written = self.inner.write_object_with_filter_and_provider(
+            object.inner.get(),
+            object_name,
+            |file, source| {
+                if filter.is_null_or_undefined() {
+                    return true;
+                };
+
+                let file = JsValue::from(FileEntry::from(file));
+                let source = source
+                    .as_ref()
+                    .map(SourceFileDescriptor::from)
+                    .map(JsValue::from)
+                    .unwrap_or(JsValue::UNDEFINED);
+
+                filter
+                    .call2(&JsValue::UNDEFINED, &file, &source)
+                    .unwrap_throw()
+                    .is_truthy()
+            },
+            |path| {
+                let value = provider
+                    .call1(&JsValue::UNDEFINED, &JsValue::from_str(path))
+                    .unwrap_throw();
+
+                if value.is_null_or_undefined() {
+                    return None;
+                }
+
+                Some(Cursor::new(js_sys::Uint8Array::new(&value).to_vec()))
+            },
+        );
+
+        written
+            .map(|(written, w)| written.then_some(w.into_inner()))
+            .map_err(Into::into)
+    }
+}

--- a/symbolic-wasm/src/utils.rs
+++ b/symbolic-wasm/src/utils.rs
@@ -26,6 +26,8 @@ pub(crate) use derived_from_cell;
 pub enum Error {
     #[error(transparent)]
     ObjectError(#[from] symbolic_debuginfo::ObjectError),
+    #[error(transparent)]
+    SourceBundleError(#[from] symbolic_debuginfo::sourcebundle::SourceBundleError),
 }
 
 impl From<Error> for wasm_bindgen::JsValue {

--- a/symbolic-wasm/tests/debuginfo.rs
+++ b/symbolic-wasm/tests/debuginfo.rs
@@ -58,3 +58,63 @@ fn test_archive_objects() {
     assert!(object.has_symbols());
     assert!(!object.has_sources());
 }
+
+#[cfg(target_arch = "wasm32")]
+mod wasm_only {
+    use super::*;
+
+    use std::rc::Rc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use symbolic_wasm::debuginfo::sourcebundle::SourceBundleWriter;
+    use wasm_bindgen::closure::Closure;
+    use wasm_bindgen::{JsCast, JsValue};
+
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn test_source_bundle_writer_write_object() {
+        let object = {
+            let data = common::fixture(
+                "symbolic-testutils/fixtures/windows/Sentry.Samples.Console.Basic.pdb",
+            );
+            let archive = Archive::new(&data).unwrap();
+            let mut objects = archive.objects().unwrap();
+            objects.remove(0)
+        };
+
+        let filter_call_count = Rc::new(AtomicUsize::new(0));
+        let filter = {
+            let filter_call_count = Rc::clone(&filter_call_count);
+            Closure::<dyn Fn(JsValue, JsValue) -> bool>::new(move |_, _| -> bool {
+                filter_call_count.fetch_add(1, Ordering::Relaxed);
+                true
+            })
+            .into_js_value()
+        };
+
+        let provider = Closure::<dyn Fn(String) -> js_sys::Uint8Array>::new(move |path| {
+            let source = format!("// synthetic source for {path}\n");
+            js_sys::Uint8Array::new_from_slice(source.as_bytes())
+        })
+        .into_js_value();
+
+        let writer = SourceBundleWriter::new().unwrap();
+        let bundle = writer
+            .write_object(
+                &object,
+                "whatever",
+                &filter.unchecked_into(),
+                &provider.unchecked_into(),
+            )
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(filter_call_count.load(Ordering::Relaxed), 4);
+
+        let bundle_archive = Archive::new(&bundle).unwrap();
+        assert_eq!(bundle_archive.file_format(), "sourcebundle");
+
+        let bundle_objects = bundle_archive.objects().unwrap();
+        assert_eq!(bundle_objects.len(), 1);
+        assert!(bundle_objects[0].has_sources());
+    }
+}


### PR DESCRIPTION
Based on #988 

Makes some changes to the `SourceBundleWriter` API which was introduced in the stacked PR to recover the writer and reduce API surface a bit.

This introduces the missing API surface that is required by Sentry CLI.