### PR TITLE
feat(wasm): expose ObjectFile.debugSession() for source enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**
+
+- WASM: expose `ObjectFile.debugSession()` returning a `DebugSession` with `files()` (the source files referenced by the object) and `sourceByPath(path)` (resolving embedded contents or a source link). `symbolic-debuginfo` also implements `AsSelf` for `ObjectDebugSession` so it can be held in a `SelfCell`. ([#997](https://github.com/getsentry/symbolic/pull/997))
+
 ## 13.4.0
 
 **Features**

--- a/symbolic-debuginfo/src/object.rs
+++ b/symbolic-debuginfo/src/object.rs
@@ -394,6 +394,14 @@ impl<'slf, 'data: 'slf> AsSelf<'slf> for Object<'data> {
     }
 }
 
+impl<'slf, 'data: 'slf> AsSelf<'slf> for ObjectDebugSession<'data> {
+    type Ref = ObjectDebugSession<'slf>;
+
+    fn as_self(&'slf self) -> &'slf Self::Ref {
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
 impl<'data: 'object, 'object> ObjectLike<'data, 'object> for Object<'data> {
     type Error = ObjectError;
     type Session = ObjectDebugSession<'data>;

--- a/symbolic-wasm/npm/package-smoke.test.mjs
+++ b/symbolic-wasm/npm/package-smoke.test.mjs
@@ -43,3 +43,19 @@ test("the shipped package parses a debug file via the Archive API", () => {
 test("Archive.peek detects the format without a full parse", () => {
   assert.equal(symbolic.Archive.peek(data), "elf");
 });
+
+test("the debug session enumerates referenced source files", () => {
+  const archive = new symbolic.Archive(data);
+  const [object] = archive.objects();
+
+  const session = object.debugSession();
+  const files = session.files();
+  assert.ok(Array.isArray(files), "files() should return an array");
+  assert.ok(files.length > 0, "expected at least one referenced source file");
+  for (const file of files) {
+    assert.ok(file.abs_path_str.length > 0, "expected a non-empty source path");
+  }
+
+  // A path the object does not reference resolves to undefined.
+  assert.equal(session.sourceByPath("/definitely/not/referenced"), undefined);
+});

--- a/symbolic-wasm/src/debuginfo/mod.rs
+++ b/symbolic-wasm/src/debuginfo/mod.rs
@@ -8,6 +8,8 @@ use crate::utils::{self, Error, Result};
 
 pub mod sourcebundle;
 
+use sourcebundle::{FileEntry, SourceFileDescriptor};
+
 /// A generic archive that can contain one or more object files.
 #[wasm_bindgen]
 pub struct Archive {
@@ -128,5 +130,55 @@ impl Object {
     #[wasm_bindgen(getter, js_name = hasSources)]
     pub fn has_sources(&self) -> bool {
         self.inner.get().has_sources()
+    }
+
+    /// Returns a debug session that provides access to debugging information
+    /// stored in this object, in particular the source files it references.
+    #[wasm_bindgen(js_name = debugSession)]
+    pub fn debug_session(&self) -> Result<DebugSession> {
+        let session = self.inner.get().debug_session()?;
+        Ok(DebugSession {
+            // SAFETY: `session` is directly derived from `self.inner` and only
+            // borrows data from the same `ByteView`.
+            inner: unsafe { utils::derived_from_cell!(ObjectDebugSession, self.inner, session) },
+        })
+    }
+}
+
+/// A debug session that provides access to an object's debugging information.
+///
+/// In particular, this enumerates the source files referenced by the object and
+/// resolves their contents (when embedded) or source links.
+#[wasm_bindgen]
+pub struct DebugSession {
+    inner: SelfCell<ByteView<'static>, di::ObjectDebugSession<'static>>,
+}
+
+#[wasm_bindgen]
+impl DebugSession {
+    /// Returns all source files referenced by the object.
+    ///
+    /// Note that this only lists referenced files; use [`Self::source_by_path`]
+    /// to retrieve a file's embedded contents or source link.
+    pub fn files(&self) -> Result<Vec<FileEntry>> {
+        self.inner
+            .get()
+            .files()
+            .map(|file| file.map(|file| FileEntry::from(&file)).map_err(Error::from))
+            .collect()
+    }
+
+    /// Looks up a source file by its full, canonicalized path.
+    ///
+    /// Returns the descriptor (embedded contents or a source link) if the path
+    /// is referenced by the object, otherwise `undefined`.
+    #[wasm_bindgen(js_name = sourceByPath)]
+    pub fn source_by_path(&self, path: &str) -> Result<Option<SourceFileDescriptor>> {
+        Ok(self
+            .inner
+            .get()
+            .source_by_path(path)?
+            .as_ref()
+            .map(SourceFileDescriptor::from))
     }
 }

--- a/symbolic-wasm/tests/debuginfo.rs
+++ b/symbolic-wasm/tests/debuginfo.rs
@@ -59,6 +59,46 @@ fn test_archive_objects() {
     assert!(!object.has_sources());
 }
 
+#[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
+fn test_debug_session_files() {
+    let data =
+        common::fixture("symbolic-testutils/fixtures/windows/Sentry.Samples.Console.Basic.pdb");
+
+    let archive = Archive::new(&data).unwrap();
+    let mut objects = archive.objects().unwrap();
+    let object = objects.remove(0);
+
+    let session = object.debug_session().unwrap();
+    let files = session.files().unwrap();
+
+    assert!(!files.is_empty());
+    assert!(files.iter().all(|file| !file.abs_path_str().is_empty()));
+}
+
+#[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
+fn test_debug_session_source_by_path() {
+    let data =
+        common::fixture("symbolic-testutils/fixtures/windows/Sentry.Samples.Console.Basic.pdb");
+
+    let archive = Archive::new(&data).unwrap();
+    let mut objects = archive.objects().unwrap();
+    let object = objects.remove(0);
+
+    let session = object.debug_session().unwrap();
+    let first = session.files().unwrap().remove(0).abs_path_str();
+
+    // A referenced path resolves without error (contents may or may not be embedded).
+    session.source_by_path(&first).unwrap();
+
+    // A path the object does not reference resolves to nothing.
+    assert!(session
+        .source_by_path("/definitely/not/a/referenced/source")
+        .unwrap()
+        .is_none());
+}
+
 #[cfg(target_arch = "wasm32")]
 mod wasm_only {
     use super::*;


### PR DESCRIPTION
Exposes the API needed to enumerate the source files an object references — the `print-sources` use case in `sentry-cli` ([print_sources.rs](https://github.com/getsentry/sentry-cli/blob/master/src/commands/debug_files/print_sources.rs), which iterates `object.debug_session()?.files()` and resolves each via `source_by_path`).

## Changes
- **`symbolic-debuginfo`**: implement `AsSelf` for `ObjectDebugSession`, consistent with the existing impls for `Object`/`Archive`/etc., so the session can be held in a `SelfCell`.
- **`symbolic-wasm`**: add a `DebugSession` type returned by `ObjectFile.debugSession()`:
  - `files()` → `FileEntry[]` — the referenced source files.
  - `sourceByPath(path)` → `SourceFileDescriptor | undefined` — resolves embedded contents or a source link.
  
  Both `FileEntry` and `SourceFileDescriptor` already shipped in 13.4.0; nothing returned them. Follows the `self_cell` ownership model and 1:1-with-Rust naming. Returns eager arrays for now; native JS iterators can replace them later if needed.

## Tests
- `wasm-bindgen` tests (run native + via `wasm-pack test --node`) for `files()` (non-empty, non-empty paths) and `sourceByPath` (referenced path resolves; unreferenced → `None`).
- A packaged-artifact smoke-test assertion (`npm test`) exercising `debugSession().files()`/`sourceByPath()` against the **shipped** package.

Validated locally: `cargo check --all --all-features`, `cargo test -p symbolic-wasm`, fmt + clippy clean, and `make npm` (build + packaged smoke test, 3/3).