### PR TITLE
feat(debuginfo): Add parsing option for limiting embedded source sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 **Features**
 
 - WASM: expose `ObjectFile.debugSession()` returning a `DebugSession` with `files()` (the source files referenced by the object) and `sourceByPath(path)` (resolving embedded contents or a source link). `symbolic-debuginfo` also implements `AsSelf` for `ObjectDebugSession` so it can be held in a `SelfCell`. ([#997](https://github.com/getsentry/symbolic/pull/997))
+- debuginfo: Add a new option `max_embedded_source_size` to `ParseObjectOptions`. This option limits the sizes of embedded source files
+  when they are returned from methods like `source_by_path`. ([#999](https://github.com/getsentry/symbolic/pull/999))
 
 ## 13.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Features**
 
 - WASM: expose `ObjectFile.debugSession()` returning a `DebugSession` with `files()` (the source files referenced by the object) and `sourceByPath(path)` (resolving embedded contents or a source link). `symbolic-debuginfo` also implements `AsSelf` for `ObjectDebugSession` so it can be held in a `SelfCell`. ([#997](https://github.com/getsentry/symbolic/pull/997))
-- debuginfo: Add a new option `max_embedded_source_size` to `ParseObjectOptions`. This option limits the sizes of embedded source files
+- debuginfo: Add a new option `max_decompressed_embedded_source_size` to `ParseObjectOptions`. This option limits the sizes of compressed embedded source files
   when they are returned from methods like `source_by_path`. ([#999](https://github.com/getsentry/symbolic/pull/999))
 
 ## 13.4.0

--- a/symbolic-debuginfo/src/object.rs
+++ b/symbolic-debuginfo/src/object.rs
@@ -133,10 +133,10 @@ pub struct ParseObjectOptions {
     /// This is only relevant to ELF objects.
     pub max_decompressed_section_size: Option<usize>,
 
-    /// The maximum size for source files embedded in an object file.
+    /// The maximum uncompressed size for comprossed source files embedded in an object file.
     ///
     /// This is only relevant for source bundles and PPDB objects.
-    pub max_embedded_source_size: Option<usize>,
+    pub max_decompressed_embedded_source_size: Option<usize>,
 }
 
 /// Tries to infer the object type from the start of the given buffer.

--- a/symbolic-debuginfo/src/object.rs
+++ b/symbolic-debuginfo/src/object.rs
@@ -128,10 +128,15 @@ impl Error for ObjectError {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ParseObjectOptions {
-    /// Maximum uncompressed size for compressed debug file sections.
+    /// The maximum uncompressed size for compressed debug file sections.
     ///
     /// This is only relevant to ELF objects.
     pub max_decompressed_section_size: Option<usize>,
+
+    /// The maximum size for source files embedded in an object file.
+    ///
+    /// This is only relevant for source bundles and PPDB objects.
+    pub max_embedded_source_size: Option<usize>,
 }
 
 /// Tries to infer the object type from the start of the given buffer.

--- a/symbolic-debuginfo/src/ppdb.rs
+++ b/symbolic-debuginfo/src/ppdb.rs
@@ -23,13 +23,26 @@ pub type PortablePdbFunctionIterator<'session> =
 pub struct PortablePdbObject<'data> {
     data: &'data [u8],
     ppdb: PortablePdb<'data>,
+    max_embedded_source_size: Option<usize>,
 }
 
 impl<'data> PortablePdbObject<'data> {
     /// Tries to parse a Portable PDB object from the given slice, with default options.
     pub fn parse(data: &'data [u8]) -> Result<Self, FormatError> {
+        Self::parse_with_opts(data, Default::default())
+    }
+
+    /// Tries to parse a Portable PDB object from the given slice.
+    pub fn parse_with_opts(
+        data: &'data [u8],
+        opts: ParseObjectOptions,
+    ) -> Result<Self, FormatError> {
         let ppdb = PortablePdb::parse(data)?;
-        Ok(Self { data, ppdb })
+        Ok(Self {
+            data,
+            ppdb,
+            max_embedded_source_size: opts.max_embedded_source_size,
+        })
     }
 
     /// Returns the Portable PDB contained in this object.
@@ -99,7 +112,7 @@ impl<'data: 'object, 'object> ObjectLike<'data, 'object> for PortablePdbObject<'
 
     /// Constructs a debugging session.
     fn debug_session(&self) -> Result<PortablePdbDebugSession<'data>, FormatError> {
-        PortablePdbDebugSession::new(&self.ppdb)
+        PortablePdbDebugSession::new(&self.ppdb, self.max_embedded_source_size)
     }
 
     /// Determines whether this object contains stack unwinding information.
@@ -134,8 +147,8 @@ impl<'data> Parse<'data> for PortablePdbObject<'data> {
         PortablePdb::peek(data)
     }
 
-    fn parse_with_opts(data: &'data [u8], _opts: ParseObjectOptions) -> Result<Self, Self::Error> {
-        Self::parse(data)
+    fn parse_with_opts(data: &'data [u8], opts: ParseObjectOptions) -> Result<Self, Self::Error> {
+        Self::parse_with_opts(data, opts)
     }
 }
 
@@ -151,6 +164,7 @@ impl fmt::Debug for PortablePdbObject<'_> {
 pub struct PortablePdbDebugSession<'data> {
     ppdb: PortablePdb<'data>,
     sources: OnceLock<HashMap<String, PPDBSource<'data>>>,
+    max_embedded_source_size: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -160,10 +174,14 @@ enum PPDBSource<'data> {
 }
 
 impl<'data> PortablePdbDebugSession<'data> {
-    fn new(ppdb: &'_ PortablePdb<'data>) -> Result<Self, FormatError> {
+    fn new(
+        ppdb: &'_ PortablePdb<'data>,
+        max_embedded_source_size: Option<usize>,
+    ) -> Result<Self, FormatError> {
         Ok(PortablePdbDebugSession {
             ppdb: ppdb.clone(),
             sources: OnceLock::new(),
+            max_embedded_source_size,
         })
     }
 
@@ -206,12 +224,14 @@ impl<'data> PortablePdbDebugSession<'data> {
         let sources = self.sources.get_or_init(|| self.init_sources());
         match sources.get(path) {
             None => Ok(None),
-            Some(PPDBSource::Embedded(source)) => source.get_contents().map(|bytes| {
-                Some(SourceFileDescriptor::new_embedded(
-                    from_utf8_cow_lossy(&bytes),
-                    None,
-                ))
-            }),
+            Some(PPDBSource::Embedded(source)) => source
+                .get_contents(self.max_embedded_source_size)
+                .map(|bytes| {
+                    Some(SourceFileDescriptor::new_embedded(
+                        from_utf8_cow_lossy(&bytes),
+                        None,
+                    ))
+                }),
             Some(PPDBSource::Link(document)) => Ok(self
                 .ppdb
                 .get_source_link(document)
@@ -291,5 +311,38 @@ impl<'s> Iterator for PortablePdbFileIterator<'s> {
             Cow::default(),
             FileInfo::from_path_owned(document.name.as_bytes()),
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use symbolic_common::ByteView;
+    use symbolic_ppdb::FormatErrorKind as PpdbErrorKind;
+    use symbolic_testutils::fixture;
+
+    use crate::ppdb::PortablePdbObject;
+    use crate::{ObjectLike, ParseObjectOptions};
+
+    #[test]
+    fn test_ppdb_source_by_path_size_limit() {
+        let opts = ParseObjectOptions {
+            max_embedded_source_size: Some(200),
+            ..Default::default()
+        };
+
+        let view = ByteView::open(fixture("windows/Sentry.Samples.Console.Basic.pdb")).unwrap();
+        let object = PortablePdbObject::parse_with_opts(&view, opts).unwrap();
+
+        let session = object.debug_session().unwrap();
+        let err = session
+            .source_by_path(
+                "C:\\dev\\sentry-dotnet\\samples\\Sentry.Samples.Console.Basic\\Program.cs",
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            err.kind(),
+            PpdbErrorKind::EmbeddedSourceFileSizeExceeded(204)
+        ));
     }
 }

--- a/symbolic-debuginfo/src/ppdb.rs
+++ b/symbolic-debuginfo/src/ppdb.rs
@@ -23,7 +23,7 @@ pub type PortablePdbFunctionIterator<'session> =
 pub struct PortablePdbObject<'data> {
     data: &'data [u8],
     ppdb: PortablePdb<'data>,
-    max_embedded_source_size: Option<usize>,
+    max_decompressed_embedded_source_size: Option<usize>,
 }
 
 impl<'data> PortablePdbObject<'data> {
@@ -41,7 +41,7 @@ impl<'data> PortablePdbObject<'data> {
         Ok(Self {
             data,
             ppdb,
-            max_embedded_source_size: opts.max_embedded_source_size,
+            max_decompressed_embedded_source_size: opts.max_decompressed_embedded_source_size,
         })
     }
 
@@ -112,7 +112,7 @@ impl<'data: 'object, 'object> ObjectLike<'data, 'object> for PortablePdbObject<'
 
     /// Constructs a debugging session.
     fn debug_session(&self) -> Result<PortablePdbDebugSession<'data>, FormatError> {
-        PortablePdbDebugSession::new(&self.ppdb, self.max_embedded_source_size)
+        PortablePdbDebugSession::new(&self.ppdb, self.max_decompressed_embedded_source_size)
     }
 
     /// Determines whether this object contains stack unwinding information.
@@ -164,7 +164,7 @@ impl fmt::Debug for PortablePdbObject<'_> {
 pub struct PortablePdbDebugSession<'data> {
     ppdb: PortablePdb<'data>,
     sources: OnceLock<HashMap<String, PPDBSource<'data>>>,
-    max_embedded_source_size: Option<usize>,
+    max_decompressed_embedded_source_size: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -176,12 +176,12 @@ enum PPDBSource<'data> {
 impl<'data> PortablePdbDebugSession<'data> {
     fn new(
         ppdb: &'_ PortablePdb<'data>,
-        max_embedded_source_size: Option<usize>,
+        max_decompressed_embedded_source_size: Option<usize>,
     ) -> Result<Self, FormatError> {
         Ok(PortablePdbDebugSession {
             ppdb: ppdb.clone(),
             sources: OnceLock::new(),
-            max_embedded_source_size,
+            max_decompressed_embedded_source_size,
         })
     }
 
@@ -225,7 +225,7 @@ impl<'data> PortablePdbDebugSession<'data> {
         match sources.get(path) {
             None => Ok(None),
             Some(PPDBSource::Embedded(source)) => source
-                .get_contents_bounded(self.max_embedded_source_size)
+                .get_contents_bounded(self.max_decompressed_embedded_source_size)
                 .map(|bytes| {
                     Some(SourceFileDescriptor::new_embedded(
                         from_utf8_cow_lossy(&bytes),
@@ -326,7 +326,7 @@ mod tests {
     #[test]
     fn test_ppdb_source_by_path_size_limit() {
         let opts = ParseObjectOptions {
-            max_embedded_source_size: Some(200),
+            max_decompressed_embedded_source_size: Some(200),
             ..Default::default()
         };
 

--- a/symbolic-debuginfo/src/ppdb.rs
+++ b/symbolic-debuginfo/src/ppdb.rs
@@ -225,7 +225,7 @@ impl<'data> PortablePdbDebugSession<'data> {
         match sources.get(path) {
             None => Ok(None),
             Some(PPDBSource::Embedded(source)) => source
-                .get_contents(self.max_embedded_source_size)
+                .get_contents_bounded(self.max_embedded_source_size)
                 .map(|bytes| {
                     Some(SourceFileDescriptor::new_embedded(
                         from_utf8_cow_lossy(&bytes),

--- a/symbolic-debuginfo/src/sourcebundle/mod.rs
+++ b/symbolic-debuginfo/src/sourcebundle/mod.rs
@@ -105,7 +105,7 @@ pub enum SourceBundleErrorKind {
     /// A source file exceeded the configured size limit.
     ///
     /// The size limit for a source bundle can be configured
-    /// by the [`max_embedded_source_size`](crate::ParseObjectOptions::max_embedded_source_size)
+    /// by the [`max_decompressed_embedded_source_size`](crate::ParseObjectOptions::max_decompressed_embedded_source_size)
     /// parameter in [`SourceBundle::parse_with_opts`].
     SourceFileSizeExceeded,
 }
@@ -620,7 +620,7 @@ pub struct SourceBundle<'data> {
     data: &'data [u8],
     archive: zip::read::ZipArchive<std::io::Cursor<&'data [u8]>>,
     index: Arc<SourceBundleIndex<'data>>,
-    max_embedded_source_size: Option<usize>,
+    max_decompressed_embedded_source_size: Option<usize>,
 }
 
 impl fmt::Debug for SourceBundle<'_> {
@@ -636,7 +636,7 @@ impl fmt::Debug for SourceBundle<'_> {
             .field("has_unwind_info", &self.has_unwind_info())
             .field("has_sources", &self.has_sources())
             .field("is_malformed", &self.is_malformed())
-            .field("max_embedded_source_size", &self.max_embedded_source_size)
+            .field("max_decompressed_embedded_source_size", &self.max_decompressed_embedded_source_size)
             .finish()
     }
 }
@@ -666,7 +666,7 @@ impl<'data> SourceBundle<'data> {
             archive,
             data,
             index,
-            max_embedded_source_size: opts.max_embedded_source_size,
+            max_decompressed_embedded_source_size: opts.max_decompressed_embedded_source_size,
         })
     }
 
@@ -802,7 +802,7 @@ impl<'data> SourceBundle<'data> {
             index: Arc::clone(&self.index),
             archive,
             source_links,
-            max_embedded_source_size: self.max_embedded_source_size,
+            max_decompressed_embedded_source_size: self.max_decompressed_embedded_source_size,
         })
     }
 
@@ -929,7 +929,7 @@ pub struct SourceBundleDebugSession<'data> {
     archive: Mutex<zip::read::ZipArchive<std::io::Cursor<&'data [u8]>>>,
     index: Arc<SourceBundleIndex<'data>>,
     source_links: SourceLinkMappings,
-    max_embedded_source_size: Option<usize>,
+    max_decompressed_embedded_source_size: Option<usize>,
 }
 
 impl SourceBundleDebugSession<'_> {
@@ -985,7 +985,7 @@ impl SourceBundleDebugSession<'_> {
         if let Some(zip_path) = self.index.indexed_files.get(&key) {
             let zip_path = zip_path.as_str();
             let content =
-                Cow::Owned(self.source_by_zip_path(zip_path, self.max_embedded_source_size)?);
+                Cow::Owned(self.source_by_zip_path(zip_path, self.max_decompressed_embedded_source_size)?);
             let info = self.index.manifest.files.get(zip_path);
             let descriptor = SourceFileDescriptor::new_embedded(content, info);
             return Ok(Some(descriptor));
@@ -2090,7 +2090,7 @@ mod tests {
         let buffer = buffer.into_inner();
 
         let opts = ParseObjectOptions {
-            max_embedded_source_size: Some(20),
+            max_decompressed_embedded_source_size: Some(20),
             ..Default::default()
         };
 

--- a/symbolic-debuginfo/src/sourcebundle/mod.rs
+++ b/symbolic-debuginfo/src/sourcebundle/mod.rs
@@ -101,6 +101,13 @@ pub enum SourceBundleErrorKind {
 
     /// The file is not valid UTF-8 or could not be read for another reason.
     ReadFailed,
+
+    /// A source file exceeded the configured size limit.
+    ///
+    /// The size limit for a source bundle can be configured
+    /// by the [`max_embedded_source_size`](crate::ParseObjectOptions::max_embedded_source_size)
+    /// parameter in [`SourceBundle::parse_with_opts`].
+    SourceFileSizeExceeded,
 }
 
 impl fmt::Display for SourceBundleErrorKind {
@@ -111,6 +118,7 @@ impl fmt::Display for SourceBundleErrorKind {
             Self::BadDebugFile => write!(f, "malformed debug info file"),
             Self::WriteFailed => write!(f, "failed to write source bundle"),
             Self::ReadFailed => write!(f, "file could not be read as UTF-8"),
+            Self::SourceFileSizeExceeded => write!(f, "the source file exceeded the size limit"),
         }
     }
 }
@@ -473,6 +481,17 @@ impl<'a> SourceFileDescriptor<'a> {
     }
 }
 
+impl fmt::Debug for SourceFileDescriptor<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let contents = self.contents.as_ref().map(|contents| contents.len());
+        f.debug_struct("SourceFileDescriptor")
+            .field("contents", &contents)
+            .field("remote_url", &self.remote_url)
+            .field("file_info", &self.file_info)
+            .finish()
+    }
+}
+
 /// Version number of a [`SourceBundle`](struct.SourceBundle.html).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct SourceBundleVersion(pub u32);
@@ -601,6 +620,7 @@ pub struct SourceBundle<'data> {
     data: &'data [u8],
     archive: zip::read::ZipArchive<std::io::Cursor<&'data [u8]>>,
     index: Arc<SourceBundleIndex<'data>>,
+    max_embedded_source_size: Option<usize>,
 }
 
 impl fmt::Debug for SourceBundle<'_> {
@@ -616,6 +636,7 @@ impl fmt::Debug for SourceBundle<'_> {
             .field("has_unwind_info", &self.has_unwind_info())
             .field("has_sources", &self.has_sources())
             .field("is_malformed", &self.is_malformed())
+            .field("max_embedded_source_size", &self.max_embedded_source_size)
             .finish()
     }
 }
@@ -626,8 +647,16 @@ impl<'data> SourceBundle<'data> {
         bytes.starts_with(&BUNDLE_MAGIC)
     }
 
-    /// Tries to parse a `SourceBundle` from the given slice.
+    /// Tries to parse a `SourceBundle` from the given slice, with default options.
     pub fn parse(data: &'data [u8]) -> Result<SourceBundle<'data>, SourceBundleError> {
+        Self::parse_with_opts(data, Default::default())
+    }
+
+    /// Tries to parse a `SourceBundle` from the given slice.
+    pub fn parse_with_opts(
+        data: &'data [u8],
+        opts: ParseObjectOptions,
+    ) -> Result<SourceBundle<'data>, SourceBundleError> {
         let mut archive = zip::read::ZipArchive::new(std::io::Cursor::new(data))
             .map_err(|e| SourceBundleError::new(SourceBundleErrorKind::BadZip, e))?;
 
@@ -637,6 +666,7 @@ impl<'data> SourceBundle<'data> {
             archive,
             data,
             index,
+            max_embedded_source_size: opts.max_embedded_source_size,
         })
     }
 
@@ -772,6 +802,7 @@ impl<'data> SourceBundle<'data> {
             index: Arc::clone(&self.index),
             archive,
             source_links,
+            max_embedded_source_size: self.max_embedded_source_size,
         })
     }
 
@@ -812,8 +843,8 @@ impl<'slf, 'data: 'slf> AsSelf<'slf> for SourceBundle<'data> {
 impl<'data> Parse<'data> for SourceBundle<'data> {
     type Error = SourceBundleError;
 
-    fn parse_with_opts(data: &'data [u8], _opts: ParseObjectOptions) -> Result<Self, Self::Error> {
-        Self::parse(data)
+    fn parse_with_opts(data: &'data [u8], opts: ParseObjectOptions) -> Result<Self, Self::Error> {
+        Self::parse_with_opts(data, opts)
     }
 
     fn test(data: &'data [u8]) -> bool {
@@ -898,6 +929,7 @@ pub struct SourceBundleDebugSession<'data> {
     archive: Mutex<zip::read::ZipArchive<std::io::Cursor<&'data [u8]>>>,
     index: Arc<SourceBundleIndex<'data>>,
     source_links: SourceLinkMappings,
+    max_embedded_source_size: Option<usize>,
 }
 
 impl SourceBundleDebugSession<'_> {
@@ -914,11 +946,20 @@ impl SourceBundleDebugSession<'_> {
     }
 
     /// Get source by the path of a file in the bundle.
-    fn source_by_zip_path(&self, zip_path: &str) -> Result<String, SourceBundleError> {
+    fn source_by_zip_path(
+        &self,
+        zip_path: &str,
+        max_size: Option<usize>,
+    ) -> Result<String, SourceBundleError> {
         let mut archive = self.archive.lock();
         let mut file = archive
             .by_name(zip_path)
             .map_err(|e| SourceBundleError::new(SourceBundleErrorKind::BadZip, e))?;
+
+        if max_size.is_some_and(|max| file.size() as usize > max) {
+            return Err(SourceBundleErrorKind::SourceFileSizeExceeded.into());
+        }
+
         let mut source_content = String::new();
 
         file.read_to_string(&mut source_content)
@@ -936,7 +977,8 @@ impl SourceBundleDebugSession<'_> {
     ) -> Result<Option<SourceFileDescriptor<'_>>, SourceBundleError> {
         if let Some(zip_path) = self.index.indexed_files.get(&key) {
             let zip_path = zip_path.as_str();
-            let content = Cow::Owned(self.source_by_zip_path(zip_path)?);
+            let content =
+                Cow::Owned(self.source_by_zip_path(zip_path, self.max_embedded_source_size)?);
             let info = self.index.manifest.files.get(zip_path);
             let descriptor = SourceFileDescriptor::new_embedded(content, info);
             return Ok(Some(descriptor));
@@ -2019,5 +2061,39 @@ mod tests {
             .unwrap();
 
         assert!(!written);
+    }
+
+    #[test]
+    fn test_size_limit() {
+        let mut buffer = Cursor::new(Vec::new());
+        let mut bundle = SourceBundleWriter::start(&mut buffer).unwrap();
+
+        bundle
+            .add_file(
+                "bar.txt",
+                &b"this is 26 characters long"[..],
+                SourceFileInfo {
+                    path: "bar.txt".to_owned(),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        bundle.finish().unwrap();
+
+        let buffer = buffer.into_inner();
+
+        let opts = ParseObjectOptions {
+            max_embedded_source_size: Some(20),
+            ..Default::default()
+        };
+
+        let bundle = SourceBundle::parse_with_opts(&buffer, opts).unwrap();
+        let session = bundle.debug_session().unwrap();
+        let err = session.source_by_path("bar.txt").unwrap_err();
+
+        assert!(matches!(
+            err.kind(),
+            SourceBundleErrorKind::SourceFileSizeExceeded
+        ));
     }
 }

--- a/symbolic-debuginfo/src/sourcebundle/mod.rs
+++ b/symbolic-debuginfo/src/sourcebundle/mod.rs
@@ -636,7 +636,10 @@ impl fmt::Debug for SourceBundle<'_> {
             .field("has_unwind_info", &self.has_unwind_info())
             .field("has_sources", &self.has_sources())
             .field("is_malformed", &self.is_malformed())
-            .field("max_decompressed_embedded_source_size", &self.max_decompressed_embedded_source_size)
+            .field(
+                "max_decompressed_embedded_source_size",
+                &self.max_decompressed_embedded_source_size,
+            )
             .finish()
     }
 }
@@ -984,8 +987,9 @@ impl SourceBundleDebugSession<'_> {
     ) -> Result<Option<SourceFileDescriptor<'_>>, SourceBundleError> {
         if let Some(zip_path) = self.index.indexed_files.get(&key) {
             let zip_path = zip_path.as_str();
-            let content =
-                Cow::Owned(self.source_by_zip_path(zip_path, self.max_decompressed_embedded_source_size)?);
+            let content = Cow::Owned(
+                self.source_by_zip_path(zip_path, self.max_decompressed_embedded_source_size)?,
+            );
             let info = self.index.manifest.files.get(zip_path);
             let descriptor = SourceFileDescriptor::new_embedded(content, info);
             return Ok(Some(descriptor));

--- a/symbolic-debuginfo/src/sourcebundle/mod.rs
+++ b/symbolic-debuginfo/src/sourcebundle/mod.rs
@@ -952,18 +952,25 @@ impl SourceBundleDebugSession<'_> {
         max_size: Option<usize>,
     ) -> Result<String, SourceBundleError> {
         let mut archive = self.archive.lock();
-        let mut file = archive
+        let file = archive
             .by_name(zip_path)
             .map_err(|e| SourceBundleError::new(SourceBundleErrorKind::BadZip, e))?;
 
-        if max_size.is_some_and(|max| file.size() as usize > max) {
+        let size = file.size();
+        if max_size.is_some_and(|max| size as usize > max) {
             return Err(SourceBundleErrorKind::SourceFileSizeExceeded.into());
         }
 
         let mut source_content = String::new();
 
-        file.read_to_string(&mut source_content)
+        file.take(size + 1)
+            .read_to_string(&mut source_content)
             .map_err(|e| SourceBundleError::new(SourceBundleErrorKind::BadZip, e))?;
+
+        if source_content.len() != size as usize {
+            return Err(SourceBundleErrorKind::BadZip.into());
+        }
+
         Ok(source_content)
     }
 

--- a/symbolic-debuginfo/tests/test_objects.rs
+++ b/symbolic-debuginfo/tests/test_objects.rs
@@ -927,7 +927,7 @@ fn test_ppdb_source_by_path() -> Result<(), Error> {
 #[test]
 fn test_ppdb_source_by_path_size_limit() {
     let mut opts = ParseObjectOptions::default();
-    opts.max_embedded_source_size = Some(200);
+    opts.max_decompressed_embedded_source_size = Some(200);
 
     let view = ByteView::open(fixture("windows/Sentry.Samples.Console.Basic.pdb")).unwrap();
     let object = Object::parse_with_opts(&view, opts).unwrap();

--- a/symbolic-debuginfo/tests/test_objects.rs
+++ b/symbolic-debuginfo/tests/test_objects.rs
@@ -1,4 +1,6 @@
-use std::{ffi::CString, fmt, io::BufWriter};
+use std::ffi::CString;
+use std::fmt;
+use std::io::BufWriter;
 
 use symbolic_common::{ByteView, Language};
 use symbolic_debuginfo::dwarf::DwarfErrorKind;
@@ -920,6 +922,20 @@ fn test_ppdb_source_by_path() -> Result<(), Error> {
     }
 
     Ok(())
+}
+
+#[test]
+fn test_ppdb_source_by_path_size_limit() {
+    let mut opts = ParseObjectOptions::default();
+    opts.max_embedded_source_size = Some(200);
+
+    let view = ByteView::open(fixture("windows/Sentry.Samples.Console.Basic.pdb")).unwrap();
+    let object = Object::parse_with_opts(&view, opts).unwrap();
+
+    let session = object.debug_session().unwrap();
+    session
+        .source_by_path("C:\\dev\\sentry-dotnet\\samples\\Sentry.Samples.Console.Basic\\Program.cs")
+        .unwrap_err();
 }
 
 #[test]

--- a/symbolic-ppdb/src/format/mod.rs
+++ b/symbolic-ppdb/src/format/mod.rs
@@ -106,6 +106,9 @@ pub enum FormatErrorKind {
     /// Failed to parse Source Link JSON
     #[error("invalid source link JSON")]
     InvalidSourceLinkJson,
+    /// An embedded source file exceeded the configured size limit.
+    #[error("embedded source file size ({0}) exceeds maximum")]
+    EmbeddedSourceFileSizeExceeded(usize),
 }
 
 /// An error encountered while parsing a [`PortablePdb`] file.
@@ -476,7 +479,7 @@ impl<'data, 'object> EmbeddedSource<'data> {
     }
 
     /// Reads the source file contents from the Portable PDB.
-    pub fn get_contents(&self) -> Result<Cow<'data, [u8]>, FormatError> {
+    pub fn get_contents(&self, max_size: Option<usize>) -> Result<Cow<'data, [u8]>, FormatError> {
         // The blob has the following structure: `Blob ::= format content`
         // - format - int32 - Indicates how the content is serialized.
         //     0 = raw bytes, uncompressed.
@@ -488,9 +491,24 @@ impl<'data, 'object> EmbeddedSource<'data> {
         }
         let (format_blob, data_blob) = self.blob.split_at(4);
         let format = u32::from_ne_bytes(format_blob.try_into().unwrap());
+
+        // Per the above comment, the format is really an `i32`.
+        // None-negative values are currently valid, negative ones are reserved.
+        // We can't trivially change this to an `i32`, though, because of
+        // `FormatErrorKind::InvalidBlobFormat`, which expects a `u32`.
+        // Therefore, we manually bound the format here to the largest
+        // positive `i32`.
+        const MAX_VALID_FORMAT: u32 = i32::MAX as u32;
+
         match format {
             0 => Ok(Cow::Borrowed(data_blob)),
-            x if x > 0 => self.inflate_contents(format as usize, data_blob),
+            1..=MAX_VALID_FORMAT => {
+                let size = format as usize;
+                if max_size.is_some_and(|max| size > max) {
+                    return Err(FormatErrorKind::EmbeddedSourceFileSizeExceeded(size).into());
+                }
+                self.inflate_contents(size, data_blob)
+            }
             _ => Err(FormatErrorKind::InvalidBlobFormat(format).into()),
         }
     }

--- a/symbolic-ppdb/src/format/mod.rs
+++ b/symbolic-ppdb/src/format/mod.rs
@@ -479,7 +479,18 @@ impl<'data, 'object> EmbeddedSource<'data> {
     }
 
     /// Reads the source file contents from the Portable PDB.
-    pub fn get_contents(&self, max_size: Option<usize>) -> Result<Cow<'data, [u8]>, FormatError> {
+    pub fn get_contents(&self) -> Result<Cow<'data, [u8]>, FormatError> {
+        self.get_contents_bounded(None)
+    }
+
+    /// Reads the source file contents from the Portable PDB.
+    ///
+    /// If the contents are compressed, the decompressed size
+    /// can be bounded with `max_decompressed_size`.
+    pub fn get_contents_bounded(
+        &self,
+        max_decompressed_size: Option<usize>,
+    ) -> Result<Cow<'data, [u8]>, FormatError> {
         // The blob has the following structure: `Blob ::= format content`
         // - format - int32 - Indicates how the content is serialized.
         //     0 = raw bytes, uncompressed.
@@ -504,7 +515,7 @@ impl<'data, 'object> EmbeddedSource<'data> {
             0 => Ok(Cow::Borrowed(data_blob)),
             1..=MAX_VALID_FORMAT => {
                 let size = format as usize;
-                if max_size.is_some_and(|max| size > max) {
+                if max_decompressed_size.is_some_and(|max| size > max) {
                     return Err(FormatErrorKind::EmbeddedSourceFileSizeExceeded(size).into());
                 }
                 self.inflate_contents(size, data_blob)

--- a/symbolic-ppdb/src/format/mod.rs
+++ b/symbolic-ppdb/src/format/mod.rs
@@ -518,9 +518,10 @@ impl<'data, 'object> EmbeddedSource<'data> {
         size: usize,
         data: &'data [u8],
     ) -> Result<Cow<'data, [u8]>, FormatError> {
-        let mut decoder = DeflateDecoder::new(data);
-        let mut output = Vec::with_capacity(size);
+        let decoder = DeflateDecoder::new(data);
+        let mut output = Vec::with_capacity(size + 1);
         let read_size = decoder
+            .take(size as u64 + 1)
             .read_to_end(&mut output)
             .map_err(|e| FormatError::new(FormatErrorKind::InvalidBlobData, e))?;
         if read_size != size {

--- a/symbolic-ppdb/tests/test_ppdb.rs
+++ b/symbolic-ppdb/tests/test_ppdb.rs
@@ -43,7 +43,7 @@ fn test_embedded_sources() {
 }
 
 fn check_contents(item: &EmbeddedSource, length: usize, name: &str) {
-    let content = item.get_contents(None).unwrap();
+    let content = item.get_contents().unwrap();
     assert_eq!(content.len(), length);
 
     let expected = std::fs::read(format!("tests/fixtures/contents/{name}")).unwrap();

--- a/symbolic-ppdb/tests/test_ppdb.rs
+++ b/symbolic-ppdb/tests/test_ppdb.rs
@@ -43,7 +43,7 @@ fn test_embedded_sources() {
 }
 
 fn check_contents(item: &EmbeddedSource, length: usize, name: &str) {
-    let content = item.get_contents().unwrap();
+    let content = item.get_contents(None).unwrap();
     assert_eq!(content.len(), length);
 
     let expected = std::fs::read(format!("tests/fixtures/contents/{name}")).unwrap();


### PR DESCRIPTION
This adds a new field `max_embedded_source_size` to `ParseObjectOptions`. This option is only relevant for object types that can contain embedded source files (or, to be precise, from which `symbolic` can _extract_ embedded source files). Which is to say, source bundles and portable PDB files.

Both of these object types now validate the (claimed) size of embedded sources against this maximum and return an error if it is exceeded. Both file formats have gained new error kinds for this case.

# Alternatives

We could also not make this a part of `ParseObjectOptions`, but rather add versions of `source_by_{path,url,debug_id}` that take a size limit, because that's where the limit actually ends up getting used.

ref: INGEST-966