### PR TITLE
ci(ci): Add cargo semver checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
         with:
           baseline-rev: ${{ github.event.pull_request.base.sha }}
           feature-group: all-features
-          package: symbolic, symbolic-cfi, symbolic-common, symbolic-debuginfo, symbolic-demangle, symbolic-il2cpp, symbolic-ppdb, symbolic-sourcemapcache, symbolic-symcache, symbolic-unreal
 
   test-rust:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,23 @@ jobs:
 
       - run: cargo doc --workspace --all-features --document-private-items --no-deps
 
+  semver:
+    name: SemVer Checks
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          fetch-depth: 0
+
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae # v2.8
+        with:
+          baseline-rev: ${{ github.event.pull_request.base.sha }}
+          feature-group: all-features
+          package: symbolic, symbolic-cfi, symbolic-common, symbolic-debuginfo, symbolic-demangle, symbolic-il2cpp, symbolic-ppdb, symbolic-sourcemapcache, symbolic-symcache, symbolic-unreal
+
   test-rust:
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,14 +57,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-        with:
-          fetch-depth: 0
-
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae # v2.8
-        with:
-          baseline-rev: ${{ github.event.pull_request.base.sha }}
-          feature-group: all-features
 
   test-rust:
     strategy:

--- a/symbolic-debuginfo/src/object.rs
+++ b/symbolic-debuginfo/src/object.rs
@@ -125,13 +125,14 @@ impl Error for ObjectError {
 }
 
 /// Options for parsing object files.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ParseObjectOptions {
     /// Maximum uncompressed size for compressed debug file sections.
     ///
     /// This is only relevant to ELF objects.
     pub max_decompressed_section_size: Option<usize>,
+
+    pub unused: usize,
 }
 
 /// Tries to infer the object type from the start of the given buffer.


### PR DESCRIPTION
Experiment to add cargo semver checks, which hopefully catches accidental semver changes before things are merged.