### PR TITLE
fix(unreal): Handle XML parsing without recursion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,6 @@
 - `symbolic-debuginfo`: Add a new option `max_decompressed_embedded_source_size` to `ParseObjectOptions`. This option limits the sizes of compressed embedded source files
   when they are returned from methods like `source_by_path`. ([#999](https://github.com/getsentry/symbolic/pull/999))
 
-
 ## 13.5.0
 
 **Features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add limit on inline nesting depth when parsing Breakpad objects. ([#1014](https://github.com/getsentry/symbolic/pull/1014))
 - Fix potential out of bounds panic on invalid section offsets ([#1013](https://github.com/getsentry/symbolic/pull/1013))
 - Fix a potential panic when locating sections in an elf file. ([#1012](https://github.com/getsentry/symbolic/pull/1012))
+- Handle XML parsing without recursion. ([#1003](https://github.com/getsentry/symbolic/pull/1003))
 
 ## 13.8.0
 
@@ -47,6 +48,7 @@
 
 - `symbolic-debuginfo`: Add a new option `max_decompressed_embedded_source_size` to `ParseObjectOptions`. This option limits the sizes of compressed embedded source files
   when they are returned from methods like `source_by_path`. ([#999](https://github.com/getsentry/symbolic/pull/999))
+
 
 ## 13.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**
+
+- Handle XML parsing without recursion. ([#1003](https://github.com/getsentry/symbolic/pull/1003))
+
 ## 14.0.0-alpha.1
 
 - No documented changes.
@@ -11,7 +17,6 @@
 - Add limit on inline nesting depth when parsing Breakpad objects. ([#1014](https://github.com/getsentry/symbolic/pull/1014))
 - Fix potential out of bounds panic on invalid section offsets ([#1013](https://github.com/getsentry/symbolic/pull/1013))
 - Fix a potential panic when locating sections in an elf file. ([#1012](https://github.com/getsentry/symbolic/pull/1012))
-- Handle XML parsing without recursion. ([#1003](https://github.com/getsentry/symbolic/pull/1003))
 
 ## 13.8.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,6 +1804,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2640,9 +2649,9 @@ dependencies = [
  "anylog",
  "bytes",
  "chrono",
- "elementtree",
  "flate2",
  "insta",
+ "quick-xml",
  "regex",
  "scroll 0.13.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ cpp_demangle = "0.4.1"
 criterion = { version = "0.8.1", features = ["html_reports"] }
 debugid = "0.8.0"
 elementtree = "1.2.3"
+quick-xml = "0.40.1"
 elsa = "1.8.0"
 fallible-iterator = "0.3.0"
 flate2 = { version = "1.1.8", default-features = false, features = [

--- a/symbolic-unreal/Cargo.toml
+++ b/symbolic-unreal/Cargo.toml
@@ -35,6 +35,7 @@ scroll = { workspace = true, features = ["derive"] }
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true }
 time = { workspace = true }
+
 [dev-dependencies]
 insta = { workspace = true }
 similar-asserts = { workspace = true }

--- a/symbolic-unreal/Cargo.toml
+++ b/symbolic-unreal/Cargo.toml
@@ -28,14 +28,13 @@ serde = ["dep:serde", "chrono/serde"]
 anylog = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
-elementtree = { workspace = true }
+quick-xml = { workspace = true, features = ["escape-html"] }
 flate2 = { workspace = true }
 regex = { workspace = true }
 scroll = { workspace = true, features = ["derive"] }
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true }
 time = { workspace = true }
-
 [dev-dependencies]
 insta = { workspace = true }
 similar-asserts = { workspace = true }

--- a/symbolic-unreal/Cargo.toml
+++ b/symbolic-unreal/Cargo.toml
@@ -28,7 +28,7 @@ serde = ["dep:serde", "chrono/serde"]
 anylog = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
-quick-xml = { workspace = true, features = ["escape-html"] }
+quick-xml = { workspace = true }
 flate2 = { workspace = true }
 regex = { workspace = true }
 scroll = { workspace = true, features = ["derive"] }

--- a/symbolic-unreal/src/context.rs
+++ b/symbolic-unreal/src/context.rs
@@ -165,7 +165,7 @@ impl Unreal4ContextRuntimeProperties {
 
         let mut rv = Unreal4ContextRuntimeProperties::default();
 
-        if !r.first_instance_of_tag("RuntimeProperties")? {
+        if !r.next_instance_of_tag("RuntimeProperties")? {
             return Ok(None);
         }
 
@@ -258,7 +258,7 @@ impl Unreal4ContextPlatformProperties {
 
         let mut rv = Unreal4ContextPlatformProperties::default();
 
-        if !r.first_instance_of_tag("PlatformProperties")? {
+        if !r.next_instance_of_tag("PlatformProperties")? {
             return Ok(None);
         }
 
@@ -321,7 +321,7 @@ fn load_data_bag(
     let r = quick_xml::Reader::from_reader(data);
     let mut r = XMLReader::new(r);
 
-    if r.first_instance_of_tag(tag)? {
+    if r.next_instance_of_tag(tag)? {
         while let Some(mut child) = r.next_child()? {
             let name = String::from_utf8_lossy(child.tag().name().as_ref()).to_string();
             if let Some(value) = child.value::<String>()? {

--- a/symbolic-unreal/src/context.rs
+++ b/symbolic-unreal/src/context.rs
@@ -1,10 +1,9 @@
 //! Unreal Engine 4 crash context information
 #![warn(missing_docs)]
 
-use elementtree::{Element, QName};
-
 use std::collections::BTreeMap;
 
+use quick_xml::{escape::resolve_xml_entity, events::BytesStart};
 #[cfg(test)]
 use similar_asserts::assert_eq;
 
@@ -160,103 +159,230 @@ pub struct Unreal4ContextRuntimeProperties {
     pub custom: BTreeMap<String, String>,
 }
 
-impl Unreal4ContextRuntimeProperties {
-    fn from_xml(root: &Element) -> Option<Self> {
-        let list = root.find("RuntimeProperties")?;
+enum NodeState {
+    None,
+    Opened { node_depth: i32 },
+    Empty,
+}
 
-        let mut rv = Unreal4ContextRuntimeProperties::default();
+// A helper to keep track of reader state as we move through the XML.
+struct XMLReader<'a> {
+    reader: quick_xml::Reader<&'a [u8]>,
+    node_state: NodeState,
+}
 
-        fn get_text_or_none(elm: &Element) -> Option<String> {
-            let text = elm.text();
-            if !text.is_empty() {
-                Some(text.to_string())
-            } else {
-                None
+impl<'a> XMLReader<'a> {
+    fn new(reader: quick_xml::Reader<&'a [u8]>) -> Self {
+        Self {
+            reader,
+            node_state: NodeState::None,
+        }
+    }
+
+    /// Moves the reader to the specified tag if it exists.  Returns true iff
+    /// the tag exists.
+    fn find_tag(&mut self, name: &str) -> Result<bool, quick_xml::Error> {
+        loop {
+            match self.reader.read_event()? {
+                quick_xml::events::Event::Eof => break,
+
+                quick_xml::events::Event::Start(bytes_start) => {
+                    if bytes_start.name().as_ref() == name.as_bytes() {
+                        self.node_state = NodeState::Opened { node_depth: 0 };
+                        return Ok(true);
+                    }
+                }
+                quick_xml::events::Event::Empty(bytes_start) => {
+                    if bytes_start.name().as_ref() == name.as_bytes() {
+                        self.node_state = NodeState::Empty;
+                        return Ok(true);
+                    }
+                }
+
+                _ => {}
+            };
+        }
+
+        self.node_state = NodeState::None;
+        Ok(false)
+    }
+
+    /// Returns the text value, parsed, from the node at which the reader is
+    /// located.  If there is no such node or value, or the parse fails, this will
+    /// return None.  A best-effort is made to deal with text spread between xml nodes.
+    /// XML entities are resolved (so '&qout;' is resolved to '"', and the like.)
+    fn value<T: std::str::FromStr>(&mut self) -> Result<Option<T>, quick_xml::Error> {
+        let NodeState::Opened { node_depth } = &mut self.node_state else {
+            return Ok(None);
+        };
+
+        let mut val = String::new();
+        let text_depth = *node_depth;
+        loop {
+            match self.reader.read_event()? {
+                quick_xml::events::Event::Text(bytes_text) => {
+                    if text_depth == *node_depth {
+                        val += &bytes_text.decode().unwrap();
+                    }
+                }
+
+                quick_xml::events::Event::GeneralRef(bytes_text) => {
+                    if text_depth == *node_depth {
+                        val += resolve_xml_entity(&bytes_text.decode().unwrap()).unwrap();
+                    }
+                }
+
+                quick_xml::events::Event::End(_) => {
+                    *node_depth -= 1;
+                }
+
+                // It could be the case that we have text interleaved with nodes, so
+                // try to be graceful when handling.
+                quick_xml::events::Event::Start(_) => {
+                    *node_depth += 1;
+                }
+
+                _ => {}
+            };
+
+            if *node_depth < text_depth {
+                break;
             }
         }
 
-        for child in list.children() {
-            let tag = child.tag();
+        if val.len() > 0 {
+            Ok(val.parse().ok())
+        } else {
+            Ok(None)
+        }
+    }
 
+    /// Moves to the next child of this node, returning None if we exhaust the children,
+    /// otherwise returning the bytes of the start of the tag.
+    fn next_child(&mut self) -> Result<Option<BytesStart<'_>>, quick_xml::Error> {
+        let NodeState::Opened { node_depth } = &mut self.node_state else {
+            return Ok(None);
+        };
+
+        let maybe_bytes = loop {
+            let maybe_bytes = match self.reader.read_event()? {
+                quick_xml::events::Event::Start(bytes_start) => {
+                    *node_depth += 1;
+                    if *node_depth == 1 {
+                        Some(bytes_start)
+                    } else {
+                        None
+                    }
+                }
+                quick_xml::events::Event::End(_) => {
+                    *node_depth -= 1;
+                    None
+                }
+                quick_xml::events::Event::Empty(bytes_start) => {
+                    if *node_depth == 0 {
+                        Some(bytes_start)
+                    } else {
+                        None
+                    }
+                }
+
+                quick_xml::events::Event::Eof => {
+                    *node_depth = -1;
+                    break None;
+                }
+
+                _ => None,
+            };
+
+            if maybe_bytes.is_some() {
+                break maybe_bytes;
+            }
+
+            if *node_depth < 0 {
+                self.node_state = NodeState::None;
+                break None;
+            }
+        };
+
+        Ok(maybe_bytes)
+    }
+}
+
+impl Unreal4ContextRuntimeProperties {
+    fn from_xml(root: &[u8]) -> Result<Option<Self>, quick_xml::Error> {
+        let r = quick_xml::Reader::from_reader(root);
+        let mut r = XMLReader::new(r);
+
+        let mut rv = Unreal4ContextRuntimeProperties::default();
+
+        if !r.find_tag("RuntimeProperties")? {
+            return Ok(None);
+        }
+
+        while let Some(tag) = r.next_child()? {
             // We don't expect an XML with namespace here
-            if tag.ns().is_some() {
+            if tag.name().prefix().is_some() {
                 continue;
             }
-            match tag.name() {
-                "CrashGUID" => rv.crash_guid = get_text_or_none(child),
-                "ProcessId" => rv.process_id = child.text().parse::<u32>().ok(),
-                "IsInternalBuild" => rv.is_internal_build = child.text().parse::<bool>().ok(),
-                "IsSourceDistribution" => {
-                    rv.is_source_distribution = child.text().parse::<bool>().ok()
+            match tag.name().as_ref() {
+                b"CrashGUID" => rv.crash_guid = r.value()?,
+                b"ProcessId" => rv.process_id = r.value()?,
+                b"IsInternalBuild" => rv.is_internal_build = r.value()?,
+                b"IsSourceDistribution" => rv.is_source_distribution = r.value()?,
+                b"IsAssert" => rv.is_assert = r.value()?,
+                b"IsEnsure" => rv.is_ensure = r.value()?,
+                b"CrashType" => rv.crash_type = r.value()?,
+                b"SecondsSinceStart" => rv.seconds_since_start = r.value()?,
+                b"GameName" => rv.game_name = r.value()?,
+                b"ExecutableName" => rv.executable_name = r.value()?,
+                b"BuildConfiguration" => rv.build_configuration = r.value()?,
+                b"PlatformName" => rv.platform_name = r.value()?,
+                b"EngineMode" => rv.engine_mode = r.value()?,
+                b"EngineVersion" => rv.engine_version = r.value()?,
+                b"LanguageLCID" => rv.language_lcid = r.value()?,
+                b"AppDefaultLocale" => rv.app_default_locate = r.value()?,
+                b"BuildVersion" => rv.build_version = r.value()?,
+                b"IsUE4Release" => rv.is_ue4_release = r.value()?,
+                b"UserName" => rv.username = r.value()?,
+                b"BaseDir" => rv.base_dir = r.value()?,
+                b"RootDir" => rv.root_dir = r.value()?,
+                b"MachineId" => rv.machine_id = r.value()?,
+                b"LoginId" => rv.login_id = r.value()?,
+                b"EpicAccountId" => rv.epic_account_id = r.value()?,
+                b"CallStack" => rv.legacy_call_stack = r.value()?,
+                b"PCallStack" => rv.portable_call_stack = r.value()?,
+                b"UserDescription" => rv.user_description = r.value()?,
+                b"ErrorMessage" => rv.error_message = r.value()?,
+                b"CrashReporterMessage" => rv.crash_reporter_message = r.value()?,
+                b"Misc.NumberOfCores" => rv.misc_number_of_cores = r.value()?,
+                b"Misc.NumberOfCoresIncludingHyperthreads" => {
+                    rv.misc_number_of_cores_inc_hyperthread = r.value()?
                 }
-                "IsAssert" => rv.is_assert = child.text().parse::<bool>().ok(),
-                "IsEnsure" => rv.is_ensure = child.text().parse::<bool>().ok(),
-                "CrashType" => rv.crash_type = get_text_or_none(child),
-                "SecondsSinceStart" => rv.seconds_since_start = child.text().parse::<u32>().ok(),
-                "GameName" => rv.game_name = get_text_or_none(child),
-                "ExecutableName" => rv.executable_name = get_text_or_none(child),
-                "BuildConfiguration" => rv.build_configuration = get_text_or_none(child),
-                "PlatformName" => rv.platform_name = get_text_or_none(child),
-                "EngineMode" => rv.engine_mode = get_text_or_none(child),
-                "EngineVersion" => rv.engine_version = get_text_or_none(child),
-                "LanguageLCID" => rv.language_lcid = child.text().parse::<i32>().ok(),
-                "AppDefaultLocale" => rv.app_default_locate = get_text_or_none(child),
-                "BuildVersion" => rv.build_version = get_text_or_none(child),
-                "IsUE4Release" => rv.is_ue4_release = child.text().parse::<bool>().ok(),
-                "UserName" => rv.username = get_text_or_none(child),
-                "BaseDir" => rv.base_dir = get_text_or_none(child),
-                "RootDir" => rv.root_dir = get_text_or_none(child),
-                "MachineId" => rv.machine_id = get_text_or_none(child),
-                "LoginId" => rv.login_id = get_text_or_none(child),
-                "EpicAccountId" => rv.epic_account_id = get_text_or_none(child),
-                "CallStack" => rv.legacy_call_stack = get_text_or_none(child),
-                "PCallStack" => rv.portable_call_stack = get_text_or_none(child),
-                "UserDescription" => rv.user_description = get_text_or_none(child),
-                "ErrorMessage" => rv.error_message = get_text_or_none(child),
-                "CrashReporterMessage" => rv.crash_reporter_message = get_text_or_none(child),
-                "Misc.NumberOfCores" => rv.misc_number_of_cores = child.text().parse::<u32>().ok(),
-                "Misc.NumberOfCoresIncludingHyperthreads" => {
-                    rv.misc_number_of_cores_inc_hyperthread = child.text().parse::<u32>().ok()
-                }
-                "Misc.Is64bitOperatingSystem" => {
-                    rv.misc_is_64bit = child.text().parse::<bool>().ok()
-                }
-                "Misc.CPUVendor" => rv.misc_cpu_vendor = get_text_or_none(child),
-                "Misc.CPUBrand" => rv.misc_cpu_brand = get_text_or_none(child),
-                "Misc.PrimaryGPUBrand" => rv.misc_primary_gpu_brand = get_text_or_none(child),
-                "Misc.OSVersionMajor" => rv.misc_os_version_major = get_text_or_none(child),
-                "Misc.OSVersionMinor" => rv.misc_os_version_minor = get_text_or_none(child),
-                "GameStateName" => rv.game_state_name = get_text_or_none(child),
-                "MemoryStats.TotalPhysical" => {
-                    rv.memory_stats_total_physical = child.text().parse::<u64>().ok()
-                }
-                "MemoryStats.TotalVirtual" => {
-                    rv.memory_stats_total_virtual = child.text().parse::<u64>().ok()
-                }
-                "MemoryStats.PageSize" => {
-                    rv.memory_stats_page_size = child.text().parse::<u64>().ok()
-                }
-                "MemoryStats.TotalPhysicalGB" => {
-                    rv.memory_stats_total_phsysical_gb = child.text().parse::<u32>().ok()
-                }
-                "TimeOfCrash" => rv.time_of_crash = child.text().parse::<u64>().ok(),
-                "bAllowToBeContacted" => {
-                    rv.allowed_to_be_contacted = child.text().parse::<bool>().ok()
-                }
-                "CrashReportClientVersion" => {
-                    rv.crash_reporter_client_version = get_text_or_none(child)
-                }
-                "Modules" => rv.modules = get_text_or_none(child),
+                b"Misc.Is64bitOperatingSystem" => rv.misc_is_64bit = r.value()?,
+                b"Misc.CPUVendor" => rv.misc_cpu_vendor = r.value()?,
+                b"Misc.CPUBrand" => rv.misc_cpu_brand = r.value()?,
+                b"Misc.PrimaryGPUBrand" => rv.misc_primary_gpu_brand = r.value()?,
+                b"Misc.OSVersionMajor" => rv.misc_os_version_major = r.value()?,
+                b"Misc.OSVersionMinor" => rv.misc_os_version_minor = r.value()?,
+                b"GameStateName" => rv.game_state_name = r.value()?,
+                b"MemoryStats.TotalPhysical" => rv.memory_stats_total_physical = r.value()?,
+                b"MemoryStats.TotalVirtual" => rv.memory_stats_total_virtual = r.value()?,
+                b"MemoryStats.PageSize" => rv.memory_stats_page_size = r.value()?,
+                b"MemoryStats.TotalPhysicalGB" => rv.memory_stats_total_phsysical_gb = r.value()?,
+                b"TimeOfCrash" => rv.time_of_crash = r.value()?,
+                b"bAllowToBeContacted" => rv.allowed_to_be_contacted = r.value()?,
+                b"CrashReportClientVersion" => rv.crash_reporter_client_version = r.value()?,
+                b"Modules" => rv.modules = r.value()?,
                 _ => {
                     rv.custom.insert(
-                        tag.name().to_string(),
-                        get_text_or_none(child).unwrap_or_default(),
+                        String::from_utf8_lossy(tag.name().as_ref()).to_string(),
+                        r.value()?.unwrap_or_default(),
                     );
                 }
             }
         }
 
-        Some(rv)
+        Ok(Some(rv))
     }
 }
 
@@ -274,30 +400,35 @@ pub struct Unreal4ContextPlatformProperties {
 }
 
 impl Unreal4ContextPlatformProperties {
-    fn from_xml(root: &Element) -> Option<Self> {
-        let list = root.find("PlatformProperties")?;
+    fn from_xml(root: &[u8]) -> Result<Option<Self>, quick_xml::Error> {
+        let r = quick_xml::Reader::from_reader(root);
+        let mut r = XMLReader::new(r);
 
         let mut rv = Unreal4ContextPlatformProperties::default();
 
-        for child in list.children() {
-            if child.tag() == &QName::from("PlatformIsRunningWindows") {
-                match child.text().parse::<u32>() {
-                    Ok(1) => rv.is_windows = Some(true),
-                    Ok(0) => rv.is_windows = Some(false),
-                    Ok(_) => {}
-                    Err(_) => {}
+        if !r.find_tag("PlatformProperties")? {
+            return Ok(None);
+        }
+
+        while let Some(tag) = r.next_child()? {
+            if tag.name().as_ref() == b"PlatformIsRunningWindows" {
+                if let Some(s) = r.value::<String>()? {
+                    match s.parse::<u32>() {
+                        Ok(1) => rv.is_windows = Some(true),
+                        Ok(0) => rv.is_windows = Some(false),
+                        _ => {}
+                    }
+
+                    if let Ok(value) = s.parse::<bool>() {
+                        rv.is_windows = Some(value);
+                    }
                 }
-                match child.text().parse::<bool>() {
-                    Ok(true) => rv.is_windows = Some(true),
-                    Ok(false) => rv.is_windows = Some(false),
-                    Err(_) => {}
-                }
-            } else if child.tag() == &QName::from("PlatformCallbackResult") {
-                rv.callback_result = child.text().parse::<i32>().ok();
+            } else if tag.name().as_ref() == b"PlatformCallbackResult" {
+                rv.callback_result = r.value::<i32>()?;
             }
         }
 
-        Some(rv)
+        Ok(Some(rv))
     }
 }
 
@@ -330,27 +461,40 @@ pub struct Unreal4Context {
     pub game_data: BTreeMap<String, String>,
 }
 
-fn load_data_bag(element: &Element) -> BTreeMap<String, String> {
-    element
-        .children()
-        .map(|child| (child.tag().name().to_string(), child.text().to_string()))
-        .collect()
+fn load_data_bag(
+    data: &[u8],
+    tag: &str,
+    dest_data: &mut BTreeMap<String, String>,
+) -> Result<(), quick_xml::Error> {
+    let r = quick_xml::Reader::from_reader(data);
+    let mut r = XMLReader::new(r);
+
+    if r.find_tag(tag)? {
+        while let Some(tag) = r.next_child()? {
+            let name = String::from_utf8_lossy(tag.name().as_ref()).to_string();
+            if let Some(value) = r.value::<String>()? {
+                dest_data.insert(name, value);
+            }
+        }
+    }
+
+    Ok(())
 }
 
 impl Unreal4Context {
     /// Parses the unreal context XML file.
     pub fn parse(data: &[u8]) -> Result<Self, Unreal4Error> {
-        let root = Element::from_reader(data)?;
+        let mut engine_data = BTreeMap::default();
+        let mut game_data = BTreeMap::default();
+
+        load_data_bag(data, "EngineData", &mut engine_data)?;
+        load_data_bag(data, "GameData", &mut game_data)?;
 
         Ok(Unreal4Context {
-            runtime_properties: Unreal4ContextRuntimeProperties::from_xml(&root),
-            platform_properties: Unreal4ContextPlatformProperties::from_xml(&root),
-            engine_data: root
-                .find("EngineData")
-                .map_or_else(Default::default, load_data_bag),
-            game_data: root
-                .find("GameData")
-                .map_or_else(Default::default, load_data_bag),
+            runtime_properties: Unreal4ContextRuntimeProperties::from_xml(&data)?,
+            platform_properties: Unreal4ContextPlatformProperties::from_xml(&data)?,
+            engine_data,
+            game_data,
         })
     }
 }
@@ -389,20 +533,29 @@ const ROOT_WITH_GAME_AND_ENGINE_DATA: &str = r#"<?xml version="1.0" encoding="UT
 
 #[test]
 fn test_get_runtime_properties_missing_element() {
-    let root = Element::from_reader(ONLY_ROOT_NODE.as_bytes()).unwrap();
-    assert!(Unreal4ContextRuntimeProperties::from_xml(&root).is_none());
+    assert!(
+        Unreal4ContextRuntimeProperties::from_xml(ONLY_ROOT_NODE.as_bytes())
+            .unwrap()
+            .is_none()
+    );
 }
 
 #[test]
 fn test_get_platform_properties_missing_element() {
-    let root = Element::from_reader(ONLY_ROOT_NODE.as_bytes()).unwrap();
-    assert!(Unreal4ContextPlatformProperties::from_xml(&root).is_none());
+    //let root = Element::from_reader().unwrap();
+    assert!(
+        Unreal4ContextPlatformProperties::from_xml(ONLY_ROOT_NODE.as_bytes())
+            .unwrap()
+            .is_none()
+    );
 }
 
 #[test]
 fn test_get_runtime_properties_no_children() {
-    let root = Element::from_reader(ONLY_ROOT_AND_CHILD_NODES.as_bytes()).unwrap();
-    let actual = Unreal4ContextRuntimeProperties::from_xml(&root).expect("default struct");
+    //let root = Element::from_reader().unwrap();
+    let actual = Unreal4ContextRuntimeProperties::from_xml(ONLY_ROOT_AND_CHILD_NODES.as_bytes())
+        .unwrap()
+        .expect("default struct");
     assert_eq!(Unreal4ContextRuntimeProperties::default(), actual)
 }
 
@@ -424,9 +577,37 @@ fn test_get_game_and_engine_data() {
 }
 
 #[test]
+fn test_deeply_nested_xml() {
+    let mut data = r#"<FGenericCrashContext>
+    <RuntimeProperties>
+    </RuntimeProperties>
+    <PlatformProperties>
+    </PlatformProperties>
+    <EngineData>
+        <RHI.IsGPUOverclocked>false</RHI.IsGPUOverclocked>
+    </EngineData>
+    <GameData>
+        <sentry>{&quot;release&quot;:"foo.bar.baz@1.0.0"}</sentry>
+    </GameData>"#
+        .to_owned();
+
+    for _ in 0..30_000 {
+        data.push_str("<n>");
+    }
+    for _ in 0..30_000 {
+        data.push_str("</n>");
+    }
+    data.push_str("</FGenericCrashContext>");
+
+    let _ = Unreal4Context::parse(data.as_bytes()).unwrap();
+}
+
+#[test]
 fn test_get_platform_properties_no_children() {
-    let root = Element::from_reader(ONLY_ROOT_AND_CHILD_NODES.as_bytes()).unwrap();
-    let actual = Unreal4ContextPlatformProperties::from_xml(&root).expect("default struct");
+    //let root = Element::from_reader().unwrap();
+    let actual = Unreal4ContextPlatformProperties::from_xml(ONLY_ROOT_AND_CHILD_NODES.as_bytes())
+        .unwrap()
+        .expect("default struct");
     assert_eq!(Unreal4ContextPlatformProperties::default(), actual)
 }
 
@@ -439,9 +620,8 @@ macro_rules! test_unreal_contect {
             #[test]
             fn test_some() {
                 #[rustfmt::skip]
-                let xml = concat!("<FGenericCrashContext><", $xml_parent, "><", $xml_elm, ">", $expect, "</", $xml_elm, "></", $xml_parent, "></FGenericCrashContext>");
-                let root = Element::from_reader(xml.as_bytes()).unwrap();
-                let runtime_properties = $func_name(&root).expect("RuntimeProperties exists");
+                let xml = concat!("<", $xml_parent, ">", "<", $xml_elm, ">", $expect, "</", $xml_elm, ">","</", $xml_parent, ">");
+                let runtime_properties = $func_name(xml.as_bytes()).unwrap().expect(concat!($xml_parent, " exists"));
                 similar_asserts::assert_eq!(
                     $expect,
                     runtime_properties.$name.expect("missing property value")
@@ -451,9 +631,8 @@ macro_rules! test_unreal_contect {
             #[test]
             fn test_none() {
                 #[rustfmt::skip]
-                let xml = concat!("<FGenericCrashContext><", $xml_parent, "><", $xml_elm, "></", $xml_elm, "></", $xml_parent, "></FGenericCrashContext>");
-                let root = Element::from_reader(xml.as_bytes()).unwrap();
-                let runtime_properties = $func_name(&root).expect("RuntimeProperties exists");
+                let xml = concat!("<", $xml_parent, ">", "<", $xml_elm, ">","</", $xml_elm, ">","</", $xml_parent, ">");
+                let runtime_properties = $func_name(xml.as_bytes()).unwrap().expect(concat!($xml_parent, " exists"));
                 assert!(runtime_properties.$name.is_none());
             }
         }

--- a/symbolic-unreal/src/context.rs
+++ b/symbolic-unreal/src/context.rs
@@ -324,9 +324,8 @@ fn load_data_bag(
     if r.next_instance_of_tag(tag)? {
         while let Some(mut child) = r.next_child()? {
             let name = String::from_utf8_lossy(child.tag().name().as_ref()).to_string();
-            if let Some(value) = child.value::<String>()? {
-                dest_data.insert(name, value);
-            }
+            let value = child.value::<String>()?.unwrap_or_default();
+            dest_data.insert(name, value);
         }
     }
 
@@ -394,7 +393,6 @@ fn test_get_runtime_properties_missing_element() {
 
 #[test]
 fn test_get_platform_properties_missing_element() {
-    //let root = Element::from_reader().unwrap();
     assert!(
         Unreal4ContextPlatformProperties::from_xml(ONLY_ROOT_NODE.as_bytes())
             .unwrap()
@@ -404,7 +402,6 @@ fn test_get_platform_properties_missing_element() {
 
 #[test]
 fn test_get_runtime_properties_no_children() {
-    //let root = Element::from_reader().unwrap();
     let actual = Unreal4ContextRuntimeProperties::from_xml(ONLY_ROOT_AND_CHILD_NODES.as_bytes())
         .unwrap()
         .expect("default struct");
@@ -456,7 +453,6 @@ fn test_deeply_nested_xml() {
 
 #[test]
 fn test_get_platform_properties_no_children() {
-    //let root = Element::from_reader().unwrap();
     let actual = Unreal4ContextPlatformProperties::from_xml(ONLY_ROOT_AND_CHILD_NODES.as_bytes())
         .unwrap()
         .expect("default struct");

--- a/symbolic-unreal/src/context.rs
+++ b/symbolic-unreal/src/context.rs
@@ -3,11 +3,10 @@
 
 use std::collections::BTreeMap;
 
-use quick_xml::{escape::resolve_xml_entity, events::BytesStart};
 #[cfg(test)]
 use similar_asserts::assert_eq;
 
-use crate::error::Unreal4Error;
+use crate::{error::Unreal4Error, xml::XMLReader};
 
 /// RuntimeProperties context element.
 ///
@@ -159,155 +158,6 @@ pub struct Unreal4ContextRuntimeProperties {
     pub custom: BTreeMap<String, String>,
 }
 
-enum NodeState {
-    None,
-    Opened { node_depth: i32 },
-    Empty,
-}
-
-// A helper to keep track of reader state as we move through the XML.
-struct XMLReader<'a> {
-    reader: quick_xml::Reader<&'a [u8]>,
-    node_state: NodeState,
-}
-
-impl<'a> XMLReader<'a> {
-    fn new(reader: quick_xml::Reader<&'a [u8]>) -> Self {
-        Self {
-            reader,
-            node_state: NodeState::None,
-        }
-    }
-
-    /// Moves the reader to the specified tag if it exists.  Returns true iff
-    /// the tag exists.
-    fn find_tag(&mut self, name: &str) -> Result<bool, quick_xml::Error> {
-        loop {
-            match self.reader.read_event()? {
-                quick_xml::events::Event::Eof => break,
-
-                quick_xml::events::Event::Start(bytes_start) => {
-                    if bytes_start.name().as_ref() == name.as_bytes() {
-                        self.node_state = NodeState::Opened { node_depth: 0 };
-                        return Ok(true);
-                    }
-                }
-                quick_xml::events::Event::Empty(bytes_start) => {
-                    if bytes_start.name().as_ref() == name.as_bytes() {
-                        self.node_state = NodeState::Empty;
-                        return Ok(true);
-                    }
-                }
-
-                _ => {}
-            };
-        }
-
-        self.node_state = NodeState::None;
-        Ok(false)
-    }
-
-    /// Returns the text value, parsed, from the node at which the reader is
-    /// located.  If there is no such node or value, or the parse fails, this will
-    /// return None.  A best-effort is made to deal with text spread between xml nodes.
-    /// XML entities are resolved (so '&qout;' is resolved to '"', and the like.)
-    fn value<T: std::str::FromStr>(&mut self) -> Result<Option<T>, quick_xml::Error> {
-        let NodeState::Opened { node_depth } = &mut self.node_state else {
-            return Ok(None);
-        };
-
-        let mut val = String::new();
-        let text_depth = *node_depth;
-        loop {
-            match self.reader.read_event()? {
-                quick_xml::events::Event::Text(bytes_text) => {
-                    if text_depth == *node_depth {
-                        val += &bytes_text.decode().unwrap();
-                    }
-                }
-
-                quick_xml::events::Event::GeneralRef(bytes_text) => {
-                    if text_depth == *node_depth {
-                        val += resolve_xml_entity(&bytes_text.decode().unwrap()).unwrap();
-                    }
-                }
-
-                quick_xml::events::Event::End(_) => {
-                    *node_depth -= 1;
-                }
-
-                // It could be the case that we have text interleaved with nodes, so
-                // try to be graceful when handling.
-                quick_xml::events::Event::Start(_) => {
-                    *node_depth += 1;
-                }
-
-                _ => {}
-            };
-
-            if *node_depth < text_depth {
-                break;
-            }
-        }
-
-        if val.len() > 0 {
-            Ok(val.parse().ok())
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// Moves to the next child of this node, returning None if we exhaust the children,
-    /// otherwise returning the bytes of the start of the tag.
-    fn next_child(&mut self) -> Result<Option<BytesStart<'_>>, quick_xml::Error> {
-        let NodeState::Opened { node_depth } = &mut self.node_state else {
-            return Ok(None);
-        };
-
-        let maybe_bytes = loop {
-            let maybe_bytes = match self.reader.read_event()? {
-                quick_xml::events::Event::Start(bytes_start) => {
-                    *node_depth += 1;
-                    if *node_depth == 1 {
-                        Some(bytes_start)
-                    } else {
-                        None
-                    }
-                }
-                quick_xml::events::Event::End(_) => {
-                    *node_depth -= 1;
-                    None
-                }
-                quick_xml::events::Event::Empty(bytes_start) => {
-                    if *node_depth == 0 {
-                        Some(bytes_start)
-                    } else {
-                        None
-                    }
-                }
-
-                quick_xml::events::Event::Eof => {
-                    *node_depth = -1;
-                    break None;
-                }
-
-                _ => None,
-            };
-
-            if maybe_bytes.is_some() {
-                break maybe_bytes;
-            }
-
-            if *node_depth < 0 {
-                self.node_state = NodeState::None;
-                break None;
-            }
-        };
-
-        Ok(maybe_bytes)
-    }
-}
-
 impl Unreal4ContextRuntimeProperties {
     fn from_xml(root: &[u8]) -> Result<Option<Self>, quick_xml::Error> {
         let r = quick_xml::Reader::from_reader(root);
@@ -315,68 +165,70 @@ impl Unreal4ContextRuntimeProperties {
 
         let mut rv = Unreal4ContextRuntimeProperties::default();
 
-        if !r.find_tag("RuntimeProperties")? {
+        if !r.first_instance_of_tag("RuntimeProperties")? {
             return Ok(None);
         }
 
-        while let Some(tag) = r.next_child()? {
+        while let Some(mut child) = r.next_child()? {
             // We don't expect an XML with namespace here
-            if tag.name().prefix().is_some() {
+            if child.tag().name().prefix().is_some() {
                 continue;
             }
-            match tag.name().as_ref() {
-                b"CrashGUID" => rv.crash_guid = r.value()?,
-                b"ProcessId" => rv.process_id = r.value()?,
-                b"IsInternalBuild" => rv.is_internal_build = r.value()?,
-                b"IsSourceDistribution" => rv.is_source_distribution = r.value()?,
-                b"IsAssert" => rv.is_assert = r.value()?,
-                b"IsEnsure" => rv.is_ensure = r.value()?,
-                b"CrashType" => rv.crash_type = r.value()?,
-                b"SecondsSinceStart" => rv.seconds_since_start = r.value()?,
-                b"GameName" => rv.game_name = r.value()?,
-                b"ExecutableName" => rv.executable_name = r.value()?,
-                b"BuildConfiguration" => rv.build_configuration = r.value()?,
-                b"PlatformName" => rv.platform_name = r.value()?,
-                b"EngineMode" => rv.engine_mode = r.value()?,
-                b"EngineVersion" => rv.engine_version = r.value()?,
-                b"LanguageLCID" => rv.language_lcid = r.value()?,
-                b"AppDefaultLocale" => rv.app_default_locate = r.value()?,
-                b"BuildVersion" => rv.build_version = r.value()?,
-                b"IsUE4Release" => rv.is_ue4_release = r.value()?,
-                b"UserName" => rv.username = r.value()?,
-                b"BaseDir" => rv.base_dir = r.value()?,
-                b"RootDir" => rv.root_dir = r.value()?,
-                b"MachineId" => rv.machine_id = r.value()?,
-                b"LoginId" => rv.login_id = r.value()?,
-                b"EpicAccountId" => rv.epic_account_id = r.value()?,
-                b"CallStack" => rv.legacy_call_stack = r.value()?,
-                b"PCallStack" => rv.portable_call_stack = r.value()?,
-                b"UserDescription" => rv.user_description = r.value()?,
-                b"ErrorMessage" => rv.error_message = r.value()?,
-                b"CrashReporterMessage" => rv.crash_reporter_message = r.value()?,
-                b"Misc.NumberOfCores" => rv.misc_number_of_cores = r.value()?,
+            match child.tag().name().as_ref() {
+                b"CrashGUID" => rv.crash_guid = child.value()?,
+                b"ProcessId" => rv.process_id = child.value()?,
+                b"IsInternalBuild" => rv.is_internal_build = child.value()?,
+                b"IsSourceDistribution" => rv.is_source_distribution = child.value()?,
+                b"IsAssert" => rv.is_assert = child.value()?,
+                b"IsEnsure" => rv.is_ensure = child.value()?,
+                b"CrashType" => rv.crash_type = child.value()?,
+                b"SecondsSinceStart" => rv.seconds_since_start = child.value()?,
+                b"GameName" => rv.game_name = child.value()?,
+                b"ExecutableName" => rv.executable_name = child.value()?,
+                b"BuildConfiguration" => rv.build_configuration = child.value()?,
+                b"PlatformName" => rv.platform_name = child.value()?,
+                b"EngineMode" => rv.engine_mode = child.value()?,
+                b"EngineVersion" => rv.engine_version = child.value()?,
+                b"LanguageLCID" => rv.language_lcid = child.value()?,
+                b"AppDefaultLocale" => rv.app_default_locate = child.value()?,
+                b"BuildVersion" => rv.build_version = child.value()?,
+                b"IsUE4Release" => rv.is_ue4_release = child.value()?,
+                b"UserName" => rv.username = child.value()?,
+                b"BaseDir" => rv.base_dir = child.value()?,
+                b"RootDir" => rv.root_dir = child.value()?,
+                b"MachineId" => rv.machine_id = child.value()?,
+                b"LoginId" => rv.login_id = child.value()?,
+                b"EpicAccountId" => rv.epic_account_id = child.value()?,
+                b"CallStack" => rv.legacy_call_stack = child.value()?,
+                b"PCallStack" => rv.portable_call_stack = child.value()?,
+                b"UserDescription" => rv.user_description = child.value()?,
+                b"ErrorMessage" => rv.error_message = child.value()?,
+                b"CrashReporterMessage" => rv.crash_reporter_message = child.value()?,
+                b"Misc.NumberOfCores" => rv.misc_number_of_cores = child.value()?,
                 b"Misc.NumberOfCoresIncludingHyperthreads" => {
-                    rv.misc_number_of_cores_inc_hyperthread = r.value()?
+                    rv.misc_number_of_cores_inc_hyperthread = child.value()?
                 }
-                b"Misc.Is64bitOperatingSystem" => rv.misc_is_64bit = r.value()?,
-                b"Misc.CPUVendor" => rv.misc_cpu_vendor = r.value()?,
-                b"Misc.CPUBrand" => rv.misc_cpu_brand = r.value()?,
-                b"Misc.PrimaryGPUBrand" => rv.misc_primary_gpu_brand = r.value()?,
-                b"Misc.OSVersionMajor" => rv.misc_os_version_major = r.value()?,
-                b"Misc.OSVersionMinor" => rv.misc_os_version_minor = r.value()?,
-                b"GameStateName" => rv.game_state_name = r.value()?,
-                b"MemoryStats.TotalPhysical" => rv.memory_stats_total_physical = r.value()?,
-                b"MemoryStats.TotalVirtual" => rv.memory_stats_total_virtual = r.value()?,
-                b"MemoryStats.PageSize" => rv.memory_stats_page_size = r.value()?,
-                b"MemoryStats.TotalPhysicalGB" => rv.memory_stats_total_phsysical_gb = r.value()?,
-                b"TimeOfCrash" => rv.time_of_crash = r.value()?,
-                b"bAllowToBeContacted" => rv.allowed_to_be_contacted = r.value()?,
-                b"CrashReportClientVersion" => rv.crash_reporter_client_version = r.value()?,
-                b"Modules" => rv.modules = r.value()?,
+                b"Misc.Is64bitOperatingSystem" => rv.misc_is_64bit = child.value()?,
+                b"Misc.CPUVendor" => rv.misc_cpu_vendor = child.value()?,
+                b"Misc.CPUBrand" => rv.misc_cpu_brand = child.value()?,
+                b"Misc.PrimaryGPUBrand" => rv.misc_primary_gpu_brand = child.value()?,
+                b"Misc.OSVersionMajor" => rv.misc_os_version_major = child.value()?,
+                b"Misc.OSVersionMinor" => rv.misc_os_version_minor = child.value()?,
+                b"GameStateName" => rv.game_state_name = child.value()?,
+                b"MemoryStats.TotalPhysical" => rv.memory_stats_total_physical = child.value()?,
+                b"MemoryStats.TotalVirtual" => rv.memory_stats_total_virtual = child.value()?,
+                b"MemoryStats.PageSize" => rv.memory_stats_page_size = child.value()?,
+                b"MemoryStats.TotalPhysicalGB" => {
+                    rv.memory_stats_total_phsysical_gb = child.value()?
+                }
+                b"TimeOfCrash" => rv.time_of_crash = child.value()?,
+                b"bAllowToBeContacted" => rv.allowed_to_be_contacted = child.value()?,
+                b"CrashReportClientVersion" => rv.crash_reporter_client_version = child.value()?,
+                b"Modules" => rv.modules = child.value()?,
                 _ => {
                     rv.custom.insert(
-                        String::from_utf8_lossy(tag.name().as_ref()).to_string(),
-                        r.value()?.unwrap_or_default(),
+                        String::from_utf8_lossy(child.tag().name().as_ref()).to_string(),
+                        child.value()?.unwrap_or_default(),
                     );
                 }
             }
@@ -406,13 +258,13 @@ impl Unreal4ContextPlatformProperties {
 
         let mut rv = Unreal4ContextPlatformProperties::default();
 
-        if !r.find_tag("PlatformProperties")? {
+        if !r.first_instance_of_tag("PlatformProperties")? {
             return Ok(None);
         }
 
-        while let Some(tag) = r.next_child()? {
-            if tag.name().as_ref() == b"PlatformIsRunningWindows" {
-                if let Some(s) = r.value::<String>()? {
+        while let Some(mut child) = r.next_child()? {
+            if child.tag().name().as_ref() == b"PlatformIsRunningWindows" {
+                if let Some(s) = child.value::<String>()? {
                     match s.parse::<u32>() {
                         Ok(1) => rv.is_windows = Some(true),
                         Ok(0) => rv.is_windows = Some(false),
@@ -423,8 +275,8 @@ impl Unreal4ContextPlatformProperties {
                         rv.is_windows = Some(value);
                     }
                 }
-            } else if tag.name().as_ref() == b"PlatformCallbackResult" {
-                rv.callback_result = r.value::<i32>()?;
+            } else if child.tag().name().as_ref() == b"PlatformCallbackResult" {
+                rv.callback_result = child.value::<i32>()?;
             }
         }
 
@@ -469,10 +321,10 @@ fn load_data_bag(
     let r = quick_xml::Reader::from_reader(data);
     let mut r = XMLReader::new(r);
 
-    if r.find_tag(tag)? {
-        while let Some(tag) = r.next_child()? {
-            let name = String::from_utf8_lossy(tag.name().as_ref()).to_string();
-            if let Some(value) = r.value::<String>()? {
+    if r.first_instance_of_tag(tag)? {
+        while let Some(mut child) = r.next_child()? {
+            let name = String::from_utf8_lossy(child.tag().name().as_ref()).to_string();
+            if let Some(value) = child.value::<String>()? {
                 dest_data.insert(name, value);
             }
         }

--- a/symbolic-unreal/src/context.rs
+++ b/symbolic-unreal/src/context.rs
@@ -343,8 +343,8 @@ impl Unreal4Context {
         load_data_bag(data, "GameData", &mut game_data)?;
 
         Ok(Unreal4Context {
-            runtime_properties: Unreal4ContextRuntimeProperties::from_xml(&data)?,
-            platform_properties: Unreal4ContextPlatformProperties::from_xml(&data)?,
+            runtime_properties: Unreal4ContextRuntimeProperties::from_xml(data)?,
+            platform_properties: Unreal4ContextPlatformProperties::from_xml(data)?,
             engine_data,
             game_data,
         })

--- a/symbolic-unreal/src/error.rs
+++ b/symbolic-unreal/src/error.rs
@@ -75,8 +75,8 @@ impl From<Unreal4ErrorKind> for Unreal4Error {
     }
 }
 
-impl From<elementtree::Error> for Unreal4Error {
-    fn from(source: elementtree::Error) -> Self {
+impl From<quick_xml::Error> for Unreal4Error {
+    fn from(source: quick_xml::Error) -> Self {
         Self::new(Unreal4ErrorKind::InvalidXml, source)
     }
 }

--- a/symbolic-unreal/src/lib.rs
+++ b/symbolic-unreal/src/lib.rs
@@ -5,6 +5,7 @@ mod container;
 mod context;
 mod error;
 mod logs;
+mod xml;
 
 pub use container::*;
 pub use context::*;

--- a/symbolic-unreal/src/xml.rs
+++ b/symbolic-unreal/src/xml.rs
@@ -85,6 +85,9 @@ impl<'a> XMLReader<'a> {
                 quick_xml::events::Event::Start(_) => {
                     *node_depth += 1;
                 }
+                quick_xml::events::Event::Eof => {
+                    break;
+                }
 
                 _ => {}
             };

--- a/symbolic-unreal/src/xml.rs
+++ b/symbolic-unreal/src/xml.rs
@@ -1,4 +1,7 @@
-use quick_xml::{escape::resolve_xml_entity, events::BytesStart};
+use quick_xml::{
+    escape::{resolve_xml_entity, unescape},
+    events::BytesStart,
+};
 
 enum NodeState {
     None,
@@ -62,24 +65,32 @@ impl<'a> XMLReader<'a> {
         if *consumed {
             return Ok(None);
         }
+
         let mut val = String::new();
         let start_depth = *node_depth;
         loop {
-            match self.reader.read_event()? {
+            let v = self.reader.read_event()?;
+            match v {
                 quick_xml::events::Event::Text(bytes_text) => {
-                    if start_depth == *node_depth {
-                        if let Ok(decoded) = bytes_text.decode() {
-                            val += &decoded;
-                        }
+                    if start_depth != *node_depth {
+                        continue;
+                    }
+
+                    if let Ok(decoded) = bytes_text.decode() {
+                        val += &decoded;
                     }
                 }
 
                 quick_xml::events::Event::GeneralRef(bytes_text) => {
-                    if start_depth == *node_depth {
-                        if let Ok(decoded) = bytes_text.decode() {
-                            if let Some(resolved) = resolve_xml_entity(&decoded) {
-                                val += resolved;
-                            }
+                    if start_depth != *node_depth {
+                        continue;
+                    }
+
+                    if let Ok(Some(ch)) = bytes_text.resolve_char_ref() {
+                        val.push(ch);
+                    } else if let Ok(decoded) = bytes_text.decode() {
+                        if let Some(resolved) = resolve_xml_entity(&decoded) {
+                            val += resolved;
                         }
                     }
                 }
@@ -95,10 +106,12 @@ impl<'a> XMLReader<'a> {
                 }
 
                 quick_xml::events::Event::CData(data) => {
-                    if start_depth == *node_depth {
-                        if let Ok(decoded) = data.decode() {
-                            val += &decoded;
-                        }
+                    if start_depth != *node_depth {
+                        continue;
+                    }
+
+                    if let Ok(decoded) = data.decode() {
+                        val += &decoded;
                     }
                 }
 

--- a/symbolic-unreal/src/xml.rs
+++ b/symbolic-unreal/src/xml.rs
@@ -1,7 +1,4 @@
-use quick_xml::{
-    escape::{resolve_xml_entity, unescape},
-    events::BytesStart,
-};
+use quick_xml::{escape::resolve_xml_entity, events::BytesStart};
 
 enum NodeState {
     None,

--- a/symbolic-unreal/src/xml.rs
+++ b/symbolic-unreal/src/xml.rs
@@ -1,0 +1,194 @@
+use quick_xml::{escape::resolve_xml_entity, events::BytesStart};
+
+enum NodeState {
+    None,
+    Opened { node_depth: i32 },
+    Empty,
+}
+
+// A helper to keep track of reader state as we move through the XML.
+pub struct XMLReader<'a> {
+    reader: quick_xml::Reader<&'a [u8]>,
+    node_state: NodeState,
+}
+
+// Contains the starting tag of the child node, and accesors for interacting with
+// that node.
+pub struct ChildNode<'a, 'b> {
+    reader: &'a mut XMLReader<'b>,
+    tag: BytesStart<'b>,
+    is_empty: bool,
+}
+
+impl<'a, 'b> ChildNode<'a, 'b> {
+    /// Returns the text value, parsed, from the node at which the reader is
+    /// located.
+    pub fn value<T: std::str::FromStr>(&mut self) -> Result<Option<T>, quick_xml::Error> {
+        if self.is_empty {
+            return Ok(None);
+        }
+
+        self.reader.value()
+    }
+
+    // Returns the starting tag of the node (which includes name, attributes, and
+    // the like.)
+    pub fn tag(&self) -> &BytesStart<'_> {
+        &self.tag
+    }
+}
+
+impl<'a> XMLReader<'a> {
+    pub fn new(reader: quick_xml::Reader<&'a [u8]>) -> Self {
+        Self {
+            reader,
+            node_state: NodeState::None,
+        }
+    }
+
+    /// Returns the text value, parsed, from the node at which the reader is
+    /// located.  If there is no such node or value, or the parse fails, this will
+    /// return None.  A best-effort is made to deal with text spread between xml nodes.
+    /// XML entities are resolved (so '&qout;' is resolved to '"', and the like.)
+    fn value<T: std::str::FromStr>(&mut self) -> Result<Option<T>, quick_xml::Error> {
+        let NodeState::Opened { node_depth } = &mut self.node_state else {
+            return Ok(None);
+        };
+        let mut val = String::new();
+        let start_depth = *node_depth;
+        loop {
+            match self.reader.read_event()? {
+                quick_xml::events::Event::Text(bytes_text) => {
+                    if start_depth == *node_depth {
+                        if let Ok(decoded) = bytes_text.decode() {
+                            val += &decoded;
+                        }
+                    }
+                }
+
+                quick_xml::events::Event::GeneralRef(bytes_text) => {
+                    if start_depth == *node_depth {
+                        if let Ok(decoded) = bytes_text.decode() {
+                            if let Some(resolved) = resolve_xml_entity(&decoded) {
+                                val += resolved;
+                            }
+                        }
+                    }
+                }
+
+                quick_xml::events::Event::End(_) => {
+                    *node_depth -= 1;
+                }
+
+                // It could be the case that we have text interleaved with nodes, so
+                // try to be graceful when handling.
+                quick_xml::events::Event::Start(_) => {
+                    *node_depth += 1;
+                }
+
+                _ => {}
+            };
+
+            if *node_depth < start_depth {
+                break;
+            }
+        }
+
+        if val.len() > 0 {
+            Ok(val.parse().ok())
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Moves the reader to the next instance of the specified tag, if it exists, relative
+    /// to the current position of the reader. Returns true iff the tag exists.
+    pub fn next_instance_of_tag(&mut self, name: &str) -> Result<bool, quick_xml::Error> {
+        loop {
+            match self.reader.read_event()? {
+                quick_xml::events::Event::Eof => break,
+
+                quick_xml::events::Event::Start(bytes_start) => {
+                    if bytes_start.name().as_ref() == name.as_bytes() {
+                        self.node_state = NodeState::Opened { node_depth: 0 };
+                        return Ok(true);
+                    }
+                }
+                quick_xml::events::Event::Empty(bytes_start) => {
+                    if bytes_start.name().as_ref() == name.as_bytes() {
+                        self.node_state = NodeState::Empty;
+                        return Ok(true);
+                    }
+                }
+
+                _ => {}
+            };
+        }
+
+        self.node_state = NodeState::None;
+        Ok(false)
+    }
+
+    /// Moves to the next child of this node, returning None if we exhaust the children,
+    /// or an instance of ChildNode.
+    pub fn next_child<'t>(&'t mut self) -> Result<Option<ChildNode<'t, 'a>>, quick_xml::Error> {
+        let NodeState::Opened { node_depth } = &mut self.node_state else {
+            return Ok(None);
+        };
+
+        let maybe_bytes = loop {
+            let maybe_bytes = match self.reader.read_event()? {
+                quick_xml::events::Event::Start(bytes_start) => {
+                    *node_depth += 1;
+                    if *node_depth == 1 {
+                        Some(bytes_start)
+                    } else {
+                        None
+                    }
+                }
+                quick_xml::events::Event::End(_) => {
+                    *node_depth -= 1;
+                    None
+                }
+                quick_xml::events::Event::Empty(bytes_start) => {
+                    if *node_depth == 0 {
+                        Some(bytes_start)
+                    } else {
+                        None
+                    }
+                }
+
+                quick_xml::events::Event::Eof => {
+                    *node_depth = -1;
+                    break None;
+                }
+
+                _ => None,
+            };
+
+            if maybe_bytes.is_some() {
+                break maybe_bytes;
+            }
+
+            if *node_depth < 0 {
+                self.node_state = NodeState::None;
+                break None;
+            }
+        };
+
+        if let Some(bytes) = maybe_bytes {
+            let is_empty = if let NodeState::Opened { node_depth } = self.node_state {
+                node_depth == 0
+            } else {
+                false
+            };
+            return Ok(Some(ChildNode {
+                reader: self,
+                is_empty,
+                tag: bytes,
+            }));
+        }
+
+        Ok(None)
+    }
+}

--- a/symbolic-unreal/src/xml.rs
+++ b/symbolic-unreal/src/xml.rs
@@ -246,10 +246,6 @@ impl<'a> XMLReader<'a> {
 }
 #[cfg(test)]
 mod tests {
-    // cdata?
-    // get value a few times
-    // missing tags
-
     use crate::xml::XMLReader;
     use std::assert_eq;
     use std::assert_matches;
@@ -281,5 +277,17 @@ mod tests {
         let mut x = XMLReader::new(r);
         x.next_instance_of_tag("t3").unwrap();
         assert_matches!(x.value::<String>(), Err(_));
+    }
+
+    #[test]
+    fn test_cdata() {
+        let data = r#"<t1><![CDATA[some text]]></t1>"#;
+        let r = quick_xml::Reader::from_reader(data.as_bytes());
+        let mut x = XMLReader::new(r);
+        x.next_instance_of_tag("t1").unwrap();
+        assert_eq!(
+            x.value::<String>().unwrap().unwrap(),
+            "some text".to_owned()
+        );
     }
 }

--- a/symbolic-unreal/src/xml.rs
+++ b/symbolic-unreal/src/xml.rs
@@ -97,10 +97,10 @@ impl<'a> XMLReader<'a> {
             }
         }
 
-        if val.len() > 0 {
-            Ok(val.parse().ok())
-        } else {
+        if val.is_empty() {
             Ok(None)
+        } else {
+            Ok(val.parse().ok())
         }
     }
 
@@ -111,17 +111,17 @@ impl<'a> XMLReader<'a> {
             match self.reader.read_event()? {
                 quick_xml::events::Event::Eof => break,
 
-                quick_xml::events::Event::Start(bytes_start) => {
-                    if bytes_start.name().as_ref() == name.as_bytes() {
-                        self.node_state = NodeState::Opened { node_depth: 0 };
-                        return Ok(true);
-                    }
+                quick_xml::events::Event::Start(bytes_start)
+                    if bytes_start.name().as_ref() == name.as_bytes() =>
+                {
+                    self.node_state = NodeState::Opened { node_depth: 0 };
+                    return Ok(true);
                 }
-                quick_xml::events::Event::Empty(bytes_start) => {
-                    if bytes_start.name().as_ref() == name.as_bytes() {
-                        self.node_state = NodeState::Empty;
-                        return Ok(true);
-                    }
+                quick_xml::events::Event::Empty(bytes_start)
+                    if bytes_start.name().as_ref() == name.as_bytes() =>
+                {
+                    self.node_state = NodeState::Empty;
+                    return Ok(true);
                 }
 
                 _ => {}

--- a/symbolic-unreal/src/xml.rs
+++ b/symbolic-unreal/src/xml.rs
@@ -2,7 +2,7 @@ use quick_xml::{escape::resolve_xml_entity, events::BytesStart};
 
 enum NodeState {
     None,
-    Opened { node_depth: i32 },
+    Opened { node_depth: i32, consumed: bool },
     Empty,
 }
 
@@ -47,13 +47,21 @@ impl<'a> XMLReader<'a> {
     }
 
     /// Returns the text value, parsed, from the node at which the reader is
-    /// located.  If there is no such node or value, or the parse fails, this will
-    /// return None.  A best-effort is made to deal with text spread between xml nodes.
+    /// located.  If there is no such node or value, this will return None.
+    /// A best-effort is made to deal with text spread between xml nodes.
     /// XML entities are resolved (so '&qout;' is resolved to '"', and the like.)
     fn value<T: std::str::FromStr>(&mut self) -> Result<Option<T>, quick_xml::Error> {
-        let NodeState::Opened { node_depth } = &mut self.node_state else {
+        let NodeState::Opened {
+            node_depth,
+            consumed,
+        } = &mut self.node_state
+        else {
             return Ok(None);
         };
+
+        if *consumed {
+            return Ok(None);
+        }
         let mut val = String::new();
         let start_depth = *node_depth;
         loop {
@@ -85,17 +93,33 @@ impl<'a> XMLReader<'a> {
                 quick_xml::events::Event::Start(_) => {
                     *node_depth += 1;
                 }
+
+                quick_xml::events::Event::CData(data) => {
+                    if start_depth == *node_depth {
+                        if let Ok(decoded) = data.decode() {
+                            val += &decoded;
+                        }
+                    }
+                }
+
                 quick_xml::events::Event::Eof => {
                     break;
                 }
-
-                _ => {}
+                quick_xml::events::Event::Empty(_)
+                | quick_xml::events::Event::Comment(_)
+                | quick_xml::events::Event::Decl(_)
+                | quick_xml::events::Event::PI(_)
+                | quick_xml::events::Event::DocType(_) => {
+                    // Explicitly skip these.
+                }
             };
 
             if *node_depth < start_depth {
                 break;
             }
         }
+
+        *consumed = true;
 
         if val.is_empty() {
             Ok(None)
@@ -108,13 +132,18 @@ impl<'a> XMLReader<'a> {
     /// to the current position of the reader. Returns true iff the tag exists.
     pub fn next_instance_of_tag(&mut self, name: &str) -> Result<bool, quick_xml::Error> {
         loop {
-            match self.reader.read_event()? {
+            let e = self.reader.read_event()?;
+
+            match e {
                 quick_xml::events::Event::Eof => break,
 
                 quick_xml::events::Event::Start(bytes_start)
                     if bytes_start.name().as_ref() == name.as_bytes() =>
                 {
-                    self.node_state = NodeState::Opened { node_depth: 0 };
+                    self.node_state = NodeState::Opened {
+                        node_depth: 0,
+                        consumed: false,
+                    };
                     return Ok(true);
                 }
                 quick_xml::events::Event::Empty(bytes_start)
@@ -135,9 +164,15 @@ impl<'a> XMLReader<'a> {
     /// Moves to the next child of this node, returning None if we exhaust the children,
     /// or an instance of ChildNode.
     pub fn next_child<'t>(&'t mut self) -> Result<Option<ChildNode<'t, 'a>>, quick_xml::Error> {
-        let NodeState::Opened { node_depth } = &mut self.node_state else {
+        let NodeState::Opened {
+            node_depth,
+            consumed,
+        } = &mut self.node_state
+        else {
             return Ok(None);
         };
+
+        *consumed = false;
 
         let maybe_bytes = loop {
             let maybe_bytes = match self.reader.read_event()? {
@@ -180,7 +215,11 @@ impl<'a> XMLReader<'a> {
         };
 
         if let Some(bytes) = maybe_bytes {
-            let is_empty = if let NodeState::Opened { node_depth } = self.node_state {
+            let is_empty = if let NodeState::Opened {
+                node_depth,
+                consumed: _,
+            } = self.node_state
+            {
                 node_depth == 0
             } else {
                 false
@@ -193,5 +232,44 @@ impl<'a> XMLReader<'a> {
         }
 
         Ok(None)
+    }
+}
+#[cfg(test)]
+mod tests {
+    // cdata?
+    // get value a few times
+    // missing tags
+
+    use crate::xml::XMLReader;
+    use std::assert_eq;
+    use std::assert_matches;
+
+    #[test]
+    fn test_empty_tag() {
+        let data = r#"<t1><t2></t2><t3></t3></t1>"#;
+        let r = quick_xml::Reader::from_reader(data.as_bytes());
+        let mut x = XMLReader::new(r);
+        x.next_instance_of_tag("t3").unwrap();
+        assert_eq!(x.value::<String>().unwrap(), None);
+    }
+
+    #[test]
+    fn test_get_value_twice() {
+        let data = r#"<t1><t2></t2><t3>hello</t3></t1>"#;
+        let r = quick_xml::Reader::from_reader(data.as_bytes());
+        let mut x = XMLReader::new(r);
+        x.next_instance_of_tag("t3").unwrap();
+
+        assert_eq!(x.value::<String>().unwrap(), Some("hello".to_owned()));
+        assert_eq!(x.value::<String>().unwrap(), None);
+    }
+
+    #[test]
+    fn test_missing_close() {
+        let data = r#"<t1><t2></t2><t3></t1>"#;
+        let r = quick_xml::Reader::from_reader(data.as_bytes());
+        let mut x = XMLReader::new(r);
+        x.next_instance_of_tag("t3").unwrap();
+        assert_matches!(x.value::<String>(), Err(_));
     }
 }


### PR DESCRIPTION
Sadly, quickxml's serde support does not handle empty tags the way we'd like--even for an optional field, like `foo : Option<String>`, if it sees a `<foo>` tag in the xml, it expects there to be a value in the tag, and it will error if there isn't one, while we'd like to interpret an empty tag (`<foo></foo>`) as just None.  So, do it the hard way.