### PR TITLE
feat(wasm): expose ObjectFile.embeddedPpdb() for embedded Portable PDB extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**
 
 - WASM: expose `ObjectFile.debugSession()` returning a `DebugSession` with `files()` (the source files referenced by the object) and `sourceByPath(path)` (resolving embedded contents or a source link). `symbolic-debuginfo` also implements `AsSelf` for `ObjectDebugSession` so it can be held in a `SelfCell`. ([#997](https://github.com/getsentry/symbolic/pull/997))
+- WASM: expose `ObjectFile.embeddedPpdb()` returning the decompressed Portable PDB embedded in a managed Windows PE (a standalone, parseable debug information file), or `undefined` when the object is not a PE or has no embedded PPDB. ([#1004](https://github.com/getsentry/symbolic/pull/1004))
 
 ## 13.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Features**
 
 - WASM: expose `ObjectFile.debugSession()` returning a `DebugSession` with `files()` (the source files referenced by the object) and `sourceByPath(path)` (resolving embedded contents or a source link). `symbolic-debuginfo` also implements `AsSelf` for `ObjectDebugSession` so it can be held in a `SelfCell`. ([#997](https://github.com/getsentry/symbolic/pull/997))
-- WASM: expose `ObjectFile.embeddedPpdb()` returning the decompressed Portable PDB embedded in a managed Windows PE (a standalone, parseable debug information file), or `undefined` when the object is not a PE or has no embedded PPDB. ([#1004](https://github.com/getsentry/symbolic/pull/1004))
+- WASM: expose `ObjectFile.asPe()` to narrow an object to a `PeFile`, and `PeFile.embeddedPpdb()` returning the decompressed Portable PDB embedded in a managed Windows PE (a standalone, parseable debug information file), or `undefined` when there is no embedded PPDB. ([#1004](https://github.com/getsentry/symbolic/pull/1004))
 
 ## 13.4.0
 

--- a/symbolic-wasm/npm/package-smoke.test.mjs
+++ b/symbolic-wasm/npm/package-smoke.test.mjs
@@ -45,11 +45,14 @@ test("Archive.peek detects the format without a full parse", () => {
   assert.equal(symbolic.Archive.peek(data), "elf");
 });
 
-test("embeddedPpdb extracts a standalone Portable PDB from a managed PE", () => {
+test("asPe().embeddedPpdb() extracts a standalone Portable PDB from a managed PE", () => {
   const [object] = new symbolic.Archive(ppdbData).objects();
   assert.equal(object.fileFormat, "pe");
 
-  const ppdb = object.embeddedPpdb();
+  const pe = object.asPe();
+  assert.ok(pe, "expected asPe() to return a PeFile for a PE object");
+
+  const ppdb = pe.embeddedPpdb();
   assert.ok(ppdb instanceof Uint8Array, "expected embeddedPpdb() to return bytes");
   assert.equal(ppdb.length, 10540);
 
@@ -59,10 +62,10 @@ test("embeddedPpdb extracts a standalone Portable PDB from a managed PE", () => 
   assert.equal(ppdbArchive.objectCount, 1);
 });
 
-test("embeddedPpdb returns undefined when there is no embedded PPDB", () => {
-  // The ELF fixture is not a PE, so it can never carry an embedded PPDB.
+test("asPe() returns undefined for a non-PE object", () => {
+  // The ELF fixture is not a PE, so it cannot be narrowed to a PeFile.
   const [object] = new symbolic.Archive(data).objects();
-  assert.equal(object.embeddedPpdb(), undefined);
+  assert.equal(object.asPe(), undefined);
 });
 
 test("the debug session enumerates referenced source files", () => {

--- a/symbolic-wasm/npm/package-smoke.test.mjs
+++ b/symbolic-wasm/npm/package-smoke.test.mjs
@@ -25,6 +25,7 @@ const wasmPath = require.resolve("@sentry/symbolic/symbolic_bg.wasm");
 symbolic.initSync({ module: readFileSync(wasmPath) });
 
 const data = new Uint8Array(readFileSync(process.env.SMOKE_FIXTURE));
+const ppdbData = new Uint8Array(readFileSync(process.env.SMOKE_FIXTURE_PPDB));
 
 test("the shipped package parses a debug file via the Archive API", () => {
   const archive = new symbolic.Archive(data);
@@ -42,6 +43,26 @@ test("the shipped package parses a debug file via the Archive API", () => {
 
 test("Archive.peek detects the format without a full parse", () => {
   assert.equal(symbolic.Archive.peek(data), "elf");
+});
+
+test("embeddedPpdb extracts a standalone Portable PDB from a managed PE", () => {
+  const [object] = new symbolic.Archive(ppdbData).objects();
+  assert.equal(object.fileFormat, "pe");
+
+  const ppdb = object.embeddedPpdb();
+  assert.ok(ppdb instanceof Uint8Array, "expected embeddedPpdb() to return bytes");
+  assert.equal(ppdb.length, 10540);
+
+  // The extracted bytes are themselves a parseable Portable PDB.
+  const ppdbArchive = new symbolic.Archive(ppdb);
+  assert.equal(ppdbArchive.fileFormat, "portablepdb");
+  assert.equal(ppdbArchive.objectCount, 1);
+});
+
+test("embeddedPpdb returns undefined when there is no embedded PPDB", () => {
+  // The ELF fixture is not a PE, so it can never carry an embedded PPDB.
+  const [object] = new symbolic.Archive(data).objects();
+  assert.equal(object.embeddedPpdb(), undefined);
 });
 
 test("the debug session enumerates referenced source files", () => {

--- a/symbolic-wasm/npm/smoke-test.mjs
+++ b/symbolic-wasm/npm/smoke-test.mjs
@@ -19,7 +19,7 @@ const here = (rel) => fileURLToPath(new URL(rel, import.meta.url));
 const PKG_DIR = here(".");
 const FIXTURE = here("../../symbolic-testutils/fixtures/linux/crash.debug");
 // A managed PE that embeds a deflate-compressed Portable PDB — exercises the
-// embeddedPpdb() extraction + decompression path in the real wasm runtime.
+// asPe().embeddedPpdb() extraction + decompression path in the real wasm runtime.
 const FIXTURE_PPDB = here(
   "../../symbolic-testutils/fixtures/windows/Sentry.Samples.Console.Basic-embedded-ppdb.dll",
 );

--- a/symbolic-wasm/npm/smoke-test.mjs
+++ b/symbolic-wasm/npm/smoke-test.mjs
@@ -18,6 +18,11 @@ import { fileURLToPath } from "node:url";
 const here = (rel) => fileURLToPath(new URL(rel, import.meta.url));
 const PKG_DIR = here(".");
 const FIXTURE = here("../../symbolic-testutils/fixtures/linux/crash.debug");
+// A managed PE that embeds a deflate-compressed Portable PDB — exercises the
+// embeddedPpdb() extraction + decompression path in the real wasm runtime.
+const FIXTURE_PPDB = here(
+  "../../symbolic-testutils/fixtures/windows/Sentry.Samples.Console.Basic-embedded-ppdb.dll",
+);
 
 const run = (cmd, args, opts) =>
   execFileSync(cmd, args, { stdio: "inherit", ...opts });
@@ -44,7 +49,7 @@ try {
   cpSync(here("./package-smoke.test.mjs"), join(dir, "package-smoke.test.mjs"));
   run("node", ["--test", "package-smoke.test.mjs"], {
     cwd: dir,
-    env: { ...process.env, SMOKE_FIXTURE: FIXTURE },
+    env: { ...process.env, SMOKE_FIXTURE: FIXTURE, SMOKE_FIXTURE_PPDB: FIXTURE_PPDB },
   });
   console.log("packaged-artifact smoke test passed");
 } finally {

--- a/symbolic-wasm/src/debuginfo/mod.rs
+++ b/symbolic-wasm/src/debuginfo/mod.rs
@@ -143,6 +143,34 @@ impl Object {
             inner: unsafe { utils::derived_from_cell!(ObjectDebugSession, self.inner, session) },
         })
     }
+
+    /// Extracts the embedded Portable PDB from this object, if present.
+    ///
+    /// Some Windows PE images (managed/.NET assemblies) embed their Portable
+    /// PDB debug companion directly in the executable (debug directory entry
+    /// type 17, deflate-compressed). This decompresses and returns those bytes,
+    /// which are themselves a standalone Portable PDB debug information file
+    /// that can be parsed (e.g. via [`Archive`]) and uploaded independently.
+    ///
+    /// Returns `undefined` when the object is not a PE, or is a PE without an
+    /// embedded Portable PDB.
+    #[wasm_bindgen(js_name = embeddedPpdb)]
+    pub fn embedded_ppdb(&self) -> Result<Option<Vec<u8>>> {
+        let di::Object::Pe(pe) = self.inner.get() else {
+            return Ok(None);
+        };
+        let Some(ppdb) = pe.embedded_ppdb()? else {
+            return Ok(None);
+        };
+        // Decompress into a growable buffer rather than pre-allocating from
+        // `ppdb.get_size()`: the uncompressed size is read verbatim from the
+        // (untrusted) PE debug-directory header, so a crafted file could claim a
+        // huge size and trigger an oversized speculative allocation. Letting the
+        // deflate decoder grow the buffer bounds memory to the actual output.
+        let mut buf = Vec::new();
+        ppdb.decompress_to(&mut buf)?;
+        Ok(Some(buf))
+    }
 }
 
 /// A debug session that provides access to an object's debugging information.

--- a/symbolic-wasm/src/debuginfo/mod.rs
+++ b/symbolic-wasm/src/debuginfo/mod.rs
@@ -151,28 +151,11 @@ impl Object {
     /// equivalent on other object formats, mirroring the `Object::Pe` variant of
     /// the underlying `symbolic_debuginfo` types.
     #[wasm_bindgen(js_name = asPe)]
-    pub fn as_pe(&self) -> Result<Option<PeFile>> {
-        let di::Object::Pe(pe) = self.inner.get() else {
-            return Ok(None);
-        };
-        // `PeObject` is neither `Clone` nor movable out of the borrowed enum, so
-        // re-parse it from the same backing bytes to obtain an owned handle that
-        // can live in its own cell sharing this object's `ByteView`. Parsing only
-        // reads the PE header and is cheap; the heavy lifting happens lazily in the
-        // PE-specific operations on `PeFile`.
-        let pe = di::pe::PeObject::parse(pe.data())?;
-        Ok(Some(PeFile {
-            // SAFETY: `pe` is derived from `self.inner` and only borrows data from
-            // the same `ByteView`.
-            inner: unsafe {
-                utils::derived_from_cell!(
-                    di::pe::PeObject<'_>,
-                    di::pe::PeObject<'static>,
-                    self.inner,
-                    pe
-                )
-            },
-        }))
+    pub fn as_pe(self) -> Option<PeFile> {
+        match self.inner.get() {
+            di::Object::Pe(_) => Some(PeFile { inner: self.inner }),
+            _ => None,
+        }
     }
 }
 
@@ -182,11 +165,21 @@ impl Object {
 /// PE-specific surface of `symbolic_debuginfo`'s `PeObject`.
 #[wasm_bindgen(js_name = PeFile)]
 pub struct PeFile {
-    inner: SelfCell<ByteView<'static>, di::pe::PeObject<'static>>,
+    // Since we don't have a good way of extracting a `PeObject` from the
+    // `SelfCell`, we just rely on the invariant to always be constructed
+    // with a valid `PeObject`.
+    inner: SelfCell<ByteView<'static>, di::Object<'static>>,
 }
 
 #[wasm_bindgen(js_class = PeFile)]
 impl PeFile {
+    fn pe(&self) -> &di::pe::PeObject<'_> {
+        match self.inner.get() {
+            di::Object::Pe(pe) => pe,
+            _ => unreachable!("inner must always be a pe object"),
+        }
+    }
+
     /// Extracts the embedded Portable PDB from this PE, if present.
     ///
     /// Some Windows PE images (managed/.NET assemblies) embed their Portable
@@ -198,7 +191,7 @@ impl PeFile {
     /// Returns `undefined` when this PE has no embedded Portable PDB.
     #[wasm_bindgen(js_name = embeddedPpdb)]
     pub fn embedded_ppdb(&self) -> Result<Option<Vec<u8>>> {
-        let Some(ppdb) = self.inner.get().embedded_ppdb()? else {
+        let Some(ppdb) = self.pe().embedded_ppdb()? else {
             return Ok(None);
         };
         // Decompress into a growable buffer rather than pre-allocating from

--- a/symbolic-wasm/src/debuginfo/mod.rs
+++ b/symbolic-wasm/src/debuginfo/mod.rs
@@ -144,7 +144,50 @@ impl Object {
         })
     }
 
-    /// Extracts the embedded Portable PDB from this object, if present.
+    /// Narrows this object to a Windows PE image, if it is one.
+    ///
+    /// Returns `undefined` for non-PE objects. The returned [`PeFile`] exposes
+    /// PE-specific operations (such as [`PeFile::embedded_ppdb`]) that have no
+    /// equivalent on other object formats, mirroring the `Object::Pe` variant of
+    /// the underlying `symbolic_debuginfo` types.
+    #[wasm_bindgen(js_name = asPe)]
+    pub fn as_pe(&self) -> Result<Option<PeFile>> {
+        let di::Object::Pe(pe) = self.inner.get() else {
+            return Ok(None);
+        };
+        // `PeObject` is neither `Clone` nor movable out of the borrowed enum, so
+        // re-parse it from the same backing bytes to obtain an owned handle that
+        // can live in its own cell sharing this object's `ByteView`. Parsing only
+        // reads the PE header and is cheap; the heavy lifting happens lazily in the
+        // PE-specific operations on `PeFile`.
+        let pe = di::pe::PeObject::parse(pe.data())?;
+        Ok(Some(PeFile {
+            // SAFETY: `pe` is derived from `self.inner` and only borrows data from
+            // the same `ByteView`.
+            inner: unsafe {
+                utils::derived_from_cell!(
+                    di::pe::PeObject<'_>,
+                    di::pe::PeObject<'static>,
+                    self.inner,
+                    pe
+                )
+            },
+        }))
+    }
+}
+
+/// A Windows PE image (an executable or a managed/.NET assembly).
+///
+/// Obtain one by narrowing an [`Object`] via [`Object::as_pe`]. This exposes the
+/// PE-specific surface of `symbolic_debuginfo`'s `PeObject`.
+#[wasm_bindgen(js_name = PeFile)]
+pub struct PeFile {
+    inner: SelfCell<ByteView<'static>, di::pe::PeObject<'static>>,
+}
+
+#[wasm_bindgen(js_class = PeFile)]
+impl PeFile {
+    /// Extracts the embedded Portable PDB from this PE, if present.
     ///
     /// Some Windows PE images (managed/.NET assemblies) embed their Portable
     /// PDB debug companion directly in the executable (debug directory entry
@@ -152,14 +195,10 @@ impl Object {
     /// which are themselves a standalone Portable PDB debug information file
     /// that can be parsed (e.g. via [`Archive`]) and uploaded independently.
     ///
-    /// Returns `undefined` when the object is not a PE, or is a PE without an
-    /// embedded Portable PDB.
+    /// Returns `undefined` when this PE has no embedded Portable PDB.
     #[wasm_bindgen(js_name = embeddedPpdb)]
     pub fn embedded_ppdb(&self) -> Result<Option<Vec<u8>>> {
-        let di::Object::Pe(pe) = self.inner.get() else {
-            return Ok(None);
-        };
-        let Some(ppdb) = pe.embedded_ppdb()? else {
+        let Some(ppdb) = self.inner.get().embedded_ppdb()? else {
             return Ok(None);
         };
         // Decompress into a growable buffer rather than pre-allocating from

--- a/symbolic-wasm/src/debuginfo/mod.rs
+++ b/symbolic-wasm/src/debuginfo/mod.rs
@@ -1,5 +1,7 @@
 //! Exposes `symbolic_debuginfo` to WASM.
 
+use std::sync::Arc;
+
 use symbolic_common::{ByteView, SelfCell};
 use symbolic_debuginfo as di;
 use wasm_bindgen::prelude::*;
@@ -59,7 +61,9 @@ impl Archive {
                     .map(|object| Object {
                         // SAFETY: `object` is directly derived from `self.inner` and
                         // only borrows data from the same `ByteView`.
-                        inner: unsafe { utils::derived_from_cell!(Object, self.inner, object) },
+                        inner: Arc::new(unsafe {
+                            utils::derived_from_cell!(Object, self.inner, object)
+                        }),
                     })
                     .map_err(Error::from)
             })
@@ -70,7 +74,7 @@ impl Archive {
 /// A generic object file providing uniform access to various file formats.
 #[wasm_bindgen(js_name = ObjectFile)]
 pub struct Object {
-    inner: SelfCell<ByteView<'static>, di::Object<'static>>,
+    inner: Arc<SelfCell<ByteView<'static>, di::Object<'static>>>,
 }
 
 #[wasm_bindgen(js_class = ObjectFile)]
@@ -151,9 +155,11 @@ impl Object {
     /// equivalent on other object formats, mirroring the `Object::Pe` variant of
     /// the underlying `symbolic_debuginfo` types.
     #[wasm_bindgen(js_name = asPe)]
-    pub fn as_pe(self) -> Option<PeFile> {
+    pub fn as_pe(&self) -> Option<PeFile> {
         match self.inner.get() {
-            di::Object::Pe(_) => Some(PeFile { inner: self.inner }),
+            di::Object::Pe(_) => Some(PeFile {
+                inner: Arc::clone(&self.inner),
+            }),
             _ => None,
         }
     }
@@ -168,7 +174,7 @@ pub struct PeFile {
     // Since we don't have a good way of extracting a `PeObject` from the
     // `SelfCell`, we just rely on the invariant to always be constructed
     // with a valid `PeObject`.
-    inner: SelfCell<ByteView<'static>, di::Object<'static>>,
+    inner: Arc<SelfCell<ByteView<'static>, di::Object<'static>>>,
 }
 
 #[wasm_bindgen(js_class = PeFile)]

--- a/symbolic-wasm/src/utils.rs
+++ b/symbolic-wasm/src/utils.rs
@@ -8,14 +8,25 @@ use wasm_bindgen::JsError;
 ///
 /// This is unsafe and callers must ensure the derived value only borrows from the data
 /// of the owning [`symbolic_common::SelfCell`].
+///
+/// Two forms are supported:
+///
+/// - `derived_from_cell!(Ty, owner, derived)` for types re-exported at the
+///   `symbolic_debuginfo` crate root (e.g. `Object`, `ObjectDebugSession`).
+/// - `derived_from_cell!(Ty<'_>, Ty<'static>, owner, derived)` for types behind a
+///   module path (e.g. `pe::PeObject`), where the borrowed and `'static` forms must
+///   be spelled out because a `path` fragment cannot be followed by a lifetime.
 macro_rules! derived_from_cell {
-    ($ty:ident, $owner:expr, $derived:expr) => {{
-        let derived = std::mem::transmute::<
-            // Temporary workaround, once we expand the functionality of the crate,
-            // we'll have to fix the macro to accepts `path::type`.
+    ($ty:ident, $owner:expr, $derived:expr) => {
+        $crate::utils::derived_from_cell!(
             symbolic_debuginfo::$ty<'_>,
             symbolic_debuginfo::$ty<'static>,
-        >($derived);
+            $owner,
+            $derived
+        )
+    };
+    ($borrowed:ty, $static:ty, $owner:expr, $derived:expr) => {{
+        let derived = std::mem::transmute::<$borrowed, $static>($derived);
         ::symbolic_common::SelfCell::from_raw($owner.owner().clone(), derived)
     }};
 }

--- a/symbolic-wasm/src/utils.rs
+++ b/symbolic-wasm/src/utils.rs
@@ -25,9 +25,11 @@ pub(crate) use derived_from_cell;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]
-    ObjectError(#[from] symbolic_debuginfo::ObjectError),
+    Object(#[from] symbolic_debuginfo::ObjectError),
     #[error(transparent)]
-    SourceBundleError(#[from] symbolic_debuginfo::sourcebundle::SourceBundleError),
+    SourceBundle(#[from] symbolic_debuginfo::sourcebundle::SourceBundleError),
+    #[error(transparent)]
+    Pe(#[from] symbolic_debuginfo::pe::PeError),
 }
 
 impl From<Error> for wasm_bindgen::JsValue {

--- a/symbolic-wasm/tests/debuginfo.rs
+++ b/symbolic-wasm/tests/debuginfo.rs
@@ -61,6 +61,60 @@ fn test_archive_objects() {
 
 #[test]
 #[wasm_bindgen_test::wasm_bindgen_test]
+fn test_embedded_ppdb_none() {
+    // A managed PE that does NOT embed a Portable PDB.
+    let data =
+        common::fixture("symbolic-testutils/fixtures/windows/Sentry.Samples.Console.Basic.dll");
+
+    let archive = Archive::new(&data).unwrap();
+    let mut objects = archive.objects().unwrap();
+    let object = objects.remove(0);
+
+    assert_eq!(&object.file_format(), "pe");
+    assert!(object.embedded_ppdb().unwrap().is_none());
+}
+
+#[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
+fn test_embedded_ppdb_some() {
+    // A managed PE that embeds a deflate-compressed Portable PDB.
+    let data = common::fixture(
+        "symbolic-testutils/fixtures/windows/Sentry.Samples.Console.Basic-embedded-ppdb.dll",
+    );
+
+    let archive = Archive::new(&data).unwrap();
+    let mut objects = archive.objects().unwrap();
+    let object = objects.remove(0);
+
+    let ppdb = object.embedded_ppdb().unwrap().unwrap();
+
+    // Decompressed size matches what symbolic-debuginfo reports for this fixture,
+    // and the bytes carry the Portable PDB metadata version string.
+    assert_eq!(ppdb.len(), 10540);
+    assert_eq!(&ppdb[15..25], b"\0PDB v1.0\0");
+
+    // The extracted bytes are a standalone Portable PDB that parses on its own.
+    let ppdb_archive = Archive::new(&ppdb).unwrap();
+    assert_eq!(ppdb_archive.file_format(), "portablepdb");
+    assert_eq!(ppdb_archive.object_count(), 1);
+}
+
+#[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
+fn test_embedded_ppdb_non_pe() {
+    // Non-PE objects never carry an embedded Portable PDB.
+    let data = common::fixture("symbolic-testutils/fixtures/linux/crash.debug");
+
+    let archive = Archive::new(&data).unwrap();
+    let mut objects = archive.objects().unwrap();
+    let object = objects.remove(0);
+
+    assert_eq!(&object.file_format(), "elf");
+    assert!(object.embedded_ppdb().unwrap().is_none());
+}
+
+#[test]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn test_debug_session_files() {
     let data =
         common::fixture("symbolic-testutils/fixtures/windows/Sentry.Samples.Console.Basic.pdb");

--- a/symbolic-wasm/tests/debuginfo.rs
+++ b/symbolic-wasm/tests/debuginfo.rs
@@ -71,7 +71,8 @@ fn test_embedded_ppdb_none() {
     let object = objects.remove(0);
 
     assert_eq!(&object.file_format(), "pe");
-    assert!(object.embedded_ppdb().unwrap().is_none());
+    let pe = object.as_pe().unwrap().expect("expected a PE file");
+    assert!(pe.embedded_ppdb().unwrap().is_none());
 }
 
 #[test]
@@ -86,7 +87,8 @@ fn test_embedded_ppdb_some() {
     let mut objects = archive.objects().unwrap();
     let object = objects.remove(0);
 
-    let ppdb = object.embedded_ppdb().unwrap().unwrap();
+    let pe = object.as_pe().unwrap().expect("expected a PE file");
+    let ppdb = pe.embedded_ppdb().unwrap().unwrap();
 
     // Decompressed size matches what symbolic-debuginfo reports for this fixture,
     // and the bytes carry the Portable PDB metadata version string.
@@ -101,8 +103,8 @@ fn test_embedded_ppdb_some() {
 
 #[test]
 #[wasm_bindgen_test::wasm_bindgen_test]
-fn test_embedded_ppdb_non_pe() {
-    // Non-PE objects never carry an embedded Portable PDB.
+fn test_as_pe_none_for_non_pe() {
+    // Non-PE objects cannot be narrowed to a PE, so `as_pe` yields `None`.
     let data = common::fixture("symbolic-testutils/fixtures/linux/crash.debug");
 
     let archive = Archive::new(&data).unwrap();
@@ -110,7 +112,7 @@ fn test_embedded_ppdb_non_pe() {
     let object = objects.remove(0);
 
     assert_eq!(&object.file_format(), "elf");
-    assert!(object.embedded_ppdb().unwrap().is_none());
+    assert!(object.as_pe().unwrap().is_none());
 }
 
 #[test]

--- a/symbolic-wasm/tests/debuginfo.rs
+++ b/symbolic-wasm/tests/debuginfo.rs
@@ -71,7 +71,7 @@ fn test_embedded_ppdb_none() {
     let object = objects.remove(0);
 
     assert_eq!(&object.file_format(), "pe");
-    let pe = object.as_pe().unwrap().expect("expected a PE file");
+    let pe = object.as_pe().unwrap();
     assert!(pe.embedded_ppdb().unwrap().is_none());
 }
 
@@ -87,7 +87,7 @@ fn test_embedded_ppdb_some() {
     let mut objects = archive.objects().unwrap();
     let object = objects.remove(0);
 
-    let pe = object.as_pe().unwrap().expect("expected a PE file");
+    let pe = object.as_pe().unwrap();
     let ppdb = pe.embedded_ppdb().unwrap().unwrap();
 
     // Decompressed size matches what symbolic-debuginfo reports for this fixture,
@@ -112,7 +112,7 @@ fn test_as_pe_none_for_non_pe() {
     let object = objects.remove(0);
 
     assert_eq!(&object.file_format(), "elf");
-    assert!(object.as_pe().unwrap().is_none());
+    assert!(object.as_pe().is_none());
 }
 
 #[test]


### PR DESCRIPTION
Exposes the API needed to extract an embedded Portable PDB from a managed Windows PE — the upload use case in `sentry-cli`, where `.NET` assemblies that carry their debug companion inline (debug-directory entry type 17, deflate-compressed) must have that PPDB pulled out and uploaded as a standalone debug information file.

## Changes
- **`symbolic-wasm`**: add `ObjectFile.embeddedPpdb()`:
  - Returns `Uint8Array` — the decompressed Portable PDB bytes, themselves a parseable, uploadable DIF (re-parse as a `portablepdb` archive).
  - Returns `undefined` when the object is not a PE, or is a PE without an embedded PPDB.
  - Wraps the existing `PeObject::embedded_ppdb()` + `PeEmbeddedPortablePDB::decompress_to()`; nothing in the wasm layer returned this before.
- **`symbolic-wasm` error plumbing**: add a `Pe(PeError)` variant to the internal `Error` enum and drop the redundant `Error` suffix on every variant (`Object`, `SourceBundle`, `Pe`) to satisfy `clippy::enum_variant_names`, which trips once a third `*Error` variant exists. The enum is internal (surfaced to JS via `Display` → `JsValue`), so the rename is non-breaking.

### Hardening
Decompresses into a growable `Vec` rather than pre-allocating from `get_size()`. The uncompressed size is read verbatim from the untrusted PE debug-directory header, so pre-allocating would let a crafted file trigger an oversized speculative allocation; growing the buffer bounds memory to the actual decompressed output.

## Tests
- `wasm-bindgen` tests (run native + via `wasm-pack test --node`) covering all three branches: a PE **with** an embedded PPDB (asserts the decompressed size, the Portable PDB version string, and that the bytes re-parse as a standalone `portablepdb` archive), a PE **without** one (`None`), and a **non-PE** object (`None`).
- A packaged-artifact smoke-test assertion (`npm test`) exercising `embeddedPpdb()` against the **shipped** package in the real wasm runtime — both the extract-and-re-parse path and the `undefined` path.

Validated locally: `cargo test -p symbolic-wasm`, fmt + clippy clean, `wasm32-unknown-unknown` release build, and the full `build-npm.sh` pipeline (build + packaged smoke test, 5/5).