### PR TITLE
fix(msvc): Fix bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Vendor [msvc-demangler](https://github.com/mstange/msvc-demangler-rust). ([#998](https://github.com/getsentry/symbolic/pull/998))
 
+**Fixes**
+
+- Fix bugs in the vendored msvc-demangler lib. ([#1008](https://github.com/getsentry/symbolic/pull/1008))
+
 **Dependencies**
 
 - Bump the `memmap2` floor to 0.9.11 to exclude versions affected by [RUSTSEC-2026-0186](https://rustsec.org/advisories/RUSTSEC-2026-0186.html). ([#996](https://github.com/getsentry/symbolic/pull/996))

--- a/symbolic-demangle/vendor/msvc-demangler/lib.rs
+++ b/symbolic-demangle/vendor/msvc-demangler/lib.rs
@@ -750,14 +750,14 @@ impl<'a> ParserState<'a> {
                     let c = self.get()?;
                     match c {
                         b'A'..=b'Z' => c - b'A' + 0xe1,
-                        b'a'..=b'z' => c - b'A' + 0xc1,
+                        b'a'..=b'z' => c - b'a' + 0xc1,
                         b'0'..=b'9' => {
                             let v = b",/\\:. \n\t'-";
                             v[(c - b'0') as usize]
                         }
                         b'$' => {
-                            let high = self.get()? - b'A';
-                            let low = self.get()? - b'A';
+                            let high = self.get()?.saturating_sub(b'A');
+                            let low = self.get()?.saturating_sub(b'A');
                             (high << 4) | low
                         }
                         _ => {

--- a/symbolic-demangle/vendor/msvc-demangler/lib.rs
+++ b/symbolic-demangle/vendor/msvc-demangler/lib.rs
@@ -749,8 +749,8 @@ impl<'a> ParserState<'a> {
                 b'?' => {
                     let c = self.get()?;
                     match c {
-                        b'A'..=b'Z' => c - b'A' + 0xe1,
-                        b'a'..=b'z' => c - b'a' + 0xc1,
+                        b'A'..=b'Z' => c - b'A' + 0xc1,
+                        b'a'..=b'z' => c - b'a' + 0xe1,
                         b'0'..=b'9' => {
                             let v = b",/\\:. \n\t'-";
                             v[(c - b'0') as usize]


### PR DESCRIPTION
While vendoring the MSVC library (https://github.com/getsentry/symbolic/pull/998) SentryBot found some bugs, which this PR now tries to fix.