### PR TITLE
fix(elf): Fix a potential panic when locating sections in an elf file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixes**
 
 - Fix function range to addr/line resolution, this fixes a case where WASM binaries compiled with Emscripten failed to have their source code mappings resolved. (#[1002](https://github.com/getsentry/symbolic/pull/1002))
+- Fix a potential panic when locating sections in an elf file. ([#1012](https://github.com/getsentry/symbolic/pull/1012))
 
 ## 13.6.0
 

--- a/symbolic-debuginfo/src/elf.rs
+++ b/symbolic-debuginfo/src/elf.rs
@@ -671,7 +671,10 @@ impl<'data> ElfObject<'data> {
                 // Support this as an override to the flag.
                 let (compressed, section_name) = match section_name.strip_prefix(".z") {
                     Some(name) => (true, name),
-                    None => (header.sh_flags & SHF_COMPRESSED != 0, &section_name[1..]),
+                    None => (
+                        header.sh_flags & SHF_COMPRESSED != 0,
+                        section_name.strip_prefix('.').unwrap_or(section_name),
+                    ),
                 };
 
                 if section_name != name {

--- a/symbolic-debuginfo/src/elf.rs
+++ b/symbolic-debuginfo/src/elf.rs
@@ -671,10 +671,11 @@ impl<'data> ElfObject<'data> {
                 // Support this as an override to the flag.
                 let (compressed, section_name) = match section_name.strip_prefix(".z") {
                     Some(name) => (true, name),
-                    None => (
-                        header.sh_flags & SHF_COMPRESSED != 0,
-                        section_name.strip_prefix('.').unwrap_or(section_name),
-                    ),
+                    None => match section_name.strip_prefix('.') {
+                        Some(name) => (header.sh_flags & SHF_COMPRESSED != 0, name),
+                        // We expect any section we look for to actually start with a `.`.
+                        None => continue,
+                    },
                 };
 
                 if section_name != name {


### PR DESCRIPTION
The implicit assumption is that a section name always starts with a `.`, it's technically possible that a section's first character is outside of ascii, which would panic here.

Fixes: INGEST-993