### PR TITLE
fix(elf): Fix potential out of bounds panic on invalid section offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**
+
+- Fix potential out of bounds panic on invalid section offsets ([#1013](https://github.com/getsentry/symbolic/pull/1013))
+- Fix a potential panic when locating sections in an elf file. ([#1012](https://github.com/getsentry/symbolic/pull/1012))
+
 ## 13.8.0
 
 **Features**
@@ -28,7 +35,6 @@
 **Fixes**
 
 - Fix function range to addr/line resolution, this fixes a case where WASM binaries compiled with Emscripten failed to have their source code mappings resolved. (#[1002](https://github.com/getsentry/symbolic/pull/1002))
-- Fix a potential panic when locating sections in an elf file. ([#1012](https://github.com/getsentry/symbolic/pull/1012))
 
 ## 13.6.0
 

--- a/symbolic-debuginfo/src/elf.rs
+++ b/symbolic-debuginfo/src/elf.rs
@@ -683,7 +683,7 @@ impl<'data> ElfObject<'data> {
                 }
 
                 let size = header.sh_size as usize;
-                let data = &self.data[offset..][..size];
+                let data = &self.data.get(offset..)?.get(..size)?;
                 let section = DwarfSection {
                     data: Cow::Borrowed(data),
                     address: header.sh_addr,


### PR DESCRIPTION
Fixes: INGEST-989

This returns `None` if there is a matching section but with incorrect offsets, which I think is reasonable. The alternative is to keep searching, but is it really expected to find another section with the same name but no broken offsets?