### PR TITLE
feat(variables): Parse very basic variable information from DWARF files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Breaking Changes**
 
 - Change the MSRV version to 1.85 and Rust Edition 2024. ([#1028](https://github.com/getsentry/symbolic/pull/1028))
+- Adds variables to functions. ([#1025](https://github.com/getsentry/symbolic/pull/1025))
 
 ## 14.0.0-alpha.3
 
@@ -16,6 +17,7 @@
 - Removed the deprecated `BreakpadErrorKind::BadSyntax` variant. ([#1024](https://github.com/getsentry/symbolic/pull/1024))
 
 **Dependencies**
+
 - Bump `pdb-addr2line` to 0.12.0. This includes a switch from `pdb` to `pdb2`. ([#1018](https://github.com/getsentry/symbolic/pull/1018))
 
 ## 14.0.0-alpha.2

--- a/examples/addr2line/src/main.rs
+++ b/examples/addr2line/src/main.rs
@@ -6,7 +6,7 @@ use clap::builder::ValueParser;
 use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 
 use symbolic::common::{ByteView, Language, Name, NameMangling};
-use symbolic::debuginfo::{Function, Object};
+use symbolic::debuginfo::{Function, Location, Object};
 use symbolic::demangle::{Demangle, DemangleOptions};
 
 fn print_name<'a, N: Borrow<Name<'a>>>(name: Option<N>, matches: &ArgMatches) {
@@ -41,6 +41,7 @@ fn resolve(function: &Function<'_>, addr: u64, matches: &ArgMatches) -> Result<b
         }
     }
 
+    let mut found_line = false;
     for line in &function.lines {
         if line.address + line.size.unwrap_or(1) <= addr {
             continue;
@@ -64,10 +65,35 @@ fn resolve(function: &Function<'_>, addr: u64, matches: &ArgMatches) -> Result<b
         print_range(line.address, line.size, matches);
         println!();
 
-        return Ok(true);
+        found_line = true;
+        break;
     }
 
-    Ok(false)
+    if found_line && *matches.get_one("variables").unwrap() {
+        for variable in &function.variables {
+            let mut locations = variable
+                .locations
+                .iter()
+                .take_while(|location| location.address <= addr)
+                .filter(|location| addr - location.address < location.size)
+                .peekable();
+
+            if locations.peek().is_some() {
+                println!("    {} ({})", variable.name, variable.kind);
+            }
+
+            for location in locations {
+                print!("      ");
+                match location.location {
+                    Location::Register { id } => print!("reg:{id}"),
+                }
+                print_range(location.address, Some(location.size), matches);
+                println!();
+            }
+        }
+    }
+
+    Ok(found_line)
 }
 
 fn execute(matches: &ArgMatches) -> Result<()> {
@@ -168,6 +194,13 @@ In the second, addr2line reads hexadecimal addresses from standard input, and pr
                 .long("inlinees")
                 .action(ArgAction::SetTrue)
                 .help("If the address belongs to a function that was inlined, the source information for all enclosing scopes back to the first non-inlined function will also be printed. For example, if \"main\" inlines \"callee1\" which inlines \"callee2\", and address is from \"callee2\", the source information for \"callee1\" and \"main\" will also be printed.")
+        )
+        .arg(
+            Arg::new("variables")
+                .short('v')
+                .long("variables")
+                .action(ArgAction::SetTrue)
+                .help("Display variable information."),
         )
         .arg(
             Arg::new("addrs")

--- a/symbolic-debuginfo/src/base.rs
+++ b/symbolic-debuginfo/src/base.rs
@@ -756,6 +756,7 @@ impl fmt::Debug for Function<'_> {
             .field("lines", &self.lines)
             .field("inlinees", &self.inlinees)
             .field("inline", &self.inline)
+            .field("variables", &self.variables)
             .finish()
     }
 }

--- a/symbolic-debuginfo/src/base.rs
+++ b/symbolic-debuginfo/src/base.rs
@@ -7,6 +7,7 @@ use symbolic_common::{Arch, CodeId, DebugId, Name, clean_path, join_path};
 
 use crate::ParseObjectOptions;
 use crate::sourcebundle::SourceFileDescriptor;
+use crate::variable;
 
 pub(crate) trait Parse<'data>: Sized {
     type Error;
@@ -729,6 +730,8 @@ pub struct Function<'data> {
     pub inlinees: Vec<Function<'data>>,
     /// Specifies whether this function is inlined.
     pub inline: bool,
+    /// List of local variables and parameters of this function.
+    pub variables: Vec<variable::Variable<'data>>,
 }
 
 impl Function<'_> {

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -1441,7 +1441,7 @@ impl<'s> Iterator for BreakpadFunctionIterator<'s> {
                         call_line: inline_record.call_site_line,
                         variables: Vec::new(),
                     };
-                    builder.add_inlinee2(inlinee);
+                    builder.add_inlinee(inlinee);
                 }
                 continue;
             }

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -13,7 +13,7 @@ use symbolic_common::{Arch, AsSelf, CodeId, DebugId, Language, Name, NameManglin
 
 use crate::ParseObjectOptions;
 use crate::base::*;
-use crate::function_builder::FunctionBuilder;
+use crate::function_builder::{FunctionBuilder, FunctionBuilderInlinee};
 use crate::sourcebundle::SourceFileDescriptor;
 
 #[derive(Clone, Debug)]
@@ -1426,20 +1426,22 @@ impl<'s> Iterator for BreakpadFunctionIterator<'s> {
                     .unwrap_or_default();
 
                 for address_range in &inline_record.address_ranges {
-                    builder.add_inlinee(
-                        inline_record.inline_depth as u32,
-                        Name::new(name, NameMangling::Unmangled, Language::Unknown),
-                        address_range.address,
-                        address_range.size,
-                        FileInfo::from_path(
+                    let inlinee = FunctionBuilderInlinee {
+                        depth: inline_record.inline_depth as u32,
+                        address: address_range.address,
+                        size: address_range.size,
+                        name: Name::new(name, NameMangling::Unmangled, Language::Unknown),
+                        call_file: FileInfo::from_path(
                             self.file_map
                                 .get(&inline_record.call_site_file_id)
                                 .cloned()
                                 .unwrap_or_default()
                                 .as_bytes(),
                         ),
-                        inline_record.call_site_line,
-                    );
+                        call_line: inline_record.call_site_line,
+                        variables: Vec::new(),
+                    };
+                    builder.add_inlinee2(inlinee);
                 }
                 continue;
             }

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -19,17 +19,20 @@ use std::sync::Arc;
 
 use fallible_iterator::FallibleIterator;
 use gimli::read::{AttributeValue, Error as GimliError, Range};
-use gimli::{AbbreviationsCacheStrategy, DwarfFileType, UnitSectionOffset, constants};
+use gimli::{
+    AbbreviationsCacheStrategy, DwarfFileType, Expression, LocListIter, Operation,
+    UnitSectionOffset, constants,
+};
 use once_cell::sync::OnceCell;
 use thiserror::Error;
 
 use symbolic_common::{AsSelf, Language, Name, NameMangling, SelfCell};
 
-use crate::base::*;
 use crate::function_builder::FunctionBuilder;
 #[cfg(feature = "macho")]
 use crate::macho::BcSymbolMap;
 use crate::sourcebundle::SourceFileDescriptor;
+use crate::{Kind, Location, LocationInfo, base::*, variable};
 
 /// This is a fake BcSymbolMap used when macho support is turned off since they are unfortunately
 /// part of the dwarf interface
@@ -145,6 +148,10 @@ impl From<GimliError> for DwarfError {
         Self::new(DwarfErrorKind::CorruptedData, e)
     }
 }
+
+/// A reference to a type in the DWARF file.
+#[derive(Debug, Clone)]
+pub struct DwarfTypeRef(UnitSectionOffset);
 
 /// DWARF section information including its data.
 ///
@@ -413,6 +420,15 @@ impl<'d> UnitRef<'d, '_> {
         Some(String::from_utf8_lossy(slice))
     }
 
+    /// Try to return an attribute value as a location list entry iterator.
+    #[inline(always)]
+    fn attr_locations(
+        &self,
+        value: AttributeValue<Slice<'d>>,
+    ) -> Result<Option<LocListIter<Slice<'d>>>, DwarfError> {
+        Ok(self.info.attr_locations(self.unit, value)?)
+    }
+
     /// Resolves an entry and if found invokes a function to transform it.
     ///
     /// As this might resolve into cached information the data borrowed from
@@ -435,6 +451,17 @@ impl<'d> UnitRef<'d, '_> {
             f(unit, entry)
         } else {
             Ok(None)
+        }
+    }
+
+    /// Resolves a attribute unit ref or debug info ref to a [`UnitSectionOffset`].
+    ///
+    /// Returns `None` for attributes not containing a reference or unsupported references.
+    fn to_unit_section_offset(&self, attr: Attribute<'d>) -> Option<UnitSectionOffset> {
+        match attr.value() {
+            AttributeValue::UnitRef(offset) => Some(offset.to_unit_section_offset(self.unit)),
+            AttributeValue::DebugInfoRef(offset) => offset.to_unit_section_offset(self.unit),
+            _ => return None,
         }
     }
 
@@ -988,6 +1015,9 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
                         language,
                     )?;
                 }
+                constants::DW_TAG_variable => {
+                    self.parse_variable(entries, abbrev, builders)?;
+                }
                 _ => {
                     entries.skip_attributes(abbrev.attributes())?;
                 }
@@ -1076,6 +1106,151 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
         self.parse_function_children(depth, inline_depth + 1, entries, builders, output, language)
     }
 
+    fn parse_variable(
+        &self,
+        entries: &mut EntriesRaw<'d, '_>,
+        abbrev: &gimli::Abbreviation,
+        builders: &mut [(Range, FunctionBuilder<'d>)],
+    ) -> Result<Option<()>, DwarfError> {
+        let mut ty = None;
+        let mut name = None;
+        let mut locations = None;
+        let mut is_declaration = false;
+
+        for &spec in abbrev.attributes() {
+            let attr = entries.read_attribute(spec)?;
+            match attr.name() {
+                constants::DW_AT_name => {
+                    name = self.inner.string_value(attr.value());
+                }
+                constants::DW_AT_declaration if attr.value() == AttributeValue::Flag(true) => {
+                    // We don't care about declarations, we only care about actual definitions of
+                    // the variables.
+                    //
+                    // No early return possible, the attributes need to be consumed fully.
+                    is_declaration = true;
+                }
+                constants::DW_AT_location => {
+                    locations = self.parse_locations(attr.value())?;
+                }
+                // This will need some further refinement, `to_unit_section_offset` is only enough
+                // for unit and debug info references, it does not yet support debug types references,
+                // and references to supplementary object files. Supplementary object files are
+                // generally not supported, but type section references should be implemented.
+                constants::DW_AT_type
+                    if let Some(offset) = self.inner.to_unit_section_offset(attr) =>
+                {
+                    ty = Some(variable::TypeRef::from(DwarfTypeRef(offset)));
+                }
+
+                // Location tells which builder this need to be added to.
+                // No Location means optimized out, we may not need to store it at all.
+                _ => {}
+            }
+        }
+
+        if is_declaration {
+            return Ok(None);
+        }
+
+        let (Some(name), Some(locations)) = (name, locations) else {
+            return Ok(None);
+        };
+
+        let kind = match abbrev.tag() {
+            constants::DW_TAG_formal_parameter => Kind::Parameter,
+            _ => Kind::Local,
+        };
+
+        for (f_range, builder) in builders {
+            let mut locations = match &locations {
+                Locations::Single(location) => vec![LocationInfo {
+                    address: offset(f_range.begin, self.inner.info.address_offset),
+                    size: f_range.end - f_range.begin,
+                    location: location.clone(),
+                }],
+                Locations::Many(locations) => locations
+                    .iter()
+                    .filter(|(r, _)| r.begin < f_range.end && f_range.begin < r.end)
+                    .map(|(_, location)| location.clone())
+                    .collect(),
+            };
+
+            locations.sort_unstable_by_key(|location| location.address);
+
+            if !locations.is_empty() {
+                builder.add_variable(variable::Variable {
+                    name: name.clone(),
+                    ty: ty.clone(),
+                    kind,
+                    locations,
+                });
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn parse_locations(
+        &self,
+        value: AttributeValue<Slice<'d>>,
+    ) -> Result<Option<Locations>, DwarfError> {
+        if let AttributeValue::Exprloc(expr) = value {
+            return self
+                .parse_location_expression(expr)
+                .map(|v| v.map(Locations::Single));
+        }
+
+        let mut result = Vec::new();
+        let locations = self.inner.attr_locations(value)?.into_iter().flatten();
+        for location in locations {
+            let location = location?;
+
+            let range = location.range;
+            let address = offset(range.begin, self.inner.info.address_offset);
+            let Some(size) = range.end.checked_sub(range.begin) else {
+                // Invalid range, end before start.
+                continue;
+            };
+
+            let location = LocationInfo {
+                address,
+                size,
+                location: match self.parse_location_expression(location.data)? {
+                    Some(location) => location,
+                    None => continue,
+                },
+            };
+            result.push((range, location));
+        }
+
+        Ok(match result.is_empty() {
+            true => None,
+            false => Some(Locations::Many(result)),
+        })
+    }
+
+    fn parse_location_expression(
+        &self,
+        expr: Expression<Slice<'d>>,
+    ) -> Result<Option<Location>, DwarfError> {
+        let mut operations = expr.operations(self.inner.unit.encoding());
+
+        let Some(op) = operations.next()? else {
+            return Ok(None);
+        };
+        if operations.next()?.is_some() {
+            // Currently we only support location expressions with a single op.
+            return Ok(None);
+        }
+
+        Ok(match op {
+            Operation::Register { register } => Some(Location::Register { id: register.0 }),
+            // Currently more operations are not supported.
+            _ => None,
+        })
+    }
+
     /// Collects all functions within this compilation unit.
     fn functions(
         &self,
@@ -1086,6 +1261,14 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
         self.parse_functions(-1, &mut entries, &mut output)?;
         Ok(output.functions)
     }
+}
+
+/// Return value of [`DwarfUnit::parse_locations`].
+enum Locations {
+    /// A single location.
+    Single(Location),
+    /// Many locations, dependent on the PC at runtime.
+    Many(Vec<(Range, LocationInfo)>),
 }
 
 /// The state we pass around during function parsing.

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -957,7 +957,24 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             })
             .collect();
 
-        self.parse_function_children(depth, 0, None, entries, &mut builders, output, language)?;
+        let mut variables = Vec::new();
+        self.parse_function_children(
+            depth,
+            0,
+            entries,
+            &mut builders,
+            output,
+            language,
+            &mut variables,
+        )?;
+
+        for (range, builder) in &mut builders {
+            for variable in &variables {
+                if let Some(variable) = self.variable_for_range(variable, *range) {
+                    builder.add_variable(variable);
+                }
+            }
+        }
 
         if let Some(line_program) = &self.line_program {
             for (range, builder) in &mut builders {
@@ -983,11 +1000,11 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
         &self,
         depth: isize,
         inline_depth: u32,
-        inline_scope: Option<usize>,
         entries: &mut EntriesRaw<'d, '_>,
         builders: &mut [(Range, FunctionBuilder<'d>)],
         output: &mut FunctionsOutput<'_, 'd>,
         language: Language,
+        variables: &mut Vec<ParsedVariable<'d>>,
     ) -> Result<(), DwarfError> {
         while !entries.is_empty() {
             let dw_die_offset = entries.next_offset();
@@ -1016,8 +1033,10 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
                         language,
                     )?;
                 }
-                constants::DW_TAG_variable => {
-                    self.parse_variable(entries, abbrev, inline_scope, builders)?;
+                constants::DW_TAG_variable | constants::DW_TAG_formal_parameter => {
+                    if let Some(variable) = self.parse_variable(entries, abbrev)? {
+                        variables.push(variable);
+                    }
                 }
                 _ => {
                     entries.skip_attributes(abbrev.attributes())?;
@@ -1061,6 +1080,7 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
         if ranges.is_empty() {
             return self.parse_functions(depth, entries, output);
         }
+        let ranges = ranges.clone();
 
         let entry = self.inner.unit.entry(dw_die_offset)?;
         let language = self.resolve_function_language(&entry, language);
@@ -1081,6 +1101,17 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             .unwrap_or_default();
         let call_line = call_location.call_line.unwrap_or(0);
 
+        let mut variables = Vec::new();
+        self.parse_function_children(
+            depth,
+            inline_depth + 1,
+            entries,
+            builders,
+            output,
+            language,
+            &mut variables,
+        )?;
+
         // Create a separate inlinee for each range.
         for range in ranges.iter() {
             // Find the builder for the outer function that covers this range. Usually there's only
@@ -1094,35 +1125,30 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
 
             let address = offset(range.begin, self.inner.info.address_offset);
             let size = range.end - range.begin;
-            builder.add_inlinee_with_scope(
-                Some(dw_die_offset.0),
+            let variables = variables
+                .iter()
+                .filter_map(|variable| self.variable_for_range(variable, *range))
+                .collect();
+
+            builder.add_inlinee_with_variables(
                 inline_depth,
                 name.clone(),
                 address,
                 size,
                 call_file.clone(),
                 call_line,
+                variables,
             );
         }
 
-        self.parse_function_children(
-            depth,
-            inline_depth + 1,
-            Some(dw_die_offset.0),
-            entries,
-            builders,
-            output,
-            language,
-        )
+        Ok(())
     }
 
     fn parse_variable(
         &self,
         entries: &mut EntriesRaw<'d, '_>,
         abbrev: &gimli::Abbreviation,
-        inline_scope: Option<usize>,
-        builders: &mut [(Range, FunctionBuilder<'d>)],
-    ) -> Result<Option<()>, DwarfError> {
+    ) -> Result<Option<ParsedVariable<'d>>, DwarfError> {
         let mut ty = None;
         let mut name = None;
         let mut locations = None;
@@ -1154,8 +1180,7 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
                     ty = Some(variable::TypeRef::from(DwarfTypeRef(offset)));
                 }
 
-                // Location tells which builder this need to be added to.
-                // No Location means optimized out, we may not need to store it at all.
+                // No location means optimized out, so we do not store the variable for now.
                 _ => {}
             }
         }
@@ -1173,36 +1198,41 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             _ => Kind::Local,
         };
 
-        for (f_range, builder) in builders {
-            let mut locations = match &locations {
-                Locations::Single(location) => vec![LocationInfo {
-                    address: offset(f_range.begin, self.inner.info.address_offset),
-                    size: f_range.end - f_range.begin,
-                    location: location.clone(),
-                }],
-                Locations::Many(locations) => locations
-                    .iter()
-                    .filter(|(r, _)| r.begin < f_range.end && f_range.begin < r.end)
-                    .map(|(_, location)| location.clone())
-                    .collect(),
-            };
+        Ok(Some(ParsedVariable {
+            name,
+            ty,
+            kind,
+            locations,
+        }))
+    }
 
-            locations.sort_unstable_by_key(|location| location.address);
+    fn variable_for_range(
+        &self,
+        variable: &ParsedVariable<'d>,
+        range: Range,
+    ) -> Option<variable::Variable<'d>> {
+        let mut locations = match &variable.locations {
+            Locations::Single(location) => vec![LocationInfo {
+                address: offset(range.begin, self.inner.info.address_offset),
+                size: range.end - range.begin,
+                location: location.clone(),
+            }],
+            Locations::Many(locations) => locations
+                .iter()
+                .filter(|(location_range, _)| {
+                    location_range.begin < range.end && range.begin < location_range.end
+                })
+                .map(|(_, location)| location.clone())
+                .collect(),
+        };
 
-            if !locations.is_empty() {
-                builder.add_variable_for_scope(
-                    inline_scope,
-                    variable::Variable {
-                        name: name.clone(),
-                        ty: ty.clone(),
-                        kind,
-                        locations,
-                    },
-                );
-            }
-        }
-
-        Ok(None)
+        locations.sort_unstable_by_key(|location| location.address);
+        (!locations.is_empty()).then(|| variable::Variable {
+            name: variable.name.clone(),
+            ty: variable.ty.clone(),
+            kind: variable.kind,
+            locations,
+        })
     }
 
     fn parse_locations(
@@ -1275,6 +1305,14 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
         self.parse_functions(-1, &mut entries, &mut output)?;
         Ok(output.functions)
     }
+}
+
+/// A variable before its locations are restricted to a concrete ranges.
+struct ParsedVariable<'data> {
+    name: Cow<'data, str>,
+    ty: Option<variable::TypeRef>,
+    kind: Kind,
+    locations: Locations,
 }
 
 /// Return value of [`DwarfUnit::parse_locations`].

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -957,7 +957,7 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             })
             .collect();
 
-        self.parse_function_children(depth, 0, entries, &mut builders, output, language)?;
+        self.parse_function_children(depth, 0, None, entries, &mut builders, output, language)?;
 
         if let Some(line_program) = &self.line_program {
             for (range, builder) in &mut builders {
@@ -983,6 +983,7 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
         &self,
         depth: isize,
         inline_depth: u32,
+        inline_scope: Option<usize>,
         entries: &mut EntriesRaw<'d, '_>,
         builders: &mut [(Range, FunctionBuilder<'d>)],
         output: &mut FunctionsOutput<'_, 'd>,
@@ -1016,7 +1017,7 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
                     )?;
                 }
                 constants::DW_TAG_variable => {
-                    self.parse_variable(entries, abbrev, builders)?;
+                    self.parse_variable(entries, abbrev, inline_scope, builders)?;
                 }
                 _ => {
                     entries.skip_attributes(abbrev.attributes())?;
@@ -1093,7 +1094,8 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
 
             let address = offset(range.begin, self.inner.info.address_offset);
             let size = range.end - range.begin;
-            builder.add_inlinee(
+            builder.add_inlinee_with_scope(
+                Some(dw_die_offset.0),
                 inline_depth,
                 name.clone(),
                 address,
@@ -1103,13 +1105,22 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             );
         }
 
-        self.parse_function_children(depth, inline_depth + 1, entries, builders, output, language)
+        self.parse_function_children(
+            depth,
+            inline_depth + 1,
+            Some(dw_die_offset.0),
+            entries,
+            builders,
+            output,
+            language,
+        )
     }
 
     fn parse_variable(
         &self,
         entries: &mut EntriesRaw<'d, '_>,
         abbrev: &gimli::Abbreviation,
+        inline_scope: Option<usize>,
         builders: &mut [(Range, FunctionBuilder<'d>)],
     ) -> Result<Option<()>, DwarfError> {
         let mut ty = None;
@@ -1179,12 +1190,15 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             locations.sort_unstable_by_key(|location| location.address);
 
             if !locations.is_empty() {
-                builder.add_variable(variable::Variable {
-                    name: name.clone(),
-                    ty: ty.clone(),
-                    kind,
-                    locations,
-                });
+                builder.add_variable_for_scope(
+                    inline_scope,
+                    variable::Variable {
+                        name: name.clone(),
+                        ty: ty.clone(),
+                        kind,
+                        locations,
+                    },
+                );
             }
         }
 

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -151,7 +151,7 @@ impl From<GimliError> for DwarfError {
 
 /// A reference to a type in the DWARF file.
 #[derive(Debug, Clone)]
-pub struct DwarfTypeRef(UnitSectionOffset);
+pub struct DwarfTypeRef(#[expect(unused)] UnitSectionOffset);
 
 /// DWARF section information including its data.
 ///
@@ -1220,24 +1220,32 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             }],
             Locations::Many(locations) => locations
                 .iter()
-                .filter(|(location_range, _)| {
-                    location_range.begin < range.end && range.begin < location_range.end
+                // Make sure the ranges overlap
+                .filter(|(lr, _)| lr.begin < range.end && range.begin < lr.end)
+                // Trim location range to parent range, technically not necessary, but makes
+                // everything a bit nicer to look at and deal with.
+                .map(|(lr, location)| {
+                    let address = lr.begin.max(range.begin);
+                    LocationInfo {
+                        address: offset(address, self.inner.info.address_offset),
+                        size: lr.end.min(range.end) - address,
+                        location: location.location.clone(),
+                    }
                 })
-                .map(|(_, location)| location.clone())
                 .collect(),
         };
 
-        locations.sort_unstable_by_key(|location| location.address);
-
-        match !locations.is_empty() {
-            true => Some(variable::Variable {
-                name: variable.name.clone(),
-                ty: variable.ty.clone(),
-                kind: variable.kind,
-                locations,
-            }),
-            false => None,
+        if locations.is_empty() {
+            return None;
         }
+
+        locations.sort_unstable_by_key(|location| location.address);
+        Some(variable::Variable {
+            name: variable.name.clone(),
+            ty: variable.ty.clone(),
+            kind: variable.kind,
+            locations,
+        })
     }
 
     fn parse_locations(
@@ -1273,10 +1281,7 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             result.push((range, location));
         }
 
-        Ok(match !result.is_empty() {
-            true => Some(Locations::Many(result)),
-            false => None,
-        })
+        Ok((!result.is_empty()).then_some(Locations::Many(result)))
     }
 
     fn parse_location_expression(

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -28,7 +28,7 @@ use thiserror::Error;
 
 use symbolic_common::{AsSelf, Language, Name, NameMangling, SelfCell};
 
-use crate::function_builder::FunctionBuilder;
+use crate::function_builder::{FunctionBuilder, FunctionBuilderInlinee};
 #[cfg(feature = "macho")]
 use crate::macho::BcSymbolMap;
 use crate::sourcebundle::SourceFileDescriptor;
@@ -457,11 +457,11 @@ impl<'d> UnitRef<'d, '_> {
     /// Resolves a attribute unit ref or debug info ref to a [`UnitSectionOffset`].
     ///
     /// Returns `None` for attributes not containing a reference or unsupported references.
-    fn to_unit_section_offset(&self, attr: Attribute<'d>) -> Option<UnitSectionOffset> {
+    fn to_unit_section_offset(self, attr: Attribute<'d>) -> Option<UnitSectionOffset> {
         match attr.value() {
             AttributeValue::UnitRef(offset) => Some(offset.to_unit_section_offset(self.unit)),
             AttributeValue::DebugInfoRef(offset) => offset.to_unit_section_offset(self.unit),
-            _ => return None,
+            _ => None,
         }
     }
 
@@ -996,6 +996,7 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
     }
 
     /// Traverses a subtree during function parsing.
+    #[allow(clippy::too_many_arguments)]
     fn parse_function_children(
         &self,
         depth: isize,
@@ -1130,15 +1131,15 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
                 .filter_map(|variable| self.variable_for_range(variable, *range))
                 .collect();
 
-            builder.add_inlinee_with_variables(
-                inline_depth,
-                name.clone(),
+            builder.add_inlinee(FunctionBuilderInlinee {
+                depth: inline_depth,
+                name: name.clone(),
                 address,
                 size,
-                call_file.clone(),
+                call_file: call_file.clone(),
                 call_line,
                 variables,
-            );
+            });
         }
 
         Ok(())
@@ -1227,12 +1228,16 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
         };
 
         locations.sort_unstable_by_key(|location| location.address);
-        (!locations.is_empty()).then(|| variable::Variable {
-            name: variable.name.clone(),
-            ty: variable.ty.clone(),
-            kind: variable.kind,
-            locations,
-        })
+
+        match !locations.is_empty() {
+            true => Some(variable::Variable {
+                name: variable.name.clone(),
+                ty: variable.ty.clone(),
+                kind: variable.kind,
+                locations,
+            }),
+            false => None,
+        }
     }
 
     fn parse_locations(
@@ -1268,9 +1273,9 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
             result.push((range, location));
         }
 
-        Ok(match result.is_empty() {
-            true => None,
-            false => Some(Locations::Many(result)),
+        Ok(match !result.is_empty() {
+            true => Some(Locations::Many(result)),
+            false => None,
         })
     }
 

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -1317,7 +1317,7 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
     }
 }
 
-/// A variable before its locations are restricted to a concrete ranges.
+/// A variable before its locations are restricted to a concrete range.
 struct ParsedVariable<'data> {
     name: Cow<'data, str>,
     ty: Option<variable::TypeRef>,

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use fallible_iterator::FallibleIterator;
 use gimli::read::{AttributeValue, Error as GimliError, Range};
 use gimli::{
-    AbbreviationsCacheStrategy, DwarfFileType, Expression, LocListIter, Operation,
+    AbbreviationsCacheStrategy, DwarfFileType, Expression, LocListIter, LocationLists, Operation,
     UnitSectionOffset, constants,
 };
 use once_cell::sync::OnceCell;
@@ -1436,6 +1436,8 @@ struct DwarfSections<'data> {
     debug_info: DwarfSectionData<'data, gimli::read::DebugInfo<Slice<'data>>>,
     debug_line: DwarfSectionData<'data, gimli::read::DebugLine<Slice<'data>>>,
     debug_line_str: DwarfSectionData<'data, gimli::read::DebugLineStr<Slice<'data>>>,
+    debug_loc: DwarfSectionData<'data, gimli::read::DebugLoc<Slice<'data>>>,
+    debug_loclists: DwarfSectionData<'data, gimli::read::DebugLocLists<Slice<'data>>>,
     debug_names: DwarfSectionData<'data, gimli::read::DebugNames<Slice<'data>>>,
     debug_str: DwarfSectionData<'data, gimli::read::DebugStr<Slice<'data>>>,
     debug_str_offsets: DwarfSectionData<'data, gimli::read::DebugStrOffsets<Slice<'data>>>,
@@ -1458,6 +1460,8 @@ impl<'data> DwarfSections<'data> {
             debug_info: DwarfSectionData::load(dwarf),
             debug_line: DwarfSectionData::load(dwarf),
             debug_line_str: DwarfSectionData::load(dwarf),
+            debug_loc: DwarfSectionData::load(dwarf),
+            debug_loclists: DwarfSectionData::load(dwarf),
             debug_names: DwarfSectionData::load(dwarf),
             debug_str: DwarfSectionData::load(dwarf),
             debug_str_offsets: DwarfSectionData::load(dwarf),
@@ -1508,7 +1512,10 @@ impl<'d> DwarfInfo<'d> {
             debug_types: Default::default(),
             debug_macinfo: sections.debug_macinfo.to_gimli(),
             debug_macro: sections.debug_macro.to_gimli(),
-            locations: Default::default(),
+            locations: LocationLists::new(
+                sections.debug_loc.to_gimli(),
+                sections.debug_loclists.to_gimli(),
+            ),
             ranges: RangeLists::new(
                 sections.debug_ranges.to_gimli(),
                 sections.debug_rnglists.to_gimli(),

--- a/symbolic-debuginfo/src/function_builder.rs
+++ b/symbolic-debuginfo/src/function_builder.rs
@@ -4,8 +4,8 @@
 use std::{cmp::Reverse, collections::BinaryHeap};
 
 use crate::{
-    base::{FileInfo, Function, LineInfo},
     Variable,
+    base::{FileInfo, Function, LineInfo},
 };
 use symbolic_common::Name;
 

--- a/symbolic-debuginfo/src/function_builder.rs
+++ b/symbolic-debuginfo/src/function_builder.rs
@@ -3,7 +3,10 @@
 
 use std::{cmp::Reverse, collections::BinaryHeap};
 
-use crate::base::{FileInfo, Function, LineInfo};
+use crate::{
+    base::{FileInfo, Function, LineInfo},
+    variable, Variable,
+};
 use symbolic_common::Name;
 
 /// Allows creating a [`Function`] from unordered line and inlinee records.
@@ -29,6 +32,8 @@ pub struct FunctionBuilder<'s> {
     /// The lines, in any order. They will be sorted in `finish()`. These record specify locations
     /// at the innermost level of the inline stack at the line record's address.
     lines: Vec<LineInfo<'s>>,
+    /// All variables found inside the function.
+    variables: Vec<Variable<'s>>,
     max_inline_depth: Option<u32>,
 }
 
@@ -42,6 +47,7 @@ impl<'s> FunctionBuilder<'s> {
             size,
             inlinees: BinaryHeap::new(),
             lines: Vec::new(),
+            variables: Vec::new(),
             max_inline_depth: None,
         }
     }
@@ -82,6 +88,11 @@ impl<'s> FunctionBuilder<'s> {
         }));
     }
 
+    /// Add a variable to the function.
+    pub fn add_variable(&mut self, variable: Variable<'s>) {
+        self.variables.push(variable);
+    }
+
     /// Add a line record, specifying the line at this address inside the innermost inlinee that
     /// covers that address. This method can be called in any order.
     pub fn add_leaf_line(
@@ -119,6 +130,7 @@ impl<'s> FunctionBuilder<'s> {
             address,
             size,
             inlinees,
+            variables,
             mut lines,
             max_inline_depth: _,
         } = self;
@@ -135,6 +147,7 @@ impl<'s> FunctionBuilder<'s> {
             compilation_dir,
             lines: Vec::new(),
             inlinees: Vec::new(),
+            variables,
             inline: false,
         };
         let outer_function_end = address + size;
@@ -176,6 +189,7 @@ impl<'s> FunctionBuilder<'s> {
                     compilation_dir,
                     lines: Vec::new(),
                     inlinees: Vec::new(),
+                    variables: Vec::new(),
                     inline: true,
                 });
                 next_inlinee = inlinee_iter.next();

--- a/symbolic-debuginfo/src/function_builder.rs
+++ b/symbolic-debuginfo/src/function_builder.rs
@@ -32,8 +32,8 @@ pub struct FunctionBuilder<'s> {
     /// The lines, in any order. They will be sorted in `finish()`. These record specify locations
     /// at the innermost level of the inline stack at the line record's address.
     lines: Vec<LineInfo<'s>>,
-    /// All variables found inside the function and its inlinees.
-    variables: Vec<FunctionBuilderVariable<'s>>,
+    /// All variables found inside the function.
+    variables: Vec<Variable<'s>>,
     max_inline_depth: Option<u32>,
 }
 
@@ -72,20 +72,28 @@ impl<'s> FunctionBuilder<'s> {
         call_file: FileInfo<'s>,
         call_line: u64,
     ) {
-        self.add_inlinee_with_scope(None, depth, name, address, size, call_file, call_line);
+        self.add_inlinee_with_variables(
+            depth,
+            name,
+            address,
+            size,
+            call_file,
+            call_line,
+            Vec::new(),
+        );
     }
 
-    /// Add an inlinee record associated with a specific debug information scope.
+    /// Add an inlinee record with its variables.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn add_inlinee_with_scope(
+    pub fn add_inlinee_with_variables(
         &mut self,
-        scope_id: Option<usize>,
         depth: u32,
         name: Name<'s>,
         address: u64,
         size: u64,
         call_file: FileInfo<'s>,
         call_line: u64,
+        variables: Vec<Variable<'s>>,
     ) {
         // An inlinee that starts before the function is obviously bogus same for an inlinee that
         // has a depth deeper than the limit.
@@ -94,29 +102,32 @@ impl<'s> FunctionBuilder<'s> {
         }
 
         self.inlinees.push(Reverse(FunctionBuilderInlinee {
-            scope_id,
             depth,
             address,
             size,
             name,
             call_file,
             call_line,
+            variables,
         }));
+    }
+
+    /// Add an inlinee record with its variables.
+    pub fn add_inlinee2(&mut self, inlinee: FunctionBuilderInlinee<'s>) {
+        // An inlinee that starts before the function is obviously bogus same for an inlinee that
+        // has a depth deeper than the limit.
+        if inlinee.address < self.address
+            || inlinee.depth > self.max_inline_depth.unwrap_or(u32::MAX)
+        {
+            return;
+        }
+
+        self.inlinees.push(Reverse(inlinee));
     }
 
     /// Add a variable to the function.
     pub fn add_variable(&mut self, variable: Variable<'s>) {
-        self.add_variable_for_scope(None, variable);
-    }
-
-    /// Add a variable associated with a specific debug information scope.
-    pub(crate) fn add_variable_for_scope(
-        &mut self,
-        scope_id: Option<usize>,
-        variable: Variable<'s>,
-    ) {
-        self.variables
-            .push(FunctionBuilderVariable { scope_id, variable });
+        self.variables.push(variable);
     }
 
     /// Add a line record, specifying the line at this address inside the innermost inlinee that
@@ -166,11 +177,6 @@ impl<'s> FunctionBuilder<'s> {
         // Sort the lines by address.
         lines.sort_by_key(|line| line.address);
 
-        let outer_variables = variables
-            .iter()
-            .filter(|variable| variable.scope_id.is_none())
-            .map(|variable| variable.variable.clone())
-            .collect();
         let outer_function = Function {
             address,
             size,
@@ -178,7 +184,7 @@ impl<'s> FunctionBuilder<'s> {
             compilation_dir,
             lines: Vec::new(),
             inlinees: Vec::new(),
-            variables: outer_variables,
+            variables,
             inline: false,
         };
         let outer_function_end = address + size;
@@ -214,20 +220,10 @@ impl<'s> FunctionBuilder<'s> {
                     line: inlinee.call_line,
                 });
                 let inline_variables = inlinee
-                    .scope_id
-                    .into_iter()
-                    .flat_map(|scope_id| {
-                        variables.iter().filter_map(move |variable| {
-                            (variable.scope_id == Some(scope_id))
-                                .then(|| {
-                                    variable_for_range(
-                                        &variable.variable,
-                                        inlinee.address,
-                                        inlinee.size,
-                                    )
-                                })
-                                .flatten()
-                        })
+                    .variables
+                    .iter()
+                    .filter_map(|variable| {
+                        variable_for_range(variable, inlinee.address, inlinee.size)
                     })
                     .collect();
                 stack.push(Function {
@@ -294,10 +290,8 @@ impl<'s> FunctionBuilder<'s> {
 }
 
 /// Represents a contiguous address range which is covered by an inlined function call.
-#[derive(PartialEq, Eq, Clone, Debug)]
-struct FunctionBuilderInlinee<'s> {
-    /// The debug information scope that produced this inline call.
-    pub scope_id: Option<usize>,
+#[derive(Clone, Debug)]
+pub struct FunctionBuilderInlinee<'s> {
     /// The inline nesting level of this inline call. Calls from the outer function have depth 0.
     pub depth: u32,
     /// The start address.
@@ -310,13 +304,17 @@ struct FunctionBuilderInlinee<'s> {
     pub call_file: FileInfo<'s>,
     /// The line number of the location of the call.
     pub call_line: u64,
+    /// Variables owned by this inline call.
+    pub variables: Vec<Variable<'s>>,
 }
 
-/// A variable and the debug information scope that owns it.
-struct FunctionBuilderVariable<'s> {
-    pub scope_id: Option<usize>,
-    pub variable: Variable<'s>,
+impl PartialEq for FunctionBuilderInlinee<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        (self.address, self.depth) == (other.address, other.depth)
+    }
 }
+
+impl Eq for FunctionBuilderInlinee<'_> {}
 
 fn variable_for_range<'s>(
     variable: &Variable<'s>,
@@ -571,14 +569,15 @@ mod tests {
         // 0x20 - 0x40: bar in bar.c on line 1
         // - inlined into: foo in foo.c on line 2
         let mut builder = FunctionBuilder::new(Name::from("foo"), &[], 0x10, 0x30);
-        builder.add_inlinee(
-            0,
-            Name::from("bar"),
-            0x20,
-            0x20,
-            FileInfo::from_filename(b"foo.c"),
-            2,
-        );
+        builder.add_inlinee2(FunctionBuilderInlinee {
+            depth: 0,
+            name: Name::from("bar"),
+            address: 0x20,
+            size: 0x20,
+            call_file: FileInfo::from_filename(b"foo.c"),
+            call_line: 2,
+            variables: Vec::new(),
+        });
         builder.add_leaf_line(0x10, Some(0x10), FileInfo::from_filename(b"foo.c"), 1);
         builder.add_leaf_line(0x20, Some(0x20), FileInfo::from_filename(b"bar.c"), 1);
         let func = builder.finish();
@@ -602,30 +601,28 @@ mod tests {
     }
 
     #[test]
-    fn test_inlinee_variables_are_assigned_by_scope() {
+    fn test_inlinee_variables_are_attached_structurally() {
         let mut builder = FunctionBuilder::new(Name::from("outer"), &[], 0x10, 0x40);
-        builder.add_inlinee_with_scope(
-            Some(1),
+        builder.add_inlinee_with_variables(
             0,
             Name::from("first"),
             0x20,
             0x10,
             FileInfo::default(),
             0,
+            vec![variable("first_var", 0x10, 0x40)],
         );
-        builder.add_inlinee_with_scope(
-            Some(2),
+        builder.add_inlinee_with_variables(
             0,
             Name::from("second"),
             0x30,
             0x10,
             FileInfo::default(),
             0,
+            vec![variable("second_var", 0x10, 0x40)],
         );
 
         builder.add_variable(variable("outer_var", 0x10, 0x40));
-        builder.add_variable_for_scope(Some(1), variable("first_var", 0x10, 0x40));
-        builder.add_variable_for_scope(Some(2), variable("second_var", 0x10, 0x40));
 
         let function = builder.finish();
 

--- a/symbolic-debuginfo/src/function_builder.rs
+++ b/symbolic-debuginfo/src/function_builder.rs
@@ -169,13 +169,6 @@ impl<'s> FunctionBuilder<'s> {
                     file: inlinee.call_file,
                     line: inlinee.call_line,
                 });
-                let inline_variables = inlinee
-                    .variables
-                    .iter()
-                    .filter_map(|variable| {
-                        variable_for_range(variable, inlinee.address, inlinee.size)
-                    })
-                    .collect();
                 stack.push(Function {
                     address: inlinee.address,
                     size: inlinee.size,
@@ -183,7 +176,7 @@ impl<'s> FunctionBuilder<'s> {
                     compilation_dir,
                     lines: Vec::new(),
                     inlinees: Vec::new(),
-                    variables: inline_variables,
+                    variables: inlinee.variables,
                     inline: true,
                 });
                 next_inlinee = inlinee_iter.next();
@@ -265,20 +258,6 @@ impl PartialEq for FunctionBuilderInlinee<'_> {
 }
 
 impl Eq for FunctionBuilderInlinee<'_> {}
-
-fn variable_for_range<'s>(
-    variable: &Variable<'s>,
-    address: u64,
-    size: u64,
-) -> Option<Variable<'s>> {
-    let end_address = address.saturating_add(size);
-    let mut variable = variable.clone();
-    variable.locations.retain(|location| {
-        let location_end = location.address.saturating_add(location.size);
-        location.address < end_address && address < location_end
-    });
-    (!variable.locations.is_empty()).then_some(variable)
-}
 
 /// Implement ordering in DFS order, i.e. first by address and then by depth.
 impl PartialOrd for FunctionBuilderInlinee<'_> {
@@ -478,6 +457,23 @@ fn ensure_proper_nesting(
             // function. Those inlinees can be as long as they want; we don't try to
             // force them to stay within the outer function's address range here.
         }
+
+        // Clip inlinee variable to the new range.
+        inlinee.variables.retain_mut(|variable| {
+            variable.locations.retain_mut(|location| {
+                let location_end = location.address.saturating_add(location.size);
+                let location_end = location_end.min(end_address);
+                location.address = location.address.max(start_address);
+                if location.address >= location_end {
+                    return false;
+                }
+                location.size = location_end - location.address;
+                true
+            });
+
+            !variable.locations.is_empty()
+        });
+
         result.push(inlinee);
         end_address_stack.push(end_address); // this goes into end_address_stack[depth]
     }
@@ -486,8 +482,9 @@ fn ensure_proper_nesting(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::{Kind, Location, LocationInfo};
+
+    use super::*;
 
     #[test]
     fn test_simple() {
@@ -535,6 +532,90 @@ mod tests {
             &func.inlinees[0].lines,
             &[LineInfo::new(0x20, 0x20, b"bar.c", 1)]
         );
+    }
+
+    #[test]
+    fn test_inlinee_variable_fixup_location_ranges() {
+        let variable = Variable {
+            name: "value".into(),
+            ty: None,
+            kind: Kind::Local,
+            locations: vec![LocationInfo {
+                address: 0x10,
+                size: 0x40,
+                location: Location::Register { id: 0 },
+            }],
+        };
+
+        let mut builder = FunctionBuilder::new(Name::from("outer"), &[], 0x10, 0x40);
+        builder.add_inlinee(FunctionBuilderInlinee {
+            depth: 0,
+            address: 0x20,
+            size: 0x10,
+            name: Name::from("inline"),
+            call_file: FileInfo::default(),
+            call_line: 0,
+            variables: vec![variable],
+        });
+
+        let function = builder.finish();
+
+        insta::assert_debug_snapshot!(function, @r#"
+        Function {
+            address: 0x10,
+            size: 0x40,
+            name: Name {
+                string: "outer",
+                lang: Unknown,
+                mangling: Unknown,
+            },
+            compilation_dir: "",
+            lines: [
+                LineInfo {
+                    address: 0x20,
+                    size: 0x10,
+                    file: FileInfo {
+                        name: "",
+                        dir: "",
+                    },
+                    line: 0,
+                },
+            ],
+            inlinees: [
+                Function {
+                    address: 0x20,
+                    size: 0x10,
+                    name: Name {
+                        string: "inline",
+                        lang: Unknown,
+                        mangling: Unknown,
+                    },
+                    compilation_dir: "",
+                    lines: [],
+                    inlinees: [],
+                    inline: true,
+                    variables: [
+                        Variable {
+                            name: "value",
+                            ty: None,
+                            kind: Local,
+                            locations: [
+                                LocationInfo {
+                                    address: 0x20,
+                                    size: 0x10,
+                                    location: Register {
+                                        id: 0,
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            inline: false,
+            variables: [],
+        }
+        "#);
     }
 
     #[test]

--- a/symbolic-debuginfo/src/function_builder.rs
+++ b/symbolic-debuginfo/src/function_builder.rs
@@ -63,57 +63,7 @@ impl<'s> FunctionBuilder<'s> {
     /// Add an inlinee record. This method can be called in any order.
     ///
     /// Inlinees which are called directly from the outer function have depth 0.
-    pub fn add_inlinee(
-        &mut self,
-        depth: u32,
-        name: Name<'s>,
-        address: u64,
-        size: u64,
-        call_file: FileInfo<'s>,
-        call_line: u64,
-    ) {
-        self.add_inlinee_with_variables(
-            depth,
-            name,
-            address,
-            size,
-            call_file,
-            call_line,
-            Vec::new(),
-        );
-    }
-
-    /// Add an inlinee record with its variables.
-    #[allow(clippy::too_many_arguments)]
-    pub fn add_inlinee_with_variables(
-        &mut self,
-        depth: u32,
-        name: Name<'s>,
-        address: u64,
-        size: u64,
-        call_file: FileInfo<'s>,
-        call_line: u64,
-        variables: Vec<Variable<'s>>,
-    ) {
-        // An inlinee that starts before the function is obviously bogus same for an inlinee that
-        // has a depth deeper than the limit.
-        if address < self.address || depth > self.max_inline_depth.unwrap_or(u32::MAX) {
-            return;
-        }
-
-        self.inlinees.push(Reverse(FunctionBuilderInlinee {
-            depth,
-            address,
-            size,
-            name,
-            call_file,
-            call_line,
-            variables,
-        }));
-    }
-
-    /// Add an inlinee record with its variables.
-    pub fn add_inlinee2(&mut self, inlinee: FunctionBuilderInlinee<'s>) {
+    pub fn add_inlinee(&mut self, inlinee: FunctionBuilderInlinee<'s>) {
         // An inlinee that starts before the function is obviously bogus same for an inlinee that
         // has a depth deeper than the limit.
         if inlinee.address < self.address
@@ -539,19 +489,6 @@ mod tests {
     use super::*;
     use crate::{Kind, Location, LocationInfo};
 
-    fn variable(name: &'static str, address: u64, size: u64) -> Variable<'static> {
-        Variable {
-            name: name.into(),
-            ty: None,
-            kind: Kind::Local,
-            locations: vec![LocationInfo {
-                address,
-                size,
-                location: Location::Register { id: 0 },
-            }],
-        }
-    }
-
     #[test]
     fn test_simple() {
         // 0x10 - 0x40: foo in foo.c on line 1
@@ -569,7 +506,7 @@ mod tests {
         // 0x20 - 0x40: bar in bar.c on line 1
         // - inlined into: foo in foo.c on line 2
         let mut builder = FunctionBuilder::new(Name::from("foo"), &[], 0x10, 0x30);
-        builder.add_inlinee2(FunctionBuilderInlinee {
+        builder.add_inlinee(FunctionBuilderInlinee {
             depth: 0,
             name: Name::from("bar"),
             address: 0x20,
@@ -601,41 +538,6 @@ mod tests {
     }
 
     #[test]
-    fn test_inlinee_variables_are_attached_structurally() {
-        let mut builder = FunctionBuilder::new(Name::from("outer"), &[], 0x10, 0x40);
-        builder.add_inlinee_with_variables(
-            0,
-            Name::from("first"),
-            0x20,
-            0x10,
-            FileInfo::default(),
-            0,
-            vec![variable("first_var", 0x10, 0x40)],
-        );
-        builder.add_inlinee_with_variables(
-            0,
-            Name::from("second"),
-            0x30,
-            0x10,
-            FileInfo::default(),
-            0,
-            vec![variable("second_var", 0x10, 0x40)],
-        );
-
-        builder.add_variable(variable("outer_var", 0x10, 0x40));
-
-        let function = builder.finish();
-
-        assert_eq!(function.variables.len(), 1);
-        assert_eq!(function.variables[0].name, "outer_var");
-        assert_eq!(function.inlinees.len(), 2);
-        assert_eq!(function.inlinees[0].variables.len(), 1);
-        assert_eq!(function.inlinees[0].variables[0].name, "first_var");
-        assert_eq!(function.inlinees[1].variables.len(), 1);
-        assert_eq!(function.inlinees[1].variables[0].name, "second_var");
-    }
-
-    #[test]
     fn test_longer_line_record() {
         // Consider the following code:
         //
@@ -664,30 +566,33 @@ mod tests {
         //               |---------|      (child2.c line 1)
 
         let mut builder = FunctionBuilder::new(Name::from("parent"), &[], 0x10, 0x40);
-        builder.add_inlinee(
-            0,
-            Name::from("child1"),
-            0x20,
-            0x10,
-            FileInfo::from_filename(b"parent.c"),
-            1,
-        );
-        builder.add_inlinee(
-            1,
-            Name::from("child2"),
-            0x20,
-            0x10,
-            FileInfo::from_filename(b"child1.c"),
-            1,
-        );
-        builder.add_inlinee(
-            0,
-            Name::from("child2"),
-            0x30,
-            0x10,
-            FileInfo::from_filename(b"parent.c"),
-            2,
-        );
+        builder.add_inlinee(FunctionBuilderInlinee {
+            depth: 0,
+            name: Name::from("child1"),
+            address: 0x20,
+            size: 0x10,
+            call_file: FileInfo::from_filename(b"parent.c"),
+            call_line: 1,
+            variables: Vec::new(),
+        });
+        builder.add_inlinee(FunctionBuilderInlinee {
+            depth: 1,
+            name: Name::from("child2"),
+            address: 0x20,
+            size: 0x10,
+            call_file: FileInfo::from_filename(b"child1.c"),
+            call_line: 1,
+            variables: Vec::new(),
+        });
+        builder.add_inlinee(FunctionBuilderInlinee {
+            depth: 0,
+            name: Name::from("child2"),
+            address: 0x30,
+            size: 0x10,
+            call_file: FileInfo::from_filename(b"parent.c"),
+            call_line: 2,
+            variables: Vec::new(),
+        });
         builder.add_leaf_line(0x10, Some(0x10), FileInfo::from_filename(b"parent.c"), 1);
         builder.add_leaf_line(0x20, Some(0x20), FileInfo::from_filename(b"child2.c"), 1);
         builder.add_leaf_line(0x40, Some(0x10), FileInfo::from_filename(b"parent.c"), 1);

--- a/symbolic-debuginfo/src/function_builder.rs
+++ b/symbolic-debuginfo/src/function_builder.rs
@@ -5,7 +5,7 @@ use std::{cmp::Reverse, collections::BinaryHeap};
 
 use crate::{
     base::{FileInfo, Function, LineInfo},
-    variable, Variable,
+    Variable,
 };
 use symbolic_common::Name;
 
@@ -32,8 +32,8 @@ pub struct FunctionBuilder<'s> {
     /// The lines, in any order. They will be sorted in `finish()`. These record specify locations
     /// at the innermost level of the inline stack at the line record's address.
     lines: Vec<LineInfo<'s>>,
-    /// All variables found inside the function.
-    variables: Vec<Variable<'s>>,
+    /// All variables found inside the function and its inlinees.
+    variables: Vec<FunctionBuilderVariable<'s>>,
     max_inline_depth: Option<u32>,
 }
 
@@ -72,6 +72,21 @@ impl<'s> FunctionBuilder<'s> {
         call_file: FileInfo<'s>,
         call_line: u64,
     ) {
+        self.add_inlinee_with_scope(None, depth, name, address, size, call_file, call_line);
+    }
+
+    /// Add an inlinee record associated with a specific debug information scope.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn add_inlinee_with_scope(
+        &mut self,
+        scope_id: Option<usize>,
+        depth: u32,
+        name: Name<'s>,
+        address: u64,
+        size: u64,
+        call_file: FileInfo<'s>,
+        call_line: u64,
+    ) {
         // An inlinee that starts before the function is obviously bogus same for an inlinee that
         // has a depth deeper than the limit.
         if address < self.address || depth > self.max_inline_depth.unwrap_or(u32::MAX) {
@@ -79,6 +94,7 @@ impl<'s> FunctionBuilder<'s> {
         }
 
         self.inlinees.push(Reverse(FunctionBuilderInlinee {
+            scope_id,
             depth,
             address,
             size,
@@ -90,7 +106,17 @@ impl<'s> FunctionBuilder<'s> {
 
     /// Add a variable to the function.
     pub fn add_variable(&mut self, variable: Variable<'s>) {
-        self.variables.push(variable);
+        self.add_variable_for_scope(None, variable);
+    }
+
+    /// Add a variable associated with a specific debug information scope.
+    pub(crate) fn add_variable_for_scope(
+        &mut self,
+        scope_id: Option<usize>,
+        variable: Variable<'s>,
+    ) {
+        self.variables
+            .push(FunctionBuilderVariable { scope_id, variable });
     }
 
     /// Add a line record, specifying the line at this address inside the innermost inlinee that
@@ -140,6 +166,11 @@ impl<'s> FunctionBuilder<'s> {
         // Sort the lines by address.
         lines.sort_by_key(|line| line.address);
 
+        let outer_variables = variables
+            .iter()
+            .filter(|variable| variable.scope_id.is_none())
+            .map(|variable| variable.variable.clone())
+            .collect();
         let outer_function = Function {
             address,
             size,
@@ -147,7 +178,7 @@ impl<'s> FunctionBuilder<'s> {
             compilation_dir,
             lines: Vec::new(),
             inlinees: Vec::new(),
-            variables,
+            variables: outer_variables,
             inline: false,
         };
         let outer_function_end = address + size;
@@ -182,6 +213,23 @@ impl<'s> FunctionBuilder<'s> {
                     file: inlinee.call_file,
                     line: inlinee.call_line,
                 });
+                let inline_variables = inlinee
+                    .scope_id
+                    .into_iter()
+                    .flat_map(|scope_id| {
+                        variables.iter().filter_map(move |variable| {
+                            (variable.scope_id == Some(scope_id))
+                                .then(|| {
+                                    variable_for_range(
+                                        &variable.variable,
+                                        inlinee.address,
+                                        inlinee.size,
+                                    )
+                                })
+                                .flatten()
+                        })
+                    })
+                    .collect();
                 stack.push(Function {
                     address: inlinee.address,
                     size: inlinee.size,
@@ -189,7 +237,7 @@ impl<'s> FunctionBuilder<'s> {
                     compilation_dir,
                     lines: Vec::new(),
                     inlinees: Vec::new(),
-                    variables: Vec::new(),
+                    variables: inline_variables,
                     inline: true,
                 });
                 next_inlinee = inlinee_iter.next();
@@ -248,6 +296,8 @@ impl<'s> FunctionBuilder<'s> {
 /// Represents a contiguous address range which is covered by an inlined function call.
 #[derive(PartialEq, Eq, Clone, Debug)]
 struct FunctionBuilderInlinee<'s> {
+    /// The debug information scope that produced this inline call.
+    pub scope_id: Option<usize>,
     /// The inline nesting level of this inline call. Calls from the outer function have depth 0.
     pub depth: u32,
     /// The start address.
@@ -260,6 +310,26 @@ struct FunctionBuilderInlinee<'s> {
     pub call_file: FileInfo<'s>,
     /// The line number of the location of the call.
     pub call_line: u64,
+}
+
+/// A variable and the debug information scope that owns it.
+struct FunctionBuilderVariable<'s> {
+    pub scope_id: Option<usize>,
+    pub variable: Variable<'s>,
+}
+
+fn variable_for_range<'s>(
+    variable: &Variable<'s>,
+    address: u64,
+    size: u64,
+) -> Option<Variable<'s>> {
+    let end_address = address.saturating_add(size);
+    let mut variable = variable.clone();
+    variable.locations.retain(|location| {
+        let location_end = location.address.saturating_add(location.size);
+        location.address < end_address && address < location_end
+    });
+    (!variable.locations.is_empty()).then_some(variable)
 }
 
 /// Implement ordering in DFS order, i.e. first by address and then by depth.
@@ -469,6 +539,20 @@ fn ensure_proper_nesting(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{Kind, Location, LocationInfo};
+
+    fn variable(name: &'static str, address: u64, size: u64) -> Variable<'static> {
+        Variable {
+            name: name.into(),
+            ty: None,
+            kind: Kind::Local,
+            locations: vec![LocationInfo {
+                address,
+                size,
+                location: Location::Register { id: 0 },
+            }],
+        }
+    }
 
     #[test]
     fn test_simple() {
@@ -515,6 +599,43 @@ mod tests {
             &func.inlinees[0].lines,
             &[LineInfo::new(0x20, 0x20, b"bar.c", 1)]
         );
+    }
+
+    #[test]
+    fn test_inlinee_variables_are_assigned_by_scope() {
+        let mut builder = FunctionBuilder::new(Name::from("outer"), &[], 0x10, 0x40);
+        builder.add_inlinee_with_scope(
+            Some(1),
+            0,
+            Name::from("first"),
+            0x20,
+            0x10,
+            FileInfo::default(),
+            0,
+        );
+        builder.add_inlinee_with_scope(
+            Some(2),
+            0,
+            Name::from("second"),
+            0x30,
+            0x10,
+            FileInfo::default(),
+            0,
+        );
+
+        builder.add_variable(variable("outer_var", 0x10, 0x40));
+        builder.add_variable_for_scope(Some(1), variable("first_var", 0x10, 0x40));
+        builder.add_variable_for_scope(Some(2), variable("second_var", 0x10, 0x40));
+
+        let function = builder.finish();
+
+        assert_eq!(function.variables.len(), 1);
+        assert_eq!(function.variables[0].name, "outer_var");
+        assert_eq!(function.inlinees.len(), 2);
+        assert_eq!(function.inlinees[0].variables.len(), 1);
+        assert_eq!(function.inlinees[0].variables[0].name, "first_var");
+        assert_eq!(function.inlinees[1].variables.len(), 1);
+        assert_eq!(function.inlinees[1].variables[0].name, "second_var");
     }
 
     #[test]

--- a/symbolic-debuginfo/src/lib.rs
+++ b/symbolic-debuginfo/src/lib.rs
@@ -36,6 +36,8 @@
 #![warn(missing_docs)]
 
 mod base;
+mod variable;
+
 #[cfg(all(
     feature = "breakpad",
     feature = "dwarf",
@@ -73,6 +75,8 @@ pub mod sourcebundle;
 pub mod wasm;
 
 pub use crate::base::*;
+pub use crate::variable::*;
+
 #[cfg(all(
     feature = "breakpad",
     feature = "dwarf",

--- a/symbolic-debuginfo/src/pdb/mod.rs
+++ b/symbolic-debuginfo/src/pdb/mod.rs
@@ -869,6 +869,7 @@ impl<'s> Unit<'s> {
             compilation_dir: &[],
             lines,
             inlinees: Vec::new(),
+            variables: Vec::new(),
             inline: false,
         }))
     }
@@ -936,6 +937,7 @@ impl<'s> Unit<'s> {
             compilation_dir: &[],
             lines,
             inlinees: Vec::new(),
+            variables: Vec::new(),
             inline: true,
         }))
     }

--- a/symbolic-debuginfo/src/variable.rs
+++ b/symbolic-debuginfo/src/variable.rs
@@ -26,7 +26,7 @@ pub struct Variable<'data> {
     pub name: Cow<'data, str>,
     /// The type of the variable.
     ///
-    /// May be `None` if the variable had no type information attached or could not be parsed.
+    /// May be `None` if the variable had no type information attached or it could not be parsed.
     pub ty: Option<TypeRef>,
     /// The kind of the variable.
     pub kind: Kind,
@@ -55,15 +55,6 @@ impl fmt::Display for Kind {
             Self::Local => f.write_str("local"),
         }
     }
-}
-
-/// A half open address range.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Range {
-    /// The beginning address of the range.
-    pub begin: u64,
-    /// The first address past the end of the range.
-    pub end: u64,
 }
 
 /// Contains metadata describing the location of a variable at runtime.

--- a/symbolic-debuginfo/src/variable.rs
+++ b/symbolic-debuginfo/src/variable.rs
@@ -1,13 +1,15 @@
 use std::{borrow::Cow, fmt};
 
+/// A type reference.
 ///
+/// Links a variable to a concrete type.
 #[derive(Debug, Clone)]
-pub struct TypeRef(NativeTypeRef);
+pub struct TypeRef(#[expect(unused, reason = "not yet implemented")] NativeTypeRef);
 
 #[derive(Debug, Clone)]
 enum NativeTypeRef {
     #[cfg(feature = "dwarf")]
-    Dwarf(crate::dwarf::DwarfTypeRef),
+    Dwarf(#[expect(unused)] crate::dwarf::DwarfTypeRef),
 }
 
 #[cfg(feature = "dwarf")]
@@ -17,6 +19,7 @@ impl From<crate::dwarf::DwarfTypeRef> for TypeRef {
     }
 }
 
+/// A single variable available in a function scope.
 #[derive(Debug, Clone)]
 pub struct Variable<'data> {
     /// The name of the variable.
@@ -28,6 +31,8 @@ pub struct Variable<'data> {
     /// The kind of the variable.
     pub kind: Kind,
     /// Possible locations at runtime of the variable.
+    ///
+    /// Locations are stored in ascending order based on their [`LocationInfo::address`].
     ///
     /// There may be multiple overlapping locations for the same pc range, if the variable
     /// can be sourced from multiple locations.
@@ -62,7 +67,7 @@ pub struct Range {
 }
 
 /// Contains metadata describing the location of a variable at runtime.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct LocationInfo {
     /// Start of the address range of this location's validity.
     pub address: u64,
@@ -70,6 +75,16 @@ pub struct LocationInfo {
     pub size: u64,
     /// The location of the variable at runtime.
     pub location: Location,
+}
+
+impl fmt::Debug for LocationInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LocationInfo")
+            .field("address", &format_args!("{:#x}", self.address))
+            .field("size", &format_args!("{:#x}", self.size))
+            .field("location", &self.location)
+            .finish()
+    }
 }
 
 /// Describes the location of a variable at runtime.

--- a/symbolic-debuginfo/src/variable.rs
+++ b/symbolic-debuginfo/src/variable.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, fmt};
 
 ///
 #[derive(Debug, Clone)]
@@ -41,6 +41,15 @@ pub enum Kind {
     Parameter,
     /// The variable is a local.
     Local,
+}
+
+impl fmt::Display for Kind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Parameter => f.write_str("parameter"),
+            Self::Local => f.write_str("local"),
+        }
+    }
 }
 
 /// A half open address range.

--- a/symbolic-debuginfo/src/variable.rs
+++ b/symbolic-debuginfo/src/variable.rs
@@ -1,0 +1,74 @@
+use std::borrow::Cow;
+
+///
+#[derive(Debug, Clone)]
+pub struct TypeRef(NativeTypeRef);
+
+#[derive(Debug, Clone)]
+enum NativeTypeRef {
+    #[cfg(feature = "dwarf")]
+    Dwarf(crate::dwarf::DwarfTypeRef),
+}
+
+#[cfg(feature = "dwarf")]
+impl From<crate::dwarf::DwarfTypeRef> for TypeRef {
+    fn from(value: crate::dwarf::DwarfTypeRef) -> Self {
+        Self(NativeTypeRef::Dwarf(value))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Variable<'data> {
+    /// The name of the variable.
+    pub name: Cow<'data, str>,
+    /// The type of the variable.
+    ///
+    /// May be `None` if the variable had no type information attached or could not be parsed.
+    pub ty: Option<TypeRef>,
+    /// The kind of the variable.
+    pub kind: Kind,
+    /// Possible locations at runtime of the variable.
+    ///
+    /// There may be multiple overlapping locations for the same pc range, if the variable
+    /// can be sourced from multiple locations.
+    pub locations: Vec<LocationInfo>,
+}
+
+/// The variable kind.
+#[derive(Debug, Copy, Clone)]
+pub enum Kind {
+    /// The variable is a function parameter.
+    Parameter,
+    /// The variable is a local.
+    Local,
+}
+
+/// A half open address range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Range {
+    /// The beginning address of the range.
+    pub begin: u64,
+    /// The first address past the end of the range.
+    pub end: u64,
+}
+
+/// Contains metadata describing the location of a variable at runtime.
+#[derive(Debug, Clone)]
+pub struct LocationInfo {
+    /// Start of the address range of this location's validity.
+    pub address: u64,
+    /// Size of the range marking the end of the location's validity.
+    pub size: u64,
+    /// The location of the variable at runtime.
+    pub location: Location,
+}
+
+/// Describes the location of a variable at runtime.
+#[derive(Debug, Clone)]
+pub enum Location {
+    /// The variable can be found in a register.
+    Register {
+        /// An architecture dependent id of the register.
+        id: u16,
+    },
+}

--- a/symbolic-debuginfo/tests/snapshots/test_objects__elf_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__elf_functions.snap
@@ -101,6 +101,11 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x1d82: main.cpp:33 (../linux)
   0x1d8a: main.cpp:37 (../linux)
   0x1dac: main.cpp:33 (../linux)
+  variables:
+    argc (parameter)
+      0x1c70..0x1d2b: register 5
+    argv (parameter)
+      0x1c70..0x1cc3: register 4
 
   > 0x1c89: _ZN15google_breakpad18MinidumpDescriptorC4ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE (0x7)
     0x1c89: minidump_descriptor.h:68 (../deps/breakpad/src/client/linux/handler)
@@ -721,6 +726,33 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x2996: exception_handler.cc:508 (../deps/breakpad/src/client/linux/handler)
   0x299d: exception_handler.cc:568 (../deps/breakpad/src/client/linux/handler)
   0x29a5: exception_handler.cc:505 (../deps/breakpad/src/client/linux/handler)
+  variables:
+    this (parameter)
+      0x2520..0x2538: register 5
+      0x2538..0x255a: register 3
+      0x257f..0x2777: register 3
+      0x27c6..0x299d: register 3
+      0x29a2..0x29ab: register 3
+    context (parameter)
+      0x2520..0x2557: register 4
+      0x2557..0x255a: register 6
+      0x257f..0x2595: register 4
+      0x2595..0x2655: register 6
+      0x27c6..0x27dd: register 6
+      0x2996..0x2998: register 6
+    stack (local)
+      0x260d..0x272f: register 15
+      0x272f..0x2735: register 4
+      0x2735..0x2782: register 15
+      0x27e2..0x27f6: register 15
+      0x27f6..0x282b: register 4
+      0x282b..0x2877: register 15
+    r (local)
+      0x28cd..0x28f1: register 4
+      0x28f7..0x291d: register 4
+      0x293f..0x294b: register 4
+    success (local)
+      0x291d..0x293a: register 6
 
   > 0x2534: _ZNK15google_breakpad16ExceptionHandler14IsOutOfProcessEv (0x4)
     0x2534: exception_handler.h:205 (../deps/breakpad/src/client/linux/handler)
@@ -949,6 +981,28 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x2da0: exception_handler.cc:398 (../deps/breakpad/src/client/linux/handler)
   0x2dae: exception_handler.cc:368 (../deps/breakpad/src/client/linux/handler)
   0x2dba: exception_handler.cc:409 (../deps/breakpad/src/client/linux/handler)
+  variables:
+    sig (parameter)
+      0x2bd0..0x2c08: register 5
+      0x2c08..0x2c2f: register 12
+      0x2c34..0x2dbf: register 12
+    info (parameter)
+      0x2bd0..0x2c08: register 4
+      0x2c08..0x2c0d: register 13
+      0x2c34..0x2d43: register 13
+      0x2d88..0x2dae: register 13
+    uc (parameter)
+      0x2bd0..0x2c08: register 1
+      0x2c08..0x2c33: register 14
+      0x2c34..0x2dbf: register 14
+    handled (local)
+      0x2c7f..0x2c8f: register 0
+      0x2ca8..0x2cb5: register 0
+      0x2d88..0x2d99: register 0
+    i (local)
+      0x2c74..0x2ca8: register 3
+      0x2cab..0x2ce7: register 3
+      0x2d88..0x2d9f: register 3
 
   > 0x2c63: _ZNKSt6vectorIPN15google_breakpad16ExceptionHandlerESaIS2_EE4sizeEv (0x3)
     0x2c63: stl_vector.h:655 (/usr/include/c++/5/bits)

--- a/symbolic-debuginfo/tests/snapshots/test_objects__mach_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__mach_functions.snap
@@ -12,6 +12,9 @@ expression: "FunctionsDebug(&functions[..10], 0)"
 > 0xd40: _ZN15google_breakpad18MinidumpFileWriterC1Ev (0x1a)
   0xd40: minidump_file_writer.cc:96 (../deps/breakpad/src/client)
   0xd59: minidump_file_writer.cc:97 (../deps/breakpad/src/client)
+  variables:
+    this (parameter)
+      0xd40..0xd5a: register 5
 
   > 0xd40: _ZN15google_breakpad18MinidumpFileWriterC2Ev (0x19)
     0xd40: minidump_file_writer.cc:93 (../deps/breakpad/src/client)
@@ -54,6 +57,11 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0xde4: minidump_file_writer.cc:99 (../deps/breakpad/src/client)
   0xe0a: minidump_file_writer.cc:102 (../deps/breakpad/src/client)
   0xe0c: minidump_file_writer.cc:99 (../deps/breakpad/src/client)
+  variables:
+    this (parameter)
+      0xde0..0xde4: register 5
+      0xde4..0xe0b: register 3
+      0xe0c..0xe14: register 3
 
   > 0xde4: _ZN15google_breakpad18MinidumpFileWriterD2Ev (0x26)
     0xde4: minidump_file_writer.cc:100 (../deps/breakpad/src/client)
@@ -80,6 +88,15 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0xe42: minidump_file_writer.cc:112 (../deps/breakpad/src/client)
   0xe48: minidump_file_writer.cc:112 (../deps/breakpad/src/client)
   0xe4a: minidump_file_writer.cc:105 (../deps/breakpad/src/client)
+  variables:
+    this (parameter)
+      0xe20..0xe27: register 5
+      0xe27..0xe49: register 3
+      0xe4a..0xe69: register 3
+    path (parameter)
+      0xe20..0xe24: register 4
+      0xe24..0xe40: register 2
+      0xe4a..0xe5f: register 2
 
 > 0xe70: _ZN15google_breakpad18MinidumpFileWriter7SetFileEi (0x2d)
   0xe70: minidump_file_writer.cc:116 (../deps/breakpad/src/client)
@@ -87,6 +104,9 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0xe78: minidump_file_writer.cc:118 (../deps/breakpad/src/client)
   0xe7c: minidump_file_writer.cc:122 (../deps/breakpad/src/client)
   0xe7e: minidump_file_writer.cc:116 (../deps/breakpad/src/client)
+  variables:
+    this (parameter)
+      0xe70..0xe85: register 5
 
 > 0xea0: _ZN15google_breakpad18MinidumpFileWriter20CopyStringToMDStringEPKwjPNS_10TypedMDRVAI8MDStringEE (0x147)
   0xea0: minidump_file_writer.cc:150 (../deps/breakpad/src/client)
@@ -106,6 +126,20 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0xf7b: minidump_file_writer.cc:160 (../deps/breakpad/src/client)
   0xf97: minidump_file_writer.cc:179 (../deps/breakpad/src/client)
   0xfa9: minidump_file_writer.cc:174 (../deps/breakpad/src/client)
+  variables:
+    this (parameter)
+      0xea0..0xed2: register 5
+    str (parameter)
+      0xea0..0xeb6: register 4
+      0xeb6..0xf23: register 3
+      0xf76..0xf94: register 3
+      0xfa9..0xfe7: register 3
+    mdstring (parameter)
+      0xea0..0xeb1: register 2
+      0xeb1..0xf41: register 12
+      0xfa9..0xfe7: register 12
+    out_size (local)
+      0xf23..0xf72: register 3
 
   > 0xefa: _ZN15google_breakpad10TypedMDRVAI8MDStringE20CopyIndexAfterObjectEjPKvm (0x25)
     0xefa: minidump_file_writer-inl.h:83 (../deps/breakpad/src/client)
@@ -153,6 +187,19 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x10c5: minidump_file_writer.cc:189 (../deps/breakpad/src/client)
   0x10e7: minidump_file_writer.cc:205 (../deps/breakpad/src/client)
   0x10f9: minidump_file_writer.cc:201 (../deps/breakpad/src/client)
+  variables:
+    this (parameter)
+      0xff0..0x1023: register 5
+    str (parameter)
+      0xff0..0x1006: register 4
+      0x1006..0x10ef: register 3
+      0x10f9..0x1137: register 3
+    mdstring (parameter)
+      0xff0..0x1001: register 2
+      0x1001..0x107b: register 14
+      0x10f9..0x1137: register 14
+    out_size (local)
+      0x106b..0x10b7: register 6
 
   > 0x1049: _ZN15google_breakpad10TypedMDRVAI8MDStringE20CopyIndexAfterObjectEjPKvm (0x1e)
     0x1049: minidump_file_writer-inl.h:83 (../deps/breakpad/src/client)
@@ -186,3 +233,10 @@ expression: "FunctionsDebug(&functions[..10], 0)"
 
 > 0x1140: _ZN15google_breakpad18MinidumpFileWriter11WriteStringEPKwjP20MDLocationDescriptor (0x5)
   0x1140: minidump_file_writer.cc:245 (../deps/breakpad/src/client)
+  variables:
+    this (parameter)
+      0x1140..0x1145: register 5
+    str (parameter)
+      0x1140..0x1145: register 4
+    location (parameter)
+      0x1140..0x1145: register 2

--- a/symbolic-debuginfo/tests/snapshots/test_objects__pe_dwarf_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__pe_dwarf_functions.snap
@@ -7,6 +7,9 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x14f4: crtexe.c:419 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
   0x14f9: crtexe.c:419 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
   0x14ff: crtexe.c:420 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
+  variables:
+    func (parameter)
+      0x14f0..0x14f8: register 2
 
 > 0x1180: __tmainCRTStartup (0x326)
   0x1180: crtexe.c:223 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
@@ -95,6 +98,24 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x148e: crtexe.c:251 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
   0x1494: crtexe.c:252 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
   0x149e: crtexe.c:324 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
+  variables:
+    lpszCommandLine (local)
+      0x1291..0x12fd: register 0
+    inDoubleQuote (local)
+      0x1298..0x12a7: register 2
+      0x12ae..0x12c8: register 2
+    lock_free (local)
+      0x11d3..0x11e8: register 0
+      0x11f1..0x1201: register 0
+      0x13f2..0x1406: register 0
+    fiberid (local)
+      0x11c8..0x11fd: register 4
+      0x13f2..0x13ff: register 4
+    nested (local)
+      0x11ff..0x1315: register 6
+      0x13e3..0x13f2: register 6
+      0x1404..0x144f: register 6
+      0x147b..0x149e: register 6
 
   > 0x11b4: NtCurrentTeb (0x10)
     0x11b4: winnt.h:9094 (/mxe/usr/x86_64-w64-mingw32.static/include)
@@ -138,6 +159,9 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x14e1: crtexe.c:202 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
   0x14e6: crtexe.c:204 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
   0x14e8: crtexe.c:213 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
+  variables:
+    ret (local)
+      0x14e6..0x14ed: register 0
 
 > 0x14b0: WinMainCRTStartup (0x1d)
   0x14b0: crtexe.c:170 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
@@ -145,6 +169,9 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x14c1: crtexe.c:176 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
   0x14c6: crtexe.c:178 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
   0x14c8: crtexe.c:187 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
+  variables:
+    ret (local)
+      0x14c6..0x14cd: register 0
 
 > 0x1130: pre_cpp_init (0x49)
   0x1130: crtexe.c:155 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
@@ -199,12 +226,26 @@ expression: "FunctionsDebug(&functions[..10], 0)"
 
 > 0x1000: __mingw_invalidParameterHandler (0x1)
   0x1000: crtexe.c:123 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
+  variables:
+    expression (parameter)
+      0x1000..0x1001: register 2
+    function (parameter)
+      0x1000..0x1001: register 1
+    file (parameter)
+      0x1000..0x1001: register 8
+    line (parameter)
+      0x1000..0x1001: register 9
 
 > 0x1572: main (0x1f)
   0x1572: hello.c:3 (/src)
   0x1576: hello.c:3 (/src)
   0x157b: hello.c:4 (/src)
   0x1587: hello.c:5 (/src)
+  variables:
+    argc (parameter)
+      0x1572..0x157a: register 2
+    argv (parameter)
+      0x1572..0x157a: register 1
 
 > 0x1530: printf (0x42)
   0x1530: stdio.h:369 (/mxe/usr/x86_64-w64-mingw32.static/include)
@@ -213,6 +254,12 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x1557: stdio.h:372 (/mxe/usr/x86_64-w64-mingw32.static/include)
   0x156b: stdio.h:375 (/mxe/usr/x86_64-w64-mingw32.static/include)
   0x1570: stdio.h:375 (/mxe/usr/x86_64-w64-mingw32.static/include)
+  variables:
+    __format (parameter)
+      0x1530..0x1557: register 2
+      0x1557..0x1570: register 3
+    __retval (local)
+      0x156b..0x1572: register 0
 
 > 0x1650: __main (0x1f)
   0x1650: gccmain.c:55 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)

--- a/symbolic-debuginfo/tests/snapshots/test_objects__pe_dwarf_msys2_qglib_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__pe_dwarf_msys2_qglib_functions.snap
@@ -113,6 +113,19 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x1332: mingw-w64/mingw-w64-crt/crt/crtdll.c:178 (D:/W/B/src)
   0x1335: mingw-w64/mingw-w64-crt/crt/crtdll.c:178 (D:/W/B/src)
   0x133f: mingw-w64/mingw-w64-crt/crt/crtdll.c:170 (D:/W/B/src)
+  variables:
+    hDllHandle (parameter)
+      0x11e0..0x11f6: register 2
+      0x11f6..0x12b8: register 5
+    dwReason (parameter)
+      0x11e0..0x11f6: register 1
+      0x11f6..0x12c9: register 3
+    lpreserved (parameter)
+      0x11e0..0x11f6: register 8
+      0x11f6..0x12bf: register 4
+    retcode (local)
+      0x121d..0x1223: register 0
+      0x1259..0x1288: register 14
 
   > 0x123c: _CRT_INIT (0x5)
     0x123c: mingw-w64/mingw-w64-crt/crt/crtdll.c:129 (D:/W/B/src)
@@ -158,6 +171,10 @@ expression: "FunctionsDebug(&functions[..10], 0)"
 > 0x1350: atexit (0xf)
   0x1350: mingw-w64/mingw-w64-crt/crt/crtdll.c:182 (D:/W/B/src)
   0x1353: mingw-w64/mingw-w64-crt/crt/crtdll.c:185 (D:/W/B/src)
+  variables:
+    func (parameter)
+      0x1350..0x135a: register 2
+      0x135a..0x135f: register 1
 
 > 0x1360: _Z13lcNetInfoGlibv (0x60)
   0x1360: qtbase-everywhere-src-6.10.1/src/plugins/networkinformation/glib/qglibnetworkinformationbackend.cpp:17 (D:/W/B/src)
@@ -307,6 +324,10 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x149d: qtbase-everywhere-src-6.10.1/src/plugins/networkinformation/glib/qglibnetworkinformationbackend.cpp:117 (D:/W/B/src)
   0x14c2: qtbase-everywhere-src-6.10.1/src/plugins/networkinformation/glib/qglibnetworkinformationbackend.cpp:117 (D:/W/B/src)
   0x14c5: qtbase-everywhere-src-6.10.1/src/plugins/networkinformation/glib/qglibnetworkinformationbackend.cpp:119 (D:/W/B/src)
+  variables:
+    this (parameter)
+      0x13e4..0x13f8: register 2
+      0x13f8..0x14cc: register 4
 
   > 0x13f0: _ZN26QNetworkInformationBackendC2Ev (0x15)
     0x13f0: qtbase-everywhere-src-6.10.1/src/network/kernel/qnetworkinformation_p.h:47 (D:/W/B/src)
@@ -326,6 +347,13 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x15da: qtbase-everywhere-src-6.10.1/src/corelib/thread/qreadwritelock.h:0 (D:/W/B/src)
   0x15ea: qtbase-everywhere-src-6.10.1/src/plugins/networkinformation/glib/qglibnetworkinformationbackend.cpp:139 (D:/W/B/src)
   0x15fb: qtbase-everywhere-src-6.10.1/src/plugins/networkinformation/glib/qglibnetworkinformationbackend.cpp:0 (D:/W/B/src)
+  variables:
+    backend (parameter)
+      0x14d4..0x14fd: register 2
+      0x14fd..0x15f2: register 4
+      0x15fb..0x1601: register 4
+    connectivityState (local)
+      0x1505..0x15ac: register 5
 
   > 0x1505: _ZN12_GLOBAL__N_136reachabilityFromGNetworkConnectivityE20GNetworkConnectivity (0x16)
     0x1505: qtbase-everywhere-src-6.10.1/src/plugins/networkinformation/glib/qglibnetworkinformationbackend.cpp:22 (D:/W/B/src)
@@ -413,6 +441,11 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x16ba: qtbase-everywhere-src-6.10.1/src/corelib/thread/qreadwritelock.h:0 (D:/W/B/src)
   0x16ca: qtbase-everywhere-src-6.10.1/src/plugins/networkinformation/glib/qglibnetworkinformationbackend.cpp:144 (D:/W/B/src)
   0x16d5: qtbase-everywhere-src-6.10.1/src/plugins/networkinformation/glib/qglibnetworkinformationbackend.cpp:0 (D:/W/B/src)
+  variables:
+    backend (parameter)
+      0x1614..0x1637: register 2
+      0x1637..0x167f: register 4
+      0x1687..0x16a7: register 4
 
   > 0x1645: _ZN26QNetworkInformationBackend10setMeteredEb (0x42)
     0x1645: qtbase-everywhere-src-6.10.1/src/network/kernel/qnetworkinformation_p.h:116 (D:/W/B/src)

--- a/symbolic-debuginfo/tests/snapshots/test_objects__wasm_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__wasm_functions.snap
@@ -62,6 +62,7 @@ expression: r
             ],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -87,6 +88,7 @@ expression: r
             ],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -121,6 +123,7 @@ expression: r
             ],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -155,6 +158,7 @@ expression: r
             ],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -189,6 +193,7 @@ expression: r
             ],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -214,6 +219,7 @@ expression: r
             ],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -239,6 +245,7 @@ expression: r
             ],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -254,6 +261,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -269,6 +277,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -284,6 +293,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -299,6 +309,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -314,6 +325,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -329,6 +341,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -344,6 +357,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -359,6 +373,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -374,6 +389,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -389,6 +405,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -404,6 +421,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -419,6 +437,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -434,6 +453,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -449,6 +469,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -464,6 +485,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -479,6 +501,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -494,6 +517,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -509,6 +533,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -524,6 +549,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -539,6 +565,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -554,6 +581,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -569,6 +597,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -584,6 +613,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -599,6 +629,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -614,6 +645,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -629,6 +661,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -644,6 +677,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -669,6 +703,7 @@ expression: r
             ],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -694,6 +729,7 @@ expression: r
             ],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -709,6 +745,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -724,6 +761,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -739,6 +777,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -754,6 +793,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -769,6 +809,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -784,6 +825,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -799,6 +841,7 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -833,6 +876,7 @@ expression: r
             ],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -867,6 +911,7 @@ expression: r
             ],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
     Ok(
@@ -1306,6 +1351,7 @@ expression: r
             ],
             inlinees: [],
             inline: false,
+            variables: [],
         },
     ),
 ]

--- a/symbolic-debuginfo/tests/test_objects.rs
+++ b/symbolic-debuginfo/tests/test_objects.rs
@@ -6,7 +6,7 @@ use symbolic_common::{ByteView, Language};
 use symbolic_debuginfo::dwarf::DwarfErrorKind;
 use symbolic_debuginfo::elf::ElfObject;
 use symbolic_debuginfo::{
-    FileEntry, Function, LineInfo, Object, ParseObjectOptions, SymbolMap, pe::PeObject,
+    FileEntry, Function, LineInfo, Location, Object, ParseObjectOptions, SymbolMap, pe::PeObject,
 };
 use symbolic_testutils::fixture;
 
@@ -72,6 +72,34 @@ impl fmt::Debug for FunctionsDebug<'_> {
                     line.file.dir_str(),
                     indent = self.1 * 2
                 )?;
+            }
+
+            if !function.variables.is_empty() {
+                writeln!(f, "{:indent$}  variables:", "", indent = self.1 * 2)?;
+            }
+
+            for variable in &function.variables {
+                writeln!(
+                    f,
+                    "{:indent$}    {} ({})",
+                    "",
+                    variable.name,
+                    variable.kind,
+                    indent = self.1 * 2
+                )?;
+
+                for location in &variable.locations {
+                    match location.location {
+                        Location::Register { id } => writeln!(
+                            f,
+                            "{:indent$}      {:#x}..{:#x}: register {id}",
+                            "",
+                            location.address,
+                            location.address.saturating_add(location.size),
+                            indent = self.1 * 2
+                        )?,
+                    }
+                }
             }
 
             write!(f, "{:?}", FunctionsDebug(&function.inlinees, self.1 + 1))?;

--- a/symbolic-symcache/tests/test_writer.rs
+++ b/symbolic-symcache/tests/test_writer.rs
@@ -278,6 +278,7 @@ fn test_lookup_gap_inlinee() -> Result<(), Error> {
                 }],
                 inlinees: vec![],
                 inline: true,
+                variables: vec![],
             },
             Function {
                 address: 0x1000,
@@ -300,9 +301,11 @@ fn test_lookup_gap_inlinee() -> Result<(), Error> {
                 ],
                 inlinees: vec![],
                 inline: true,
+                variables: vec![],
             },
         ],
         inline: false,
+        variables: vec![],
     });
     converter.serialize(&mut buffer)?;
     let symcache = SymCache::parse(&buffer)?;


### PR DESCRIPTION
Implements the first steps to getting variable support in for DWARF:
- Parses location sections, needed for variable lookups
- Parses variables from functions and inlinees and attaches them to either the full function scope or the inlinees
- Parses **only** variable locations which are single op references to registers
- Adds basic type references (very wip and just a concept) to later add an API to resolve the type

This really is just a very basic concept, many more PRs and changes to follow.

Closes: INGEST-1071

```
└─ % ./run addr2line -e symbolic-testutils/fixtures/linux/crash.debug -f -r -s -i -v 0x1d72
+ cargo run --quiet --package addr2line -- -e symbolic-testutils/fixtures/linux/crash.debug -f -r -s -i -v 0x1c70

main (0x1c70 - 0x1dbc)
  at main.cpp:32 (0x1c70 - 0x1c71)
    argc (parameter)
      reg:5 (0x1c70 - 0x1d2b)
    argv (parameter)
      reg:4 (0x1c70 - 0x1cc3)
```