### PR TITLE
feat(variables): Implements fbreg op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@
 - Adds variables to functions. ([#1025](https://github.com/getsentry/symbolic/pull/1025))
 
 **Dependencies**
+
 - Bump `pdb-addr2line` to 0.12.1 to fix a potential infinite recursion. ([#1030](https://github.com/getsentry/symbolic/pull/1030))
+
+**Features**
+
+- Implements variables at a frame offset. ([#1026](https://github.com/getsentry/symbolic/pull/1026))
 
 ## 14.0.0-alpha.3
 

--- a/examples/addr2line/src/main.rs
+++ b/examples/addr2line/src/main.rs
@@ -86,6 +86,7 @@ fn resolve(function: &Function<'_>, addr: u64, matches: &ArgMatches) -> Result<b
                 print!("      ");
                 match location.location {
                     Location::Register { id } => print!("reg:{id}"),
+                    Location::FrameOffset { offset } => print!("fbreg:{offset}"),
                 }
                 print_range(location.address, Some(location.size), matches);
                 println!();

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -1299,6 +1299,7 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
 
         Ok(match op {
             Operation::Register { register } => Some(Location::Register { id: register.0 }),
+            Operation::FrameOffset { offset } => Some(Location::FrameOffset { offset }),
             // Currently more operations are not supported.
             _ => None,
         })

--- a/symbolic-debuginfo/src/variable.rs
+++ b/symbolic-debuginfo/src/variable.rs
@@ -86,4 +86,9 @@ pub enum Location {
         /// An architecture dependent id of the register.
         id: u16,
     },
+    /// The variable can be found at an offset relative to the function's frame base.
+    FrameOffset {
+        /// The signed offset from the frame base.
+        offset: i64,
+    },
 }

--- a/symbolic-debuginfo/tests/snapshots/test_objects__elf_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__elf_functions.snap
@@ -106,6 +106,10 @@ expression: "FunctionsDebug(&functions[..10], 0)"
       0x1c70..0x1d2b: register 5
     argv (parameter)
       0x1c70..0x1cc3: register 4
+    descriptor (local)
+      0x1c70..0x1dbc: frame base -416
+    eh (local)
+      0x1c70..0x1dbc: frame base -272
 
   > 0x1c89: _ZN15google_breakpad18MinidumpDescriptorC4ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE (0x7)
     0x1c89: minidump_descriptor.h:68 (../deps/breakpad/src/client/linux/handler)
@@ -738,7 +742,9 @@ expression: "FunctionsDebug(&functions[..10], 0)"
       0x2557..0x255a: register 6
       0x257f..0x2595: register 4
       0x2595..0x2655: register 6
+      0x2655..0x2661: frame base -88
       0x27c6..0x27dd: register 6
+      0x27e2..0x27f6: frame base -88
       0x2996..0x2998: register 6
     stack (local)
       0x260d..0x272f: register 15
@@ -747,8 +753,13 @@ expression: "FunctionsDebug(&functions[..10], 0)"
       0x27e2..0x27f6: register 15
       0x27f6..0x282b: register 4
       0x282b..0x2877: register 15
+    thread_arg (local)
+      0x2520..0x29e6: frame base -112
+    status (local)
+      0x2520..0x29e6: frame base -116
     r (local)
       0x28cd..0x28f1: register 4
+      0x28f1..0x28f7: frame base -144
       0x28f7..0x291d: register 4
       0x293f..0x294b: register 4
     success (local)
@@ -995,6 +1006,8 @@ expression: "FunctionsDebug(&functions[..10], 0)"
       0x2bd0..0x2c08: register 1
       0x2c08..0x2c33: register 14
       0x2c34..0x2dbf: register 14
+    cur_handler (local)
+      0x2bd0..0x2dbf: frame base -208
     handled (local)
       0x2c7f..0x2c8f: register 0
       0x2ca8..0x2cb5: register 0

--- a/symbolic-debuginfo/tests/snapshots/test_objects__mach_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__mach_functions.snap
@@ -138,6 +138,8 @@ expression: "FunctionsDebug(&functions[..10], 0)"
       0xea0..0xeb1: register 2
       0xeb1..0xf41: register 12
       0xfa9..0xfe7: register 12
+    out (local)
+      0xea0..0xfe7: frame base +16
     out_size (local)
       0xf23..0xf72: register 3
 
@@ -198,6 +200,8 @@ expression: "FunctionsDebug(&functions[..10], 0)"
       0xff0..0x1001: register 2
       0x1001..0x107b: register 14
       0x10f9..0x1137: register 14
+    out (local)
+      0xff0..0x1137: frame base +8
     out_size (local)
       0x106b..0x10b7: register 6
 

--- a/symbolic-debuginfo/tests/snapshots/test_objects__pe_dwarf_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__pe_dwarf_functions.snap
@@ -101,6 +101,8 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   variables:
     lpszCommandLine (local)
       0x1291..0x12fd: register 0
+    StartupInfo (local)
+      0x1180..0x14a6: frame base -176
     inDoubleQuote (local)
       0x1298..0x12a7: register 2
       0x12ae..0x12c8: register 2
@@ -235,6 +237,8 @@ expression: "FunctionsDebug(&functions[..10], 0)"
       0x1000..0x1001: register 8
     line (parameter)
       0x1000..0x1001: register 9
+    pReserved (parameter)
+      0x1000..0x1001: frame base +32
 
 > 0x1572: main (0x1f)
   0x1572: hello.c:3 (/src)
@@ -260,6 +264,8 @@ expression: "FunctionsDebug(&functions[..10], 0)"
       0x1557..0x1570: register 3
     __retval (local)
       0x156b..0x1572: register 0
+    __local_argv (local)
+      0x1530..0x1572: frame base -40
 
 > 0x1650: __main (0x1f)
   0x1650: gccmain.c:55 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)

--- a/symbolic-debuginfo/tests/snapshots/test_objects__wasm_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__wasm_functions.snap
@@ -62,7 +62,56 @@ expression: r
             ],
             inlinees: [],
             inline: false,
-            variables: [],
+            variables: [
+                Variable {
+                    name: "a",
+                    ty: Some(
+                        TypeRef(
+                            Dwarf(
+                                DwarfTypeRef(
+                                    UnitSectionOffset(
+                                        687,
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                    kind: Parameter,
+                    locations: [
+                        LocationInfo {
+                            address: 0x1a6,
+                            size: 0x29,
+                            location: FrameOffset {
+                                offset: 12,
+                            },
+                        },
+                    ],
+                },
+                Variable {
+                    name: "b",
+                    ty: Some(
+                        TypeRef(
+                            Dwarf(
+                                DwarfTypeRef(
+                                    UnitSectionOffset(
+                                        687,
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                    kind: Parameter,
+                    locations: [
+                        LocationInfo {
+                            address: 0x1a6,
+                            size: 0x29,
+                            location: FrameOffset {
+                                offset: 8,
+                            },
+                        },
+                    ],
+                },
+            ],
         },
     ),
     Ok(
@@ -533,7 +582,32 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
-            variables: [],
+            variables: [
+                Variable {
+                    name: "tmp",
+                    ty: Some(
+                        TypeRef(
+                            Dwarf(
+                                DwarfTypeRef(
+                                    UnitSectionOffset(
+                                        9384,
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                    kind: Local,
+                    locations: [
+                        LocationInfo {
+                            address: 0x10000019e,
+                            size: 0xd7,
+                            location: FrameOffset {
+                                offset: 8,
+                            },
+                        },
+                    ],
+                },
+            ],
         },
     ),
     Ok(
@@ -629,7 +703,32 @@ expression: r
             lines: [],
             inlinees: [],
             inline: false,
-            variables: [],
+            variables: [
+                Variable {
+                    name: "t",
+                    ty: Some(
+                        TypeRef(
+                            Dwarf(
+                                DwarfTypeRef(
+                                    UnitSectionOffset(
+                                        11615,
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                    kind: Local,
+                    locations: [
+                        LocationInfo {
+                            address: 0x10000019e,
+                            size: 0xc7,
+                            location: FrameOffset {
+                                offset: 0,
+                            },
+                        },
+                    ],
+                },
+            ],
         },
     ),
     Ok(

--- a/symbolic-debuginfo/tests/test_objects.rs
+++ b/symbolic-debuginfo/tests/test_objects.rs
@@ -98,6 +98,14 @@ impl fmt::Debug for FunctionsDebug<'_> {
                             location.address.saturating_add(location.size),
                             indent = self.1 * 2
                         )?,
+                        Location::FrameOffset { offset } => writeln!(
+                            f,
+                            "{:indent$}      {:#x}..{:#x}: frame base {offset:+}",
+                            "",
+                            location.address,
+                            location.address.saturating_add(location.size),
+                            indent = self.1 * 2
+                        )?,
                     }
                 }
             }


### PR DESCRIPTION
```
└─ % ./run addr2line -e symbolic-testutils/fixtures/linux/crash.debug -f -r -s -i -v 0x1c70
+ cargo run --quiet --package addr2line -- -e symbolic-testutils/fixtures/linux/crash.debug -f -r -s -i -v 0x1c70
main (0x1c70 - 0x1dbc)
  at main.cpp:32 (0x1c70 - 0x1c71)
    argc (parameter)
      reg:5 (0x1c70 - 0x1d2b)
    argv (parameter)
      reg:4 (0x1c70 - 0x1cc3)
    descriptor (local)
      fbreg:-416 (0x1c70 - 0x1dbc)
    eh (local)
      fbreg:-272 (0x1c70 - 0x1dbc)
```

Closes: INGEST-1084