### PR TITLE
deps: Update pdb-addr2line to 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Change the MSRV version to 1.85 and Rust Edition 2024. ([#1028](https://github.com/getsentry/symbolic/pull/1028))
 
+**Dependencies**
+- Bump `pdb-addr2line` to 0.12.1 to fix a potential infinite recursion. ([#1030](https://github.com/getsentry/symbolic/pull/1030))
+
 ## 14.0.0-alpha.3
 
 **Breaking Changes**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "pdb-addr2line"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d37ea3b284071f1c03aba6b97fd2c8d884348ef8fd0a9f2c2e0f66c2f451ba17"
+checksum = "c3263467eb4f7871a8bd6650fe7230de816d1f744e32e9a9754df9898d0540ce"
 dependencies = [
  "bitflags",
  "elsa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ nom = "7.1.3"
 nom-supreme = "0.8.0"
 once_cell = "1.17.1"
 parking_lot = "0.12.1"
-pdb-addr2line = "0.12.0"
+pdb-addr2line = "0.12.1"
 proguard = { version = "5.8.1", features = ["uuid"] }
 proptest = "1.6.0"
 regex = "1.7.1"


### PR DESCRIPTION
This includes https://github.com/mstange/pdb-addr2line/pull/71.

ref: INGEST-1081