### PR TITLE
feat(variables): Implement type ref lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 **Features**
 
 - Implements variables at a frame offset. ([#1026](https://github.com/getsentry/symbolic/pull/1026))
+- Implement resolution for primitive and pointer type references contained in variables. ([#1032](https://github.com/getsentry/symbolic/pull/1032))
 
 ## 14.0.0-alpha.3
 

--- a/examples/addr2line/src/main.rs
+++ b/examples/addr2line/src/main.rs
@@ -6,7 +6,7 @@ use clap::builder::ValueParser;
 use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 
 use symbolic::common::{ByteView, Language, Name, NameMangling};
-use symbolic::debuginfo::{DebugSession, Function, Location, Object, ObjectDebugSession};
+use symbolic::debuginfo::{Function, Location, Object, ObjectDebugSession, Type, TypeRef};
 use symbolic::demangle::{Demangle, DemangleOptions};
 
 fn print_name<'a, N: Borrow<Name<'a>>>(name: Option<N>, matches: &ArgMatches) {
@@ -28,6 +28,27 @@ fn print_range(start: u64, len: Option<u64>, matches: &ArgMatches) {
             None => print!("??)"),
         }
     }
+}
+
+fn print_type(session: &ObjectDebugSession<'_>, ty: &TypeRef, max_depth: usize) -> Result<()> {
+    if max_depth == 0 {
+        return Ok(());
+    }
+
+    let Some(ty) = session.lookup_type(ty)? else {
+        print!("<unknown>");
+        return Ok(());
+    };
+
+    match ty {
+        Type::Primitive(t) => print!("{}", t.name.as_deref().unwrap_or("?")),
+        Type::Pointer(t) => {
+            print_type(session, &t.pointee, max_depth - 1)?;
+            print!("*")
+        }
+    }
+
+    Ok(())
 }
 
 fn resolve(
@@ -88,7 +109,7 @@ fn resolve(
             }
 
             for location in locations {
-                print!("      ");
+                print!("      location: ");
                 match location.location {
                     Location::Register { id } => print!("reg:{id}"),
                     Location::FrameOffset { offset } => print!("fbreg:{offset}"),
@@ -97,7 +118,11 @@ fn resolve(
                 println!();
             }
 
-            let ty = variable.ty.as_ref().map(|ty| session.lookup_type(ty));
+            if let Some(ty) = &variable.ty {
+                print!("      type: ");
+                print_type(session, ty, 10)?;
+                println!()
+            }
         }
     }
 

--- a/examples/addr2line/src/main.rs
+++ b/examples/addr2line/src/main.rs
@@ -6,7 +6,7 @@ use clap::builder::ValueParser;
 use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 
 use symbolic::common::{ByteView, Language, Name, NameMangling};
-use symbolic::debuginfo::{Function, Location, Object};
+use symbolic::debuginfo::{DebugSession, Function, Location, Object, ObjectDebugSession};
 use symbolic::demangle::{Demangle, DemangleOptions};
 
 fn print_name<'a, N: Borrow<Name<'a>>>(name: Option<N>, matches: &ArgMatches) {
@@ -30,14 +30,19 @@ fn print_range(start: u64, len: Option<u64>, matches: &ArgMatches) {
     }
 }
 
-fn resolve(function: &Function<'_>, addr: u64, matches: &ArgMatches) -> Result<bool> {
+fn resolve(
+    session: &ObjectDebugSession<'_>,
+    function: &Function<'_>,
+    addr: u64,
+    matches: &ArgMatches,
+) -> Result<bool> {
     if function.address > addr || function.address + function.size <= addr {
         return Ok(false);
     }
 
     if *matches.get_one("inlinees").unwrap() {
         for il in &function.inlinees {
-            resolve(il, addr, matches)?;
+            resolve(session, il, addr, matches)?;
         }
     }
 
@@ -91,6 +96,8 @@ fn resolve(function: &Function<'_>, addr: u64, matches: &ArgMatches) -> Result<b
                 print_range(location.address, Some(location.size), matches);
                 println!();
             }
+
+            let ty = variable.ty.as_ref().map(|ty| session.lookup_type(ty));
         }
     }
 
@@ -110,7 +117,7 @@ fn execute(matches: &ArgMatches) -> Result<()> {
     'addrs: for &addr in matches.get_many::<u64>("addrs").unwrap_or_default() {
         for function in session.functions() {
             let function = function.context("failed to read function")?;
-            if resolve(&function, addr, matches)? {
+            if resolve(&session, &function, addr, matches)? {
                 continue 'addrs;
             }
         }

--- a/symbolic-debuginfo/src/base.rs
+++ b/symbolic-debuginfo/src/base.rs
@@ -5,9 +5,9 @@ use std::str::FromStr;
 
 use symbolic_common::{Arch, CodeId, DebugId, Name, clean_path, join_path};
 
-use crate::ParseObjectOptions;
 use crate::sourcebundle::SourceFileDescriptor;
-use crate::variable;
+use crate::{ParseObjectOptions, TypeRef};
+use crate::{Type, variable};
 
 pub(crate) trait Parse<'data>: Sized {
     type Error;
@@ -809,6 +809,10 @@ pub trait DebugSession<'session> {
 
     /// Returns an iterator over all source files referenced by this debug file.
     fn files(&'session self) -> Self::FileIterator;
+
+    fn lookup_type(&'session self, ty: &TypeRef) -> Result<Option<Type>, Self::Error> {
+        todo!()
+    }
 
     /// Looks up a file's source by its full canonicalized path.
     ///

--- a/symbolic-debuginfo/src/base.rs
+++ b/symbolic-debuginfo/src/base.rs
@@ -810,9 +810,11 @@ pub trait DebugSession<'session> {
     /// Returns an iterator over all source files referenced by this debug file.
     fn files(&'session self) -> Self::FileIterator;
 
-    fn lookup_type(&'session self, ty: &TypeRef) -> Result<Option<Type>, Self::Error> {
-        todo!()
-    }
+    /// Resolves a single [`TypeRef`] in this debug file.
+    ///
+    /// The [`TypeRef`] must have been acquired from the same session and cannot be re-used across
+    /// multiple sessions.
+    fn lookup_type(&'session self, ty: &TypeRef) -> Result<Option<Type<'session>>, Self::Error>;
 
     /// Looks up a file's source by its full canonicalized path.
     ///

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -12,6 +12,8 @@ use thiserror::Error;
 use symbolic_common::{Arch, AsSelf, CodeId, DebugId, Language, Name, NameMangling};
 
 use crate::ParseObjectOptions;
+use crate::Type;
+use crate::TypeRef;
 use crate::base::*;
 use crate::function_builder::FunctionBuilderError;
 use crate::function_builder::FunctionBuilderErrorKind;
@@ -1298,6 +1300,13 @@ impl BreakpadDebugSession<'_> {
         }
     }
 
+    /// Resolves a [`TypeRef`] in this debug file.
+    ///
+    /// See also: [`DebugSession::lookup_type`].
+    pub fn lookup_type(&self, _ty: &TypeRef) -> Result<Option<Type<'_>>, BreakpadError> {
+        Ok(None)
+    }
+
     /// See [DebugSession::source_by_path] for more information.
     pub fn source_by_path(
         &self,
@@ -1318,6 +1327,10 @@ impl<'session> DebugSession<'session> for BreakpadDebugSession<'_> {
 
     fn files(&'session self) -> Self::FileIterator {
         self.files()
+    }
+
+    fn lookup_type(&'session self, ty: &TypeRef) -> Result<Option<Type<'session>>, Self::Error> {
+        self.lookup_type(ty)
     }
 
     fn source_by_path(&self, path: &str) -> Result<Option<SourceFileDescriptor<'_>>, Self::Error> {

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -11,14 +11,12 @@ use thiserror::Error;
 
 use symbolic_common::{Arch, AsSelf, CodeId, DebugId, Language, Name, NameMangling};
 
-use crate::ParseObjectOptions;
-use crate::Type;
-use crate::TypeRef;
 use crate::base::*;
-use crate::function_builder::FunctionBuilderError;
-use crate::function_builder::FunctionBuilderErrorKind;
-use crate::function_builder::{FunctionBuilder, FunctionBuilderInlinee};
+use crate::function_builder::{
+    FunctionBuilder, FunctionBuilderError, FunctionBuilderErrorKind, FunctionBuilderInlinee,
+};
 use crate::sourcebundle::SourceFileDescriptor;
+use crate::{ParseObjectOptions, Type, TypeRef};
 
 #[derive(Clone, Debug)]
 struct LineOffsets<'data> {

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -493,7 +493,7 @@ impl<'d> UnitRef<'d, '_> {
         }
     }
 
-    /// Resolves a attribute unit ref or debug info ref to a [`UnitSectionOffset`].
+    /// Resolves a attribute unit ref or debug info ref to a [`DwarfTypeRef`].
     ///
     /// Returns `None` for attributes not containing a reference or unsupported references.
     fn to_type_ref(self, attr: Attribute<'d>) -> Option<DwarfTypeRef> {
@@ -1886,6 +1886,8 @@ impl<'data> DwarfDebugSession<'data> {
     /// Resolves a [`TypeRef`] in this debug file.
     ///
     /// The [`TypeRef`] must have been previously acquired from the same debug file.
+    /// This is a more lenient constraint than [`DebugSession::lookup_type`] which requires the [`TypeRef`]
+    /// to be acquired from the same session.
     ///
     /// See also: [`DebugSession::lookup_type`].
     pub fn lookup_type(&self, ty: &TypeRef) -> Result<Option<Type<'_>>, DwarfError> {

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -10,7 +10,7 @@
 //! [`PeObject`]: ../pe/struct.PeObject.html
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::error::Error;
 use std::fmt;
 use std::marker::PhantomData;
@@ -20,8 +20,8 @@ use std::sync::{Arc, OnceLock};
 use fallible_iterator::FallibleIterator;
 use gimli::read::{AttributeValue, Error as GimliError, Range};
 use gimli::{
-    AbbreviationsCacheStrategy, DwarfFileType, Expression, LocListIter, LocationLists, Operation,
-    UnitSectionOffset, constants,
+    AbbreviationsCacheStrategy, DebugTypeSignature, DwarfFileType, Expression, LocListIter,
+    LocationLists, Operation, SectionId, UnitSectionOffset, UnitType, constants,
 };
 use thiserror::Error;
 
@@ -34,7 +34,7 @@ use crate::function_builder::{
 #[cfg(feature = "macho")]
 use crate::macho::BcSymbolMap;
 use crate::sourcebundle::SourceFileDescriptor;
-use crate::{Kind, Location, LocationInfo, variable};
+use crate::{Kind, Location, LocationInfo, Type, TypeRef, base::*, variable};
 
 /// This is a fake BcSymbolMap used when macho support is turned off since they are unfortunately
 /// part of the dwarf interface
@@ -168,7 +168,23 @@ impl From<FunctionBuilderError> for DwarfError {
 
 /// A reference to a type in the DWARF file.
 #[derive(Debug, Clone)]
-pub struct DwarfTypeRef(#[expect(unused)] UnitSectionOffset);
+pub struct DwarfTypeRef(DwarfTypeRefInner);
+
+/// All possible representations of a DWARF type reference, which we can resolve.
+#[derive(Debug, Clone)]
+enum DwarfTypeRefInner {
+    /// A offset into a section.
+    Offset {
+        /// Which section the `offset` belongs to.
+        ///
+        /// Must be either [`SectionId::DebugInfo`] or [`SectionId::DebugTypes`].
+        section: SectionId,
+        /// Offset into the section.
+        offset: UnitSectionOffset,
+    },
+    /// A type signature.
+    Signature(DebugTypeSignature),
+}
 
 /// DWARF section information including its data.
 ///
@@ -460,7 +476,7 @@ impl<'d> UnitRef<'d, '_> {
     {
         let (unit, offset) = match attr.value() {
             AttributeValue::UnitRef(offset) => (*self, offset),
-            AttributeValue::DebugInfoRef(offset) => self.info.find_unit_offset(offset)?,
+            AttributeValue::DebugInfoRef(offset) => self.info.find_info_unit_offset(offset)?,
             // TODO: There is probably more that can come back here.
             _ => return Ok(None),
         };
@@ -478,12 +494,26 @@ impl<'d> UnitRef<'d, '_> {
     /// Resolves a attribute unit ref or debug info ref to a [`UnitSectionOffset`].
     ///
     /// Returns `None` for attributes not containing a reference or unsupported references.
-    fn to_unit_section_offset(self, attr: Attribute<'d>) -> Option<UnitSectionOffset> {
+    fn to_type_ref(self, attr: Attribute<'d>) -> Option<DwarfTypeRef> {
         match attr.value() {
-            AttributeValue::UnitRef(offset) => Some(offset.to_unit_section_offset(self.unit)),
-            AttributeValue::DebugInfoRef(offset) => offset.to_unit_section_offset(self.unit),
+            AttributeValue::UnitRef(offset) => Some(DwarfTypeRefInner::Offset {
+                section: self.unit.section(),
+                offset: offset.to_unit_section_offset(self.unit),
+            }),
+            AttributeValue::DebugInfoRef(offset) => {
+                offset
+                    .to_unit_section_offset(self.unit)
+                    .map(|offset| DwarfTypeRefInner::Offset {
+                        section: SectionId::DebugInfo,
+                        offset,
+                    })
+            }
+            AttributeValue::DebugTypesRef(signature) => {
+                Some(DwarfTypeRefInner::Signature(signature))
+            }
             _ => None,
         }
+        .map(DwarfTypeRef)
     }
 
     /// Returns the offset of this unit within its section.
@@ -1217,16 +1247,9 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
                 constants::DW_AT_location => {
                     locations = self.parse_locations(attr.value())?;
                 }
-                // This will need some further refinement, `to_unit_section_offset` is only enough
-                // for unit and debug info references, it does not yet support debug types references,
-                // and references to supplementary object files. Supplementary object files are
-                // generally not supported, but type section references should be implemented.
-                constants::DW_AT_type
-                    if let Some(offset) = self.inner.to_unit_section_offset(attr) =>
-                {
-                    ty = Some(variable::TypeRef::from(DwarfTypeRef(offset)));
+                constants::DW_AT_type => {
+                    ty = self.inner.to_type_ref(attr).map(TypeRef::from);
                 }
-
                 // No location means optimized out, so we do not store the variable for now.
                 _ => {}
             }
@@ -1493,13 +1516,14 @@ struct DwarfSections<'data> {
     debug_line_str: DwarfSectionData<'data, gimli::read::DebugLineStr<Slice<'data>>>,
     debug_loc: DwarfSectionData<'data, gimli::read::DebugLoc<Slice<'data>>>,
     debug_loclists: DwarfSectionData<'data, gimli::read::DebugLocLists<Slice<'data>>>,
-    debug_names: DwarfSectionData<'data, gimli::read::DebugNames<Slice<'data>>>,
-    debug_str: DwarfSectionData<'data, gimli::read::DebugStr<Slice<'data>>>,
-    debug_str_offsets: DwarfSectionData<'data, gimli::read::DebugStrOffsets<Slice<'data>>>,
-    debug_ranges: DwarfSectionData<'data, gimli::read::DebugRanges<Slice<'data>>>,
-    debug_rnglists: DwarfSectionData<'data, gimli::read::DebugRngLists<Slice<'data>>>,
     debug_macinfo: DwarfSectionData<'data, gimli::read::DebugMacinfo<Slice<'data>>>,
     debug_macro: DwarfSectionData<'data, gimli::read::DebugMacro<Slice<'data>>>,
+    debug_names: DwarfSectionData<'data, gimli::read::DebugNames<Slice<'data>>>,
+    debug_ranges: DwarfSectionData<'data, gimli::read::DebugRanges<Slice<'data>>>,
+    debug_rnglists: DwarfSectionData<'data, gimli::read::DebugRngLists<Slice<'data>>>,
+    debug_str: DwarfSectionData<'data, gimli::read::DebugStr<Slice<'data>>>,
+    debug_str_offsets: DwarfSectionData<'data, gimli::read::DebugStrOffsets<Slice<'data>>>,
+    debug_types: DwarfSectionData<'data, gimli::read::DebugTypes<Slice<'data>>>,
 }
 
 impl<'data> DwarfSections<'data> {
@@ -1524,14 +1548,120 @@ impl<'data> DwarfSections<'data> {
             debug_rnglists: DwarfSectionData::load(dwarf),
             debug_macinfo: DwarfSectionData::load(dwarf),
             debug_macro: DwarfSectionData::load(dwarf),
+            debug_types: DwarfSectionData::load(dwarf),
         }
+    }
+}
+
+struct DwarfUnitTable<'data> {
+    headers: Vec<UnitHeader<'data>>,
+    units: Vec<OnceLock<Option<Unit<'data>>>>,
+    type_signatures: OnceLock<HashMap<DebugTypeSignature, (usize, UnitOffset)>>,
+}
+
+impl<'data> DwarfUnitTable<'data> {
+    fn from_iter<I>(iter: I) -> Result<Self, DwarfError>
+    where
+        I: FallibleIterator<Item = UnitHeader<'data>, Error = GimliError>,
+    {
+        let headers = FallibleIterator::collect::<Vec<_>>(iter)?;
+        let units = headers.iter().map(|_| OnceLock::new()).collect();
+        Ok(Self {
+            headers,
+            units,
+            type_signatures: Default::default(),
+        })
+    }
+
+    /// Loads a compilation unit.
+    fn get_unit(
+        &self,
+        index: usize,
+        inner: &DwarfInner<'data>,
+    ) -> Result<Option<&Unit<'data>>, DwarfError> {
+        // Silently ignore unit references out-of-bound
+        let cell = match self.units.get(index) {
+            Some(cell) => cell,
+            None => return Ok(None),
+        };
+
+        if let Some(unit_opt) = cell.get() {
+            return Ok(unit_opt.as_ref());
+        }
+
+        // Parse the compilation unit from the header. This requires a top-level DIE that
+        // describes the unit itself. For some older DWARF files, this DIE might be missing
+        // which causes gimli to error out. We prefer to skip them silently as this simply marks
+        // an empty unit for us.
+        let header = self.headers[index];
+        let parsed = match inner.unit(header) {
+            Ok(unit) => Some(unit),
+            Err(gimli::read::Error::MissingUnitDie) => None,
+            Err(error) => return Err(DwarfError::from(error)),
+        };
+
+        Ok(cell.get_or_init(|| parsed).as_ref())
+    }
+
+    /// Resolves an offset into a different compilation unit.
+    fn find_unit_offset(
+        &self,
+        offset: UnitSectionOffset,
+        inner: &DwarfInner<'data>,
+    ) -> Result<(&Unit<'data>, UnitOffset), DwarfError> {
+        let search_result = self
+            .headers
+            .binary_search_by_key(&offset, UnitHeader::offset);
+
+        let index = match search_result {
+            Ok(index) => index,
+            Err(0) => return Err(DwarfErrorKind::InvalidUnitRef(offset.0).into()),
+            Err(next_index) => next_index - 1,
+        };
+
+        if let Some(unit) = self.get_unit(index, inner)? {
+            if let Some(unit_offset) = offset.to_unit_offset(unit) {
+                return Ok((unit, unit_offset));
+            }
+        }
+
+        Err(DwarfErrorKind::InvalidUnitRef(offset.0).into())
+    }
+
+    fn find_type_signature(
+        &self,
+        signature: DebugTypeSignature,
+        inner: &DwarfInner<'data>,
+    ) -> Result<Option<(&Unit<'data>, UnitOffset)>, DwarfError> {
+        let signatures = self.type_signatures.get_or_init(|| {
+            self.headers
+                .iter()
+                .enumerate()
+                .filter_map(|(index, header)| match header.type_() {
+                    UnitType::Type {
+                        type_signature,
+                        type_offset,
+                    }
+                    | UnitType::SplitType {
+                        type_signature,
+                        type_offset,
+                    } => Some((type_signature, (index, type_offset))),
+                    _ => None,
+                })
+                .collect()
+        });
+
+        Ok(match signatures.get(&signature) {
+            Some(&(index, offset)) => self.get_unit(index, inner)?.map(|unit| (unit, offset)),
+            None => None,
+        })
     }
 }
 
 struct DwarfInfo<'data> {
     inner: DwarfInner<'data>,
-    headers: Vec<UnitHeader<'data>>,
-    units: Vec<OnceLock<Option<Unit<'data>>>>,
+    info: DwarfUnitTable<'data>,
+    types: DwarfUnitTable<'data>,
     symbol_map: SymbolMap<'data>,
     address_offset: i64,
     kind: ObjectKind,
@@ -1564,7 +1694,7 @@ impl<'d> DwarfInfo<'d> {
             debug_names: sections.debug_names.to_gimli(),
             debug_str: sections.debug_str.to_gimli(),
             debug_str_offsets: sections.debug_str_offsets.to_gimli(),
-            debug_types: Default::default(),
+            debug_types: sections.debug_types.to_gimli(),
             debug_macinfo: sections.debug_macinfo.to_gimli(),
             debug_macro: sections.debug_macro.to_gimli(),
             locations: LocationLists::new(
@@ -1581,71 +1711,58 @@ impl<'d> DwarfInfo<'d> {
         inner.populate_abbreviations_cache(AbbreviationsCacheStrategy::Duplicates);
 
         // Prepare random access to unit headers.
-        let headers = FallibleIterator::collect::<Vec<_>>(inner.units())?;
-        let units = headers.iter().map(|_| OnceLock::new()).collect();
+        let info = DwarfUnitTable::from_iter(inner.units())?;
+        let types = DwarfUnitTable::from_iter(inner.type_units())?;
 
         Ok(DwarfInfo {
             inner,
-            headers,
-            units,
+            info,
+            types,
             symbol_map,
             address_offset,
             kind,
         })
     }
 
-    /// Loads a compilation unit.
-    fn get_unit(&self, index: usize) -> Result<Option<&Unit<'d>>, DwarfError> {
-        // Silently ignore unit references out-of-bound
-        let cell = match self.units.get(index) {
-            Some(cell) => cell,
-            None => return Ok(None),
-        };
-
-        if let Some(unit_opt) = cell.get() {
-            return Ok(unit_opt.as_ref());
-        }
-
-        // Parse the compilation unit from the header. This requires a top-level DIE that
-        // describes the unit itself. For some older DWARF files, this DIE might be missing
-        // which causes gimli to error out. We prefer to skip them silently as this simply marks
-        // an empty unit for us.
-        let header = self.headers[index];
-        let parsed = match self.inner.unit(header) {
-            Ok(unit) => Some(unit),
-            Err(gimli::read::Error::MissingUnitDie) => None,
-            Err(error) => return Err(DwarfError::from(error)),
-        };
-
-        Ok(cell.get_or_init(|| parsed).as_ref())
+    /// Loads a `.debug_info` compilation unit.
+    fn get_info_unit(&self, index: usize) -> Result<Option<&Unit<'d>>, DwarfError> {
+        self.info.get_unit(index, &self.inner)
     }
 
-    /// Resolves an offset into a different compilation unit.
-    fn find_unit_offset(
+    /// Resolves an offset into a different `.debug_info` compilation unit.
+    fn find_info_unit_offset(
         &self,
         offset: DebugInfoOffset,
     ) -> Result<(UnitRef<'d, '_>, UnitOffset), DwarfError> {
-        let section_offset = UnitSectionOffset(offset.0);
-        let search_result = self
-            .headers
-            .binary_search_by_key(&section_offset, UnitHeader::offset);
-
-        let index = match search_result {
-            Ok(index) => index,
-            Err(0) => return Err(DwarfErrorKind::InvalidUnitRef(offset.0).into()),
-            Err(next_index) => next_index - 1,
-        };
-
-        if let Some(unit) = self.get_unit(index)? {
-            if let Some(unit_offset) = section_offset.to_unit_offset(unit) {
-                return Ok((UnitRef { unit, info: self }, unit_offset));
-            }
-        }
-
-        Err(DwarfErrorKind::InvalidUnitRef(offset.0).into())
+        self.info
+            .find_unit_offset(UnitSectionOffset(offset.0), &self.inner)
+            .map(|(unit, offset)| (UnitRef { unit, info: self }, offset))
     }
 
-    /// Returns an iterator over all compilation units.
+    /// Resolves an offset into a different `.debug_info` compilation unit.
+    fn find_types_unit_offset(
+        &self,
+        offset: UnitSectionOffset,
+    ) -> Result<(UnitRef<'d, '_>, UnitOffset), DwarfError> {
+        self.types
+            .find_unit_offset(offset, &self.inner)
+            .map(|(unit, offset)| (UnitRef { unit, info: self }, offset))
+    }
+
+    /// Resolves a type signature to its defining type entry.
+    fn find_type_signature(
+        &self,
+        signature: DebugTypeSignature,
+    ) -> Result<Option<(UnitRef<'d, '_>, UnitOffset)>, DwarfError> {
+        let res = match self.info.find_type_signature(signature, &self.inner)? {
+            Some(v) => Some(v),
+            None => self.types.find_type_signature(signature, &self.inner)?,
+        };
+
+        Ok(res.map(|(unit, offset)| (UnitRef { unit, info: self }, offset)))
+    }
+
+    /// Returns an iterator over all `.debug_info` compilation units.
     fn units(&'d self, bcsymbolmap: Option<&'d BcSymbolMap<'d>>) -> DwarfUnitIterator<'d> {
         DwarfUnitIterator {
             info: self,
@@ -1666,7 +1783,8 @@ impl<'slf, 'd: 'slf> AsSelf<'slf> for DwarfInfo<'d> {
 impl fmt::Debug for DwarfInfo<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DwarfInfo")
-            .field("headers", &self.headers)
+            .field("info", &self.info.headers)
+            .field("types", &self.types.headers)
             .field("symbol_map", &self.symbol_map)
             .field("address_offset", &self.address_offset)
             .finish()
@@ -1684,8 +1802,8 @@ impl<'s> Iterator for DwarfUnitIterator<'s> {
     type Item = Result<DwarfUnit<'s, 's>, DwarfError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while self.index < self.info.headers.len() {
-            let result = self.info.get_unit(self.index);
+        while self.index < self.info.info.headers.len() {
+            let result = self.info.get_info_unit(self.index);
             self.index += 1;
 
             let unit = match result {
@@ -1763,6 +1881,33 @@ impl<'data> DwarfDebugSession<'data> {
         }
     }
 
+    pub fn lookup_type(&self, ty: &TypeRef) -> Result<Option<Type>, DwarfError> {
+        let Some(DwarfTypeRef(ty)) = ty.as_dwarf() else {
+            return Ok(None);
+        };
+
+        let info = self.cell.get();
+        let unit = match ty {
+            DwarfTypeRefInner::Offset {
+                section: SectionId::DebugInfo,
+                offset,
+            } => Some(info.find_info_unit_offset(gimli::DebugInfoOffset(offset.0))?),
+            DwarfTypeRefInner::Offset {
+                section: SectionId::DebugTypes,
+                offset,
+            } => Some(info.find_types_unit_offset(*offset)?),
+            DwarfTypeRefInner::Signature(signature) => info.find_type_signature(*signature)?,
+            _ => None,
+        };
+        let Some((unit, offset)) = unit else {
+            return Ok(None);
+        };
+
+        dbg!(unit.unit.entry(offset)?);
+
+        Ok(Some(Type {}))
+    }
+
     /// See [DebugSession::source_by_path] for more information.
     pub fn source_by_path(
         &self,
@@ -1783,6 +1928,10 @@ impl<'session> DebugSession<'session> for DwarfDebugSession<'_> {
 
     fn files(&'session self) -> Self::FileIterator {
         self.files()
+    }
+
+    fn lookup_type(&'session self, ty: &TypeRef) -> Result<Option<Type>, Self::Error> {
+        self.lookup_type(ty)
     }
 
     fn source_by_path(&self, path: &str) -> Result<Option<SourceFileDescriptor<'_>>, Self::Error> {

--- a/symbolic-debuginfo/src/dwarf.rs
+++ b/symbolic-debuginfo/src/dwarf.rs
@@ -31,10 +31,12 @@ use crate::base::*;
 use crate::function_builder::{
     FunctionBuilder, FunctionBuilderError, FunctionBuilderErrorKind, FunctionBuilderInlinee,
 };
+mod types;
+
 #[cfg(feature = "macho")]
 use crate::macho::BcSymbolMap;
 use crate::sourcebundle::SourceFileDescriptor;
-use crate::{Kind, Location, LocationInfo, Type, TypeRef, base::*, variable};
+use crate::{Kind, Location, LocationInfo, Type, TypeRef, variable};
 
 /// This is a fake BcSymbolMap used when macho support is turned off since they are unfortunately
 /// part of the dwarf interface
@@ -1881,7 +1883,12 @@ impl<'data> DwarfDebugSession<'data> {
         }
     }
 
-    pub fn lookup_type(&self, ty: &TypeRef) -> Result<Option<Type>, DwarfError> {
+    /// Resolves a [`TypeRef`] in this debug file.
+    ///
+    /// The [`TypeRef`] must have been previously acquired from the same debug file.
+    ///
+    /// See also: [`DebugSession::lookup_type`].
+    pub fn lookup_type(&self, ty: &TypeRef) -> Result<Option<Type<'_>>, DwarfError> {
         let Some(DwarfTypeRef(ty)) = ty.as_dwarf() else {
             return Ok(None);
         };
@@ -1903,12 +1910,10 @@ impl<'data> DwarfDebugSession<'data> {
             return Ok(None);
         };
 
-        dbg!(unit.unit.entry(offset)?);
-
-        Ok(Some(Type {}))
+        self::types::parse_type(unit, offset)
     }
 
-    /// See [DebugSession::source_by_path] for more information.
+    /// See [`DebugSession::source_by_path`] for more information.
     pub fn source_by_path(
         &self,
         _path: &str,
@@ -1930,7 +1935,7 @@ impl<'session> DebugSession<'session> for DwarfDebugSession<'_> {
         self.files()
     }
 
-    fn lookup_type(&'session self, ty: &TypeRef) -> Result<Option<Type>, Self::Error> {
+    fn lookup_type(&'session self, ty: &TypeRef) -> Result<Option<Type<'session>>, Self::Error> {
         self.lookup_type(ty)
     }
 

--- a/symbolic-debuginfo/src/dwarf/types.rs
+++ b/symbolic-debuginfo/src/dwarf/types.rs
@@ -1,0 +1,84 @@
+use gimli::{AttributeValue, DebuggingInformationEntry, UnitOffset, constants};
+
+use crate::dwarf::{DwarfError, Slice, UnitRef};
+use crate::{PointerType, PrimitiveEncoding, PrimitiveType, Type, TypeRef, TypeSize};
+
+pub fn parse_type<'d>(
+    unit: UnitRef<'d, '_>,
+    offset: UnitOffset,
+) -> Result<Option<Type<'d>>, DwarfError> {
+    let entry = unit.unit.entry(offset)?;
+
+    Ok(match entry.tag {
+        constants::DW_TAG_base_type => parse_base_type(unit, entry).map(Type::Primitive),
+        // Pointers may be nested within `DW_TAG_restrict_type`, `DW_TAG_const_type` etc.
+        constants::DW_TAG_pointer_type
+        | constants::DW_TAG_reference_type
+        | constants::DW_TAG_rvalue_reference_type => {
+            parse_pointer_type(unit, entry).map(Type::Pointer)
+        }
+        _ => None,
+    })
+}
+
+fn parse_base_type<'d>(
+    unit: UnitRef<'d, '_>,
+    entry: DebuggingInformationEntry<Slice<'d>>,
+) -> Option<PrimitiveType<'d>> {
+    let mut name = None;
+    let mut encoding = None;
+    let mut size = None;
+
+    for attr in entry.attrs {
+        match attr.name() {
+            constants::DW_AT_name => {
+                // May also need to check `DW_AT_specification` and `DW_AT_abstract_origin` for the name.
+                name = unit.string_value(attr.value());
+            }
+            // Need to handle `bit` sizes here eventually.
+            constants::DW_AT_byte_size => size = attr.udata_value(),
+            constants::DW_AT_encoding => {
+                use AttributeValue::Encoding;
+                encoding = Some(match attr.value() {
+                    Encoding(constants::DW_ATE_boolean) => PrimitiveEncoding::Boolean,
+                    Encoding(constants::DW_ATE_address) => PrimitiveEncoding::Address,
+                    Encoding(constants::DW_ATE_signed) => PrimitiveEncoding::SignedInt,
+                    Encoding(constants::DW_ATE_unsigned) => PrimitiveEncoding::UnsignedInt,
+                    Encoding(constants::DW_ATE_signed_char) => PrimitiveEncoding::SignedChar,
+                    Encoding(constants::DW_ATE_unsigned_char) => PrimitiveEncoding::UnsignedChar,
+                    Encoding(constants::DW_ATE_float) => PrimitiveEncoding::Float,
+                    Encoding(constants::DW_ATE_complex_float) => PrimitiveEncoding::ComplexFloat,
+                    _ => continue,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    Some(PrimitiveType {
+        name,
+        encoding,
+        size: TypeSize::Bytes(size?),
+    })
+}
+
+fn parse_pointer_type<'d>(
+    unit: UnitRef<'d, '_>,
+    entry: DebuggingInformationEntry<Slice<'d>>,
+) -> Option<PointerType> {
+    let mut pointee = None;
+    let mut size = None;
+
+    for attr in entry.attrs {
+        match attr.name() {
+            constants::DW_AT_type => pointee = unit.to_type_ref(attr),
+            constants::DW_AT_byte_size => size = attr.udata_value(),
+            _ => {}
+        }
+    }
+
+    Some(PointerType {
+        pointee: pointee.map(TypeRef::from)?,
+        size: TypeSize::Bytes(size.unwrap_or_else(|| unit.unit.encoding().address_size.into())),
+    })
+}

--- a/symbolic-debuginfo/src/object.rs
+++ b/symbolic-debuginfo/src/object.rs
@@ -6,6 +6,8 @@ use std::fmt;
 use symbolic_common::{Arch, AsSelf, CodeId, DebugId};
 use symbolic_ppdb::PortablePdb;
 
+use crate::Type;
+use crate::TypeRef;
 use crate::base::*;
 use crate::breakpad::*;
 use crate::dwarf::*;
@@ -518,6 +520,16 @@ impl ObjectDebugSession<'_> {
         }
     }
 
+    pub fn lookup_type(&self, ty: &TypeRef) -> Result<Option<Type>, ObjectError> {
+        match *self {
+            ObjectDebugSession::Breakpad(_) => Ok(None),
+            ObjectDebugSession::Dwarf(ref s) => s.lookup_type(ty).map_err(ObjectError::transparent),
+            ObjectDebugSession::Pdb(_) => Ok(None),
+            ObjectDebugSession::SourceBundle(_) => Ok(None),
+            ObjectDebugSession::PortablePdb(_) => Ok(None),
+        }
+    }
+
     /// Looks up a file's source by its full canonicalized path.
     /// Returns either source contents, if it was embedded, or a source link.
     pub fn source_by_path(
@@ -555,6 +567,10 @@ impl<'session> DebugSession<'session> for ObjectDebugSession<'_> {
 
     fn files(&'session self) -> Self::FileIterator {
         self.files()
+    }
+
+    fn lookup_type(&'session self, ty: &TypeRef) -> Result<Option<Type>, Self::Error> {
+        self.lookup_type(ty)
     }
 
     fn source_by_path(&self, path: &str) -> Result<Option<SourceFileDescriptor<'_>>, Self::Error> {

--- a/symbolic-debuginfo/src/object.rs
+++ b/symbolic-debuginfo/src/object.rs
@@ -520,7 +520,13 @@ impl ObjectDebugSession<'_> {
         }
     }
 
-    pub fn lookup_type(&self, ty: &TypeRef) -> Result<Option<Type>, ObjectError> {
+    /// Resolves a single [`TypeRef`] in this debug file.
+    ///
+    /// The [`TypeRef`] must have been acquired from the same session and cannot be re-used across
+    /// multiple sessions.
+    ///
+    /// See also: [`DebugSession::lookup_type`].
+    pub fn lookup_type(&self, ty: &TypeRef) -> Result<Option<Type<'_>>, ObjectError> {
         match *self {
             ObjectDebugSession::Breakpad(_) => Ok(None),
             ObjectDebugSession::Dwarf(ref s) => s.lookup_type(ty).map_err(ObjectError::transparent),
@@ -569,7 +575,7 @@ impl<'session> DebugSession<'session> for ObjectDebugSession<'_> {
         self.files()
     }
 
-    fn lookup_type(&'session self, ty: &TypeRef) -> Result<Option<Type>, Self::Error> {
+    fn lookup_type(&'session self, ty: &TypeRef) -> Result<Option<Type<'session>>, Self::Error> {
         self.lookup_type(ty)
     }
 

--- a/symbolic-debuginfo/src/pdb/mod.rs
+++ b/symbolic-debuginfo/src/pdb/mod.rs
@@ -22,11 +22,11 @@ use symbolic_common::{
     Arch, AsSelf, CodeId, CpuFamily, DebugId, Language, Name, NameMangling, SelfCell, Uuid,
 };
 
-use crate::ParseObjectOptions;
 use crate::base::*;
 use crate::function_stack::FunctionStack;
 use crate::pdb::srcsrv::{SourceServerInfo, SourceServerMappings};
 use crate::sourcebundle::SourceFileDescriptor;
+use crate::{ParseObjectOptions, Type, TypeRef};
 
 mod srcsrv;
 
@@ -679,6 +679,13 @@ impl<'d> PdbDebugSession<'d> {
         }
     }
 
+    /// Resolves a [`TypeRef`] in this debug file.
+    ///
+    /// See also: [`DebugSession::lookup_type`].
+    pub fn lookup_type(&self, _ty: &TypeRef) -> Result<Option<Type<'_>>, PdbError> {
+        Ok(None)
+    }
+
     /// See [DebugSession::source_by_path] for more information.
     pub fn source_by_path(
         &self,
@@ -712,6 +719,10 @@ impl<'session> DebugSession<'session> for PdbDebugSession<'_> {
 
     fn files(&'session self) -> Self::FileIterator {
         self.files()
+    }
+
+    fn lookup_type(&'session self, ty: &TypeRef) -> Result<Option<Type<'session>>, Self::Error> {
+        self.lookup_type(ty)
     }
 
     fn source_by_path(&self, path: &str) -> Result<Option<SourceFileDescriptor<'_>>, Self::Error> {

--- a/symbolic-debuginfo/src/ppdb.rs
+++ b/symbolic-debuginfo/src/ppdb.rs
@@ -10,6 +10,8 @@ use symbolic_ppdb::EmbeddedSource;
 use symbolic_ppdb::{Document, FormatError, PortablePdb};
 
 use crate::ParseObjectOptions;
+use crate::Type;
+use crate::TypeRef;
 use crate::base::*;
 use crate::sourcebundle::SourceFileDescriptor;
 
@@ -216,6 +218,13 @@ impl<'data> PortablePdbDebugSession<'data> {
         PortablePdbFileIterator::new(&self.ppdb)
     }
 
+    /// Resolves a [`TypeRef`] in this debug file.
+    ///
+    /// See also: [`DebugSession::lookup_type`].
+    pub fn lookup_type(&self, _ty: &TypeRef) -> Result<Option<Type<'_>>, FormatError> {
+        Ok(None)
+    }
+
     /// See [DebugSession::source_by_path] for more information.
     pub fn source_by_path(
         &self,
@@ -251,6 +260,10 @@ impl<'session> DebugSession<'session> for PortablePdbDebugSession<'_> {
 
     fn files(&'session self) -> Self::FileIterator {
         self.files()
+    }
+
+    fn lookup_type(&'session self, ty: &TypeRef) -> Result<Option<Type<'session>>, Self::Error> {
+        self.lookup_type(ty)
     }
 
     fn source_by_path(&self, path: &str) -> Result<Option<SourceFileDescriptor<'_>>, Self::Error> {

--- a/symbolic-debuginfo/src/sourcebundle/mod.rs
+++ b/symbolic-debuginfo/src/sourcebundle/mod.rs
@@ -63,11 +63,11 @@ use zip::{ZipWriter, write::SimpleFileOptions};
 use symbolic_common::{Arch, AsSelf, CodeId, DebugId, SourceLinkMappings};
 
 use self::utf8_reader::Utf8Reader;
-use crate::ParseObjectOptions;
 use crate::base::*;
 use crate::js::{
     discover_debug_id, discover_sourcemap_embedded_debug_id, discover_sourcemaps_location,
 };
+use crate::{ParseObjectOptions, Type, TypeRef};
 
 /// Magic bytes of a source bundle. They are prepended to the ZIP file.
 static BUNDLE_MAGIC: [u8; 4] = *b"SYSB";
@@ -948,6 +948,13 @@ impl SourceBundleDebugSession<'_> {
         std::iter::empty()
     }
 
+    /// Resolves a [`TypeRef`] in this debug file.
+    ///
+    /// See also: [`DebugSession::lookup_type`].
+    pub fn lookup_type(&self, _ty: &TypeRef) -> Result<Option<Type<'_>>, SourceBundleError> {
+        Ok(None)
+    }
+
     /// Get source by the path of a file in the bundle.
     fn source_by_zip_path(
         &self,
@@ -1054,6 +1061,10 @@ impl<'session> DebugSession<'session> for SourceBundleDebugSession<'_> {
 
     fn files(&'session self) -> Self::FileIterator {
         self.files()
+    }
+
+    fn lookup_type(&'session self, ty: &TypeRef) -> Result<Option<Type<'session>>, Self::Error> {
+        self.lookup_type(ty)
     }
 
     fn source_by_path(&self, path: &str) -> Result<Option<SourceFileDescriptor<'_>>, Self::Error> {

--- a/symbolic-debuginfo/src/variable.rs
+++ b/symbolic-debuginfo/src/variable.rs
@@ -8,7 +8,7 @@ pub struct TypeRef(NativeTypeRef);
 
 impl TypeRef {
     #[cfg(feature = "dwarf")]
-    pub fn as_dwarf(&self) -> Option<&crate::dwarf::DwarfTypeRef> {
+    pub(crate) fn as_dwarf(&self) -> Option<&crate::dwarf::DwarfTypeRef> {
         match &self.0 {
             NativeTypeRef::Dwarf(dwarf) => Some(dwarf),
         }
@@ -28,7 +28,73 @@ impl From<crate::dwarf::DwarfTypeRef> for TypeRef {
     }
 }
 
-pub struct Type {}
+/// A concrete type.
+#[derive(Debug, Clone)]
+pub enum Type<'data> {
+    /// A primitive type.
+    Primitive(PrimitiveType<'data>),
+    /// A pointer type.
+    Pointer(PointerType),
+}
+
+/// A primitive type.
+///
+/// A primitive type does not link to other types and contains a concrete value, this class contains
+/// integers, floats, booleans, chars, etc.
+#[derive(Debug, Clone)]
+pub struct PrimitiveType<'data> {
+    /// The name of the type.
+    ///
+    /// In rare cases the name may not be available.
+    pub name: Option<Cow<'data, str>>,
+    /// An optional encoding of the type.
+    ///
+    /// The encoding gives additional information how the value of the type is to be interpreted.
+    pub encoding: Option<PrimitiveEncoding>,
+    /// The size of the primitive type.
+    pub size: TypeSize,
+}
+
+/// An encoding for a [`PrimitiveType`].
+///
+/// The encoding provides supplementary information how to interpret the value of a primitive type.
+#[derive(Debug, Clone)]
+pub enum PrimitiveEncoding {
+    /// The value is a boolean.
+    Boolean,
+    /// The value is an address.
+    Address,
+    /// The value is a signed integer.
+    SignedInt,
+    /// The value is an un-signed integer.
+    UnsignedInt,
+    /// The value is a signed char.
+    SignedChar,
+    /// The value is a un-signed char.
+    UnsignedChar,
+    /// The value is a float.
+    Float,
+    /// The value is a complex float.
+    ComplexFloat,
+}
+
+/// A pointer or reference type.
+///
+/// This type always links to another type via a memory address.
+#[derive(Debug, Clone)]
+pub struct PointerType {
+    /// The type the pointer references.
+    pub pointee: TypeRef,
+    /// The size of a pointer.
+    pub size: TypeSize,
+}
+
+/// The size of a type in memory.
+#[derive(Debug, Clone)]
+pub enum TypeSize {
+    /// The size is given in bytes.
+    Bytes(u64),
+}
 
 /// A single variable available in a function scope.
 #[derive(Debug, Clone)]

--- a/symbolic-debuginfo/src/variable.rs
+++ b/symbolic-debuginfo/src/variable.rs
@@ -4,12 +4,21 @@ use std::{borrow::Cow, fmt};
 ///
 /// Links a variable to a concrete type.
 #[derive(Debug, Clone)]
-pub struct TypeRef(#[expect(unused, reason = "not yet implemented")] NativeTypeRef);
+pub struct TypeRef(NativeTypeRef);
+
+impl TypeRef {
+    #[cfg(feature = "dwarf")]
+    pub fn as_dwarf(&self) -> Option<&crate::dwarf::DwarfTypeRef> {
+        match &self.0 {
+            NativeTypeRef::Dwarf(dwarf) => Some(dwarf),
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 enum NativeTypeRef {
     #[cfg(feature = "dwarf")]
-    Dwarf(#[expect(unused)] crate::dwarf::DwarfTypeRef),
+    Dwarf(crate::dwarf::DwarfTypeRef),
 }
 
 #[cfg(feature = "dwarf")]
@@ -18,6 +27,8 @@ impl From<crate::dwarf::DwarfTypeRef> for TypeRef {
         Self(NativeTypeRef::Dwarf(value))
     }
 }
+
+pub struct Type {}
 
 /// A single variable available in a function scope.
 #[derive(Debug, Clone)]

--- a/symbolic-debuginfo/tests/snapshots/test_objects__breakpad_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__breakpad_functions.snap
@@ -1,6 +1,6 @@
 ---
 source: symbolic-debuginfo/tests/test_objects.rs
-expression: "FunctionsDebug(&functions[..10], 0)"
+expression: "FunctionsDebug::new(&session, &functions[..10])"
 ---
 > 0x1000: google_breakpad::CrashGenerationClient::RequestDump(_EXCEPTION_POINTERS *,MDRawAssertionInfo *) (0x114)
   0x1000: crash_generation_client.cc:323 (c:\projects\breakpad-tools\deps\breakpad\src\client\windows\crash_generation)

--- a/symbolic-debuginfo/tests/snapshots/test_objects__breakpad_functions_mac_with_inlines.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__breakpad_functions_mac_with_inlines.snap
@@ -1,6 +1,6 @@
 ---
 source: symbolic-debuginfo/tests/test_objects.rs
-expression: "FunctionsDebug(&functions[..10], 0)"
+expression: "FunctionsDebug::new(&session, &functions[..10])"
 ---
 > 0xd20: google_breakpad::MinidumpFileWriter::MinidumpFileWriter() (0x1a)
   0xd20: minidump_file_writer.cc:93 (/Users/travis/build/getsentry/breakpad-tools/deps/breakpad/src/client)

--- a/symbolic-debuginfo/tests/snapshots/test_objects__elf_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__elf_functions.snap
@@ -1,6 +1,6 @@
 ---
 source: symbolic-debuginfo/tests/test_objects.rs
-expression: "FunctionsDebug(&functions[..10], 0)"
+expression: "FunctionsDebug::new(&session, &functions[..10])"
 ---
 > 0x1ec0: _ZN12_GLOBAL__N_18callbackERKN15google_breakpad18MinidumpDescriptorEPvb (0x3b)
   0x1ec0: main.cpp:9 (../linux)
@@ -103,12 +103,22 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x1dac: main.cpp:33 (../linux)
   variables:
     argc (parameter)
+      type:
+        > Primitive: int (SignedInt, 4 bytes)
       0x1c70..0x1d2b: register 5
     argv (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Pointer (8 bytes)
+            > Primitive: char (SignedChar, 1 byte)
       0x1c70..0x1cc3: register 4
     descriptor (local)
+      type:
+        > Unknown
       0x1c70..0x1dbc: frame base -416
     eh (local)
+      type:
+        > Unknown
       0x1c70..0x1dbc: frame base -272
 
   > 0x1c89: _ZN15google_breakpad18MinidumpDescriptorC4ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE (0x7)
@@ -732,12 +742,17 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x29a5: exception_handler.cc:505 (../deps/breakpad/src/client/linux/handler)
   variables:
     this (parameter)
+      type:
+        > Unknown
       0x2520..0x2538: register 5
       0x2538..0x255a: register 3
       0x257f..0x2777: register 3
       0x27c6..0x299d: register 3
       0x29a2..0x29ab: register 3
     context (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0x2520..0x2557: register 4
       0x2557..0x255a: register 6
       0x257f..0x2595: register 4
@@ -747,6 +762,9 @@ expression: "FunctionsDebug(&functions[..10], 0)"
       0x27e2..0x27f6: frame base -88
       0x2996..0x2998: register 6
     stack (local)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0x260d..0x272f: register 15
       0x272f..0x2735: register 4
       0x2735..0x2782: register 15
@@ -754,15 +772,23 @@ expression: "FunctionsDebug(&functions[..10], 0)"
       0x27f6..0x282b: register 4
       0x282b..0x2877: register 15
     thread_arg (local)
+      type:
+        > Unknown
       0x2520..0x29e6: frame base -112
     status (local)
+      type:
+        > Primitive: int (SignedInt, 4 bytes)
       0x2520..0x29e6: frame base -116
     r (local)
+      type:
+        > Unknown
       0x28cd..0x28f1: register 4
       0x28f1..0x28f7: frame base -144
       0x28f7..0x291d: register 4
       0x293f..0x294b: register 4
     success (local)
+      type:
+        > Primitive: bool (Boolean, 1 byte)
       0x291d..0x293a: register 6
 
   > 0x2534: _ZNK15google_breakpad16ExceptionHandler14IsOutOfProcessEv (0x4)
@@ -994,25 +1020,38 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x2dba: exception_handler.cc:409 (../deps/breakpad/src/client/linux/handler)
   variables:
     sig (parameter)
+      type:
+        > Primitive: int (SignedInt, 4 bytes)
       0x2bd0..0x2c08: register 5
       0x2c08..0x2c2f: register 12
       0x2c34..0x2dbf: register 12
     info (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0x2bd0..0x2c08: register 4
       0x2c08..0x2c0d: register 13
       0x2c34..0x2d43: register 13
       0x2d88..0x2dae: register 13
     uc (parameter)
+      type:
+        > Unknown
       0x2bd0..0x2c08: register 1
       0x2c08..0x2c33: register 14
       0x2c34..0x2dbf: register 14
     cur_handler (local)
+      type:
+        > Unknown
       0x2bd0..0x2dbf: frame base -208
     handled (local)
+      type:
+        > Primitive: bool (Boolean, 1 byte)
       0x2c7f..0x2c8f: register 0
       0x2ca8..0x2cb5: register 0
       0x2d88..0x2d99: register 0
     i (local)
+      type:
+        > Primitive: int (SignedInt, 4 bytes)
       0x2c74..0x2ca8: register 3
       0x2cab..0x2ce7: register 3
       0x2d88..0x2d9f: register 3

--- a/symbolic-debuginfo/tests/snapshots/test_objects__mach_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__mach_functions.snap
@@ -1,6 +1,6 @@
 ---
 source: symbolic-debuginfo/tests/test_objects.rs
-expression: "FunctionsDebug(&functions[..10], 0)"
+expression: "FunctionsDebug::new(&session, &functions[..10])"
 ---
 > 0xd20: _ZN15google_breakpad18MinidumpFileWriterC2Ev (0x1a)
   0xd20: minidump_file_writer.cc:93 (../deps/breakpad/src/client)
@@ -14,6 +14,9 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0xd59: minidump_file_writer.cc:97 (../deps/breakpad/src/client)
   variables:
     this (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0xd40..0xd5a: register 5
 
   > 0xd40: _ZN15google_breakpad18MinidumpFileWriterC2Ev (0x19)
@@ -59,6 +62,9 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0xe0c: minidump_file_writer.cc:99 (../deps/breakpad/src/client)
   variables:
     this (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0xde0..0xde4: register 5
       0xde4..0xe0b: register 3
       0xe0c..0xe14: register 3
@@ -90,10 +96,16 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0xe4a: minidump_file_writer.cc:105 (../deps/breakpad/src/client)
   variables:
     this (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0xe20..0xe27: register 5
       0xe27..0xe49: register 3
       0xe4a..0xe69: register 3
     path (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0xe20..0xe24: register 4
       0xe24..0xe40: register 2
       0xe4a..0xe5f: register 2
@@ -106,6 +118,9 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0xe7e: minidump_file_writer.cc:116 (../deps/breakpad/src/client)
   variables:
     this (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0xe70..0xe85: register 5
 
 > 0xea0: _ZN15google_breakpad18MinidumpFileWriter20CopyStringToMDStringEPKwjPNS_10TypedMDRVAI8MDStringEE (0x147)
@@ -128,19 +143,32 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0xfa9: minidump_file_writer.cc:174 (../deps/breakpad/src/client)
   variables:
     this (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0xea0..0xed2: register 5
     str (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0xea0..0xeb6: register 4
       0xeb6..0xf23: register 3
       0xf76..0xf94: register 3
       0xfa9..0xfe7: register 3
     mdstring (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0xea0..0xeb1: register 2
       0xeb1..0xf41: register 12
       0xfa9..0xfe7: register 12
     out (local)
+      type:
+        > Unknown
       0xea0..0xfe7: frame base +16
     out_size (local)
+      type:
+        > Unknown
       0xf23..0xf72: register 3
 
   > 0xefa: _ZN15google_breakpad10TypedMDRVAI8MDStringE20CopyIndexAfterObjectEjPKvm (0x25)
@@ -191,18 +219,31 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x10f9: minidump_file_writer.cc:201 (../deps/breakpad/src/client)
   variables:
     this (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0xff0..0x1023: register 5
     str (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0xff0..0x1006: register 4
       0x1006..0x10ef: register 3
       0x10f9..0x1137: register 3
     mdstring (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0xff0..0x1001: register 2
       0x1001..0x107b: register 14
       0x10f9..0x1137: register 14
     out (local)
+      type:
+        > Unknown
       0xff0..0x1137: frame base +8
     out_size (local)
+      type:
+        > Unknown
       0x106b..0x10b7: register 6
 
   > 0x1049: _ZN15google_breakpad10TypedMDRVAI8MDStringE20CopyIndexAfterObjectEjPKvm (0x1e)
@@ -239,8 +280,17 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x1140: minidump_file_writer.cc:245 (../deps/breakpad/src/client)
   variables:
     this (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0x1140..0x1145: register 5
     str (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0x1140..0x1145: register 4
     location (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0x1140..0x1145: register 2

--- a/symbolic-debuginfo/tests/snapshots/test_objects__pdb_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__pdb_functions.snap
@@ -1,6 +1,6 @@
 ---
 source: symbolic-debuginfo/tests/test_objects.rs
-expression: "FunctionsDebug(&functions[..10], 0)"
+expression: "FunctionsDebug::new(&session, &functions[..10])"
 ---
 > 0x1120: std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::~basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >() (0x54)
   0x1120: xstring:2424 (c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.13.26128\include)

--- a/symbolic-debuginfo/tests/snapshots/test_objects__pe_dwarf_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__pe_dwarf_functions.snap
@@ -1,6 +1,6 @@
 ---
 source: symbolic-debuginfo/tests/test_objects.rs
-expression: "FunctionsDebug(&functions[..10], 0)"
+expression: "FunctionsDebug::new(&session, &functions[..10])"
 ---
 > 0x14f0: atexit (0x14)
   0x14f0: crtexe.c:418 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
@@ -9,6 +9,8 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x14ff: crtexe.c:420 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
   variables:
     func (parameter)
+      type:
+        > Unknown
       0x14f0..0x14f8: register 2
 
 > 0x1180: __tmainCRTStartup (0x326)
@@ -100,20 +102,33 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x149e: crtexe.c:324 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
   variables:
     lpszCommandLine (local)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0x1291..0x12fd: register 0
     StartupInfo (local)
+      type:
+        > Unknown
       0x1180..0x14a6: frame base -176
     inDoubleQuote (local)
+      type:
+        > Unknown
       0x1298..0x12a7: register 2
       0x12ae..0x12c8: register 2
     lock_free (local)
+      type:
+        > Unknown
       0x11d3..0x11e8: register 0
       0x11f1..0x1201: register 0
       0x13f2..0x1406: register 0
     fiberid (local)
+      type:
+        > Unknown
       0x11c8..0x11fd: register 4
       0x13f2..0x13ff: register 4
     nested (local)
+      type:
+        > Primitive: int (SignedInt, 4 bytes)
       0x11ff..0x1315: register 6
       0x13e3..0x13f2: register 6
       0x1404..0x144f: register 6
@@ -163,6 +178,8 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x14e8: crtexe.c:213 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
   variables:
     ret (local)
+      type:
+        > Primitive: int (SignedInt, 4 bytes)
       0x14e6..0x14ed: register 0
 
 > 0x14b0: WinMainCRTStartup (0x1d)
@@ -173,6 +190,8 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x14c8: crtexe.c:187 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
   variables:
     ret (local)
+      type:
+        > Primitive: int (SignedInt, 4 bytes)
       0x14c6..0x14cd: register 0
 
 > 0x1130: pre_cpp_init (0x49)
@@ -230,14 +249,27 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x1000: crtexe.c:123 (/mxe/tmp-gcc-x86_64-w64-mingw32.static/gcc-11.3.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt)
   variables:
     expression (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0x1000..0x1001: register 2
     function (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0x1000..0x1001: register 1
     file (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0x1000..0x1001: register 8
     line (parameter)
+      type:
+        > Primitive: unsigned int (UnsignedInt, 4 bytes)
       0x1000..0x1001: register 9
     pReserved (parameter)
+      type:
+        > Unknown
       0x1000..0x1001: frame base +32
 
 > 0x1572: main (0x1f)
@@ -247,8 +279,14 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x1587: hello.c:5 (/src)
   variables:
     argc (parameter)
+      type:
+        > Primitive: int (SignedInt, 4 bytes)
       0x1572..0x157a: register 2
     argv (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Pointer (8 bytes)
+            > Primitive: char (SignedChar, 1 byte)
       0x1572..0x157a: register 1
 
 > 0x1530: printf (0x42)
@@ -260,11 +298,19 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x1570: stdio.h:375 (/mxe/usr/x86_64-w64-mingw32.static/include)
   variables:
     __format (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0x1530..0x1557: register 2
       0x1557..0x1570: register 3
     __retval (local)
+      type:
+        > Primitive: int (SignedInt, 4 bytes)
       0x156b..0x1572: register 0
     __local_argv (local)
+      type:
+        > Pointer (8 bytes)
+          > Primitive: char (SignedChar, 1 byte)
       0x1530..0x1572: frame base -40
 
 > 0x1650: __main (0x1f)

--- a/symbolic-debuginfo/tests/snapshots/test_objects__pe_dwarf_msys2_qglib_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__pe_dwarf_msys2_qglib_functions.snap
@@ -1,6 +1,6 @@
 ---
 source: symbolic-debuginfo/tests/test_objects.rs
-expression: "FunctionsDebug(&functions[..10], 0)"
+expression: "FunctionsDebug::new(&session, &functions[..10])"
 ---
 > 0x1000: _CRT_INIT (0x1d7)
   0x1000: mingw-w64/mingw-w64-crt/crt/crtdll.c:42 (D:/W/B/src)
@@ -115,15 +115,23 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x133f: mingw-w64/mingw-w64-crt/crt/crtdll.c:170 (D:/W/B/src)
   variables:
     hDllHandle (parameter)
+      type:
+        > Unknown
       0x11e0..0x11f6: register 2
       0x11f6..0x12b8: register 5
     dwReason (parameter)
+      type:
+        > Unknown
       0x11e0..0x11f6: register 1
       0x11f6..0x12c9: register 3
     lpreserved (parameter)
+      type:
+        > Unknown
       0x11e0..0x11f6: register 8
       0x11f6..0x12bf: register 4
     retcode (local)
+      type:
+        > Unknown
       0x121d..0x1223: register 0
       0x1259..0x1288: register 14
 
@@ -173,6 +181,8 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x1353: mingw-w64/mingw-w64-crt/crt/crtdll.c:185 (D:/W/B/src)
   variables:
     func (parameter)
+      type:
+        > Unknown
       0x1350..0x135a: register 2
       0x135a..0x135f: register 1
 
@@ -326,6 +336,9 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x14c5: qtbase-everywhere-src-6.10.1/src/plugins/networkinformation/glib/qglibnetworkinformationbackend.cpp:119 (D:/W/B/src)
   variables:
     this (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0x13e4..0x13f8: register 2
       0x13f8..0x14cc: register 4
 
@@ -349,10 +362,15 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x15fb: qtbase-everywhere-src-6.10.1/src/plugins/networkinformation/glib/qglibnetworkinformationbackend.cpp:0 (D:/W/B/src)
   variables:
     backend (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0x14d4..0x14fd: register 2
       0x14fd..0x15f2: register 4
       0x15fb..0x1601: register 4
     connectivityState (local)
+      type:
+        > Unknown
       0x1505..0x15ac: register 5
 
   > 0x1505: _ZN12_GLOBAL__N_136reachabilityFromGNetworkConnectivityE20GNetworkConnectivity (0x16)
@@ -443,6 +461,9 @@ expression: "FunctionsDebug(&functions[..10], 0)"
   0x16d5: qtbase-everywhere-src-6.10.1/src/plugins/networkinformation/glib/qglibnetworkinformationbackend.cpp:0 (D:/W/B/src)
   variables:
     backend (parameter)
+      type:
+        > Pointer (8 bytes)
+          > Unknown
       0x1614..0x1637: register 2
       0x1637..0x167f: register 4
       0x1687..0x16a7: register 4

--- a/symbolic-debuginfo/tests/snapshots/test_objects__wasm_functions.snap
+++ b/symbolic-debuginfo/tests/snapshots/test_objects__wasm_functions.snap
@@ -69,9 +69,12 @@ expression: r
                         TypeRef(
                             Dwarf(
                                 DwarfTypeRef(
-                                    UnitSectionOffset(
-                                        687,
-                                    ),
+                                    Offset {
+                                        section: DebugInfo,
+                                        offset: UnitSectionOffset(
+                                            687,
+                                        ),
+                                    },
                                 ),
                             ),
                         ),
@@ -93,9 +96,12 @@ expression: r
                         TypeRef(
                             Dwarf(
                                 DwarfTypeRef(
-                                    UnitSectionOffset(
-                                        687,
-                                    ),
+                                    Offset {
+                                        section: DebugInfo,
+                                        offset: UnitSectionOffset(
+                                            687,
+                                        ),
+                                    },
                                 ),
                             ),
                         ),
@@ -589,9 +595,12 @@ expression: r
                         TypeRef(
                             Dwarf(
                                 DwarfTypeRef(
-                                    UnitSectionOffset(
-                                        9384,
-                                    ),
+                                    Offset {
+                                        section: DebugInfo,
+                                        offset: UnitSectionOffset(
+                                            9384,
+                                        ),
+                                    },
                                 ),
                             ),
                         ),
@@ -710,9 +719,12 @@ expression: r
                         TypeRef(
                             Dwarf(
                                 DwarfTypeRef(
-                                    UnitSectionOffset(
-                                        11615,
-                                    ),
+                                    Offset {
+                                        section: DebugInfo,
+                                        offset: UnitSectionOffset(
+                                            11615,
+                                        ),
+                                    },
                                 ),
                             ),
                         ),

--- a/symbolic-debuginfo/tests/test_objects.rs
+++ b/symbolic-debuginfo/tests/test_objects.rs
@@ -3,10 +3,12 @@ use std::fmt;
 use std::io::BufWriter;
 
 use symbolic_common::{ByteView, Language};
+use symbolic_debuginfo::ObjectDebugSession;
 use symbolic_debuginfo::dwarf::DwarfErrorKind;
 use symbolic_debuginfo::elf::ElfObject;
 use symbolic_debuginfo::{
-    FileEntry, Function, LineInfo, Location, Object, ParseObjectOptions, SymbolMap, pe::PeObject,
+    FileEntry, Function, LineInfo, Location, Object, ParseObjectOptions, SymbolMap, Type, TypeRef,
+    TypeSize, pe::PeObject,
 };
 use symbolic_testutils::fixture;
 
@@ -46,11 +48,28 @@ impl fmt::Debug for FilesDebug<'_> {
 }
 
 /// Helper to create neat snapshots for function trees.
-struct FunctionsDebug<'a>(&'a [Function<'a>], usize);
+struct FunctionsDebug<'data, 'session> {
+    session: &'session ObjectDebugSession<'data>,
+    functions: &'session [Function<'session>],
+    depth: usize,
+}
 
-impl fmt::Debug for FunctionsDebug<'_> {
+impl<'data, 'session> FunctionsDebug<'data, 'session> {
+    fn new(
+        session: &'session ObjectDebugSession<'data>,
+        functions: &'session [Function<'session>],
+    ) -> Self {
+        Self {
+            session,
+            functions,
+            depth: 0,
+        }
+    }
+}
+
+impl fmt::Debug for FunctionsDebug<'_, '_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for function in self.0 {
+        for function in self.functions {
             writeln!(
                 f,
                 "\n{:indent$}> {:#x}: {} ({:#x})",
@@ -58,7 +77,7 @@ impl fmt::Debug for FunctionsDebug<'_> {
                 function.address,
                 function.name,
                 function.size,
-                indent = self.1 * 2
+                indent = self.depth * 2
             )?;
 
             for line in &function.lines {
@@ -70,12 +89,12 @@ impl fmt::Debug for FunctionsDebug<'_> {
                     line.file.name_str(),
                     line.line,
                     line.file.dir_str(),
-                    indent = self.1 * 2
+                    indent = self.depth * 2
                 )?;
             }
 
             if !function.variables.is_empty() {
-                writeln!(f, "{:indent$}  variables:", "", indent = self.1 * 2)?;
+                writeln!(f, "{:indent$}  variables:", "", indent = self.depth * 2)?;
             }
 
             for variable in &function.variables {
@@ -85,8 +104,21 @@ impl fmt::Debug for FunctionsDebug<'_> {
                     "",
                     variable.name,
                     variable.kind,
-                    indent = self.1 * 2
+                    indent = self.depth * 2
                 )?;
+
+                if let Some(ty) = &variable.ty {
+                    writeln!(f, "{:indent$}      type:", "", indent = self.depth * 2)?;
+                    write!(
+                        f,
+                        "{:?}",
+                        TypeDebug {
+                            session: self.session,
+                            ty,
+                            depth: self.depth + 4,
+                        }
+                    )?;
+                }
 
                 for location in &variable.locations {
                     match location.location {
@@ -96,7 +128,7 @@ impl fmt::Debug for FunctionsDebug<'_> {
                             "",
                             location.address,
                             location.address.saturating_add(location.size),
-                            indent = self.1 * 2
+                            indent = self.depth * 2
                         )?,
                         Location::FrameOffset { offset } => writeln!(
                             f,
@@ -104,16 +136,81 @@ impl fmt::Debug for FunctionsDebug<'_> {
                             "",
                             location.address,
                             location.address.saturating_add(location.size),
-                            indent = self.1 * 2
+                            indent = self.depth * 2
                         )?,
                     }
                 }
             }
 
-            write!(f, "{:?}", FunctionsDebug(&function.inlinees, self.1 + 1))?;
+            write!(
+                f,
+                "{:?}",
+                FunctionsDebug {
+                    session: self.session,
+                    functions: &function.inlinees,
+                    depth: self.depth + 1,
+                }
+            )?;
         }
 
         Ok(())
+    }
+}
+
+struct TypeDebug<'data, 'session, 'type_ref> {
+    session: &'session ObjectDebugSession<'data>,
+    ty: &'type_ref TypeRef,
+    depth: usize,
+}
+
+impl fmt::Debug for TypeDebug<'_, '_, '_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Some(ty) = self.session.lookup_type(self.ty).unwrap() else {
+            return writeln!(f, "{:indent$}> Unknown", "", indent = self.depth * 2);
+        };
+
+        match ty {
+            Type::Primitive(ty) => {
+                let TypeSize::Bytes(size) = ty.size;
+                let unit = if size == 1 { "byte" } else { "bytes" };
+                let name = ty.name.as_deref().unwrap_or("<unknown>");
+
+                match ty.encoding {
+                    Some(encoding) => writeln!(
+                        f,
+                        "{:indent$}> Primitive: {name} ({encoding:?}, {size} {unit})",
+                        "",
+                        indent = self.depth * 2
+                    ),
+                    None => writeln!(
+                        f,
+                        "{:indent$}> Primitive: {name} (<unknown encoding>, {size} {unit})",
+                        "",
+                        indent = self.depth * 2
+                    ),
+                }
+            }
+            Type::Pointer(ty) => {
+                let TypeSize::Bytes(size) = ty.size;
+                let unit = if size == 1 { "byte" } else { "bytes" };
+
+                writeln!(
+                    f,
+                    "{:indent$}> Pointer ({size} {unit})",
+                    "",
+                    indent = self.depth * 2
+                )?;
+                write!(
+                    f,
+                    "{:?}",
+                    TypeDebug {
+                        session: self.session,
+                        ty: &ty.pointee,
+                        depth: self.depth + 1,
+                    }
+                )
+            }
+        }
     }
 }
 
@@ -222,7 +319,10 @@ fn test_breakpad_functions() -> Result<(), Error> {
     let session = object.debug_session()?;
     let functions = session.functions().collect::<Result<Vec<_>, _>>()?;
     check_functions(&functions);
-    insta::assert_debug_snapshot!("breakpad_functions", FunctionsDebug(&functions[..10], 0));
+    insta::assert_debug_snapshot!(
+        "breakpad_functions",
+        FunctionsDebug::new(&session, &functions[..10])
+    );
 
     Ok(())
 }
@@ -237,7 +337,7 @@ fn test_breakpad_functions_mac_with_inlines() -> Result<(), Error> {
     check_functions(&functions);
     insta::assert_debug_snapshot!(
         "breakpad_functions_mac_with_inlines",
-        FunctionsDebug(&functions[..10], 0)
+        FunctionsDebug::new(&session, &functions[..10])
     );
 
     Ok(())
@@ -390,21 +490,30 @@ fn test_elf_functions() -> Result<(), Error> {
 
     let session = object.debug_session()?;
     let functions = session.functions().collect::<Result<Vec<_>, _>>()?;
-    insta::assert_debug_snapshot!("elf_functions", FunctionsDebug(&functions[..10], 0));
+    insta::assert_debug_snapshot!(
+        "elf_functions",
+        FunctionsDebug::new(&session, &functions[..10])
+    );
 
     let view = ByteView::open(fixture("linux/crash.debug-zlib"))?;
     let object = Object::parse(&view)?;
 
     let session = object.debug_session()?;
     let functions = session.functions().collect::<Result<Vec<_>, _>>()?;
-    insta::assert_debug_snapshot!("elf_functions", FunctionsDebug(&functions[..10], 0));
+    insta::assert_debug_snapshot!(
+        "elf_functions",
+        FunctionsDebug::new(&session, &functions[..10])
+    );
 
     let view = ByteView::open(fixture("linux/crash.debug-zstd"))?;
     let object = Object::parse(&view)?;
 
     let session = object.debug_session()?;
     let functions = session.functions().collect::<Result<Vec<_>, _>>()?;
-    insta::assert_debug_snapshot!("elf_functions", FunctionsDebug(&functions[..10], 0));
+    insta::assert_debug_snapshot!(
+        "elf_functions",
+        FunctionsDebug::new(&session, &functions[..10])
+    );
 
     Ok(())
 }
@@ -596,7 +705,10 @@ fn test_mach_functions() -> Result<(), Error> {
     let session = object.debug_session()?;
     let functions = session.functions().collect::<Result<Vec<_>, _>>()?;
     check_functions(&functions);
-    insta::assert_debug_snapshot!("mach_functions", FunctionsDebug(&functions[..10], 0));
+    insta::assert_debug_snapshot!(
+        "mach_functions",
+        FunctionsDebug::new(&session, &functions[..10])
+    );
 
     Ok(())
 }
@@ -697,7 +809,10 @@ fn test_pe_dwarf_functions() -> Result<(), Error> {
 
     let session = object.debug_session()?;
     let functions = session.functions().collect::<Result<Vec<_>, _>>()?;
-    insta::assert_debug_snapshot!("pe_dwarf_functions", FunctionsDebug(&functions[..10], 0));
+    insta::assert_debug_snapshot!(
+        "pe_dwarf_functions",
+        FunctionsDebug::new(&session, &functions[..10])
+    );
 
     Ok(())
 }
@@ -717,7 +832,7 @@ fn test_pe_dwarf_msys2_qglib() -> Result<(), Error> {
     let functions = session.functions().collect::<Result<Vec<_>, _>>()?;
     insta::assert_debug_snapshot!(
         "pe_dwarf_msys2_qglib_functions",
-        FunctionsDebug(&functions[..10], 0)
+        FunctionsDebug::new(&session, &functions[..10])
     );
 
     Ok(())
@@ -809,7 +924,10 @@ fn test_pdb_functions() -> Result<(), Error> {
     let session = object.debug_session()?;
     let functions = session.functions().collect::<Result<Vec<_>, _>>()?;
     check_functions(&functions);
-    insta::assert_debug_snapshot!("pdb_functions", FunctionsDebug(&functions[..10], 0));
+    insta::assert_debug_snapshot!(
+        "pdb_functions",
+        FunctionsDebug::new(&session, &functions[..10])
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Implements basic type resolution for primitive and pointer/reference types.

```
+ cargo run --quiet --package addr2line -- -e symbolic-testutils/fixtures/linux/crash.debug -f -r -s -i -v 0x1c70
main (0x1c70 - 0x1dbc)
  at main.cpp:32 (0x1c70 - 0x1c71)
    argc (parameter)
      location: reg:5 (0x1c70 - 0x1d2b)
      type: int
    argv (parameter)
      location: reg:4 (0x1c70 - 0x1cc3)
      type: char**
    descriptor (local)
      location: fbreg:-416 (0x1c70 - 0x1dbc)
      type: <unknown>
    eh (local)
      location: fbreg:-272 (0x1c70 - 0x1dbc)
      type: <unknown>
```