### PR TITLE
ref(symcache): Re-org module structure, simplify multi version implementations

### DIFF
--- a/symbolic-symcache/src/lib.rs
+++ b/symbolic-symcache/src/lib.rs
@@ -119,8 +119,6 @@ pub use error::{Error, ErrorKind};
 pub use lookup::*;
 pub use writer::SymCacheConverter;
 
-use crate::v9::SymCacheV9;
-
 type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// The latest version of the file format.
@@ -170,7 +168,7 @@ impl<'data> SymCache<'data> {
         }
 
         let inner = match version.version {
-            9 => SymCacheInner::V9(SymCacheV9::parse(rest)?),
+            9 => SymCacheInner::V9(v9::SymCache::parse(rest)?),
             _ => return Err(ErrorKind::WrongVersion.into()),
         };
 
@@ -212,5 +210,5 @@ impl<'slf, 'd: 'slf> AsSelf<'slf> for SymCache<'d> {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum SymCacheInner<'data> {
-    V9(SymCacheV9<'data>),
+    V9(v9::SymCache<'data>),
 }

--- a/symbolic-symcache/src/lib.rs
+++ b/symbolic-symcache/src/lib.rs
@@ -143,14 +143,12 @@ pub const SYMCACHE_VERSION: u32 = 9;
 #[derive(Clone, PartialEq, Eq)]
 pub struct SymCache<'data> {
     version: &'data raw::VersionInfo,
-    inner: SymCacheInner<'data>,
+    inner: lookup::SymCacheInner<'data>,
 }
 
 impl std::fmt::Debug for SymCache<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.inner {
-            SymCacheInner::V9(ref sym_cache_v9) => sym_cache_v9.fmt(f),
-        }
+        self.inner.fmt(f)
     }
 }
 
@@ -206,9 +204,4 @@ impl<'slf, 'd: 'slf> AsSelf<'slf> for SymCache<'d> {
     fn as_self(&'slf self) -> &'slf Self::Ref {
         self
     }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-enum SymCacheInner<'data> {
-    V9(v9::SymCache<'data>),
 }

--- a/symbolic-symcache/src/lookup.rs
+++ b/symbolic-symcache/src/lookup.rs
@@ -2,10 +2,7 @@ use std::fmt;
 
 use symbolic_common::{Language, Name, NameMangling};
 
-use crate::SymCacheInner;
-use crate::v9::lookup::{FilesV9, FunctionsV9, SourceLocationV9, SourceLocationsV9};
-
-use super::SymCache;
+use crate::{SymCache, SymCacheInner};
 
 impl<'data> SymCache<'data> {
     /// Looks up an instruction address in the SymCache, yielding an iterator of [`SourceLocation`]s
@@ -135,11 +132,6 @@ impl Default for Function<'_> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum SourceLocationInner<'data, 'cache> {
-    V9(SourceLocationV9<'data, 'cache>),
-}
-
 /// A source location as included in the SymCache.
 ///
 /// A `SourceLocation` represents source information about a particular instruction.
@@ -147,91 +139,13 @@ enum SourceLocationInner<'data, 'cache> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceLocation<'data, 'cache>(SourceLocationInner<'data, 'cache>);
 
-impl<'data> SourceLocation<'data, '_> {
-    /// The source line corresponding to the instruction.
-    ///
-    /// 0 denotes an unknown line number.
-    pub fn line(&self) -> u32 {
-        match self.0 {
-            SourceLocationInner::V9(ref loc) => loc.line(),
-        }
-    }
-
-    /// The source file corresponding to the instruction.
-    pub fn file(&self) -> Option<File<'data>> {
-        match self.0 {
-            SourceLocationInner::V9(ref loc) => loc.file(),
-        }
-    }
-
-    /// The function corresponding to the instruction.
-    pub fn function(&self) -> Function<'data> {
-        match self.0 {
-            SourceLocationInner::V9(ref loc) => loc.function(),
-        }
-    }
-
-    // TODO: maybe forward some of the `File` and `Function` accessors, such as:
-    // `function_name` or `full_path` for convenience.
-}
-
-impl<'data, 'cache> From<SourceLocationV9<'data, 'cache>> for SourceLocation<'data, 'cache> {
-    fn from(value: SourceLocationV9<'data, 'cache>) -> Self {
-        Self(SourceLocationInner::V9(value))
-    }
-}
-
-#[derive(Debug, Clone)]
-enum SourceLocationsInner<'data, 'cache> {
-    V9(SourceLocationsV9<'data, 'cache>),
-}
-
 /// An Iterator that yields [`SourceLocation`]s, representing an inlining hierarchy.
 #[derive(Debug, Clone)]
 pub struct SourceLocations<'data, 'cache>(SourceLocationsInner<'data, 'cache>);
 
-impl<'data, 'cache> Iterator for SourceLocations<'data, 'cache> {
-    type Item = SourceLocation<'data, 'cache>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.0 {
-            SourceLocationsInner::V9(ref mut locations) => {
-                locations.next().map(SourceLocation::from)
-            }
-        }
-    }
-}
-
-impl<'data, 'cache> From<SourceLocationsV9<'data, 'cache>> for SourceLocations<'data, 'cache> {
-    fn from(value: SourceLocationsV9<'data, 'cache>) -> Self {
-        Self(SourceLocationsInner::V9(value))
-    }
-}
-
-#[derive(Debug, Clone)]
-enum FunctionsInner<'data> {
-    V9(FunctionsV9<'data>),
-}
-
 /// Iterator returned by [`SymCache::functions`]; see documentation there.
 #[derive(Debug, Clone)]
 pub struct Functions<'data>(FunctionsInner<'data>);
-
-impl<'data> Iterator for Functions<'data> {
-    type Item = Function<'data>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.0 {
-            FunctionsInner::V9(ref mut functions) => functions.next(),
-        }
-    }
-}
-
-impl<'data> From<FunctionsV9<'data>> for Functions<'data> {
-    fn from(value: FunctionsV9<'data>) -> Self {
-        Self(FunctionsInner::V9(value))
-    }
-}
 
 /// A helper struct for printing the functions contained in a symcache.
 ///
@@ -253,30 +167,9 @@ impl fmt::Debug for FunctionsDebug<'_> {
     }
 }
 
-#[derive(Debug, Clone)]
-enum FilesInner<'data> {
-    V9(FilesV9<'data>),
-}
-
 /// Iterator returned by [`SymCache::files`]; see documentation there.
 #[derive(Debug, Clone)]
 pub struct Files<'data>(FilesInner<'data>);
-
-impl<'data> Iterator for Files<'data> {
-    type Item = File<'data>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.0 {
-            FilesInner::V9(ref mut files) => files.next(),
-        }
-    }
-}
-
-impl<'data> From<FilesV9<'data>> for Files<'data> {
-    fn from(value: FilesV9<'data>) -> Self {
-        Self(FilesInner::V9(value))
-    }
-}
 
 /// A helper struct for printing the files contained in a symcache.
 ///
@@ -296,3 +189,114 @@ impl fmt::Debug for FilesDebug<'_> {
         Ok(())
     }
 }
+
+macro_rules! impl_version {
+    ($([$version:ident, $module:ident]),+) => {
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        enum SourceLocationInner<'data, 'cache> {
+            $($version(crate::$module::lookup::SourceLocation<'data, 'cache>),)+
+        }
+
+        impl<'data> SourceLocation<'data, '_> {
+            /// The source line corresponding to the instruction.
+            ///
+            /// 0 denotes an unknown line number.
+            pub fn line(&self) -> u32 {
+                match self.0 {
+                    $(SourceLocationInner::$version(ref loc) => loc.line(),)+
+                }
+            }
+
+            /// The source file corresponding to the instruction.
+            pub fn file(&self) -> Option<File<'data>> {
+                match self.0 {
+                    $(SourceLocationInner::$version(ref loc) => loc.file(),)+
+                }
+            }
+
+            /// The function corresponding to the instruction.
+            pub fn function(&self) -> Function<'data> {
+                match self.0 {
+                    $(SourceLocationInner::$version(ref loc) => loc.function(),)+
+                }
+            }
+        }
+
+        #[derive(Debug, Clone)]
+        enum SourceLocationsInner<'data, 'cache> {
+            $($version(crate::$module::lookup::SourceLocations<'data, 'cache>),)+
+        }
+
+        impl<'data, 'cache> Iterator for SourceLocations<'data, 'cache> {
+            type Item = SourceLocation<'data, 'cache>;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                match self.0 {
+                    $(SourceLocationsInner::$version(ref mut locations) => locations.next().map(From::from),)+
+                }
+            }
+        }
+
+        #[derive(Debug, Clone)]
+        enum FunctionsInner<'data> {
+            $($version(crate::$module::lookup::Functions<'data>),)+
+        }
+
+        impl<'data> Iterator for Functions<'data> {
+            type Item = Function<'data>;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                match self.0 {
+                    $(FunctionsInner::$version(ref mut functions) => functions.next().map(From::from),)+
+                }
+            }
+        }
+
+        #[derive(Debug, Clone)]
+        enum FilesInner<'data> {
+            $($version(crate::$module::lookup::Files<'data>),)+
+        }
+
+        impl<'data> Iterator for Files<'data> {
+            type Item = File<'data>;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                match self.0 {
+                    $(FilesInner::$version(ref mut files) => files.next().map(From::from),)+
+                }
+            }
+        }
+
+        $(
+            impl<'data, 'cache> From<crate::$module::lookup::SourceLocations<'data, 'cache>>
+                for SourceLocations<'data, 'cache>
+            {
+                fn from(value: crate::$module::lookup::SourceLocations<'data, 'cache>) -> Self {
+                    Self(SourceLocationsInner::$version(value))
+                }
+            }
+
+            impl<'data, 'cache> From<crate::$module::lookup::SourceLocation<'data, 'cache>>
+                for SourceLocation<'data, 'cache>
+            {
+                fn from(value: crate::$module::lookup::SourceLocation<'data, 'cache>) -> Self {
+                    Self(SourceLocationInner::$version(value))
+                }
+            }
+
+            impl<'data> From<crate::$module::lookup::Functions<'data>> for Functions<'data> {
+                fn from(value: crate::$module::lookup::Functions<'data>) -> Self {
+                    Self(FunctionsInner::$version(value))
+                }
+            }
+
+            impl<'data> From<crate::$module::lookup::Files<'data>> for Files<'data> {
+                fn from(value: crate::$module::lookup::Files<'data>) -> Self {
+                    Self(FilesInner::$version(value))
+                }
+            }
+        )+
+    };
+}
+
+impl_version!([V9, v9]);

--- a/symbolic-symcache/src/lookup.rs
+++ b/symbolic-symcache/src/lookup.rs
@@ -2,39 +2,7 @@ use std::fmt;
 
 use symbolic_common::{Language, Name, NameMangling};
 
-use crate::{SymCache, SymCacheInner};
-
-impl<'data> SymCache<'data> {
-    /// Looks up an instruction address in the SymCache, yielding an iterator of [`SourceLocation`]s
-    /// representing a hierarchy of inlined function calls.
-    pub fn lookup(&self, addr: u64) -> SourceLocations<'data, '_> {
-        match self.inner {
-            SymCacheInner::V9(ref cache) => cache.lookup(addr).into(),
-        }
-    }
-
-    /// An iterator over the functions in this SymCache.
-    ///
-    /// Only functions with a valid entry pc, i.e., one not equal to `u32::MAX`,
-    /// will be returned.
-    /// Note that functions are *not* returned ordered by name or entry pc,
-    /// but in insertion order, which is essentially random.
-    pub fn functions(&self) -> Functions<'data> {
-        match self.inner {
-            SymCacheInner::V9(ref cache) => cache.functions().into(),
-        }
-    }
-
-    /// An iterator over the files in this SymCache.
-    ///
-    /// Note that files are *not* returned ordered by name or full path,
-    /// but in insertion order, which is essentially random.
-    pub fn files(&self) -> Files<'data> {
-        match self.inner {
-            SymCacheInner::V9(ref cache) => cache.files().into(),
-        }
-    }
-}
+use crate::SymCache;
 
 /// A source File included in the SymCache.
 #[derive(Debug, Clone)]
@@ -192,6 +160,51 @@ impl fmt::Debug for FilesDebug<'_> {
 
 macro_rules! impl_version {
     ($([$version:ident, $module:ident]),+) => {
+        #[derive(Clone, PartialEq, Eq)]
+        pub(crate) enum SymCacheInner<'data> {
+            $($version(crate::$module::SymCache<'data>),)+
+        }
+
+        impl std::fmt::Debug for SymCacheInner<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self {
+                    $(SymCacheInner::$version(cache) => cache.fmt(f),)+
+                }
+            }
+        }
+
+        impl<'data> SymCache<'data> {
+            /// Looks up an instruction address in the SymCache, yielding an iterator of [`SourceLocation`]s
+            /// representing a hierarchy of inlined function calls.
+            pub fn lookup(&self, addr: u64) -> SourceLocations<'data, '_> {
+                match self.inner {
+                    $(SymCacheInner::$version(ref cache) => cache.lookup(addr).into(),)+
+                }
+            }
+
+            /// An iterator over the functions in this SymCache.
+            ///
+            /// Only functions with a valid entry pc, i.e., one not equal to `u32::MAX`,
+            /// will be returned.
+            /// Note that functions are *not* returned ordered by name or entry pc,
+            /// but in insertion order, which is essentially random.
+            pub fn functions(&self) -> Functions<'data> {
+                match self.inner {
+                    $(SymCacheInner::$version(ref cache) => cache.functions().into(),)+
+                }
+            }
+
+            /// An iterator over the files in this SymCache.
+            ///
+            /// Note that files are *not* returned ordered by name or full path,
+            /// but in insertion order, which is essentially random.
+            pub fn files(&self) -> Files<'data> {
+                match self.inner {
+                    $(SymCacheInner::$version(ref cache) => cache.files().into(),)+
+                }
+            }
+        }
+
         #[derive(Debug, Clone, PartialEq, Eq)]
         enum SourceLocationInner<'data, 'cache> {
             $($version(crate::$module::lookup::SourceLocation<'data, 'cache>),)+

--- a/symbolic-symcache/src/raw.rs
+++ b/symbolic-symcache/src/raw.rs
@@ -1,7 +1,4 @@
 //! The raw SymCache binary file format internals.
-//!
-
-pub(crate) mod v9;
 
 use watto::Pod;
 

--- a/symbolic-symcache/src/v9/lookup.rs
+++ b/symbolic-symcache/src/v9/lookup.rs
@@ -1,17 +1,16 @@
 use symbolic_common::Language;
 
-use crate::raw::v9 as raw;
-use crate::v9::SymCacheV9;
+use crate::v9::{SymCache, raw};
 use crate::{File, Function};
 
-impl<'data> SymCacheV9<'data> {
-    /// Looks up an instruction address in the SymCacheV9, yielding an iterator of [`SourceLocationV9`]s
+impl<'data> SymCache<'data> {
+    /// Looks up an instruction address in the v9 `SymCache`, yielding an iterator of [`SourceLocation`]s
     /// representing a hierarchy of inlined function calls.
-    pub(crate) fn lookup(&self, addr: u64) -> SourceLocationsV9<'data, '_> {
+    pub fn lookup(&self, addr: u64) -> SourceLocations<'data, '_> {
         let addr = match u32::try_from(addr) {
             Ok(addr) => addr,
             Err(_) => {
-                return SourceLocationsV9 {
+                return SourceLocations {
                     cache: self,
                     source_location_idx: u32::MAX,
                 };
@@ -31,13 +30,13 @@ impl<'data> SymCacheV9<'data> {
             }
         }
 
-        SourceLocationsV9 {
+        SourceLocations {
             cache: self,
             source_location_idx,
         }
     }
 
-    pub(crate) fn get_file(&self, file_idx: u32) -> Option<File<'data>> {
+    pub fn get_file(&self, file_idx: u32) -> Option<File<'data>> {
         let raw_file = self.files.get(file_idx as usize)?;
         Some(File {
             comp_dir: self.get_string(raw_file.comp_dir_offset),
@@ -49,7 +48,7 @@ impl<'data> SymCacheV9<'data> {
         })
     }
 
-    pub(crate) fn get_function(&self, function_idx: u32) -> Option<Function<'data>> {
+    pub fn get_function(&self, function_idx: u32) -> Option<Function<'data>> {
         let raw_function = self.functions.get(function_idx as usize)?;
         Some(Function {
             name: self.get_string(raw_function.name_offset).unwrap_or("?"),
@@ -58,71 +57,71 @@ impl<'data> SymCacheV9<'data> {
         })
     }
 
-    /// An iterator over the functions in this SymCacheV9.
+    /// An iterator over the functions in this SymCache.
     ///
     /// Only functions with a valid entry pc, i.e., one not equal to `u32::MAX`,
     /// will be returned.
     /// Note that functions are *not* returned ordered by name or entry pc,
     /// but in insertion order, which is essentially random.
-    pub(crate) fn functions(&self) -> FunctionsV9<'data> {
-        FunctionsV9 {
+    pub fn functions(&self) -> Functions<'data> {
+        Functions {
             cache: self.clone(),
             function_idx: 0,
         }
     }
 
-    /// An iterator over the files in this SymCacheV9.
+    /// An iterator over the files in this SymCache.
     ///
     /// Note that files are *not* returned ordered by name or full path,
     /// but in insertion order, which is essentially random.
-    pub(crate) fn files(&self) -> FilesV9<'data> {
-        FilesV9 {
+    pub fn files(&self) -> Files<'data> {
+        Files {
             cache: self.clone(),
             file_idx: 0,
         }
     }
 }
 
-/// A source location as included in the SymCacheV9.
+/// A source location as included in the SymCache.
 ///
 /// A `SourceLocation` represents source information about a particular instruction.
 /// It always has a `[Function]` associated with it and may also have a `[File]` and a line number.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SourceLocationV9<'data, 'cache> {
-    pub(crate) cache: &'cache SymCacheV9<'data>,
-    pub(crate) source_location: &'data raw::SourceLocation,
+pub struct SourceLocation<'data, 'cache> {
+    pub cache: &'cache SymCache<'data>,
+    pub source_location: &'data raw::SourceLocation,
 }
 
-impl<'data> SourceLocationV9<'data, '_> {
+impl<'data> SourceLocation<'data, '_> {
     /// The source line corresponding to the instruction.
     ///
     /// 0 denotes an unknown line number.
-    pub(crate) fn line(&self) -> u32 {
+    pub fn line(&self) -> u32 {
         self.source_location.line
     }
 
     /// The source file corresponding to the instruction.
-    pub(crate) fn file(&self) -> Option<File<'data>> {
+    pub fn file(&self) -> Option<File<'data>> {
         self.cache.get_file(self.source_location.file_idx)
     }
 
     /// The function corresponding to the instruction.
-    pub(crate) fn function(&self) -> Function<'data> {
+    pub fn function(&self) -> Function<'data> {
         self.cache
             .get_function(self.source_location.function_idx)
             .unwrap_or_default()
     }
 }
 
-/// An Iterator that yields [`SourceLocationV9`]s, representing an inlining hierarchy.
+/// An Iterator that yields [`SourceLocation`]s, representing an inlining hierarchy.
 #[derive(Debug, Clone)]
-pub(crate) struct SourceLocationsV9<'data, 'cache> {
-    pub(crate) cache: &'cache SymCacheV9<'data>,
-    pub(crate) source_location_idx: u32,
+pub struct SourceLocations<'data, 'cache> {
+    pub cache: &'cache SymCache<'data>,
+    pub source_location_idx: u32,
 }
 
-impl<'data, 'cache> Iterator for SourceLocationsV9<'data, 'cache> {
-    type Item = SourceLocationV9<'data, 'cache>;
+impl<'data, 'cache> Iterator for SourceLocations<'data, 'cache> {
+    type Item = SourceLocation<'data, 'cache>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.source_location_idx == u32::MAX {
@@ -133,7 +132,7 @@ impl<'data, 'cache> Iterator for SourceLocationsV9<'data, 'cache> {
             .get(self.source_location_idx as usize)
             .map(|source_location| {
                 self.source_location_idx = source_location.inlined_into_idx;
-                SourceLocationV9 {
+                SourceLocation {
                     cache: self.cache,
                     source_location,
                 }
@@ -141,14 +140,14 @@ impl<'data, 'cache> Iterator for SourceLocationsV9<'data, 'cache> {
     }
 }
 
-/// Iterator returned by [`SymCacheV9::functions`]; see documentation there.
+/// Iterator returned by [`SymCache::functions`]; see documentation there.
 #[derive(Debug, Clone)]
-pub(crate) struct FunctionsV9<'data> {
-    cache: SymCacheV9<'data>,
+pub struct Functions<'data> {
+    cache: SymCache<'data>,
     function_idx: u32,
 }
 
-impl<'data> Iterator for FunctionsV9<'data> {
+impl<'data> Iterator for Functions<'data> {
     type Item = Function<'data>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -171,14 +170,14 @@ impl<'data> Iterator for FunctionsV9<'data> {
     }
 }
 
-/// Iterator returned by [`SymCacheV9::files`]; see documentation there.
+/// Iterator returned by [`SymCache::files`]; see documentation there.
 #[derive(Debug, Clone)]
-pub(crate) struct FilesV9<'data> {
-    cache: SymCacheV9<'data>,
+pub struct Files<'data> {
+    cache: SymCache<'data>,
     file_idx: u32,
 }
 
-impl<'data> Iterator for FilesV9<'data> {
+impl<'data> Iterator for Files<'data> {
     type Item = File<'data>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/symbolic-symcache/src/v9/mod.rs
+++ b/symbolic-symcache/src/v9/mod.rs
@@ -1,7 +1,6 @@
-pub(crate) mod lookup;
+pub mod lookup;
+pub mod raw;
 
-// V9 uses its own raw format with revision support.
-use crate::raw::v9 as raw;
 use crate::{ErrorKind, Result};
 
 use symbolic_common::Arch;
@@ -9,16 +8,16 @@ use watto::{Pod, StringTable, align_to};
 
 /// The serialized SymCache V9 binary format.
 #[derive(Clone, PartialEq, Eq)]
-pub(crate) struct SymCacheV9<'data> {
-    pub(crate) header: &'data raw::Header,
-    pub(crate) files: &'data [raw::File],
-    pub(crate) functions: &'data [raw::Function],
-    pub(crate) source_locations: &'data [raw::SourceLocation],
-    pub(crate) ranges: &'data [raw::Range],
-    pub(crate) string_bytes: &'data [u8],
+pub struct SymCache<'data> {
+    pub header: &'data raw::Header,
+    pub files: &'data [raw::File],
+    pub functions: &'data [raw::Function],
+    pub source_locations: &'data [raw::SourceLocation],
+    pub ranges: &'data [raw::Range],
+    pub string_bytes: &'data [u8],
 }
 
-impl std::fmt::Debug for SymCacheV9<'_> {
+impl std::fmt::Debug for SymCache<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SymCache")
             .field("version", &9)
@@ -33,7 +32,7 @@ impl std::fmt::Debug for SymCacheV9<'_> {
     }
 }
 
-impl<'data> SymCacheV9<'data> {
+impl<'data> SymCache<'data> {
     pub fn parse(buf: &'data [u8]) -> Result<Self> {
         let (header, rest) = raw::Header::ref_from_prefix(buf).ok_or(ErrorKind::InvalidHeader)?;
 

--- a/symbolic-symcache/src/v9/raw.rs
+++ b/symbolic-symcache/src/v9/raw.rs
@@ -1,6 +1,7 @@
 //! The raw SymCache V9 binary file format internals.
 //!
 //! V9 adds source server information support to the File structure.
+
 use watto::Pod;
 
 use symbolic_common::DebugId;
@@ -8,7 +9,7 @@ use symbolic_common::DebugId;
 /// This [`SourceLocation`] is a sentinel value that says that no source location is present here.
 /// This is used to push an "end" range that does not resolve to a valid source location.
 /// Otherwise, the ranges would implicitly extend to infinity.
-pub(crate) const NO_SOURCE_LOCATION: SourceLocation = SourceLocation {
+pub const NO_SOURCE_LOCATION: SourceLocation = SourceLocation {
     file_idx: u32::MAX,
     line: u32::MAX,
     function_idx: u32::MAX,
@@ -18,69 +19,69 @@ pub(crate) const NO_SOURCE_LOCATION: SourceLocation = SourceLocation {
 /// The header of a symcache file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[repr(C)]
-pub(crate) struct Header {
+pub struct Header {
     /// Debug identifier of the object file.
-    pub(crate) debug_id: DebugId,
+    pub debug_id: DebugId,
     /// CPU architecture of the object file.
     ///
     /// This cannot be [`symbolic_common::Arch`] because
     /// not every bit pattern is valid for that type.
-    pub(crate) arch: u32,
+    pub arch: u32,
     /// Number of included [`File`]s.
-    pub(crate) num_files: u32,
+    pub num_files: u32,
     /// Number of included [`Function`]s.
-    pub(crate) num_functions: u32,
+    pub num_functions: u32,
     /// Number of included [`SourceLocation`]s.
-    pub(crate) num_source_locations: u32,
+    pub num_source_locations: u32,
     /// Number of included [`Range`]s.
-    pub(crate) num_ranges: u32,
+    pub num_ranges: u32,
     /// Total number of bytes used for string data.
-    pub(crate) string_bytes: u32,
+    pub string_bytes: u32,
 
     /// Some reserved space in the header for future extensions that would not require a
     /// completely new parsing method.
-    pub(crate) _reserved: [u8; 16],
+    pub _reserved: [u8; 16],
 }
 
 /// Serialized Function metadata in the SymCache.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[repr(C)]
-pub(crate) struct Function {
+pub struct Function {
     /// The functions name (reference to a [`String`]).
-    pub(crate) name_offset: u32,
+    pub name_offset: u32,
     /// The compilation directory (reference to a [`String`]).
     ///
     /// This is retained for binary compatibility; all path information
     /// is contained in [`File`].
-    pub(crate) _comp_dir_offset: u32,
+    pub _comp_dir_offset: u32,
     /// The first address covered by this function.
-    pub(crate) entry_pc: u32,
+    pub entry_pc: u32,
     /// The language of the function.
-    pub(crate) lang: u32,
+    pub lang: u32,
 }
 
 /// Serialized File in the SymCache (V9 format with revision support).
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[repr(C)]
-pub(crate) struct File {
+pub struct File {
     /// The optional compilation directory prefix (reference to a [`String`]).
-    pub(crate) comp_dir_offset: u32,
+    pub comp_dir_offset: u32,
     /// The optional directory prefix (reference to a [`String`]).
-    pub(crate) directory_offset: u32,
+    pub directory_offset: u32,
     /// The file path (reference to a [`String`]).
-    pub(crate) name_offset: u32,
+    pub name_offset: u32,
     /// The optional base name on the source server (reference to a [`String`]).
     ///
     /// This field was added in version 9.
-    pub(crate) srcsrv_name_offset: u32,
+    pub srcsrv_name_offset: u32,
     /// The optional path to the file on the source server (reference to a [`String`]).
     ///
     /// This field was added in version 9.
-    pub(crate) srcsrv_dir_offset: u32,
+    pub srcsrv_dir_offset: u32,
     /// The optional VCS revision (reference to a [`String`]).
     ///
     /// This field was added in version 9.
-    pub(crate) srcsrv_revision_offset: u32,
+    pub srcsrv_revision_offset: u32,
 }
 
 /// A location in a source file, comprising a file, a line, a function, and
@@ -92,16 +93,16 @@ pub(crate) struct File {
 /// but have different inline information.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 #[repr(C)]
-pub(crate) struct SourceLocation {
+pub struct SourceLocation {
     /// The optional source file (reference to a [`File`]).
-    pub(crate) file_idx: u32,
+    pub file_idx: u32,
     /// The line number.
-    pub(crate) line: u32,
+    pub line: u32,
     /// The function (reference to a [`Function`]).
-    pub(crate) function_idx: u32,
+    pub function_idx: u32,
     /// The caller source location in case this location was inlined
     /// (reference to another [`SourceLocation`]).
-    pub(crate) inlined_into_idx: u32,
+    pub inlined_into_idx: u32,
 }
 
 /// A representation of a code range in the SymCache.
@@ -110,7 +111,7 @@ pub(crate) struct SourceLocation {
 /// by the next range's start.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[repr(C)]
-pub(crate) struct Range(pub(crate) u32);
+pub struct Range(pub u32);
 
 unsafe impl Pod for Header {}
 unsafe impl Pod for Function {}

--- a/symbolic-symcache/src/writer.rs
+++ b/symbolic-symcache/src/writer.rs
@@ -9,7 +9,7 @@ use symbolic_common::{Arch, DebugId};
 use symbolic_debuginfo::{DebugSession, FileFormat, Function, ObjectLike, Symbol};
 use watto::{Pod, StringTable, Writer};
 
-use crate::raw::v9::NO_SOURCE_LOCATION;
+use crate::v9;
 use crate::{Error, ErrorKind};
 use crate::{raw, transform};
 
@@ -32,18 +32,18 @@ pub struct SymCacheConverter<'a> {
     transformers: transform::Transformers<'a>,
 
     string_table: StringTable,
-    /// The set of all [`raw::v9::File`]s that have been added to this `Converter`.
-    files: IndexSet<raw::v9::File>,
-    /// The set of all [`raw::v9::Function`]s that have been added to this `Converter`.
-    functions: IndexSet<raw::v9::Function>,
-    /// The set of [`raw::v9::SourceLocation`]s used in this `Converter` that are only used as
+    /// The set of all [`v9::raw::File`]s that have been added to this `Converter`.
+    files: IndexSet<v9::raw::File>,
+    /// The set of all [`v9::raw::Function`]s that have been added to this `Converter`.
+    functions: IndexSet<v9::raw::Function>,
+    /// The set of [`v9::raw::SourceLocation`]s used in this `Converter` that are only used as
     /// "call locations", i.e. which are only referred to from `inlined_into_idx`.
-    call_locations: IndexSet<raw::v9::SourceLocation>,
-    /// A map from code ranges to the [`raw::v9::SourceLocation`]s they correspond to.
+    call_locations: IndexSet<v9::raw::SourceLocation>,
+    /// A map from code ranges to the [`v9::raw::SourceLocation`]s they correspond to.
     ///
     /// Only the starting address of a range is saved, the end address is given implicitly
     /// by the start address of the next range.
-    ranges: BTreeMap<u32, raw::v9::SourceLocation>,
+    ranges: BTreeMap<u32, v9::raw::SourceLocation>,
 
     /// This is highest addr that we know is outside of a valid function.
     /// Functions have an explicit end, while Symbols implicitly extend to infinity.
@@ -160,7 +160,7 @@ impl<'a> SymCacheConverter<'a> {
             let name_offset = string_table.insert(function_name) as u32;
 
             let lang = language as u32;
-            let (fun_idx, _) = self.functions.insert_full(raw::v9::Function {
+            let (fun_idx, _) = self.functions.insert_full(v9::raw::Function {
                 name_offset,
                 _comp_dir_offset: u32::MAX,
                 entry_pc,
@@ -260,7 +260,7 @@ impl<'a> SymCacheConverter<'a> {
                 .srcsrv_revision
                 .map_or(u32::MAX, |r| string_table.insert(&r) as u32);
 
-            let (file_idx, _) = self.files.insert_full(raw::v9::File {
+            let (file_idx, _) = self.files.insert_full(v9::raw::File {
                 name_offset,
                 directory_offset,
                 comp_dir_offset,
@@ -269,7 +269,7 @@ impl<'a> SymCacheConverter<'a> {
                 srcsrv_revision_offset,
             });
 
-            let source_location = raw::v9::SourceLocation {
+            let source_location = v9::raw::SourceLocation {
                 file_idx: file_idx as u32,
                 line: location.line,
                 function_idx,
@@ -371,7 +371,7 @@ impl<'a> SymCacheConverter<'a> {
 
         if !function.inline {
             // add the bare minimum of information for the function if there isn't any.
-            insert_source_location(&mut self.ranges, entry_pc, || raw::v9::SourceLocation {
+            insert_source_location(&mut self.ranges, entry_pc, || v9::raw::SourceLocation {
                 file_idx: u32::MAX,
                 line: 0,
                 function_idx,
@@ -404,7 +404,7 @@ impl<'a> SymCacheConverter<'a> {
         // If the next function starts right at this function's end, that's no trouble,
         // it will just overwrite this mapping with one of its ranges.
         if let btree_map::Entry::Vacant(vacant_entry) = self.ranges.entry(function_end) {
-            vacant_entry.insert(NO_SOURCE_LOCATION);
+            vacant_entry.insert(v9::raw::NO_SOURCE_LOCATION);
         }
     }
 
@@ -434,7 +434,7 @@ impl<'a> SymCacheConverter<'a> {
         // Insert a source location for the symbol, overwriting `NO_SOURCE_LOCATION` sentinel
         // values but not actual source locations coming from e.g. functions.
         insert_source_location(&mut self.ranges, symbol.address as u32, || {
-            let function = raw::v9::Function {
+            let function = v9::raw::Function {
                 name_offset: name_idx,
                 _comp_dir_offset: u32::MAX,
                 entry_pc: symbol.address as u32,
@@ -442,7 +442,7 @@ impl<'a> SymCacheConverter<'a> {
             };
             let function_idx = self.functions.insert_full(function).0 as u32;
 
-            raw::v9::SourceLocation {
+            v9::raw::SourceLocation {
                 file_idx: u32::MAX,
                 line: 0,
                 function_idx,
@@ -467,7 +467,7 @@ impl<'a> SymCacheConverter<'a> {
         if symbol.size > 0 {
             let end_address = (symbol.address + symbol.size) as u32;
             if let btree_map::Entry::Vacant(vacant_entry) = self.ranges.entry(end_address) {
-                vacant_entry.insert(NO_SOURCE_LOCATION);
+                vacant_entry.insert(v9::raw::NO_SOURCE_LOCATION);
             }
         }
     }
@@ -487,7 +487,7 @@ impl<'a> SymCacheConverter<'a> {
             // the largest range at some point.
             match self.ranges.entry(last_addr) {
                 btree_map::Entry::Vacant(entry) => {
-                    entry.insert(NO_SOURCE_LOCATION);
+                    entry.insert(v9::raw::NO_SOURCE_LOCATION);
                 }
                 btree_map::Entry::Occupied(_entry) => {
                     // BUG:
@@ -510,7 +510,7 @@ impl<'a> SymCacheConverter<'a> {
         writer.write_all(version_info.as_bytes())?;
 
         // Write v9 Header
-        let header = raw::v9::Header {
+        let header = v9::raw::Header {
             debug_id: self.debug_id,
             arch: self.arch as u32,
             num_files,
@@ -561,16 +561,16 @@ impl<'a> SymCacheConverter<'a> {
 /// starting at that same address, we want to evict that sentinel, but we wouldn't want to
 /// evict source locations carrying actual information.
 fn insert_source_location<K, F>(
-    source_locations: &mut BTreeMap<K, raw::v9::SourceLocation>,
+    source_locations: &mut BTreeMap<K, v9::raw::SourceLocation>,
     key: K,
     val: F,
 ) where
     K: Ord,
-    F: FnOnce() -> raw::v9::SourceLocation,
+    F: FnOnce() -> v9::raw::SourceLocation,
 {
     if source_locations
         .get(&key)
-        .is_none_or(|sl| *sl == NO_SOURCE_LOCATION)
+        .is_none_or(|sl| *sl == v9::raw::NO_SOURCE_LOCATION)
     {
         source_locations.insert(key, val());
     }


### PR DESCRIPTION
Instead of having version files split across two top level modules `raw/{version}.rs` and `{version}/lookup.rs`, raw is also now moved into the top level `{version}` module.

Also:
- Changes some visibility qualifiers from `pub(crate)` to either `pub` or private.
- Implements a macro to more easily manage different symcache versions.
- Instead of referring to names as `FooV9` it uses a fully qualified lookup `v9::Foo`