### PR TITLE
feat(variables): Write variables to symcaches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 **Features**
 
+- Adds variable information to symcaches. ([#1036](https://github.com/getsentry/symbolic/pull/1036))
 - Implements variables at a frame offset. ([#1026](https://github.com/getsentry/symbolic/pull/1026))
 - Implement resolution for primitive and pointer type references contained in variables. ([#1032](https://github.com/getsentry/symbolic/pull/1032))
 

--- a/examples/symcache_debug/src/main.rs
+++ b/examples/symcache_debug/src/main.rs
@@ -75,6 +75,7 @@ fn execute(matches: &ArgMatches) -> Result<()> {
             .transpose()?;
 
         let mut converter = SymCacheConverter::new();
+        converter.set_collect_variables(true);
 
         if let Some(bcsymbolmap) = bcsymbolmap_transformer {
             converter.add_transformer(bcsymbolmap);

--- a/symbolic-symcache/src/error.rs
+++ b/symbolic-symcache/src/error.rs
@@ -58,6 +58,24 @@ pub enum ErrorKind {
         /// Number of string bytes actually found in the cache file.
         found: usize,
     },
+    /// The variable header could not be parsed from the cache file.
+    #[error("could not read variable header")]
+    InvalidVariableHeader,
+    /// Function variables could not be parsed from the cache file.
+    #[error("could not read function variables")]
+    InvalidFunctionVariables,
+    /// Variables could not be parsed from the cache file.
+    #[error("could not read variables")]
+    InvalidVariables,
+    /// Variable locations could not be parsed from the cache file.
+    #[error("could not read variable locations")]
+    InvalidVariableLocations,
+    /// Types could not be parsed from the cache file.
+    #[error("could not read types")]
+    InvalidTypes,
+    /// The cache contains unexpected trailing data and is therefor considered invalid.
+    #[error("the cache contains trailing data")]
+    TrailingData,
 }
 
 /// An error returned when handling a [`SymCache`](crate::SymCache).

--- a/symbolic-symcache/src/lib.rs
+++ b/symbolic-symcache/src/lib.rs
@@ -13,6 +13,11 @@
 //! 3. Source Locations
 //! 4. Address Ranges
 //! 5. String Data
+//! 6. Variable Header
+//! 7. Function Variables
+//! 8. Variables
+//! 9. Variable Locations
+//! 10. Types
 //!
 //! The format uses `u32`s to represent line numbers, addresses, references, and string offsets.
 //! Line numbers use `0` to represent an unknown or invalid value. Addresses, references, and string
@@ -110,9 +115,7 @@ pub mod transform;
 mod v9;
 mod writer;
 
-use symbolic_common::Arch;
-use symbolic_common::AsSelf;
-use symbolic_common::DebugId;
+use symbolic_common::{Arch, AsSelf, DebugId};
 use watto::Pod;
 
 pub use error::{Error, ErrorKind};

--- a/symbolic-symcache/src/v9/mod.rs
+++ b/symbolic-symcache/src/v9/mod.rs
@@ -15,20 +15,32 @@ pub struct SymCache<'data> {
     pub source_locations: &'data [raw::SourceLocation],
     pub ranges: &'data [raw::Range],
     pub string_bytes: &'data [u8],
+    pub variable_header: Option<&'data raw::VariableHeader>,
+    pub function_variables: &'data [raw::FunctionVariables],
+    pub variables: &'data [raw::Variable],
+    pub variable_locations: &'data [raw::VariableLocation],
+    pub types: &'data [raw::Type],
 }
 
 impl std::fmt::Debug for SymCache<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SymCache")
-            .field("version", &9)
+        let mut d = f.debug_struct("SymCache");
+        d.field("version", &9)
             .field("debug_id", &self.header.debug_id)
             .field("arch", &Arch::from_u32(self.header.arch))
             .field("files", &self.header.num_files)
             .field("functions", &self.header.num_functions)
             .field("source_locations", &self.header.num_source_locations)
             .field("ranges", &self.header.num_ranges)
-            .field("string_bytes", &self.header.string_bytes)
-            .finish()
+            .field("string_bytes", &self.header.string_bytes);
+
+        if let Some(vh) = self.variable_header {
+            d.field("variables", &vh.num_variables)
+                .field("variable_locations", &vh.num_variable_locations)
+                .field("types", &vh.num_types);
+        }
+
+        d.finish()
     }
 }
 
@@ -58,12 +70,47 @@ impl<'data> SymCache<'data> {
             expected: header.string_bytes as usize,
             found: 0,
         })?;
-        if rest.len() < header.string_bytes as usize {
-            return Err(ErrorKind::UnexpectedStringBytes {
+
+        let (string_bytes, rest) = rest.split_at_checked(header.string_bytes as usize).ok_or(
+            ErrorKind::UnexpectedStringBytes {
                 expected: header.string_bytes as usize,
                 found: rest.len(),
-            }
-            .into());
+            },
+        )?;
+
+        let mut variable_header = None;
+        let mut function_variables = &[][..];
+        let mut variables = &[][..];
+        let mut variable_locations = &[][..];
+        let mut types = &[][..];
+
+        if header.variable_header == raw::VARIABLE_HEADER_VERSION {
+            let (_, rest) = align_to(rest, 8).ok_or(ErrorKind::InvalidVariableHeader)?;
+            let (vh, rest) = raw::VariableHeader::ref_from_prefix(rest)
+                .ok_or(ErrorKind::InvalidVariableHeader)?;
+            variable_header = Some(vh);
+
+            let (_, rest) = align_to(rest, 8).ok_or(ErrorKind::InvalidFunctionVariables)?;
+            let (fv, rest) =
+                raw::FunctionVariables::slice_from_prefix(rest, header.num_functions as usize)
+                    .ok_or(ErrorKind::InvalidFunctionVariables)?;
+            function_variables = fv;
+
+            let (_, rest) = align_to(rest, 8).ok_or(ErrorKind::InvalidVariables)?;
+            let (vars, rest) = raw::Variable::slice_from_prefix(rest, vh.num_variables as usize)
+                .ok_or(ErrorKind::InvalidVariables)?;
+            variables = vars;
+
+            let (_, rest) = align_to(rest, 8).ok_or(ErrorKind::InvalidVariableLocations)?;
+            let (vl, rest) =
+                raw::VariableLocation::slice_from_prefix(rest, vh.num_variable_locations as usize)
+                    .ok_or(ErrorKind::InvalidVariableLocations)?;
+            variable_locations = vl;
+
+            let (_, rest) = align_to(rest, 8).ok_or(ErrorKind::InvalidTypes)?;
+            let (tys, _) = raw::Type::slice_from_prefix(rest, vh.num_types as usize)
+                .ok_or(ErrorKind::InvalidTypes)?;
+            types = tys;
         }
 
         Ok(Self {
@@ -72,7 +119,12 @@ impl<'data> SymCache<'data> {
             functions,
             source_locations,
             ranges,
-            string_bytes: rest,
+            string_bytes,
+            variable_header,
+            function_variables,
+            variables,
+            variable_locations,
+            types,
         })
     }
 

--- a/symbolic-symcache/src/v9/raw.rs
+++ b/symbolic-symcache/src/v9/raw.rs
@@ -2,9 +2,22 @@
 //!
 //! V9 adds source server information support to the File structure.
 
+use core::fmt;
+
 use watto::Pod;
 
 use symbolic_common::DebugId;
+
+/// The current [`Header::variable_header`] version.
+///
+/// On a version mismatch, the sections referenced in the [`VariableHeader`] must not be parsed.
+pub const VARIABLE_HEADER_VERSION: u16 = 1;
+
+/// This [`FunctionVariables`] is a sentinel for functions without variables.
+pub const NO_VARIABLES: FunctionVariables = FunctionVariables {
+    variable_idx: u32::MAX,
+    num_variables: 0,
+};
 
 /// This [`SourceLocation`] is a sentinel value that says that no source location is present here.
 /// This is used to push an "end" range that does not resolve to a valid source location.
@@ -38,9 +51,30 @@ pub struct Header {
     /// Total number of bytes used for string data.
     pub string_bytes: u32,
 
+    /// Version of the optional [`VariableHeader`].
+    ///
+    /// The version is `0` there is no variable header. This allows incompatible changes
+    /// to variable and type information in a symcache without requiring a new symcache version.
+    ///
+    /// Once the format is stable, the variable header will no longer be optional in symcache
+    /// version 10.
+    pub variable_header: u16,
+
     /// Some reserved space in the header for future extensions that would not require a
     /// completely new parsing method.
-    pub _reserved: [u8; 16],
+    pub _reserved: [u8; 14],
+}
+
+/// Optional header appended to the [`Header`] if the symcache contains variable information.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(C)]
+pub struct VariableHeader {
+    /// Number of included [`Variable`]'s.
+    pub num_variables: u32,
+    /// Number of included [`VariableLocation`]'s.
+    pub num_variable_locations: u32,
+    /// Number of included [`Type`]'s.
+    pub num_types: u32,
 }
 
 /// Serialized Function metadata in the SymCache.
@@ -58,6 +92,19 @@ pub struct Function {
     pub entry_pc: u32,
     /// The language of the function.
     pub lang: u32,
+}
+
+/// Function variable metadata stored in a separate section.
+///
+/// An index into [`Function`]'s can also be used to lookup function variable information from this
+/// section.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[repr(C)]
+pub struct FunctionVariables {
+    /// The variable index of the first variable.
+    pub variable_idx: u32,
+    /// The amount of variables associated with the function.
+    pub num_variables: u32,
 }
 
 /// Serialized File in the SymCache (V9 format with revision support).
@@ -113,11 +160,181 @@ pub struct SourceLocation {
 #[repr(C)]
 pub struct Range(pub u32);
 
+/// A representation of a variable.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[repr(C)]
+pub struct Variable {
+    /// The variable name (reference to a [`String`]).
+    pub name_offset: u32,
+    /// The type (reference to a [`Type`]).
+    pub type_idx: u32,
+    /// The first location associated with the variable (reference to a [`VariableLocation`]).
+    pub location_idx: u32,
+    /// The amount of locations.
+    pub num_locations: u32,
+    /// The inlined depth of the owning function.
+    ///
+    /// If `0` the variable belongs to the outermost function. This is essentially a way to track
+    /// scopes, limited to function scopes. Each level of depth is a newly nested scope.
+    ///
+    /// The depth can be recovered by tracing [`SourceLocation::inlined_into_idx`] entries.
+    pub depth: u8,
+    /// The variable kind.
+    pub kind: u8,
+    pub _reserved: [u8; 2],
+}
+
+/// A representation of a variable location.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[repr(C)]
+pub struct VariableLocation {
+    /// First instruction address (pc) where this location is valid.
+    pub start: u32,
+    /// Size of the location, indicating the last instruction address where this location is valid.
+    pub size: u32,
+    /// The location data.
+    ///
+    /// Carries different meaning based on [`Self::kind`].
+    pub data: i32,
+    /// The location kind.
+    pub kind: u8,
+    pub _reserved: [u8; 3],
+}
+
+/// A representation of a type.
+#[derive(Clone)]
+#[repr(C)]
+pub struct Type {
+    /// The concrete type.
+    pub ty: TypeImpl,
+    /// Discriminator for [`Self::ty`].
+    pub kind: u8,
+    pub _reserved: [u8; 3],
+}
+
+impl From<PrimitiveType> for Type {
+    fn from(primitive: PrimitiveType) -> Self {
+        Self {
+            kind: 0,
+            ty: TypeImpl { primitive },
+            _reserved: [0; _],
+        }
+    }
+}
+
+impl From<PointerType> for Type {
+    fn from(pointer: PointerType) -> Self {
+        Self {
+            kind: 1,
+            ty: TypeImpl { pointer },
+            _reserved: [0; _],
+        }
+    }
+}
+
+impl fmt::Debug for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            0 => unsafe { &self.ty.primitive }.fmt(f),
+            1 => unsafe { &self.ty.pointer }.fmt(f),
+            k => write!(f, "<invalid type {k}>"),
+        }
+    }
+}
+
+impl PartialEq for Type {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            kind,
+            ty,
+            _reserved,
+        } = other;
+
+        if self.kind != *kind {
+            return false;
+        }
+
+        match self.kind {
+            0 => unsafe { self.ty.primitive == ty.primitive },
+            1 => unsafe { self.ty.pointer == ty.pointer },
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Type {}
+
+impl std::hash::Hash for Type {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.kind.hash(state);
+        match self.kind {
+            0 => unsafe { self.ty.primitive.hash(state) },
+            1 => unsafe { self.ty.pointer.hash(state) },
+            _ => {}
+        }
+    }
+}
+
+/// Any possible type.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union TypeImpl {
+    /// A primitive type.
+    pub primitive: PrimitiveType,
+    /// A pointer type.
+    pub pointer: PointerType,
+}
+
+// For the [`TypeImpl`] union to be a safe `pod`, all of its members must be pods and the same size.
+// Any bit representation of the union must be valid and initialized in all other variants.
+const _: () = {
+    const SIZE: usize = 12;
+    assert!(std::mem::size_of::<TypeImpl>() == SIZE);
+    assert!(std::mem::size_of::<PrimitiveType>() == SIZE);
+    assert!(std::mem::size_of::<PointerType>() == SIZE);
+
+    assert!(std::mem::align_of::<TypeImpl>() == 4);
+};
+
+/// A representation of a primitive type.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[repr(C)]
+pub struct PrimitiveType {
+    /// The type name (reference to a [`String`]).
+    pub name_offset: u32,
+    /// The size of the type in memory.
+    pub size: u32,
+    /// The encoding of the type.
+    pub encoding: u8,
+    /// Padding.
+    pub _reserved: [u8; 3],
+}
+
+/// A representation of a pointer type.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[repr(C)]
+pub struct PointerType {
+    /// The type this pointer points to (reference to a [`Type`]).
+    pub pointee_idx: u32,
+    /// The size/width of the pointer.
+    pub size: u32,
+    /// Padding.
+    pub _reserved: [u8; 4],
+}
+
 unsafe impl Pod for Header {}
+unsafe impl Pod for VariableHeader {}
 unsafe impl Pod for Function {}
+unsafe impl Pod for FunctionVariables {}
 unsafe impl Pod for File {}
 unsafe impl Pod for SourceLocation {}
 unsafe impl Pod for Range {}
+unsafe impl Pod for Variable {}
+unsafe impl Pod for VariableLocation {}
+unsafe impl Pod for Type {}
+unsafe impl Pod for TypeImpl {}
+unsafe impl Pod for PrimitiveType {}
+unsafe impl Pod for PointerType {}
 
 #[cfg(test)]
 mod tests {
@@ -142,6 +359,21 @@ mod tests {
 
         assert_eq!(mem::size_of::<Range>(), 4);
         assert_eq!(mem::align_of::<Range>(), 4);
+
+        assert_eq!(mem::size_of::<FunctionVariables>(), 8);
+        assert_eq!(mem::align_of::<FunctionVariables>(), 4);
+
+        assert_eq!(mem::size_of::<VariableHeader>(), 12);
+        assert_eq!(mem::align_of::<VariableHeader>(), 4);
+
+        assert_eq!(mem::size_of::<Variable>(), 20);
+        assert_eq!(mem::align_of::<Variable>(), 4);
+
+        assert_eq!(mem::size_of::<VariableLocation>(), 16);
+        assert_eq!(mem::align_of::<VariableLocation>(), 4);
+
+        assert_eq!(mem::size_of::<Type>(), 16);
+        assert_eq!(mem::align_of::<Type>(), 4);
     }
 
     #[test]

--- a/symbolic-symcache/src/v9/raw.rs
+++ b/symbolic-symcache/src/v9/raw.rs
@@ -53,7 +53,7 @@ pub struct Header {
 
     /// Version of the optional [`VariableHeader`].
     ///
-    /// The version is `0` there is no variable header. This allows incompatible changes
+    /// If the version is `0` there is no variable header. This allows incompatible changes
     /// to variable and type information in a symcache without requiring a new symcache version.
     ///
     /// Once the format is stable, the variable header will no longer be optional in symcache
@@ -177,7 +177,11 @@ pub struct Variable {
     /// If `0` the variable belongs to the outermost function. This is essentially a way to track
     /// scopes, limited to function scopes. Each level of depth is a newly nested scope.
     ///
-    /// The depth can be recovered by tracing [`SourceLocation::inlined_into_idx`] entries.
+    /// To recover which variables belong to a [`SourceLocation`], the depth of the source location
+    /// must first be computed by following [`SourceLocation::inlined_into_idx`], each step increases
+    /// the depth by one.
+    /// Knowing the depth and the outermost function, the list of variables can then be filtered down
+    /// to only variables at this depth.
     pub depth: u8,
     /// The variable kind.
     pub kind: u8,
@@ -190,7 +194,7 @@ pub struct Variable {
 pub struct VariableLocation {
     /// First instruction address (pc) where this location is valid.
     pub start: u32,
-    /// Size of the location, indicating the last instruction address where this location is valid.
+    /// Size of the location, indicating the first instruction address where this location is no longer valid.
     pub size: u32,
     /// The location data.
     ///

--- a/symbolic-symcache/src/v9/raw.rs
+++ b/symbolic-symcache/src/v9/raw.rs
@@ -2,7 +2,7 @@
 //!
 //! V9 adds source server information support to the File structure.
 
-use core::fmt;
+use std::fmt;
 
 use watto::Pod;
 

--- a/symbolic-symcache/src/writer.rs
+++ b/symbolic-symcache/src/writer.rs
@@ -6,7 +6,9 @@ use std::io::Write;
 
 use indexmap::IndexSet;
 use symbolic_common::{Arch, DebugId};
-use symbolic_debuginfo::{DebugSession, FileFormat, Function, ObjectLike, Symbol};
+use symbolic_debuginfo::{
+    self as di, DebugSession, FileFormat, Function, ObjectLike, Symbol, TypeRef,
+};
 use watto::{Pod, StringTable, Writer};
 
 use crate::v9;
@@ -28,6 +30,9 @@ pub struct SymCacheConverter<'a> {
     /// will inform us if we should undecorate function names.
     is_windows_object: bool,
 
+    /// A flag whether variable information from functions should be embedded into the symcache.
+    collect_variables: bool,
+
     /// A list of transformers that are used to transform each function / source location.
     transformers: transform::Transformers<'a>,
 
@@ -44,6 +49,18 @@ pub struct SymCacheConverter<'a> {
     /// Only the starting address of a range is saved, the end address is given implicitly
     /// by the start address of the next range.
     ranges: BTreeMap<u32, v9::raw::SourceLocation>,
+
+    /// The set of variables tied to a function.
+    ///
+    /// This is keyed with the function id and contains a list of variables associated with that function,
+    /// importantly the variables from inlined functions are attributed to their base function.
+    function_variables: BTreeMap<u32, Vec<v9::raw::Variable>>,
+    /// A list of all variable locations.
+    ///
+    /// Variable locations are stored in continous chunks per variable.
+    variable_locations: Vec<v9::raw::VariableLocation>,
+    /// The set of all types referenced from variables.
+    types: IndexSet<v9::raw::Type>,
 
     /// This is highest addr that we know is outside of a valid function.
     /// Functions have an explicit end, while Symbols implicitly extend to infinity.
@@ -79,6 +96,11 @@ impl<'a> SymCacheConverter<'a> {
         self.debug_id = debug_id;
     }
 
+    /// Sets whether the symcache should store function variable information.
+    pub fn set_collect_variables(&mut self, variables: bool) {
+        self.collect_variables = variables;
+    }
+
     // Methods processing symbolic-debuginfo [`ObjectLike`] below:
     // Feel free to move these to a separate file.
 
@@ -102,7 +124,7 @@ impl<'a> SymCacheConverter<'a> {
         for function in session.functions() {
             let function = function.map_err(|e| Error::new(ErrorKind::BadDebugFile, e))?;
 
-            self.process_symbolic_function(&function);
+            self.process_symbolic_function_recursive(&session, &function, &[(0x0, u32::MAX)], 0, 0);
         }
 
         for symbol in object.symbols() {
@@ -116,7 +138,13 @@ impl<'a> SymCacheConverter<'a> {
 
     /// Processes an individual [`Function`], adding its line information to the converter.
     pub fn process_symbolic_function(&mut self, function: &Function<'_>) {
-        self.process_symbolic_function_recursive(function, &[(0x0, u32::MAX)]);
+        self.process_symbolic_function_recursive(
+            &NoopTypeResolver,
+            function,
+            &[(0x0, u32::MAX)],
+            0,
+            0,
+        );
     }
 
     /// Processes an individual [`Function`], adding its line information to the converter.
@@ -124,10 +152,12 @@ impl<'a> SymCacheConverter<'a> {
     /// `call_locations` is a non-empty sorted list of `(address, call_location index)` pairs.
     fn process_symbolic_function_recursive(
         &mut self,
+        tr: &dyn TypeResolver,
         function: &Function<'_>,
         call_locations: &[(u32, u32)],
+        base_idx: u32,
+        fn_depth: u16,
     ) {
-        let string_table = &mut self.string_table;
         // skip over empty functions or functions whose address is too large to fit in a u32
         if function.size == 0 || function.address > u32::MAX as u64 {
             return;
@@ -157,7 +187,7 @@ impl<'a> SymCacheConverter<'a> {
                 &function.name
             };
 
-            let name_offset = string_table.insert(function_name) as u32;
+            let name_offset = self.string_table.insert(function_name) as u32;
 
             let lang = language as u32;
             let (fun_idx, _) = self.functions.insert_full(v9::raw::Function {
@@ -168,6 +198,16 @@ impl<'a> SymCacheConverter<'a> {
             });
             fun_idx as u32
         };
+
+        let base_idx = match fn_depth {
+            // If the depth is zero, the current function is a 'base' function,
+            // it has not been inlined into another function.
+            0 => function_idx,
+            // If the depth is non-zero, it means were are N levels deep in resolving
+            // inlinees. So keep the existing base.
+            _ => base_idx,
+        };
+        self.process_symbolic_variables(tr, function, base_idx, fn_depth);
 
         // We can divide the instructions in a function into two buckets:
         //  (1) Instructions which are part of an inlined function call, and
@@ -210,6 +250,8 @@ impl<'a> SymCacheConverter<'a> {
         // This will be the list we pass to our inlinees as the call_locations argument.
         // This list is ordered by address by construction.
         let mut callee_call_locations = Vec::new();
+
+        let string_table = &mut self.string_table;
 
         // Iterate over the line records.
         while let Some(line) = next_line.take() {
@@ -384,7 +426,13 @@ impl<'a> SymCacheConverter<'a> {
         // Process our inlinees.
         if !callee_call_locations.is_empty() {
             for inlinee in &function.inlinees {
-                self.process_symbolic_function_recursive(inlinee, &callee_call_locations);
+                self.process_symbolic_function_recursive(
+                    tr,
+                    inlinee,
+                    &callee_call_locations,
+                    base_idx,
+                    fn_depth + 1,
+                );
             }
         }
 
@@ -406,6 +454,114 @@ impl<'a> SymCacheConverter<'a> {
         if let btree_map::Entry::Vacant(vacant_entry) = self.ranges.entry(function_end) {
             vacant_entry.insert(v9::raw::NO_SOURCE_LOCATION);
         }
+    }
+
+    /// Collects all variables from a [`Function`].
+    ///
+    /// This takes the current `function`, which may have been inlined into an `outer` function.
+    /// If the passed function is not inlined, then `base_idx` must point to the index of `function`
+    /// and depth is `0`.
+    fn process_symbolic_variables(
+        &mut self,
+        tr: &dyn TypeResolver,
+        function: &Function<'_>,
+        base_idx: u32,
+        fn_depth: u16,
+    ) {
+        if !self.collect_variables || fn_depth > u8::MAX.into() {
+            return;
+        }
+
+        for variable in &function.variables {
+            let location_idx = self.variable_locations.len();
+            for location in &variable.locations {
+                // If the end address fits into a `u32` its components also fit.
+                if location
+                    .address
+                    .checked_add(location.size)
+                    .is_none_or(|v| v > u32::MAX as u64)
+                {
+                    continue;
+                }
+
+                let (kind, data) = match location.location {
+                    di::Location::Register { id } => (0, id.into()),
+                    di::Location::FrameOffset { offset } => (1, offset as i32),
+                };
+
+                self.variable_locations.push(v9::raw::VariableLocation {
+                    start: location.address as u32,
+                    size: location.size as u32,
+                    kind,
+                    data,
+                    _reserved: [0; _],
+                });
+            }
+
+            let num_locations = self.variable_locations.len() - location_idx;
+            if num_locations == 0 {
+                // No locations, no need to keep the variable around.
+                continue;
+            }
+
+            // Locations must already be sorted, this is an invariant on the `Function`.
+            debug_assert!(self.variable_locations[location_idx..].is_sorted_by_key(|v| v.start));
+
+            let type_idx = match &variable.ty {
+                Some(ty) => self.process_symbolic_type(tr, ty, 0),
+                None => u32::MAX,
+            };
+
+            let name_offset = self.string_table.insert(&variable.name) as u32;
+
+            self.function_variables
+                .entry(base_idx)
+                .or_default()
+                .push(v9::raw::Variable {
+                    name_offset,
+                    type_idx,
+                    location_idx: location_idx as u32,
+                    num_locations: num_locations as u32,
+                    depth: fn_depth as u8,
+                    kind: variable.kind as u8,
+                    _reserved: [0; _],
+                });
+        }
+    }
+
+    fn process_symbolic_type(&mut self, tr: &dyn TypeResolver, ty: &TypeRef, depth: usize) -> u32 {
+        // This really is just a preliminary limit. In the future we need to currently
+        // be able to handle recursive types such as `Foo(Option<Box<Foo>>)`. For the moment
+        // there is only support for primitive types and pointers which shouldn't be recursive.
+        const MAX_DEPTH: usize = 5;
+
+        if depth >= MAX_DEPTH {
+            return u32::MAX;
+        }
+
+        let Some(ty) = tr.lookup_type(ty) else {
+            return u32::MAX;
+        };
+
+        let ty = match ty {
+            symbolic_debuginfo::Type::Primitive(ty) => v9::raw::PrimitiveType {
+                name_offset: ty
+                    .name
+                    .map_or(u32::MAX, |n| self.string_table.insert(&n) as u32),
+                size: size(ty.size),
+                encoding: ty.encoding.map_or(u8::MAX, |e| e as u8),
+                _reserved: [0; _],
+            }
+            .into(),
+            symbolic_debuginfo::Type::Pointer(ty) => v9::raw::PointerType {
+                pointee_idx: self.process_symbolic_type(tr, &ty.pointee, depth + 1),
+                size: size(ty.size),
+                _reserved: [0; _],
+            }
+            .into(),
+        };
+
+        self.types.insert_full(ty).0 as u32
     }
 
     /// Processes an individual [`Symbol`].
@@ -518,36 +674,100 @@ impl<'a> SymCacheConverter<'a> {
             num_source_locations,
             num_ranges,
             string_bytes: string_bytes.len() as u32,
-            _reserved: [0; 16],
+            variable_header: match self.collect_variables {
+                true => v9::raw::VARIABLE_HEADER_VERSION,
+                false => 0,
+            },
+            _reserved: [0; 14],
         };
 
         writer.write_all(header.as_bytes())?;
-        writer.align_to(8)?;
 
+        writer.align_to(8)?;
         for f in self.files {
             writer.write_all(f.as_bytes())?;
         }
-        writer.align_to(8)?;
 
+        writer.align_to(8)?;
         for f in self.functions {
             writer.write_all(f.as_bytes())?;
         }
-        writer.align_to(8)?;
 
+        writer.align_to(8)?;
         for s in self.call_locations {
             writer.write_all(s.as_bytes())?;
         }
         for s in self.ranges.values() {
             writer.write_all(s.as_bytes())?;
         }
-        writer.align_to(8)?;
 
+        writer.align_to(8)?;
         for r in self.ranges.keys() {
             writer.write_all(r.as_bytes())?;
         }
-        writer.align_to(8)?;
 
+        writer.align_to(8)?;
         writer.write_all(&string_bytes)?;
+
+        if !self.collect_variables {
+            return Ok(());
+        }
+
+        let num_variables: u32 = self
+            .function_variables
+            .values()
+            .map(|v| v.len() as u32)
+            .sum();
+
+        writer.align_to(8)?;
+        writer.write_all(
+            v9::raw::VariableHeader {
+                num_variables,
+                num_variable_locations: self.variable_locations.len() as u32,
+                num_types: self.types.len() as u32,
+            }
+            .as_bytes(),
+        )?;
+
+        let function_variables = (0..header.num_functions).scan(0u32, |next_idx, function_idx| {
+            let variables = self
+                .function_variables
+                .get(&function_idx)
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]);
+
+            if variables.is_empty() {
+                return Some(v9::raw::NO_VARIABLES);
+            }
+
+            let res = v9::raw::FunctionVariables {
+                variable_idx: *next_idx,
+                num_variables: variables.len() as u32,
+            };
+            *next_idx += res.num_variables;
+            Some(res)
+        });
+        writer.align_to(8)?;
+        for fv in function_variables {
+            writer.write_all(fv.as_bytes())?;
+        }
+
+        writer.align_to(8)?;
+        for vars in self.function_variables.values() {
+            for v in vars {
+                writer.write_all(v.as_bytes())?;
+            }
+        }
+
+        writer.align_to(8)?;
+        for l in &self.variable_locations {
+            writer.write_all(l.as_bytes())?;
+        }
+
+        writer.align_to(8)?;
+        for t in self.types {
+            writer.write_all(t.as_bytes())?;
+        }
 
         Ok(())
     }
@@ -631,6 +851,38 @@ fn take_if<T>(opt: &mut Option<T>, predicate: impl FnOnce(&mut T) -> bool) -> Op
     if opt.as_mut().is_some_and(predicate) {
         opt.take()
     } else {
+        None
+    }
+}
+
+fn size(s: di::TypeSize) -> u32 {
+    match s {
+        di::TypeSize::Bytes(bytes) => bytes as u32,
+    }
+}
+
+/// A tiny helper which only exposes type information from a debug session.
+///
+/// This makes passing around a debug session much more convenient and also allows
+/// code to deal with no debug session [`NoopTypeResolver`].
+trait TypeResolver {
+    fn lookup_type(&self, ty: &TypeRef) -> Option<di::Type<'_>>;
+}
+
+impl<S> TypeResolver for S
+where
+    S: for<'session> DebugSession<'session>,
+{
+    fn lookup_type(&self, ty: &TypeRef) -> Option<di::Type<'_>> {
+        DebugSession::lookup_type(self, ty).ok().flatten()
+    }
+}
+
+/// A [`TypeResolver`] which never resolves a type.
+struct NoopTypeResolver;
+
+impl TypeResolver for NoopTypeResolver {
+    fn lookup_type(&self, _ty: &TypeRef) -> Option<di::Type<'_>> {
         None
     }
 }

--- a/symbolic-symcache/tests/test_writer.rs
+++ b/symbolic-symcache/tests/test_writer.rs
@@ -1,4 +1,4 @@
-use std::io::Cursor;
+use std::{fmt::Write as _, io::Cursor};
 
 use symbolic_common::ByteView;
 use symbolic_debuginfo::Object;
@@ -7,15 +7,21 @@ use symbolic_testutils::fixture;
 
 type Error = Box<dyn std::error::Error>;
 
-#[test]
-fn test_write_header_linux() -> Result<(), Error> {
-    let buffer = ByteView::open(fixture("linux/crash.debug"))?;
+fn serialize_fixture(path: &str, with_variables: bool) -> Result<Vec<u8>, Error> {
+    let buffer = ByteView::open(fixture(path))?;
     let object = Object::parse(&buffer)?;
 
-    let mut buffer = Vec::new();
+    let mut symcache = Vec::new();
     let mut converter = SymCacheConverter::new();
+    converter.set_collect_variables(with_variables);
     converter.process_object(&object)?;
-    converter.serialize(&mut Cursor::new(&mut buffer))?;
+    converter.serialize(&mut Cursor::new(&mut symcache))?;
+    Ok(symcache)
+}
+
+#[test]
+fn test_write_header_linux() -> Result<(), Error> {
+    let buffer = serialize_fixture("linux/crash.debug", false)?;
 
     #[cfg(target_endian = "little")]
     {
@@ -44,13 +50,7 @@ fn test_write_header_linux() -> Result<(), Error> {
 
 #[test]
 fn test_write_functions_linux() -> Result<(), Error> {
-    let buffer = ByteView::open(fixture("linux/crash.debug"))?;
-    let object = Object::parse(&buffer)?;
-
-    let mut buffer = Vec::new();
-    let mut converter = SymCacheConverter::new();
-    converter.process_object(&object)?;
-    converter.serialize(&mut Cursor::new(&mut buffer))?;
+    let buffer = serialize_fixture("linux/crash.debug", false)?;
     let symcache = SymCache::parse(&buffer)?;
     insta::assert_debug_snapshot!("functions_linux", FunctionsDebug(&symcache));
 
@@ -59,13 +59,7 @@ fn test_write_functions_linux() -> Result<(), Error> {
 
 #[test]
 fn test_write_header_macos() -> Result<(), Error> {
-    let buffer = ByteView::open(fixture("macos/crash.dSYM/Contents/Resources/DWARF/crash"))?;
-    let object = Object::parse(&buffer)?;
-
-    let mut buffer = Vec::new();
-    let mut converter = SymCacheConverter::new();
-    converter.process_object(&object)?;
-    converter.serialize(&mut Cursor::new(&mut buffer))?;
+    let buffer = serialize_fixture("macos/crash.dSYM/Contents/Resources/DWARF/crash", false)?;
     let symcache = SymCache::parse(&buffer)?;
     insta::assert_debug_snapshot!(symcache, @r#"
     SymCache {
@@ -88,13 +82,7 @@ fn test_write_header_macos() -> Result<(), Error> {
 
 #[test]
 fn test_write_functions_macos() -> Result<(), Error> {
-    let buffer = ByteView::open(fixture("macos/crash.dSYM/Contents/Resources/DWARF/crash"))?;
-    let object = Object::parse(&buffer)?;
-
-    let mut buffer = Vec::new();
-    let mut converter = SymCacheConverter::new();
-    converter.process_object(&object)?;
-    converter.serialize(&mut Cursor::new(&mut buffer))?;
+    let buffer = serialize_fixture("macos/crash.dSYM/Contents/Resources/DWARF/crash", false)?;
     let symcache = SymCache::parse(&buffer)?;
     insta::assert_debug_snapshot!("functions_macos", FunctionsDebug(&symcache));
 
@@ -107,15 +95,10 @@ fn test_write_functions_macos() -> Result<(), Error> {
 // compilation directory. See the overlapping_funcs directory in sentry-testutils for related files.
 #[test]
 fn test_write_functions_overlapping_funcs() -> Result<(), Error> {
-    let buffer = ByteView::open(fixture(
+    let buffer = serialize_fixture(
         "macos/overlapping_funcs.dSYM/Contents/Resources/DWARF/overlapping_funcs",
-    ))?;
-    let object = Object::parse(&buffer)?;
-
-    let mut buffer = Vec::new();
-    let mut converter = SymCacheConverter::new();
-    converter.process_object(&object)?;
-    converter.serialize(&mut Cursor::new(&mut buffer))?;
+        false,
+    )?;
     let symcache = SymCache::parse(&buffer)?;
     insta::assert_debug_snapshot!("overlapping_funcs", FunctionsDebug(&symcache));
 
@@ -124,13 +107,7 @@ fn test_write_functions_overlapping_funcs() -> Result<(), Error> {
 
 #[test]
 fn test_write_large_symbol_names() -> Result<(), Error> {
-    let buffer = ByteView::open(fixture("regression/large_symbol.sym"))?;
-    let object = Object::parse(&buffer)?;
-
-    let mut buffer = Vec::new();
-    let mut converter = SymCacheConverter::new();
-    converter.process_object(&object)?;
-    converter.serialize(&mut Cursor::new(&mut buffer))?;
+    let buffer = serialize_fixture("regression/large_symbol.sym", false)?;
     SymCache::parse(&buffer)?;
 
     Ok(())
@@ -140,13 +117,7 @@ fn test_write_large_symbol_names() -> Result<(), Error> {
 /// https://github.com/getsentry/symbolic/issues/284#issue-726898083
 #[test]
 fn test_lookup_no_lines() -> Result<(), Error> {
-    let buffer = ByteView::open(fixture("xul.sym"))?;
-    let object = Object::parse(&buffer)?;
-
-    let mut buffer = Vec::new();
-    let mut converter = SymCacheConverter::new();
-    converter.process_object(&object)?;
-    converter.serialize(&mut Cursor::new(&mut buffer))?;
+    let buffer = serialize_fixture("xul.sym", false)?;
     let symcache = SymCache::parse(&buffer)?;
     let symbols = symcache.lookup(0xc6dd98).collect::<Vec<_>>();
 
@@ -167,13 +138,7 @@ fn test_lookup_no_lines() -> Result<(), Error> {
 /// https://github.com/getsentry/symbolic/issues/284#issuecomment-715587454.
 #[test]
 fn test_lookup_no_size() -> Result<(), Error> {
-    let buffer = ByteView::open(fixture("libgallium_dri.sym"))?;
-    let object = Object::parse(&buffer)?;
-
-    let mut buffer = Vec::new();
-    let mut converter = SymCacheConverter::new();
-    converter.process_object(&object)?;
-    converter.serialize(&mut Cursor::new(&mut buffer))?;
+    let buffer = serialize_fixture("libgallium_dri.sym", false)?;
     let symcache = SymCache::parse(&buffer)?;
     let symbols = symcache.lookup(0x1489adf).collect::<Vec<_>>();
 
@@ -189,13 +154,7 @@ fn test_lookup_no_size() -> Result<(), Error> {
 /// https://github.com/getsentry/symbolic/issues/285.
 #[test]
 fn test_lookup_modulo_u16() -> Result<(), Error> {
-    let buffer = ByteView::open(fixture("xul2.sym"))?;
-    let object = Object::parse(&buffer)?;
-
-    let mut buffer = Vec::new();
-    let mut converter = SymCacheConverter::new();
-    converter.process_object(&object)?;
-    converter.serialize(&mut Cursor::new(&mut buffer))?;
+    let buffer = serialize_fixture("xul2.sym", false)?;
     let symcache = SymCache::parse(&buffer)?;
     let symbols = symcache.lookup(0x3c105a1).collect::<Vec<_>>();
 
@@ -211,13 +170,7 @@ fn test_lookup_modulo_u16() -> Result<(), Error> {
 /// https://github.com/getsentry/symbolic/issues/646.
 #[test]
 fn test_lookup_second_line_in_inlinee() -> Result<(), Error> {
-    let buffer = ByteView::open(fixture("macos/crash.dSYM/Contents/Resources/DWARF/crash"))?;
-    let object = Object::parse(&buffer)?;
-
-    let mut buffer = Vec::new();
-    let mut converter = SymCacheConverter::new();
-    converter.process_object(&object)?;
-    converter.serialize(&mut Cursor::new(&mut buffer))?;
+    let buffer = serialize_fixture("macos/crash.dSYM/Contents/Resources/DWARF/crash", false)?;
     let symcache = SymCache::parse(&buffer)?;
 
     // Test an address at the second line of an inlinee.
@@ -322,13 +275,7 @@ fn test_lookup_gap_inlinee() -> Result<(), Error> {
 
 #[test]
 fn test_undecorate_windows_symbols() -> Result<(), Error> {
-    let buffer = ByteView::open(fixture("windows/crash.pdb"))?;
-    let object = Object::parse(&buffer)?;
-
-    let mut buffer = Vec::new();
-    let mut converter = SymCacheConverter::new();
-    converter.process_object(&object)?;
-    converter.serialize(&mut Cursor::new(&mut buffer))?;
+    let buffer = serialize_fixture("windows/crash.pdb", false)?;
     let symcache = SymCache::parse(&buffer)?;
 
     let symbols = symcache.lookup(0x3756).collect::<Vec<_>>();
@@ -341,13 +288,7 @@ fn test_undecorate_windows_symbols() -> Result<(), Error> {
 /// Tests that the cache is lenient toward adding additional flags at the end.
 #[test]
 fn test_trailing_marker() -> Result<(), Error> {
-    let buffer = ByteView::open(fixture("macos/crash.dSYM/Contents/Resources/DWARF/crash"))?;
-    let object = Object::parse(&buffer)?;
-
-    let mut buffer = Vec::new();
-    let mut converter = SymCacheConverter::new();
-    converter.process_object(&object)?;
-    converter.serialize(&mut Cursor::new(&mut buffer))?;
+    let mut buffer = serialize_fixture("macos/crash.dSYM/Contents/Resources/DWARF/crash", false)?;
     buffer.extend(b"WITH_SYMBOLMAP");
 
     SymCache::parse(&buffer)?;
@@ -355,30 +296,18 @@ fn test_trailing_marker() -> Result<(), Error> {
     Ok(())
 }
 
-fn serialize_fixture_with_variables(path: &str) -> Result<Vec<u8>, Error> {
-    let buffer = ByteView::open(fixture(path))?;
-    let object = Object::parse(&buffer)?;
-
-    let mut symcache = Vec::new();
-    let mut converter = SymCacheConverter::new();
-    converter.set_collect_variables(true);
-    converter.process_object(&object)?;
-    converter.serialize(&mut Cursor::new(&mut symcache))?;
-    Ok(symcache)
-}
-
 /// This test can catch padding in the raw types.
 #[test]
 fn test_variable_serialization_is_deterministic() -> Result<(), Error> {
-    let first = serialize_fixture_with_variables("linux/crash.debug")?;
-    let second = serialize_fixture_with_variables("linux/crash.debug")?;
+    let first = serialize_fixture("linux/crash.debug", true)?;
+    let second = serialize_fixture("linux/crash.debug", true)?;
     assert_eq!(first, second);
     Ok(())
 }
 
 #[test]
 fn test_empty_variable_sections() -> Result<(), Error> {
-    let buffer = serialize_fixture_with_variables("windows/crash.sym")?;
+    let buffer = serialize_fixture("windows/crash.sym", true)?;
     let symcache = SymCache::parse(&buffer)?;
 
     insta::assert_debug_snapshot!(symcache, @r#"
@@ -405,9 +334,34 @@ fn test_empty_variable_sections() -> Result<(), Error> {
 
 #[test]
 fn test_variable_cache_with_trailing_marker() -> Result<(), Error> {
-    let mut buffer = serialize_fixture_with_variables("linux/crash.debug")?;
+    let mut buffer = serialize_fixture("linux/crash.debug", true)?;
     buffer.extend_from_slice(b"WITH_SYMBOLMAP");
     SymCache::parse(&buffer)?;
+    Ok(())
+}
+
+/// This really is just a test so we can track changes to the symcache size.
+///
+/// Any modification to the cache will be visible here and give an idea of how it impacts the size.
+/// An increase in size is not necessarily a bad thing.
+#[test]
+fn test_variable_cache_size() -> Result<(), Error> {
+    let no_vars = serialize_fixture("linux/crash.debug", false)?.len() as f64 / 1024.;
+    let with_vars = serialize_fixture("linux/crash.debug", true)?.len() as f64 / 1024.;
+    let delta = with_vars - no_vars;
+    let perc = delta / with_vars * 100.;
+
+    let mut s = String::new();
+    writeln!(&mut s, "no variables  : {no_vars:.2} KiB")?;
+    writeln!(&mut s, "with variables: {with_vars:.2} KiB")?;
+    writeln!(&mut s, "variables     : {delta:.2} KiB ({perc:.2}%)")?;
+
+    insta::assert_snapshot!(s, @r"
+    no variables  : 219.95 KiB
+    with variables: 262.50 KiB
+    variables     : 42.55 KiB (16.21%)
+    ");
+
     Ok(())
 }
 

--- a/symbolic-symcache/tests/test_writer.rs
+++ b/symbolic-symcache/tests/test_writer.rs
@@ -355,6 +355,62 @@ fn test_trailing_marker() -> Result<(), Error> {
     Ok(())
 }
 
+fn serialize_fixture_with_variables(path: &str) -> Result<Vec<u8>, Error> {
+    let buffer = ByteView::open(fixture(path))?;
+    let object = Object::parse(&buffer)?;
+
+    let mut symcache = Vec::new();
+    let mut converter = SymCacheConverter::new();
+    converter.set_collect_variables(true);
+    converter.process_object(&object)?;
+    converter.serialize(&mut Cursor::new(&mut symcache))?;
+    Ok(symcache)
+}
+
+/// This test can catch padding in the raw types.
+#[test]
+fn test_variable_serialization_is_deterministic() -> Result<(), Error> {
+    let first = serialize_fixture_with_variables("linux/crash.debug")?;
+    let second = serialize_fixture_with_variables("linux/crash.debug")?;
+    assert_eq!(first, second);
+    Ok(())
+}
+
+#[test]
+fn test_empty_variable_sections() -> Result<(), Error> {
+    let buffer = serialize_fixture_with_variables("windows/crash.sym")?;
+    let symcache = SymCache::parse(&buffer)?;
+
+    insta::assert_debug_snapshot!(symcache, @r#"
+    SymCache {
+        version: 9,
+        debug_id: DebugId {
+            uuid: "3249d99d-0c40-4931-8610-f4e4fb0b6936",
+            appendix: 1,
+        },
+        arch: X86,
+        files: 36,
+        functions: 127,
+        source_locations: 805,
+        ranges: 805,
+        string_bytes: 7118,
+        variables: 0,
+        variable_locations: 0,
+        types: 0,
+    }
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn test_variable_cache_with_trailing_marker() -> Result<(), Error> {
+    let mut buffer = serialize_fixture_with_variables("linux/crash.debug")?;
+    buffer.extend_from_slice(b"WITH_SYMBOLMAP");
+    SymCache::parse(&buffer)?;
+    Ok(())
+}
+
 /// Tests that addresses between functions are unmapped. See
 /// <https://github.com/getsentry/symbolic/pull/897>.
 #[test]


### PR DESCRIPTION
Write variable information into symcaches. I am holding off on writing more docs until we get closer to stability and release of the format, I expect it to still evolve a bit over time.

This change uses parts of the `reserved` header from the original V9 symcache, to optionally extend past the previous end of the symcache with variable information.

It also introduces not just a flag but a version counter of that additional section to allow for iteration on the cache without needing to rebuild existing caches which work fine for symbolication.

This PR does not yet implement any of the reading APIs, it only implements writing the variable information.

```
└─ % ./run symcache_debug --debug-file symbolic-testutils/fixtures/linux/crash.debug --write-cache-file --symcache-file ./test.symc --report
+ cargo run --quiet --package symcache_debug -- --debug-file symbolic-testutils/fixtures/linux/crash.debug --write-cache-file --symcache-file ./test.symc --report
Cache file written to ./test.symc
Cache info:
SymCache {
    version: 9,
    debug_id: DebugId {
        uuid: "c0bcc3f1-9827-fe65-3058-404b2831d9e6",
        appendix: 0,
    },
    arch: Amd64,
    files: 55,
    functions: 697,
    source_locations: 8431,
    ranges: 6975,
    string_bytes: 51929,
    variables: 548,
    variable_locations: 1548,
    types: 12,
}
```