### PR TITLE
ref(symcache): Improve conversion, turn location into proper tagged union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Change the MSRV version to 1.85 and Rust Edition 2024. ([#1028](https://github.com/getsentry/symbolic/pull/1028))
 - Remove support for symcache version 7 and 8. ([#1033](https://github.com/getsentry/symbolic/pull/1033))
 - Adds variables to functions. ([#1025](https://github.com/getsentry/symbolic/pull/1025))
+- `SymCache` and `SourceLocation` no longer implement `PartialEq` and `Eq`. ([#1039](https://github.com/getsentry/symbolic/pull/1039))
 
 **Dependencies**
 

--- a/symbolic-symcache/src/lib.rs
+++ b/symbolic-symcache/src/lib.rs
@@ -112,6 +112,7 @@ mod error;
 mod lookup;
 mod raw;
 pub mod transform;
+mod utils;
 mod v9;
 mod writer;
 
@@ -143,7 +144,7 @@ pub const SYMCACHE_VERSION: u32 = 9;
 ///
 /// This can be parsed from a binary buffer via [`SymCache::parse`] and lookups on it can be performed
 /// via the [`SymCache::lookup`] method.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct SymCache<'data> {
     version: &'data raw::VersionInfo,
     inner: lookup::SymCacheInner<'data>,

--- a/symbolic-symcache/src/lookup.rs
+++ b/symbolic-symcache/src/lookup.rs
@@ -178,7 +178,7 @@ pub struct VariableLocations<'data>(VariableLocationsInner<'data>);
 ///
 /// A `SourceLocation` represents source information about a particular instruction.
 /// It always has a `[Function]` associated with it and may also have a `[File]` and a line number.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct SourceLocation<'data, 'cache>(SourceLocationInner<'data, 'cache>);
 
 /// An Iterator that yields [`SourceLocation`]s, representing an inlining hierarchy.
@@ -238,7 +238,7 @@ pub struct Variables<'data, 'cache>(VariablesInner<'data, 'cache>);
 
 macro_rules! impl_version {
     ($([$version:ident, $module:ident]),+) => {
-        #[derive(Clone, PartialEq, Eq)]
+        #[derive(Clone)]
         pub(crate) enum SymCacheInner<'data> {
             $($version(crate::$module::SymCache<'data>),)+
         }
@@ -292,7 +292,7 @@ macro_rules! impl_version {
             }
         }
 
-        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[derive(Debug, Clone)]
         enum SourceLocationInner<'data, 'cache> {
             $($version(crate::$module::lookup::SourceLocation<'data, 'cache>),)+
         }

--- a/symbolic-symcache/src/utils.rs
+++ b/symbolic-symcache/src/utils.rs
@@ -1,0 +1,126 @@
+/// Macro which makes it safer and easier to use a tagged union in a symcache.
+macro_rules! tagged_union {
+    (
+        $($field:ident: $ty:ty,)+
+
+) => {
+        /// Helper module to resolve union variants to tags.
+        mod tags {
+            #[repr(u8)]
+            #[allow(non_camel_case_types, dead_code)]
+            enum Tag { $($field,)+ }
+
+            $(
+                #[allow(non_upper_case_globals)]
+                pub const $field: u8 = Tag::$field as u8;
+            )+
+        }
+
+        /// The raw storage union for a SymCache.
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub union Impl {
+            $(pub $field: $ty,)+
+        }
+
+        impl Impl where Self: watto::Pod {
+            /// Combines the union with its tag into an [`Enum`].
+            pub fn into_enum(self, tag: u8) -> Option<Enum> {
+                match tag {
+                    // SAFETY: Since `Impl` must be `Pod`, all byte patterns are valid
+                    // representations and even for an incorrect tag this will only produce
+                    // incorrect data and not introduce a soundness issue.
+                    $(tags::$field => Some(unsafe { Enum::$field(self.$field) }),)+
+                    _ => None,
+                }
+            }
+
+            /// Combines the union with its tag.
+            ///
+            /// This is useful for debug printing, comparing and hashing a union, it deals correctly
+            /// with invalid tags.
+            pub fn tagged(&self, tag: u8) -> Tagged<'_> {
+                Tagged { tag, u: self }
+            }
+        }
+
+        unsafe impl Pod for Impl where $($ty: watto::Pod,)+ {}
+
+        /// A companion to [`Impl`] which can be debug printed, compared and hashed.
+        pub struct Tagged<'a> {
+            tag: u8,
+            u: &'a Impl,
+        }
+
+        impl std::fmt::Debug for Tagged<'_> where $($ty: std::fmt::Debug,)+ {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self.tag {
+                    // SAFETY: `Tagged` can only be constructed when `Impl: Pod`. See also: `Impl::into_enum`.
+                    $(tags::$field => std::fmt::Debug::fmt(unsafe { &self.u.$field }, f),)+
+                    _ => write!(f, "<invalid tag {}>", self.tag),
+                }
+            }
+        }
+
+        impl PartialEq for Tagged<'_> where $($ty: PartialEq,)+ {
+            fn eq(&self, other: &Self) -> bool {
+                match (self.tag, other.tag) {
+                    // SAFETY: `Tagged` can only be constructed when `Impl: Pod`. See also: `Impl::into_enum`.
+                    $((tags::$field, tags::$field) => unsafe { self.u.$field == other.u.$field }),+
+                    _ => false,
+                }
+            }
+        }
+
+        impl std::hash::Hash for Tagged<'_> {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                self.tag.hash(state);
+                match self.tag {
+                    // SAFETY: `Tagged` can only be constructed when `Impl: Pod`. See also: `Impl::into_enum`.
+                    $(tags::$field => unsafe { self.u.$field.hash(state) }),+
+                    _ => {}
+                }
+            }
+        }
+
+        /// Representation of the [`Impl`] union as an enum.
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+        #[allow(non_camel_case_types)]
+        pub enum Enum {
+            $($field($ty),)+
+        }
+
+        impl Enum where $($ty: watto::Pod,)+ {
+            /// Turns the enum into its union representation [`Impl`] with its tag.
+            pub fn into_impl(self) -> (u8, Impl) {
+                match self {
+                    $(Self::$field(v) => (tags::$field as u8, Impl { $field: v }),)+
+                }
+            }
+        }
+
+        // This implicitly requires each enum variant has a distinct type.
+        $(impl From<$ty> for Enum {
+            fn from(v: $ty) -> Self {
+                Self::$field(v)
+            }
+        })+
+
+        // For the [`Impl`] union to be a safe `pod`, all of its members must be pods and the same size.
+        // Any bit representation of the union must be valid and initialized in all other variants.
+        const _: () = {
+            const fn assert_pod<T: watto::Pod>() {}
+            const SIZE: usize = std::mem::size_of::<Impl>();
+
+            $(
+                assert_pod::<$ty>();
+                assert!(std::mem::size_of::<$ty>() == SIZE);
+            )+
+            assert_pod::<Impl>();
+
+            // General invariant for symcaches.
+            assert!(std::mem::align_of::<Impl>() <= 8);
+        };
+    };
+}
+pub(crate) use tagged_union;

--- a/symbolic-symcache/src/v9/convert.rs
+++ b/symbolic-symcache/src/v9/convert.rs
@@ -1,0 +1,61 @@
+use symbolic_debuginfo::{PrimitiveTypeEncoding, VariableKind};
+
+/// Converts a `u8` back into a [`PrimitiveTypeEncoding`].
+///
+/// The inverse of [`primitive_type_encoding_to_u8`]. Invalid inputs are returned as `None`.
+pub fn u8_to_primitive_type_encoding(encoding: u8) -> Option<PrimitiveTypeEncoding> {
+    match encoding {
+        0 => Some(PrimitiveTypeEncoding::Boolean),
+        1 => Some(PrimitiveTypeEncoding::Address),
+        2 => Some(PrimitiveTypeEncoding::SignedInt),
+        3 => Some(PrimitiveTypeEncoding::UnsignedInt),
+        4 => Some(PrimitiveTypeEncoding::SignedChar),
+        5 => Some(PrimitiveTypeEncoding::UnsignedChar),
+        6 => Some(PrimitiveTypeEncoding::Float),
+        7 => Some(PrimitiveTypeEncoding::ComplexFloat),
+        u8::MAX => None,
+        _ => None,
+    }
+}
+
+/// Converts an optional [`PrimitiveTypeEncoding`] into a `u8`.
+pub fn primitive_type_encoding_to_u8(encoding: Option<PrimitiveTypeEncoding>) -> u8 {
+    match encoding {
+        Some(PrimitiveTypeEncoding::Boolean) => 0,
+        Some(PrimitiveTypeEncoding::Address) => 1,
+        Some(PrimitiveTypeEncoding::SignedInt) => 2,
+        Some(PrimitiveTypeEncoding::UnsignedInt) => 3,
+        Some(PrimitiveTypeEncoding::SignedChar) => 4,
+        Some(PrimitiveTypeEncoding::UnsignedChar) => 5,
+        Some(PrimitiveTypeEncoding::Float) => 6,
+        Some(PrimitiveTypeEncoding::ComplexFloat) => 7,
+        None => u8::MAX,
+    }
+}
+
+/// Converts a `u8` back into a [`VariableKind`].
+///
+/// The input is expected to be a tag produced by [`variable_kind_to_u8`]. If the kind is unknown
+/// the implementation falls back to [`VariableKind::Local`].
+pub fn u8_to_variable_kind(kind: u8) -> VariableKind {
+    match kind {
+        0 => VariableKind::Parameter,
+        1 => VariableKind::Local,
+        // A variable kind is not optional, an unknown value is either due to a symcache version mismatch,
+        // a corrupted cache or a bug.
+        _ => {
+            debug_assert!(false, "invalid variable kind");
+            VariableKind::Local
+        }
+    }
+}
+
+/// Converts a [`VariableKind`] to a `u8` to be stored in [`Variable::kind`].
+///
+/// [`Variable::kind`]: crate::v9::raw::Variable::kind
+pub fn variable_kind_to_u8(kind: VariableKind) -> u8 {
+    match kind {
+        VariableKind::Parameter => 0,
+        VariableKind::Local => 1,
+    }
+}

--- a/symbolic-symcache/src/v9/lookup.rs
+++ b/symbolic-symcache/src/v9/lookup.rs
@@ -3,10 +3,10 @@ use std::cmp::Ordering;
 
 use symbolic_common::Language;
 
-use crate::v9::{SymCache, raw};
+use crate::v9::{SymCache, convert, raw};
 use crate::{
-    File, Function, PointerType, PrimitiveType, PrimitiveTypeEncoding, Type, TypeId, TypeSize,
-    VariableKind, VariableLocation, VariableLocationInfo,
+    File, Function, PointerType, PrimitiveType, Type, TypeId, TypeSize, VariableKind,
+    VariableLocation, VariableLocationInfo,
 };
 
 impl<'data> SymCache<'data> {
@@ -68,32 +68,17 @@ impl<'data> SymCache<'data> {
     pub fn get_type(&self, ty_idx: u32) -> Option<Type<'data>> {
         let raw_ty = self.types.get(ty_idx as usize)?;
 
-        if let Some(primitive) = raw_ty.as_primitive() {
-            return Some(Type::Primitive(PrimitiveType {
+        Some(match raw_ty.as_enum()? {
+            raw::ty::Enum::primitive(primitive) => Type::Primitive(PrimitiveType {
                 name: self.get_string(primitive.name_offset),
                 size: TypeSize::Bytes(primitive.size.into()),
-                encoding: match primitive.encoding {
-                    0 => Some(PrimitiveTypeEncoding::Boolean),
-                    1 => Some(PrimitiveTypeEncoding::Address),
-                    2 => Some(PrimitiveTypeEncoding::SignedInt),
-                    3 => Some(PrimitiveTypeEncoding::UnsignedInt),
-                    4 => Some(PrimitiveTypeEncoding::SignedChar),
-                    5 => Some(PrimitiveTypeEncoding::UnsignedChar),
-                    6 => Some(PrimitiveTypeEncoding::Float),
-                    7 => Some(PrimitiveTypeEncoding::ComplexFloat),
-                    _ => None,
-                },
-            }));
-        }
-
-        if let Some(pointer) = raw_ty.as_pointer() {
-            return Some(Type::Pointer(PointerType {
+                encoding: convert::u8_to_primitive_type_encoding(primitive.encoding),
+            }),
+            raw::ty::Enum::pointer(pointer) => Type::Pointer(PointerType {
                 size: TypeSize::Bytes(pointer.size.into()),
                 pointee: (pointer.pointee_idx != u32::MAX).then_some(TypeId(pointer.pointee_idx)),
-            }));
-        }
-
-        None
+            }),
+        })
     }
 
     /// An iterator over the functions in this SymCache.
@@ -208,16 +193,6 @@ impl<'data, 'cache> SourceLocation<'data, 'cache> {
     }
 }
 
-impl PartialEq for SourceLocation<'_, '_> {
-    fn eq(&self, other: &Self) -> bool {
-        self.cache == other.cache
-            && self.source_location == other.source_location
-            && self.addr == other.addr
-    }
-}
-
-impl Eq for SourceLocation<'_, '_> {}
-
 /// An Iterator that yields [`SourceLocation`]s, representing an inlining hierarchy.
 #[derive(Debug, Clone)]
 pub struct SourceLocations<'data, 'cache> {
@@ -311,7 +286,7 @@ impl<'data, 'cache> Iterator for Variables<'data, 'cache> {
     type Item = Variable<'data, 'cache>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.depth == u8::MAX {
+        if self.current == u32::MAX {
             return None;
         }
 
@@ -356,14 +331,7 @@ impl<'data, 'cache> Variable<'data, 'cache> {
 
     /// The kind of the variable.
     pub fn kind(&self) -> VariableKind {
-        match self.variable.kind {
-            0 => VariableKind::Parameter,
-            1 => VariableKind::Local,
-            _ => {
-                debug_assert!(false, "invalid variable kind");
-                VariableKind::Local
-            }
-        }
+        convert::u8_to_variable_kind(self.variable.kind)
     }
 
     /// The type of the variable.
@@ -395,7 +363,7 @@ impl<'data, 'cache> Variable<'data, 'cache> {
 
 #[derive(Debug, Clone)]
 pub struct VariableLocations<'data> {
-    locations: std::slice::Iter<'data, raw::VariableLocation>,
+    locations: std::slice::Iter<'data, raw::VariableLocationInfo>,
     addr: u32,
 }
 
@@ -410,18 +378,14 @@ impl<'data> Iterator for VariableLocations<'data> {
             }
 
             if self.addr < location.start + location.size {
-                // Will need to find a better way to keep serialization and de-serialization
-                // closer together. Right now this must mirror the implementation in `writer.rs`.
-                // The code enforces that the implementations agree through the symcache version
-                // and variable section version.
-                let vl = match location.kind {
-                    0 => VariableLocation::Register {
-                        id: location.data as u16,
+                let vl = match location.location() {
+                    Some(raw::location::Enum::register(reg)) => {
+                        VariableLocation::Register { id: reg.id }
+                    }
+                    Some(raw::location::Enum::frame_offset(fo)) => VariableLocation::FrameOffset {
+                        offset: fo.offset.into(),
                     },
-                    1 => VariableLocation::FrameOffset {
-                        offset: location.data.into(),
-                    },
-                    _ => {
+                    None => {
                         debug_assert!(false, "invalid variable location kind");
                         continue;
                     }

--- a/symbolic-symcache/src/v9/mod.rs
+++ b/symbolic-symcache/src/v9/mod.rs
@@ -1,3 +1,4 @@
+pub mod convert;
 pub mod lookup;
 pub mod raw;
 
@@ -7,7 +8,7 @@ use symbolic_common::Arch;
 use watto::{Pod, StringTable, align_to};
 
 /// The serialized SymCache V9 binary format.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct SymCache<'data> {
     pub header: &'data raw::Header,
     pub files: &'data [raw::File],
@@ -18,7 +19,7 @@ pub struct SymCache<'data> {
     pub variable_header: Option<&'data raw::VariableHeader>,
     pub function_variables: &'data [raw::FunctionVariables],
     pub variables: &'data [raw::Variable],
-    pub variable_locations: &'data [raw::VariableLocation],
+    pub variable_locations: &'data [raw::VariableLocationInfo],
     pub types: &'data [raw::Type],
 }
 
@@ -102,9 +103,11 @@ impl<'data> SymCache<'data> {
             variables = vars;
 
             let (_, rest) = align_to(rest, 8).ok_or(ErrorKind::InvalidVariableLocations)?;
-            let (vl, rest) =
-                raw::VariableLocation::slice_from_prefix(rest, vh.num_variable_locations as usize)
-                    .ok_or(ErrorKind::InvalidVariableLocations)?;
+            let (vl, rest) = raw::VariableLocationInfo::slice_from_prefix(
+                rest,
+                vh.num_variable_locations as usize,
+            )
+            .ok_or(ErrorKind::InvalidVariableLocations)?;
             variable_locations = vl;
 
             let (_, rest) = align_to(rest, 8).ok_or(ErrorKind::InvalidTypes)?;

--- a/symbolic-symcache/src/v9/raw.rs
+++ b/symbolic-symcache/src/v9/raw.rs
@@ -71,7 +71,7 @@ pub struct Header {
 pub struct VariableHeader {
     /// Number of included [`Variable`]'s.
     pub num_variables: u32,
-    /// Number of included [`VariableLocation`]'s.
+    /// Number of included [`VariableLocationInfo`]'s.
     pub num_variable_locations: u32,
     /// Number of included [`Type`]'s.
     pub num_types: u32,
@@ -168,7 +168,7 @@ pub struct Variable {
     pub name_offset: u32,
     /// The type (reference to a [`Type`]).
     pub type_idx: u32,
-    /// The first location associated with the variable (reference to a [`VariableLocation`]).
+    /// The first location associated with the variable (reference to a [`VariableLocationInfo`]).
     pub location_idx: u32,
     /// The amount of locations.
     pub num_locations: u32,
@@ -184,137 +184,65 @@ pub struct Variable {
     /// to only variables at this depth.
     pub depth: u8,
     /// The variable kind.
+    ///
+    /// The variable kind is required and must not be [`u8::MAX`].
     pub kind: u8,
     pub _reserved: [u8; 2],
 }
 
-/// A representation of a variable location.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 #[repr(C)]
-pub struct VariableLocation {
+pub struct RegisterLocation {
+    pub id: u16,
+    pub _reserved: [u8; 2],
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[repr(C)]
+pub struct FrameOffsetLocation {
+    pub offset: i32,
+}
+
+pub mod location {
+    use super::*;
+
+    crate::utils::tagged_union! {
+        register: RegisterLocation,
+        frame_offset: FrameOffsetLocation,
+    }
+}
+
+/// A representation of a variable location.
+#[derive(Clone)]
+#[repr(C)]
+pub struct VariableLocationInfo {
     /// First instruction address (pc) where this location is valid.
     pub start: u32,
     /// Size of the location, indicating the first instruction address where this location is no longer valid.
     pub size: u32,
     /// The location data.
-    ///
-    /// Carries different meaning based on [`Self::kind`].
-    pub data: i32,
+    pub location: location::Impl,
     /// The location kind.
     pub kind: u8,
     pub _reserved: [u8; 3],
 }
 
-/// A representation of a type.
-#[derive(Clone)]
-#[repr(C)]
-pub struct Type {
-    /// The concrete type.
-    pub ty: TypeImpl,
-    /// Discriminator for [`Self::ty`].
-    pub kind: u8,
-    pub _reserved: [u8; 3],
-}
-
-impl Type {
-    pub fn as_primitive(&self) -> Option<&PrimitiveType> {
-        match self.kind {
-            0 => Some(unsafe { &self.ty.primitive }),
-            _ => None,
-        }
-    }
-
-    pub fn as_pointer(&self) -> Option<&PointerType> {
-        match self.kind {
-            1 => Some(unsafe { &self.ty.pointer }),
-            _ => None,
-        }
+impl VariableLocationInfo {
+    pub fn location(&self) -> Option<location::Enum> {
+        self.location.into_enum(self.kind)
     }
 }
 
-impl From<PrimitiveType> for Type {
-    fn from(primitive: PrimitiveType) -> Self {
-        Self {
-            kind: 0,
-            ty: TypeImpl { primitive },
-            _reserved: [0; _],
-        }
+impl fmt::Debug for VariableLocationInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VariableLocationInfo")
+            .field("start", &self.start)
+            .field("size", &self.size)
+            .field("location", &self.location.tagged(self.kind))
+            .field("_reserved", &self._reserved)
+            .finish()
     }
 }
-
-impl From<PointerType> for Type {
-    fn from(pointer: PointerType) -> Self {
-        Self {
-            kind: 1,
-            ty: TypeImpl { pointer },
-            _reserved: [0; _],
-        }
-    }
-}
-
-impl fmt::Debug for Type {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind {
-            0 => unsafe { &self.ty.primitive }.fmt(f),
-            1 => unsafe { &self.ty.pointer }.fmt(f),
-            k => write!(f, "<invalid type {k}>"),
-        }
-    }
-}
-
-impl PartialEq for Type {
-    fn eq(&self, other: &Self) -> bool {
-        let Self {
-            kind,
-            ty,
-            _reserved,
-        } = other;
-
-        if self.kind != *kind {
-            return false;
-        }
-
-        match self.kind {
-            0 => unsafe { self.ty.primitive == ty.primitive },
-            1 => unsafe { self.ty.pointer == ty.pointer },
-            _ => false,
-        }
-    }
-}
-
-impl Eq for Type {}
-
-impl std::hash::Hash for Type {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.kind.hash(state);
-        match self.kind {
-            0 => unsafe { self.ty.primitive.hash(state) },
-            1 => unsafe { self.ty.pointer.hash(state) },
-            _ => {}
-        }
-    }
-}
-
-/// Any possible type.
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union TypeImpl {
-    /// A primitive type.
-    pub primitive: PrimitiveType,
-    /// A pointer type.
-    pub pointer: PointerType,
-}
-
-// For the [`TypeImpl`] union to be a safe `pod`, all of its members must be pods and the same size.
-// Any bit representation of the union must be valid and initialized in all other variants.
-const _: () = {
-    const SIZE: usize = 12;
-    assert!(std::mem::size_of::<TypeImpl>() == SIZE);
-    assert!(std::mem::size_of::<PrimitiveType>() == SIZE);
-    assert!(std::mem::size_of::<PointerType>() == SIZE);
-
-    assert!(std::mem::align_of::<TypeImpl>() == 4);
-};
 
 /// A representation of a primitive type.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
@@ -342,6 +270,69 @@ pub struct PointerType {
     pub _reserved: [u8; 4],
 }
 
+pub mod ty {
+    use super::*;
+
+    crate::utils::tagged_union! {
+        primitive: PrimitiveType,
+        pointer: PointerType,
+    }
+}
+
+/// A representation of a type.
+#[derive(Clone)]
+#[repr(C)]
+pub struct Type {
+    /// The concrete type.
+    pub ty: ty::Impl,
+    /// Discriminator for [`Self::ty`].
+    pub kind: u8,
+    pub _reserved: [u8; 3],
+}
+
+impl Type {
+    pub fn as_enum(&self) -> Option<ty::Enum> {
+        self.ty.into_enum(self.kind)
+    }
+}
+
+impl<T: Into<ty::Enum>> From<T> for Type {
+    fn from(t: T) -> Self {
+        let (kind, ty) = t.into().into_impl();
+        Self {
+            kind,
+            ty,
+            _reserved: [0; _],
+        }
+    }
+}
+
+impl fmt::Debug for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.ty.tagged(self.kind).fmt(f)
+    }
+}
+
+impl PartialEq for Type {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            kind,
+            ty,
+            _reserved,
+        } = other;
+
+        self.ty.tagged(self.kind) == ty.tagged(*kind) && self._reserved == *_reserved
+    }
+}
+
+impl Eq for Type {}
+
+impl std::hash::Hash for Type {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.ty.tagged(self.kind).hash(state)
+    }
+}
+
 unsafe impl Pod for Header {}
 unsafe impl Pod for VariableHeader {}
 unsafe impl Pod for Function {}
@@ -350,9 +341,10 @@ unsafe impl Pod for File {}
 unsafe impl Pod for SourceLocation {}
 unsafe impl Pod for Range {}
 unsafe impl Pod for Variable {}
-unsafe impl Pod for VariableLocation {}
+unsafe impl Pod for RegisterLocation {}
+unsafe impl Pod for FrameOffsetLocation {}
+unsafe impl Pod for VariableLocationInfo {}
 unsafe impl Pod for Type {}
-unsafe impl Pod for TypeImpl {}
 unsafe impl Pod for PrimitiveType {}
 unsafe impl Pod for PointerType {}
 
@@ -389,8 +381,8 @@ mod tests {
         assert_eq!(mem::size_of::<Variable>(), 20);
         assert_eq!(mem::align_of::<Variable>(), 4);
 
-        assert_eq!(mem::size_of::<VariableLocation>(), 16);
-        assert_eq!(mem::align_of::<VariableLocation>(), 4);
+        assert_eq!(mem::size_of::<VariableLocationInfo>(), 16);
+        assert_eq!(mem::align_of::<VariableLocationInfo>(), 4);
 
         assert_eq!(mem::size_of::<Type>(), 16);
         assert_eq!(mem::align_of::<Type>(), 4);

--- a/symbolic-symcache/src/writer.rs
+++ b/symbolic-symcache/src/writer.rs
@@ -58,7 +58,7 @@ pub struct SymCacheConverter<'a> {
     /// A list of all variable locations.
     ///
     /// Variable locations are stored in continous chunks per variable.
-    variable_locations: Vec<v9::raw::VariableLocation>,
+    variable_locations: Vec<v9::raw::VariableLocationInfo>,
     /// The set of all types referenced from variables.
     types: IndexSet<v9::raw::Type>,
 
@@ -484,16 +484,24 @@ impl<'a> SymCacheConverter<'a> {
                     continue;
                 }
 
-                let (kind, data) = match location.location {
-                    di::VariableLocation::Register { id } => (0, id.into()),
-                    di::VariableLocation::FrameOffset { offset } => (1, offset as i32),
+                let raw_loc: v9::raw::location::Enum = match location.location {
+                    di::VariableLocation::Register { id } => v9::raw::RegisterLocation {
+                        id,
+                        _reserved: [0; _],
+                    }
+                    .into(),
+                    di::VariableLocation::FrameOffset { offset } => v9::raw::FrameOffsetLocation {
+                        offset: offset as i32,
+                    }
+                    .into(),
                 };
+                let (kind, data) = raw_loc.into_impl();
 
-                self.variable_locations.push(v9::raw::VariableLocation {
+                self.variable_locations.push(v9::raw::VariableLocationInfo {
                     start: location.address as u32,
                     size: location.size as u32,
+                    location: data,
                     kind,
-                    data,
                     _reserved: [0; _],
                 });
             }
@@ -523,7 +531,7 @@ impl<'a> SymCacheConverter<'a> {
                     location_idx: location_idx as u32,
                     num_locations: num_locations as u32,
                     depth: fn_depth as u8,
-                    kind: variable.kind as u8,
+                    kind: v9::convert::variable_kind_to_u8(variable.kind),
                     _reserved: [0; _],
                 });
         }
@@ -544,16 +552,16 @@ impl<'a> SymCacheConverter<'a> {
         };
 
         let ty = match ty {
-            symbolic_debuginfo::Type::Primitive(ty) => v9::raw::PrimitiveType {
+            di::Type::Primitive(ty) => v9::raw::PrimitiveType {
                 name_offset: ty
                     .name
                     .map_or(u32::MAX, |n| self.string_table.insert(&n) as u32),
                 size: size(ty.size),
-                encoding: ty.encoding.map_or(u8::MAX, |e| e as u8),
+                encoding: v9::convert::primitive_type_encoding_to_u8(ty.encoding),
                 _reserved: [0; _],
             }
             .into(),
-            symbolic_debuginfo::Type::Pointer(ty) => v9::raw::PointerType {
+            di::Type::Pointer(ty) => v9::raw::PointerType {
                 pointee_idx: self.process_symbolic_type(tr, &ty.pointee, depth + 1),
                 size: size(ty.size),
                 _reserved: [0; _],


### PR DESCRIPTION
Improves conversions from debuginfo types to raw types in symcaches:
- Conversions are now in a single place (`convert.rs`)
- Locations now use a tagged union like types did before

There is also a breaking change in here, the removal of `PartialEq` and `Eq` from `SymCache` and `SourceLocation`. Comparing a sym cache is not cheap, it is implemented by comparing all individually stored types. It is equivalent to running a `memcmp` on the entire data region, which would be more efficient than comparing all individual types.

If this needs to come back, we should either assign a uuid for each symcache or really do a memcmp.