### PR TITLE
fix(debuginfo): Make `Function`'s `Drop` iterative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - No unwind info on certain dsym files with sparse sections. ([#1041](https://github.com/getsentry/symbolic/pull/1041))
 - Increase inlinee limits ([#1046](https://github.com/getsentry/symbolic/pull/1046))
+- Make the `Drop` impl of `Function` nonrecursive. ([#1050](https://github.com/getsentry/symbolic/pull/1050))
 
 **Dependencies**
 

--- a/symbolic-debuginfo/src/base/mod.rs
+++ b/symbolic-debuginfo/src/base/mod.rs
@@ -769,6 +769,18 @@ impl fmt::Debug for Function<'_> {
     }
 }
 
+impl Drop for Function<'_> {
+    fn drop(&mut self) {
+        let mut inlinees = vec![std::mem::take(&mut self.inlinees)];
+
+        while let Some(next) = inlinees.pop() {
+            for mut f in next {
+                inlinees.push(std::mem::take(&mut f.inlinees));
+            }
+        }
+    }
+}
+
 /// A dynamically dispatched iterator over items with the given lifetime.
 pub type DynIterator<'a, T> = Box<dyn Iterator<Item = T> + 'a>;
 

--- a/symbolic-debuginfo/src/macho/mod.rs
+++ b/symbolic-debuginfo/src/macho/mod.rs
@@ -893,6 +893,9 @@ mod tests {
 
     #[test]
     fn test_bcsymbolmap() {
+        let bc_symbol_map_data =
+            std::fs::read("tests/fixtures/c8374b6d-6e96-34d8-ae38-efaa5fec424f.bcsymbolmap")
+                .unwrap();
         let object_data =
             std::fs::read("tests/fixtures/2d10c42f-591d-3265-b147-78ba0868073f.dwarf-hidden")
                 .unwrap();
@@ -931,9 +934,6 @@ mod tests {
         assert_eq!(&inlinee.name, "__hidden#146_");
 
         // loads the symbolmap
-        let bc_symbol_map_data =
-            std::fs::read("tests/fixtures/c8374b6d-6e96-34d8-ae38-efaa5fec424f.bcsymbolmap")
-                .unwrap();
         let bc_symbol_map = BcSymbolMap::parse(&bc_symbol_map_data).unwrap();
         object.load_symbolmap(bc_symbol_map);
 

--- a/symbolic-debuginfo/tests/test_pdb_srcsrv.rs
+++ b/symbolic-debuginfo/tests/test_pdb_srcsrv.rs
@@ -54,7 +54,7 @@ fn test_pdb_line_info() {
     let line = session
         .functions()
         .map(|function| function.unwrap())
-        .flat_map(|function| function.lines.into_iter())
+        .flat_map(|mut function| std::mem::take(&mut function.lines).into_iter())
         .find(|line| {
             // Expected specific path based on the SRCSRV data in the test PDB
             // Path should NOT contain @12345, revision should be separate


### PR DESCRIPTION
This requires some minor changes in tests because implementing `Drop` means you can't partially move a type and have to be more careful with declaration order.

ref: INGEST-1133