### PR TITLE
fix(demangle): Patch segfault in Swift demangler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - No unwind info on certain dsym files with sparse sections. ([#1041](https://github.com/getsentry/symbolic/pull/1041))
 - Increase inlinee limits ([#1046](https://github.com/getsentry/symbolic/pull/1046))
+- Patch a potential segfault in the vendored Swift demangler. ([#1052](https://github.com/getsentry/symbolic/pull/1052))
 
 **Dependencies**
 

--- a/symbolic-demangle/tests/test_swift.rs
+++ b/symbolic-demangle/tests/test_swift.rs
@@ -10,6 +10,13 @@ use symbolic_common::Language;
 use symbolic_demangle::DemangleOptions;
 
 #[test]
+fn test_demangle_swift_segfault() {
+    assert_demangle!(Language::Swift, DemangleOptions::name_only(), {
+        "$s3abcLlfMf_" => "$s3abcLlfMf_",
+    });
+}
+
+#[test]
 fn test_demangle_swift_short() {
     assert_demangle!(Language::Swift, DemangleOptions::name_only().parameters(true), {
         // Swift < 4 (old mangling)

--- a/symbolic-demangle/vendor/swift/3-null-checks.patch
+++ b/symbolic-demangle/vendor/swift/3-null-checks.patch
@@ -1,0 +1,26 @@
+diff --git a/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp b/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp
+index 2743c615..3c9a2327 100644
+--- a/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp
++++ b/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp
+@@ -2709,9 +2709,9 @@ NodePointer Demangler::demangleArchetype() {
+     auto boundGenerics = createNode(Node::Kind::TypeList);
+     for (unsigned i = boundGenericArgs.size(); i-- > 0;)
+       boundGenerics->addChild(boundGenericArgs[i], *this);
+-    opaque->addChild(boundGenerics, *this);
++    addChild(opaque, boundGenerics);
+     if (retroactiveConformances)
+-      opaque->addChild(retroactiveConformances, *this);
++      addChild(opaque, retroactiveConformances);
+     
+     auto opaqueTy = createType(opaque);
+     addSubstitution(opaqueTy);
+@@ -4613,8 +4613,7 @@ NodePointer Demangler::demangleMacroExpansion() {
+   } else {
+     result = createWithChildren(kind, context, macroName, discriminator);
+   }
+-  if (privateDiscriminator)
+-    result->addChild(privateDiscriminator, *this);
++  addChild(result, privateDiscriminator);
+   return result;
+ }
+ 

--- a/symbolic-demangle/vendor/swift/README.md
+++ b/symbolic-demangle/vendor/swift/README.md
@@ -41,8 +41,8 @@ patch is maintained in `1-arguments.patch`.
       ```
    2. Check for modifications.
    3. Commit _"feat(demangle): Import libswift demangle x.x.x"_ before proceeding.
-3. **Apply the patch:**
-   1. Apply `1-arguments.patch`.
+3. **Apply patches:**
+   1. Apply `1-arguments.patch`, `2-metatype-compat.patch`, and `3-null-checks.patch`.
    2. Build the Rust library and ensure tests work.
    3. Commit the changes.
 4. **Add tests for new mangling schemes:**

--- a/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp
+++ b/symbolic-demangle/vendor/swift/lib/Demangling/Demangler.cpp
@@ -2709,9 +2709,9 @@ NodePointer Demangler::demangleArchetype() {
     auto boundGenerics = createNode(Node::Kind::TypeList);
     for (unsigned i = boundGenericArgs.size(); i-- > 0;)
       boundGenerics->addChild(boundGenericArgs[i], *this);
-    opaque->addChild(boundGenerics, *this);
+    addChild(opaque, boundGenerics);
     if (retroactiveConformances)
-      opaque->addChild(retroactiveConformances, *this);
+      addChild(opaque, retroactiveConformances);
     
     auto opaqueTy = createType(opaque);
     addSubstitution(opaqueTy);
@@ -4613,8 +4613,7 @@ NodePointer Demangler::demangleMacroExpansion() {
   } else {
     result = createWithChildren(kind, context, macroName, discriminator);
   }
-  if (privateDiscriminator)
-    result->addChild(privateDiscriminator, *this);
+  addChild(result, privateDiscriminator);
   return result;
 }
 


### PR DESCRIPTION
It's possible to trigger a null dereference with some mangled names in the Swift demangler. This patches the vulnerability for our vendored copy. We'll also report the problem upstream.

ref: INGEST-1134