### PR TITLE
fix(unreal): Do not allocate based on untrusted input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - No unwind info on certain dsym files with sparse sections. ([#1041](https://github.com/getsentry/symbolic/pull/1041))
 - Increase inlinee limits ([#1046](https://github.com/getsentry/symbolic/pull/1046))
 - Patch a potential segfault in the vendored Swift demangler. ([#1052](https://github.com/getsentry/symbolic/pull/1052))
+- Do not allocate based on untrusted input in unreal parser ([#1055](https://github.com/getsentry/symbolic/pull/1055))
 
 **Dependencies**
 

--- a/symbolic-unreal/src/container.rs
+++ b/symbolic-unreal/src/container.rs
@@ -119,7 +119,7 @@ fn gread_files(
     if count > bytes.len() / 12 {
         return Err(Unreal4ErrorKind::BadData.into());
     }
-    let mut files = Vec::with_capacity(count);
+    let mut files = vec![];
     for _ in 0..count {
         let file_offset = *offset;
         files.push(bytes.gread_with(offset, file_offset)?);


### PR DESCRIPTION
Pre-allocating a vector is likely premature optimization and can go wrong if the count provided by the file is incorrect.

Fixes INGEST-1135.