### PR TITLE
deps: Update js-source-scopes to 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 **Dependencies**
 
 - Bump `pdb-addr2line` to 0.12.1 to fix a potential infinite recursion. ([#1030](https://github.com/getsentry/symbolic/pull/1030))
+- Bump `js-source-scopes` to 0.7.3 to fix name resolution for private functions. ([#1057](https://github.com/getsentry/symbolic/pull/1057))
 
 **Features**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,9 +1133,9 @@ checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "js-source-scopes"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad7db26c7e0013043d3f79f3a676305885c73c52a3b97e98d804ef5d6465514"
+checksum = "34ab3d2856a5b0a928d8aa637fa40fa734ebdfb8c4ff7f2055c0f15ae0f3ddfa"
 dependencies = [
  "indexmap",
  "sourcemap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ goblin = { version = "0.10.6", default-features = false }
 indexmap = "2.0.0"
 insta = { version = "1.28.0", features = ["yaml"] }
 itertools = "0.14.0"
-js-source-scopes = "0.7.2"
+js-source-scopes = "0.7.3"
 js-sys = "0.3.102"
 memchr = "2.8.0"
 memmap2 = "0.9.11"


### PR DESCRIPTION
This incorporates https://github.com/getsentry/js-source-scopes/pull/33.