### PR TITLE
ref(demangle): Add error category for too large attachments and remove warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2581,7 +2581,6 @@ dependencies = [
  "similar-asserts",
  "symbolic-common",
  "thiserror",
- "tracing",
 ]
 
 [[package]]

--- a/symbolic-demangle/Cargo.toml
+++ b/symbolic-demangle/Cargo.toml
@@ -36,7 +36,6 @@ symbolic-common = { version = "14.0.0-alpha.3", path = "../symbolic-common" }
 bitflags = { version = "2", optional = true, default-features = false }
 itoa = { version = "1.0", optional = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }
 
 [build-dependencies]
 cc = { workspace = true, optional = true }

--- a/symbolic-demangle/src/lib.rs
+++ b/symbolic-demangle/src/lib.rs
@@ -315,6 +315,9 @@ enum SwiftDemangleError {
     DemangleFail(String),
     #[error("constructing CString failed")]
     BadString(#[from] NulError),
+    // The output of demangling is currently capped at 4096 chars.
+    #[error("demangle output is too large")]
+    OutputTooLarge,
 }
 
 #[cfg(feature = "swift")]
@@ -332,10 +335,11 @@ fn try_demangle_swift(ident: &str, opts: DemangleOptions) -> Result<String, Swif
 
     unsafe {
         match symbolic_demangle_swift(sym.as_ptr(), buf.as_mut_ptr(), buf.len(), features) {
-            0 => {
+            2 => {
                 let error = CStr::from_ptr(buf.as_ptr()).to_string_lossy().to_string();
                 Err(SwiftDemangleError::DemangleFail(error))
             }
+            1 => Err(SwiftDemangleError::OutputTooLarge),
             _ => Ok(CStr::from_ptr(buf.as_ptr()).to_string_lossy().to_string()),
         }
     }

--- a/symbolic-demangle/src/lib.rs
+++ b/symbolic-demangle/src/lib.rs
@@ -476,11 +476,7 @@ impl Demangle for Name<'_> {
             Language::Rust => try_demangle_rust(self.as_str(), opts),
             Language::Cpp => try_demangle_cpp(self.as_str(), opts),
             #[cfg(feature = "swift")]
-            Language::Swift => try_demangle_swift(self.as_str(), opts)
-                .map_err(
-                    |e| tracing::warn!(error=%e, symbol = self.as_str(), "swift demangling failed"),
-                )
-                .ok(),
+            Language::Swift => try_demangle_swift(self.as_str(), opts).ok(),
             _ => None,
         }
     }

--- a/symbolic-demangle/src/swiftdemangle.cpp
+++ b/symbolic-demangle/src/swiftdemangle.cpp
@@ -25,19 +25,19 @@ extern "C" int symbolic_demangle_swift(const char *symbol,
         demangled = swift::Demangle::demangleSymbolAsString(llvm::StringRef(symbol), opts);
     } catch (const std::exception& e) {
         snprintf(buffer, buffer_length, "%s", e.what());
-        return false;
+        return 2;
     } catch (...) {
         snprintf(buffer, buffer_length, "%s", "unknown exception");
-        return false;
+        return 2;
     }
 
     if (demangled.size() == 0 || demangled.size() >= buffer_length) {
-        return false;
+        return 1;
     }
 
     memcpy(buffer, demangled.c_str(), demangled.size());
     buffer[demangled.size()] = '\0';
-    return true;
+    return 0;
 }
 
 extern "C" int symbolic_demangle_is_swift_symbol(const char *symbol) {


### PR DESCRIPTION
This warning is hit more often than expected due to symbols hitting the size limit, as such remove the warning and add a seperate error category for symbols that are too large (so that we can surface it in the future).