### PR TITLE
fix(sourcelinks): Only replace first `*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Patch potential aborts in the vendored Swift demangler. ([#1054](https://github.com/getsentry/symbolic/pull/1054), [#1059](https://github.com/getsentry/symbolic/pull/1059), [#1062](https://github.com/getsentry/symbolic/pull/1062))
 - Do not allocate based on untrusted input in unreal parser. ([#1055](https://github.com/getsentry/symbolic/pull/1055))
 - Ensure unwind sections contain any unwind information. ([#1058](https://github.com/getsentry/symbolic/pull/1058))
+- Only replace the first `*` in sourcelink expansion. ([#1064](https://github.com/getsentry/symbolic/pull/1064))
 
 **Dependencies**
 

--- a/symbolic-common/src/sourcelinks.rs
+++ b/symbolic-common/src/sourcelinks.rs
@@ -108,7 +108,7 @@ impl SourceLinkMappings {
                             .get(value.len()..)
                             .unwrap_or_default()
                             .replace('\\', "/");
-                        return Some(target.replace('*', &replacement));
+                        return Some(target.replacen('*', &replacement, 1));
                     }
                 }
             }


### PR DESCRIPTION
The intention for sourcelinks is for the replacement string to only contain one `*`, but this is not actually enforced. As a quick fix, we simply call `replace_n(1)` instead of `replace` so even if there are multiple `*`s we still only use one.

Fixes INGEST-1139.