### PR TITLE
fix(debuginfo): Remove depth limits from function parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Remove support for symcache version 7 and 8. ([#1033](https://github.com/getsentry/symbolic/pull/1033))
 - Adds variables to functions. ([#1025](https://github.com/getsentry/symbolic/pull/1025))
 - `SymCache` and `SourceLocation` no longer implement `PartialEq` and `Eq`. ([#1039](https://github.com/getsentry/symbolic/pull/1039))
+- Remove depth limits from function parsing. ([#1065](https://github.com/getsentry/symbolic/pull/1065))
 
 **Fixes**
 

--- a/symbolic-debuginfo/src/base/mod.rs
+++ b/symbolic-debuginfo/src/base/mod.rs
@@ -742,6 +742,19 @@ pub struct Function<'data> {
     pub variables: Vec<variable::Variable<'data>>,
 }
 
+// We need a custom drop implementation to avoid recursing down the inlinees.
+impl<'data> Drop for Function<'data> {
+    fn drop(&mut self) {
+        let mut inlinees = vec![std::mem::take(&mut self.inlinees)];
+
+        while let Some(inlinee_set) = inlinees.pop() {
+            for mut f in inlinee_set {
+                inlinees.push(std::mem::take(&mut f.inlinees));
+            }
+        }
+    }
+}
+
 impl Function<'_> {
     /// End address of the entire function body, including inlined functions.
     ///
@@ -751,21 +764,225 @@ impl Function<'_> {
     }
 }
 
+// The following is an iterative fmt::Debug impl for Function, written by Claude.  Because it's
+// a Debug impl, I haven't thoroughly vetted it, but it seems to produce byte-identical output.
+
+/// Writes `4 * indent` spaces.
+fn write_indent(f: &mut fmt::Formatter<'_>, indent: usize) -> fmt::Result {
+    const SPACES: &str = "                                ";
+
+    let mut remaining = indent * 4;
+    while remaining > 0 {
+        let len = remaining.min(SPACES.len());
+        f.write_str(&SPACES[..len])?;
+        remaining -= len;
+    }
+
+    Ok(())
+}
+
+/// A writer that indents every line but the first, mirroring what the standard library's debug
+/// builders do for nested values in alternate mode.
+struct PadAdapter<'a, 'b> {
+    fmt: &'a mut fmt::Formatter<'b>,
+    indent: usize,
+    on_newline: bool,
+}
+
+impl fmt::Write for PadAdapter<'_, '_> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for (i, line) in s.split('\n').enumerate() {
+            if i > 0 {
+                self.fmt.write_str("\n")?;
+                self.on_newline = true;
+            }
+
+            if line.is_empty() {
+                continue;
+            }
+
+            if self.on_newline {
+                write_indent(self.fmt, self.indent)?;
+                self.on_newline = false;
+            }
+
+            self.fmt.write_str(line)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Writes a single `name: value` field of a `Function`.
+///
+/// `sep` is the separator preceding the field in compact (non-alternate) mode, which is `" "` for
+/// the first field of a struct and `", "` for all following ones.
+fn write_field(
+    f: &mut fmt::Formatter<'_>,
+    alternate: bool,
+    indent: usize,
+    sep: &str,
+    name: &str,
+    value: &dyn fmt::Debug,
+) -> fmt::Result {
+    use fmt::Write;
+
+    if !alternate {
+        return write!(f, "{sep}{name}: {value:?}");
+    }
+
+    write_indent(f, indent)?;
+    write!(f, "{name}: ")?;
+
+    let mut pad = PadAdapter {
+        fmt: f,
+        indent,
+        on_newline: false,
+    };
+    write!(pad, "{value:#?}")?;
+
+    f.write_str(",\n")
+}
+
 impl fmt::Debug for Function<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Function")
-            .field("address", &format_args!("{:#x}", self.address))
-            .field("size", &format_args!("{:#x}", self.size))
-            .field("name", &self.name)
-            .field(
-                "compilation_dir",
-                &String::from_utf8_lossy(self.compilation_dir),
-            )
-            .field("lines", &self.lines)
-            .field("inlinees", &self.inlinees)
-            .field("inline", &self.inline)
-            .field("variables", &self.variables)
-            .finish()
+        // This is written as an explicit work list rather than the usual recursive `Debug`
+        // implementation, since deeply nested inlinees would otherwise overflow the stack.
+        enum Step<'a, 'data> {
+            /// Writes everything up to and including the opening bracket of `inlinees`.
+            Head {
+                func: &'a Function<'data>,
+                indent: usize,
+                /// Separator written before the function in compact mode.
+                prefix: &'static str,
+                /// Separator written after the function in alternate mode.
+                suffix: &'static str,
+            },
+            /// Closes `inlinees` and writes the remaining fields and the closing brace.
+            Tail {
+                func: &'a Function<'data>,
+                indent: usize,
+                /// Separator written after the function in alternate mode.
+                suffix: &'static str,
+            },
+        }
+
+        let alternate = f.alternate();
+        let mut stack = vec![Step::Head {
+            func: self,
+            indent: 0,
+            prefix: "",
+            suffix: "",
+        }];
+
+        while let Some(step) = stack.pop() {
+            match step {
+                Step::Head {
+                    func,
+                    indent,
+                    prefix,
+                    suffix,
+                } => {
+                    if alternate {
+                        write_indent(f, indent)?;
+                        f.write_str("Function {\n")?;
+                    } else {
+                        write!(f, "{prefix}Function {{")?;
+                    }
+
+                    let inner = indent + 1;
+                    write_field(
+                        f,
+                        alternate,
+                        inner,
+                        " ",
+                        "address",
+                        &format_args!("{:#x}", func.address),
+                    )?;
+                    write_field(
+                        f,
+                        alternate,
+                        inner,
+                        ", ",
+                        "size",
+                        &format_args!("{:#x}", func.size),
+                    )?;
+                    write_field(f, alternate, inner, ", ", "name", &func.name)?;
+                    write_field(
+                        f,
+                        alternate,
+                        inner,
+                        ", ",
+                        "compilation_dir",
+                        &String::from_utf8_lossy(func.compilation_dir),
+                    )?;
+                    write_field(f, alternate, inner, ", ", "lines", &func.lines)?;
+
+                    if alternate {
+                        write_indent(f, inner)?;
+                        f.write_str("inlinees: [")?;
+                    } else {
+                        f.write_str(", inlinees: [")?;
+                    }
+
+                    if func.inlinees.is_empty() {
+                        if alternate {
+                            f.write_str("],\n")?;
+                        } else {
+                            f.write_str("]")?;
+                        }
+                    } else if alternate {
+                        f.write_str("\n")?;
+                    }
+
+                    // The remaining fields are written once all inlinees have been visited.
+                    stack.push(Step::Tail {
+                        func,
+                        indent,
+                        suffix,
+                    });
+
+                    for (i, inlinee) in func.inlinees.iter().enumerate().rev() {
+                        stack.push(Step::Head {
+                            func: inlinee,
+                            indent: indent + 2,
+                            prefix: if i == 0 { "" } else { ", " },
+                            suffix: if alternate { ",\n" } else { "" },
+                        });
+                    }
+                }
+
+                Step::Tail {
+                    func,
+                    indent,
+                    suffix,
+                } => {
+                    if !func.inlinees.is_empty() {
+                        if alternate {
+                            write_indent(f, indent + 1)?;
+                            f.write_str("],\n")?;
+                        } else {
+                            f.write_str("]")?;
+                        }
+                    }
+
+                    let inner = indent + 1;
+                    write_field(f, alternate, inner, ", ", "inline", &func.inline)?;
+                    write_field(f, alternate, inner, ", ", "variables", &func.variables)?;
+
+                    if alternate {
+                        write_indent(f, indent)?;
+                        f.write_str("}")?;
+                    } else {
+                        f.write_str(" }")?;
+                    }
+
+                    f.write_str(suffix)?;
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -934,6 +1151,7 @@ mod derive_serde {
 mod tests {
     use super::*;
     use similar_asserts::assert_eq;
+    use symbolic_common::{Language, NameMangling};
 
     fn file_info<'a>(dir: &'a str, name: &'a str) -> FileInfo<'a> {
         FileInfo::new(
@@ -983,5 +1201,71 @@ mod tests {
             file_entry("/usr", "/src", "foo.h").abs_path_str(),
             "/src/foo.h"
         );
+    }
+
+    // Tests, written by Claude, to ensure that the iterative fmt::Debug implementation matches
+    // the original recursive one.
+
+    /// A recursive `Debug` implementation for `Function`, used as a reference for the iterative
+    /// one.
+    struct RecursiveDebug<'a, 'data>(&'a Function<'data>);
+
+    impl fmt::Debug for RecursiveDebug<'_, '_> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let func = self.0;
+            let inlinees: Vec<_> = func.inlinees.iter().map(RecursiveDebug).collect();
+
+            f.debug_struct("Function")
+                .field("address", &format_args!("{:#x}", func.address))
+                .field("size", &format_args!("{:#x}", func.size))
+                .field("name", &func.name)
+                .field(
+                    "compilation_dir",
+                    &String::from_utf8_lossy(func.compilation_dir),
+                )
+                .field("lines", &func.lines)
+                .field("inlinees", &inlinees)
+                .field("inline", &func.inline)
+                .field("variables", &func.variables)
+                .finish()
+        }
+    }
+
+    fn function(name: &'static str, inlinees: Vec<Function<'static>>) -> Function<'static> {
+        Function {
+            address: 0x1000,
+            size: 0x42,
+            name: Name::new(name, NameMangling::Unmangled, Language::Rust),
+            compilation_dir: b"/usr/src",
+            lines: vec![
+                LineInfo::new(0x1000, 0x10, b"foo.rs", 1),
+                LineInfo::new(0x1010, 0x10, b"bar.rs", 2),
+            ],
+            inlinees,
+            inline: true,
+            variables: Vec::new(),
+        }
+    }
+
+    /// Builds a function with `depth` levels of nested inlinees, each with two children on the
+    /// first level to also cover multiple siblings.
+    fn nested_function(depth: usize) -> Function<'static> {
+        let mut func = function("innermost", vec![function("sibling", Vec::new())]);
+        for _ in 0..depth {
+            func = function("outer", vec![func]);
+        }
+        func
+    }
+
+    #[test]
+    fn test_function_debug_matches_recursive() {
+        for depth in [0, 1, 5] {
+            let func = nested_function(depth);
+            assert_eq!(format!("{func:?}"), format!("{:?}", RecursiveDebug(&func)));
+            assert_eq!(
+                format!("{func:#?}"),
+                format!("{:#?}", RecursiveDebug(&func))
+            );
+        }
     }
 }

--- a/symbolic-debuginfo/src/base/mod.rs
+++ b/symbolic-debuginfo/src/base/mod.rs
@@ -755,234 +755,30 @@ impl<'data> Drop for Function<'data> {
     }
 }
 
+impl fmt::Debug for Function<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Function")
+            .field("address", &format_args!("{:#x}", self.address))
+            .field("size", &format_args!("{:#x}", self.size))
+            .field("name", &self.name)
+            .field(
+                "compilation_dir",
+                &String::from_utf8_lossy(self.compilation_dir),
+            )
+            .field("lines", &self.lines)
+            .field("inlinees", &self.inlinees)
+            .field("inline", &self.inline)
+            .field("variables", &self.variables)
+            .finish()
+    }
+}
+
 impl Function<'_> {
     /// End address of the entire function body, including inlined functions.
     ///
     /// This address points at the first instruction after the function body.
     pub fn end_address(&self) -> u64 {
         self.address.saturating_add(self.size)
-    }
-}
-
-// The following is an iterative fmt::Debug impl for Function, written by Claude.  Because it's
-// a Debug impl, I haven't thoroughly vetted it, but it seems to produce byte-identical output.
-
-/// Writes `4 * indent` spaces.
-fn write_indent(f: &mut fmt::Formatter<'_>, indent: usize) -> fmt::Result {
-    const SPACES: &str = "                                ";
-
-    let mut remaining = indent * 4;
-    while remaining > 0 {
-        let len = remaining.min(SPACES.len());
-        f.write_str(&SPACES[..len])?;
-        remaining -= len;
-    }
-
-    Ok(())
-}
-
-/// A writer that indents every line but the first, mirroring what the standard library's debug
-/// builders do for nested values in alternate mode.
-struct PadAdapter<'a, 'b> {
-    fmt: &'a mut fmt::Formatter<'b>,
-    indent: usize,
-    on_newline: bool,
-}
-
-impl fmt::Write for PadAdapter<'_, '_> {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        for (i, line) in s.split('\n').enumerate() {
-            if i > 0 {
-                self.fmt.write_str("\n")?;
-                self.on_newline = true;
-            }
-
-            if line.is_empty() {
-                continue;
-            }
-
-            if self.on_newline {
-                write_indent(self.fmt, self.indent)?;
-                self.on_newline = false;
-            }
-
-            self.fmt.write_str(line)?;
-        }
-
-        Ok(())
-    }
-}
-
-/// Writes a single `name: value` field of a `Function`.
-///
-/// `sep` is the separator preceding the field in compact (non-alternate) mode, which is `" "` for
-/// the first field of a struct and `", "` for all following ones.
-fn write_field(
-    f: &mut fmt::Formatter<'_>,
-    alternate: bool,
-    indent: usize,
-    sep: &str,
-    name: &str,
-    value: &dyn fmt::Debug,
-) -> fmt::Result {
-    use fmt::Write;
-
-    if !alternate {
-        return write!(f, "{sep}{name}: {value:?}");
-    }
-
-    write_indent(f, indent)?;
-    write!(f, "{name}: ")?;
-
-    let mut pad = PadAdapter {
-        fmt: f,
-        indent,
-        on_newline: false,
-    };
-    write!(pad, "{value:#?}")?;
-
-    f.write_str(",\n")
-}
-
-impl fmt::Debug for Function<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // This is written as an explicit work list rather than the usual recursive `Debug`
-        // implementation, since deeply nested inlinees would otherwise overflow the stack.
-        enum Step<'a, 'data> {
-            /// Writes everything up to and including the opening bracket of `inlinees`.
-            Head {
-                func: &'a Function<'data>,
-                indent: usize,
-                /// Separator written before the function in compact mode.
-                prefix: &'static str,
-                /// Separator written after the function in alternate mode.
-                suffix: &'static str,
-            },
-            /// Closes `inlinees` and writes the remaining fields and the closing brace.
-            Tail {
-                func: &'a Function<'data>,
-                indent: usize,
-                /// Separator written after the function in alternate mode.
-                suffix: &'static str,
-            },
-        }
-
-        let alternate = f.alternate();
-        let mut stack = vec![Step::Head {
-            func: self,
-            indent: 0,
-            prefix: "",
-            suffix: "",
-        }];
-
-        while let Some(step) = stack.pop() {
-            match step {
-                Step::Head {
-                    func,
-                    indent,
-                    prefix,
-                    suffix,
-                } => {
-                    if alternate {
-                        write_indent(f, indent)?;
-                        f.write_str("Function {\n")?;
-                    } else {
-                        write!(f, "{prefix}Function {{")?;
-                    }
-
-                    let inner = indent + 1;
-                    write_field(
-                        f,
-                        alternate,
-                        inner,
-                        " ",
-                        "address",
-                        &format_args!("{:#x}", func.address),
-                    )?;
-                    write_field(
-                        f,
-                        alternate,
-                        inner,
-                        ", ",
-                        "size",
-                        &format_args!("{:#x}", func.size),
-                    )?;
-                    write_field(f, alternate, inner, ", ", "name", &func.name)?;
-                    write_field(
-                        f,
-                        alternate,
-                        inner,
-                        ", ",
-                        "compilation_dir",
-                        &String::from_utf8_lossy(func.compilation_dir),
-                    )?;
-                    write_field(f, alternate, inner, ", ", "lines", &func.lines)?;
-
-                    if alternate {
-                        write_indent(f, inner)?;
-                        f.write_str("inlinees: [")?;
-                    } else {
-                        f.write_str(", inlinees: [")?;
-                    }
-
-                    if func.inlinees.is_empty() {
-                        if alternate {
-                            f.write_str("],\n")?;
-                        } else {
-                            f.write_str("]")?;
-                        }
-                    } else if alternate {
-                        f.write_str("\n")?;
-                    }
-
-                    // The remaining fields are written once all inlinees have been visited.
-                    stack.push(Step::Tail {
-                        func,
-                        indent,
-                        suffix,
-                    });
-
-                    for (i, inlinee) in func.inlinees.iter().enumerate().rev() {
-                        stack.push(Step::Head {
-                            func: inlinee,
-                            indent: indent + 2,
-                            prefix: if i == 0 { "" } else { ", " },
-                            suffix: if alternate { ",\n" } else { "" },
-                        });
-                    }
-                }
-
-                Step::Tail {
-                    func,
-                    indent,
-                    suffix,
-                } => {
-                    if !func.inlinees.is_empty() {
-                        if alternate {
-                            write_indent(f, indent + 1)?;
-                            f.write_str("],\n")?;
-                        } else {
-                            f.write_str("]")?;
-                        }
-                    }
-
-                    let inner = indent + 1;
-                    write_field(f, alternate, inner, ", ", "inline", &func.inline)?;
-                    write_field(f, alternate, inner, ", ", "variables", &func.variables)?;
-
-                    if alternate {
-                        write_indent(f, indent)?;
-                        f.write_str("}")?;
-                    } else {
-                        f.write_str(" }")?;
-                    }
-
-                    f.write_str(suffix)?;
-                }
-            }
-        }
-
-        Ok(())
     }
 }
 
@@ -1151,7 +947,6 @@ mod derive_serde {
 mod tests {
     use super::*;
     use similar_asserts::assert_eq;
-    use symbolic_common::{Language, NameMangling};
 
     fn file_info<'a>(dir: &'a str, name: &'a str) -> FileInfo<'a> {
         FileInfo::new(
@@ -1201,71 +996,5 @@ mod tests {
             file_entry("/usr", "/src", "foo.h").abs_path_str(),
             "/src/foo.h"
         );
-    }
-
-    // Tests, written by Claude, to ensure that the iterative fmt::Debug implementation matches
-    // the original recursive one.
-
-    /// A recursive `Debug` implementation for `Function`, used as a reference for the iterative
-    /// one.
-    struct RecursiveDebug<'a, 'data>(&'a Function<'data>);
-
-    impl fmt::Debug for RecursiveDebug<'_, '_> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            let func = self.0;
-            let inlinees: Vec<_> = func.inlinees.iter().map(RecursiveDebug).collect();
-
-            f.debug_struct("Function")
-                .field("address", &format_args!("{:#x}", func.address))
-                .field("size", &format_args!("{:#x}", func.size))
-                .field("name", &func.name)
-                .field(
-                    "compilation_dir",
-                    &String::from_utf8_lossy(func.compilation_dir),
-                )
-                .field("lines", &func.lines)
-                .field("inlinees", &inlinees)
-                .field("inline", &func.inline)
-                .field("variables", &func.variables)
-                .finish()
-        }
-    }
-
-    fn function(name: &'static str, inlinees: Vec<Function<'static>>) -> Function<'static> {
-        Function {
-            address: 0x1000,
-            size: 0x42,
-            name: Name::new(name, NameMangling::Unmangled, Language::Rust),
-            compilation_dir: b"/usr/src",
-            lines: vec![
-                LineInfo::new(0x1000, 0x10, b"foo.rs", 1),
-                LineInfo::new(0x1010, 0x10, b"bar.rs", 2),
-            ],
-            inlinees,
-            inline: true,
-            variables: Vec::new(),
-        }
-    }
-
-    /// Builds a function with `depth` levels of nested inlinees, each with two children on the
-    /// first level to also cover multiple siblings.
-    fn nested_function(depth: usize) -> Function<'static> {
-        let mut func = function("innermost", vec![function("sibling", Vec::new())]);
-        for _ in 0..depth {
-            func = function("outer", vec![func]);
-        }
-        func
-    }
-
-    #[test]
-    fn test_function_debug_matches_recursive() {
-        for depth in [0, 1, 5] {
-            let func = nested_function(depth);
-            assert_eq!(format!("{func:?}"), format!("{:?}", RecursiveDebug(&func)));
-            assert_eq!(
-                format!("{func:#?}"),
-                format!("{:#?}", RecursiveDebug(&func))
-            );
-        }
     }
 }

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -2134,6 +2134,8 @@ mod parsing {
 }
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
 
     #[test]
@@ -2626,10 +2628,8 @@ mod tests {
         let obj = BreakpadObject::parse(&buffer).expect("parse breakpad");
 
         let session = obj.debug_session().expect("session");
-        let _ = session
-            .functions()
-            .next()
-            .unwrap()
-            .expect_err("should have seen an error");
+        let e = session.functions().next().unwrap().err().unwrap();
+
+        assert_matches!(e.kind(), BreakpadErrorKind::ExhaustedResourceLimit);
     }
 }

--- a/symbolic-debuginfo/src/breakpad.rs
+++ b/symbolic-debuginfo/src/breakpad.rs
@@ -957,7 +957,6 @@ pub struct BreakpadObject<'data> {
     arch: Arch,
     module: BreakpadModuleRecord<'data>,
     data: &'data [u8],
-    max_function_parse_depth: u32,
 }
 
 impl<'data> BreakpadObject<'data> {
@@ -972,7 +971,10 @@ impl<'data> BreakpadObject<'data> {
     }
 
     /// Tries to parse a Breakpad object from the given slice.
-    fn parse_with_opts(data: &'data [u8], opts: ParseObjectOptions) -> Result<Self, BreakpadError> {
+    fn parse_with_opts(
+        data: &'data [u8],
+        _opts: ParseObjectOptions,
+    ) -> Result<Self, BreakpadError> {
         // Ensure that we do not read the entire file at once.
         let header = if data.len() > BREAKPAD_HEADER_CAP {
             match str::from_utf8(&data[..BREAKPAD_HEADER_CAP]) {
@@ -1000,7 +1002,6 @@ impl<'data> BreakpadObject<'data> {
                 .map_err(|_| BreakpadErrorKind::InvalidArchitecture)?,
             module,
             data,
-            max_function_parse_depth: opts.max_function_parse_depth,
         })
     }
 
@@ -1089,7 +1090,6 @@ impl<'data> BreakpadObject<'data> {
         Ok(BreakpadDebugSession {
             file_map: self.file_map(),
             lines: Lines::new(self.data),
-            max_function_parse_depth: self.max_function_parse_depth,
         })
     }
 
@@ -1282,17 +1282,12 @@ impl<'data> Iterator for BreakpadSymbolIterator<'data> {
 pub struct BreakpadDebugSession<'data> {
     file_map: BreakpadFileMap<'data>,
     lines: Lines<'data>,
-    max_function_parse_depth: u32,
 }
 
 impl BreakpadDebugSession<'_> {
     /// Returns an iterator over all functions in this debug file.
     pub fn functions(&self) -> BreakpadFunctionIterator<'_> {
-        BreakpadFunctionIterator::new(
-            &self.file_map,
-            self.lines.clone(),
-            self.max_function_parse_depth,
-        )
+        BreakpadFunctionIterator::new(&self.file_map, self.lines.clone())
     }
 
     /// Returns an iterator over all source files in this debug file.
@@ -1363,22 +1358,16 @@ pub struct BreakpadFunctionIterator<'s> {
     next_line: Option<&'s [u8]>,
     inline_origin_map: BreakpadInlineOriginMap<'s>,
     lines: Lines<'s>,
-    max_function_parse_depth: u32,
 }
 
 impl<'s> BreakpadFunctionIterator<'s> {
-    fn new(
-        file_map: &'s BreakpadFileMap<'s>,
-        mut lines: Lines<'s>,
-        max_function_parse_depth: u32,
-    ) -> Self {
+    fn new(file_map: &'s BreakpadFileMap<'s>, mut lines: Lines<'s>) -> Self {
         let next_line = lines.next();
         Self {
             file_map,
             next_line,
             inline_origin_map: Default::default(),
             lines,
-            max_function_parse_depth,
         }
     }
 }
@@ -1422,7 +1411,6 @@ impl<'s> Iterator for BreakpadFunctionIterator<'s> {
             b"",
             fun_record.address,
             fun_record.size,
-            self.max_function_parse_depth,
         );
 
         for line in self.lines.by_ref() {

--- a/symbolic-debuginfo/src/dwarf/mod.rs
+++ b/symbolic-debuginfo/src/dwarf/mod.rs
@@ -1078,7 +1078,6 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
         &self,
         index: usize,
         depth: isize,
-        max_parse_depth: usize,
         dw_die_offset: gimli::UnitOffset<usize>,
         entries: &mut EntriesRaw<'d, '_>,
         abbrev: &gimli::Abbreviation,
@@ -1157,13 +1156,7 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
                 let size = range.end - range.begin;
                 (
                     *range,
-                    FunctionBuilder::new(
-                        name.clone(),
-                        self.compilation_dir(),
-                        address,
-                        size,
-                        max_parse_depth as u32,
-                    ),
+                    FunctionBuilder::new(name.clone(), self.compilation_dir(), address, size),
                 )
             })
             .collect();
@@ -1245,7 +1238,6 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
         &self,
         entries: &mut EntriesRaw<'d, '_>,
         output: &mut FunctionsOutput<'_, 'd>,
-        max_parse_depth: usize,
     ) -> Result<(), DwarfError> {
         let mut function_stack: Vec<InProgressSubProgram<'d>> = vec![];
 
@@ -1280,7 +1272,6 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
                     let program = self.consume_subprogram_tag(
                         function_stack.len(),
                         next_depth,
-                        max_parse_depth,
                         dw_die_offset,
                         entries,
                         abbrev,
@@ -1324,12 +1315,6 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
                 _ => {
                     entries.skip_attributes(abbrev.attributes())?;
                 }
-            }
-            if function_stack.len() > max_parse_depth {
-                return Err(DwarfError::new(
-                    DwarfErrorKind::CorruptedData,
-                    "Exceeded max parse depth",
-                ));
             }
         }
 
@@ -1494,11 +1479,10 @@ impl<'d, 'a> DwarfUnit<'d, 'a> {
     fn functions(
         &self,
         seen_ranges: &mut BTreeSet<(u64, u64)>,
-        max_parse_depth: u32,
     ) -> Result<Vec<Function<'d>>, DwarfError> {
         let mut entries = self.inner.unit.entries_raw(None)?;
         let mut output = FunctionsOutput::with_seen_ranges(seen_ranges);
-        self.parse_functions(&mut entries, &mut output, max_parse_depth as usize)?;
+        self.parse_functions(&mut entries, &mut output)?;
         Ok(output.functions)
     }
 }
@@ -1942,7 +1926,6 @@ impl std::iter::FusedIterator for DwarfUnitIterator<'_> {}
 pub struct DwarfDebugSession<'data> {
     cell: SelfCell<Box<DwarfSections<'data>>, DwarfInfo<'data>>,
     bcsymbolmap: Option<Arc<BcSymbolMap<'data>>>,
-    max_parse_depth: u32,
 }
 
 impl<'data> DwarfDebugSession<'data> {
@@ -1952,7 +1935,6 @@ impl<'data> DwarfDebugSession<'data> {
         symbol_map: SymbolMap<'data>,
         address_offset: i64,
         kind: ObjectKind,
-        max_parse_depth: u32,
     ) -> Result<Self, DwarfError>
     where
         D: Dwarf<'data>,
@@ -1965,7 +1947,6 @@ impl<'data> DwarfDebugSession<'data> {
         Ok(DwarfDebugSession {
             cell,
             bcsymbolmap: None,
-            max_parse_depth,
         })
     }
 
@@ -1994,7 +1975,6 @@ impl<'data> DwarfDebugSession<'data> {
             functions: Vec::new().into_iter(),
             seen_ranges: BTreeSet::new(),
             finished: false,
-            max_parse_depth: self.max_parse_depth,
         }
     }
 
@@ -2141,7 +2121,6 @@ pub struct DwarfFunctionIterator<'s> {
     functions: std::vec::IntoIter<Function<'s>>,
     seen_ranges: BTreeSet<(u64, u64)>,
     finished: bool,
-    max_parse_depth: u32,
 }
 
 impl<'s> Iterator for DwarfFunctionIterator<'s> {
@@ -2163,7 +2142,7 @@ impl<'s> Iterator for DwarfFunctionIterator<'s> {
                 None => break,
             };
 
-            self.functions = match unit.functions(&mut self.seen_ranges, self.max_parse_depth) {
+            self.functions = match unit.functions(&mut self.seen_ranges) {
                 Ok(functions) => functions.into_iter(),
                 Err(error) => return Some(Err(error)),
             };

--- a/symbolic-debuginfo/src/elf.rs
+++ b/symbolic-debuginfo/src/elf.rs
@@ -72,7 +72,6 @@ pub struct ElfObject<'data> {
     data: &'data [u8],
     is_malformed: bool,
     max_decompressed_section_size: Option<usize>,
-    max_function_parse_depth: u32,
 }
 
 impl<'data> ElfObject<'data> {
@@ -172,7 +171,6 @@ impl<'data> ElfObject<'data> {
                         data,
                         is_malformed: true,
                         max_decompressed_section_size: opts.max_decompressed_section_size,
-                        max_function_parse_depth: opts.max_function_parse_depth,
                     });
                 }
             };
@@ -357,7 +355,6 @@ impl<'data> ElfObject<'data> {
             data,
             is_malformed: false,
             max_decompressed_section_size: opts.max_decompressed_section_size,
-            max_function_parse_depth: opts.max_function_parse_depth,
         })
     }
 
@@ -565,13 +562,7 @@ impl<'data> ElfObject<'data> {
     /// [`has_debug_info`](struct.ElfObject.html#method.has_debug_info).
     pub fn debug_session(&self) -> Result<DwarfDebugSession<'data>, DwarfError> {
         let symbols = self.symbol_map();
-        DwarfDebugSession::parse(
-            self,
-            symbols,
-            self.load_address() as i64,
-            self.kind(),
-            self.max_function_parse_depth,
-        )
+        DwarfDebugSession::parse(self, symbols, self.load_address() as i64, self.kind())
     }
 
     /// Determines whether this object contains stack unwinding information.

--- a/symbolic-debuginfo/src/function_builder.rs
+++ b/symbolic-debuginfo/src/function_builder.rs
@@ -63,19 +63,11 @@ pub struct FunctionBuilder<'s> {
     lines: Vec<LineInfo<'s>>,
     /// All variables found inside the function.
     variables: Vec<Variable<'s>>,
-    /// The maximum function parse depth we allow.
-    max_function_parse_depth: u32,
 }
 
 impl<'s> FunctionBuilder<'s> {
     /// Create a new builder for a given outer function.
-    pub fn new(
-        name: Name<'s>,
-        compilation_dir: &'s [u8],
-        address: u64,
-        size: u64,
-        max_function_parse_depth: u32,
-    ) -> Self {
+    pub fn new(name: Name<'s>, compilation_dir: &'s [u8], address: u64, size: u64) -> Self {
         Self {
             name,
             compilation_dir,
@@ -84,7 +76,6 @@ impl<'s> FunctionBuilder<'s> {
             inlinees: BinaryHeap::new(),
             lines: Vec::new(),
             variables: Vec::new(),
-            max_function_parse_depth,
         }
     }
 
@@ -94,7 +85,7 @@ impl<'s> FunctionBuilder<'s> {
     pub fn add_inlinee(&mut self, inlinee: FunctionBuilderInlinee<'s>) {
         // An inlinee that starts before the function is obviously bogus same for an inlinee that
         // has a depth deeper than the limit.
-        if inlinee.address < self.address || inlinee.depth > self.max_function_parse_depth {
+        if inlinee.address < self.address {
             return;
         }
 
@@ -145,7 +136,6 @@ impl<'s> FunctionBuilder<'s> {
             inlinees,
             variables,
             mut lines,
-            max_function_parse_depth: _,
         } = self;
 
         let inlinees = ensure_proper_nesting(inlinees)?;
@@ -524,7 +514,7 @@ mod tests {
     #[test]
     fn test_simple() {
         // 0x10 - 0x40: foo in foo.c on line 1
-        let mut builder = FunctionBuilder::new(Name::from("foo"), &[], 0x10, 0x30, 255);
+        let mut builder = FunctionBuilder::new(Name::from("foo"), &[], 0x10, 0x30);
         builder.add_leaf_line(0x10, Some(0x30), FileInfo::from_filename(b"foo.c"), 1);
         let func = builder.finish().unwrap();
 
@@ -537,7 +527,7 @@ mod tests {
         // 0x10 - 0x20: foo in foo.c on line 1
         // 0x20 - 0x40: bar in bar.c on line 1
         // - inlined into: foo in foo.c on line 2
-        let mut builder = FunctionBuilder::new(Name::from("foo"), &[], 0x10, 0x30, 255);
+        let mut builder = FunctionBuilder::new(Name::from("foo"), &[], 0x10, 0x30);
         builder.add_inlinee(FunctionBuilderInlinee {
             depth: 0,
             name: Name::from("bar"),
@@ -582,7 +572,7 @@ mod tests {
             }],
         };
 
-        let mut builder = FunctionBuilder::new(Name::from("outer"), &[], 0x10, 0x40, 255);
+        let mut builder = FunctionBuilder::new(Name::from("outer"), &[], 0x10, 0x40);
         builder.add_inlinee(FunctionBuilderInlinee {
             depth: 0,
             address: 0x20,
@@ -681,7 +671,7 @@ mod tests {
         //          |----|         |----| (parent.c line 1)
         //               |---------|      (child2.c line 1)
 
-        let mut builder = FunctionBuilder::new(Name::from("parent"), &[], 0x10, 0x40, 255);
+        let mut builder = FunctionBuilder::new(Name::from("parent"), &[], 0x10, 0x40);
         builder.add_inlinee(FunctionBuilderInlinee {
             depth: 0,
             name: Name::from("child1"),

--- a/symbolic-debuginfo/src/macho/mod.rs
+++ b/symbolic-debuginfo/src/macho/mod.rs
@@ -62,7 +62,6 @@ pub struct MachObject<'d> {
     macho: mach::MachO<'d>,
     data: &'d [u8],
     bcsymbolmap: Option<Arc<BcSymbolMap<'d>>>,
-    max_function_parse_depth: u32,
 }
 
 impl<'d> MachObject<'d> {
@@ -78,7 +77,6 @@ impl<'d> MachObject<'d> {
                 macho,
                 data,
                 bcsymbolmap: None,
-                max_function_parse_depth: ParseObjectOptions::default().max_function_parse_depth,
             })
             .map_err(MachError::new)
     }
@@ -321,13 +319,8 @@ impl<'d> MachObject<'d> {
     /// [`has_debug_info`](struct.MachObject.html#method.has_debug_info).
     pub fn debug_session(&self) -> Result<DwarfDebugSession<'d>, DwarfError> {
         let symbols = self.symbol_map();
-        let mut session = DwarfDebugSession::parse(
-            self,
-            symbols,
-            self.load_address() as i64,
-            self.kind(),
-            self.max_function_parse_depth,
-        )?;
+        let mut session =
+            DwarfDebugSession::parse(self, symbols, self.load_address() as i64, self.kind())?;
         session.load_symbolmap(self.bcsymbolmap.clone());
         Ok(session)
     }
@@ -395,13 +388,12 @@ impl<'d> Parse<'d> for MachObject<'d> {
     }
 
     /// Tries to parse a MachO from the given slice.
-    fn parse_with_opts(data: &'d [u8], opts: ParseObjectOptions) -> Result<Self, MachError> {
+    fn parse_with_opts(data: &'d [u8], _opts: ParseObjectOptions) -> Result<Self, MachError> {
         mach::MachO::parse(data, 0)
             .map(|macho| MachObject {
                 macho,
                 data,
                 bcsymbolmap: None,
-                max_function_parse_depth: opts.max_function_parse_depth,
             })
             .map_err(MachError::new)
     }

--- a/symbolic-debuginfo/src/macho/mod.rs
+++ b/symbolic-debuginfo/src/macho/mod.rs
@@ -885,6 +885,11 @@ mod tests {
 
     #[test]
     fn test_bcsymbolmap() {
+        // loads the symbolmap
+        let bc_symbol_map_data =
+            std::fs::read("tests/fixtures/c8374b6d-6e96-34d8-ae38-efaa5fec424f.bcsymbolmap")
+                .unwrap();
+
         let object_data =
             std::fs::read("tests/fixtures/2d10c42f-591d-3265-b147-78ba0868073f.dwarf-hidden")
                 .unwrap();
@@ -922,10 +927,6 @@ mod tests {
         let inlinee = fn_with_inlinees.inlinees.first().unwrap();
         assert_eq!(&inlinee.name, "__hidden#146_");
 
-        // loads the symbolmap
-        let bc_symbol_map_data =
-            std::fs::read("tests/fixtures/c8374b6d-6e96-34d8-ae38-efaa5fec424f.bcsymbolmap")
-                .unwrap();
         let bc_symbol_map = BcSymbolMap::parse(&bc_symbol_map_data).unwrap();
         object.load_symbolmap(bc_symbol_map);
 

--- a/symbolic-debuginfo/src/object.rs
+++ b/symbolic-debuginfo/src/object.rs
@@ -126,11 +126,9 @@ impl Error for ObjectError {
     }
 }
 
-const MAX_FUNCTION_PARSE_DEPTH_DEFAULT: u32 = 800;
-
 /// Options for parsing object files.
 #[non_exhaustive]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct ParseObjectOptions {
     /// The maximum uncompressed size for compressed debug file sections.
     ///
@@ -141,19 +139,6 @@ pub struct ParseObjectOptions {
     ///
     /// This is only relevant for source bundles and PPDB objects.
     pub max_decompressed_embedded_source_size: Option<usize>,
-
-    /// The maximum inline nesting depth to process.
-    pub max_function_parse_depth: u32,
-}
-
-impl Default for ParseObjectOptions {
-    fn default() -> Self {
-        Self {
-            max_decompressed_section_size: Default::default(),
-            max_decompressed_embedded_source_size: Default::default(),
-            max_function_parse_depth: MAX_FUNCTION_PARSE_DEPTH_DEFAULT,
-        }
-    }
 }
 
 /// Tries to infer the object type from the start of the given buffer.

--- a/symbolic-debuginfo/src/pe.rs
+++ b/symbolic-debuginfo/src/pe.rs
@@ -70,7 +70,6 @@ pub struct PeObject<'data> {
     pe: pe::PE<'data>,
     data: &'data [u8],
     is_stub: bool,
-    max_function_parse_depth: u32,
 }
 
 impl<'data> PeObject<'data> {
@@ -95,12 +94,7 @@ impl<'data> PeObject<'data> {
             .with_parse_imports(false);
         let pe = pe::PE::parse_with_opts(data, &opts).map_err(PeError::new)?;
         let is_stub = is_pe_stub(&pe);
-        Ok(PeObject {
-            pe,
-            data,
-            is_stub,
-            max_function_parse_depth: ParseObjectOptions::default().max_function_parse_depth,
-        })
+        Ok(PeObject { pe, data, is_stub })
     }
 
     /// The code identifier of this object.
@@ -257,13 +251,7 @@ impl<'data> PeObject<'data> {
     /// [`has_debug_info`](struct.PeObject.html#method.has_debug_info).
     pub fn debug_session(&self) -> Result<DwarfDebugSession<'data>, DwarfError> {
         let symbols = self.symbol_map();
-        DwarfDebugSession::parse(
-            self,
-            symbols,
-            self.load_address() as i64,
-            self.kind(),
-            self.max_function_parse_depth,
-        )
+        DwarfDebugSession::parse(self, symbols, self.load_address() as i64, self.kind())
     }
 
     /// Determines whether this object contains stack unwinding information.
@@ -409,18 +397,13 @@ impl<'data> Parse<'data> for PeObject<'data> {
         Self::test(data)
     }
 
-    fn parse_with_opts(data: &'data [u8], popts: ParseObjectOptions) -> Result<Self, Self::Error> {
+    fn parse_with_opts(data: &'data [u8], _popts: ParseObjectOptions) -> Result<Self, Self::Error> {
         let opts = pe::options::ParseOptions::default()
             .with_parse_mode(goblin::pe::options::ParseMode::Permissive)
             .with_parse_imports(false);
         let pe = pe::PE::parse_with_opts(data, &opts).map_err(PeError::new)?;
         let is_stub = is_pe_stub(&pe);
-        Ok(PeObject {
-            pe,
-            data,
-            is_stub,
-            max_function_parse_depth: popts.max_function_parse_depth,
-        })
+        Ok(PeObject { pe, data, is_stub })
     }
 }
 

--- a/symbolic-debuginfo/src/wasm.rs
+++ b/symbolic-debuginfo/src/wasm.rs
@@ -34,7 +34,6 @@ pub struct WasmObject<'data> {
     data: &'data [u8],
     code_offset: u64,
     kind: ObjectKind,
-    max_function_parse_depth: u32,
 }
 
 impl<'data> WasmObject<'data> {
@@ -119,13 +118,7 @@ impl<'data> WasmObject<'data> {
     pub fn debug_session(&self) -> Result<DwarfDebugSession<'data>, DwarfError> {
         let symbols = self.symbol_map();
         // WASM is offset by the negative offset to the code section instead of the load address
-        DwarfDebugSession::parse(
-            self,
-            symbols,
-            -(self.code_offset() as i64),
-            self.kind(),
-            self.max_function_parse_depth,
-        )
+        DwarfDebugSession::parse(self, symbols, -(self.code_offset() as i64), self.kind())
     }
 
     /// Determines whether this object contains stack unwinding information.

--- a/symbolic-debuginfo/src/wasm/parser.rs
+++ b/symbolic-debuginfo/src/wasm/parser.rs
@@ -66,7 +66,7 @@ impl<'d> Parse<'d> for WasmObject<'d> {
         Self::test(data)
     }
 
-    fn parse_with_opts(data: &'d [u8], opts: ParseObjectOptions) -> Result<Self, Self::Error> {
+    fn parse_with_opts(data: &'d [u8], _opts: ParseObjectOptions) -> Result<Self, Self::Error> {
         let mut code_offset = 0;
         let mut build_id = None;
         let mut dwarf_sections = Vec::new();
@@ -240,7 +240,6 @@ impl<'d> Parse<'d> for WasmObject<'d> {
             data,
             code_offset,
             kind,
-            max_function_parse_depth: opts.max_function_parse_depth,
         })
     }
 }

--- a/symbolic-debuginfo/tests/test_pdb_srcsrv.rs
+++ b/symbolic-debuginfo/tests/test_pdb_srcsrv.rs
@@ -54,7 +54,7 @@ fn test_pdb_line_info() {
     let line = session
         .functions()
         .map(|function| function.unwrap())
-        .flat_map(|function| function.lines.into_iter())
+        .flat_map(|function| function.lines.clone().into_iter())
         .find(|line| {
             // Expected specific path based on the SRCSRV data in the test PDB
             // Path should NOT contain @12345, revision should be separate

--- a/symbolic-debuginfo/tests/test_recursion_limits.rs
+++ b/symbolic-debuginfo/tests/test_recursion_limits.rs
@@ -1,4 +1,3 @@
-use std::assert_matches;
 use symbolic_debuginfo::Object;
 
 #[test]
@@ -25,5 +24,5 @@ fn test_function_inlining() {
 
     let func = session.functions().next().unwrap();
 
-    assert_matches!(func, Err(_));
+    assert!(func.is_ok());
 }

--- a/symbolic-symcache/src/writer.rs
+++ b/symbolic-symcache/src/writer.rs
@@ -73,7 +73,7 @@ pub struct SymCacheConverter<'a> {
 struct InProgressFunction<'a> {
     function: &'a Function<'a>,
     base_index: u32,
-    depth: u16,
+    depth: u32,
     call_locations: Rc<[(u32, u32)]>,
 }
 
@@ -487,7 +487,7 @@ impl<'a> SymCacheConverter<'a> {
         tr: &dyn TypeResolver,
         function: &Function<'_>,
         base_idx: u32,
-        fn_depth: u16,
+        fn_depth: u32,
     ) {
         if !self.collect_variables || fn_depth > u8::MAX.into() {
             return;

--- a/symbolic-symcache/tests/breakpad.rs
+++ b/symbolic-symcache/tests/breakpad.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::io::Cursor;
 
 use symbolic_common::{ByteView, clean_path};
-use symbolic_debuginfo::{Object, ParseObjectOptions, breakpad::BreakpadObject};
+use symbolic_debuginfo::{Object, breakpad::BreakpadObject};
 use symbolic_symcache::{SymCache, SymCacheConverter};
 use symbolic_testutils::fixture;
 
@@ -165,10 +165,7 @@ FUNC 1000 2000 0 outer
         sym.push_str(&format!("INLINE {depth} 1 0 0 1000 2000\n"));
     }
 
-    let limit = 512;
-    let mut opts = ParseObjectOptions::default();
-    opts.max_function_parse_depth = limit;
-    let breakpad = Object::parse_with_opts(sym.as_bytes(), opts).unwrap();
+    let breakpad = Object::parse(sym.as_bytes()).unwrap();
 
     let mut buffer = Vec::new();
     let mut converter = SymCacheConverter::new();
@@ -177,5 +174,5 @@ FUNC 1000 2000 0 outer
     let symcache = SymCache::parse(&buffer).unwrap();
 
     let lookup_result: Vec<_> = symcache.lookup(0x1000).collect();
-    assert_eq!(lookup_result.len(), limit as usize + 2);
+    assert_eq!(lookup_result.len(), 1001);
 }


### PR DESCRIPTION
We will now handle function parsing in both symcache convertor and dwarf DIE parsing iteratively, so there is no longer a need for bounding these by function depth.

This also required introducing an iterative fmt::Debug implementation for Function, authored by Claude.